### PR TITLE
fix(profile): preserve the /myprofile hero-card image across editor navigation

### DIFF
--- a/.sessions/2026-06-25-profile-card-attachment-fix.md
+++ b/.sessions/2026-06-25-profile-card-attachment-fix.md
@@ -1,0 +1,30 @@
+# 2026-06-25 — Profile hero-card attachment round-trip fix
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+
+> **Run type:** `routine · dispatch` — scheduled dispatch fire, no work order. Took the next
+> bugs-first slice spotted during orientation (Q-0166 drift/bug-on-sight).
+
+**Branch:** `claude/funny-franklin-hu26rl` (off `main` @ #1462).
+
+## What I'm about to do (intentions)
+
+Fix a real, paired UX bug on the **`/myprofile` H1 hero-card image** navigation, found while
+auditing the visual card-engine H3 adoption tail:
+
+- **`views/profile/profile_view.py` — `manage` ("⚙️ Manage settings")** does
+  `edit_message(embed=editor.build_embed(), view=editor)` with **no `attachments`**, so Discord
+  retains the profile hero-card image: it lingers as a stray image under the (image-less) settings
+  editor.
+- **`views/profile/editor.py` — `back_to_card` ("◀ Back to card")** navigates back with
+  `build_profile_embed` (a plain embed, no `set_image`) and **no re-attach**, so the round-trip
+  loses the hero card — the returned panel shows the embed without its designed image (and any
+  stray attachment from the step above dangles).
+
+Both transitions must manage `attachments` explicitly, matching the canonical pattern already used
+by `ProfileHomeView.refresh` and every other image-card hub (mining `character_hub`/`gear_panel`,
+`role_menu_view`): re-render + re-attach when there is a card, pass `attachments=[]` to clear it.
+The bug is isolated to the profile views (the other hubs already do it right).
+
+Plan: fix both transitions, add tests pinning the attachment behaviour on each, record the bug in
+`docs/health/bug-book.md`. CI mirror green + arch 0 before flipping the card.

--- a/.sessions/2026-06-25-profile-card-attachment-fix.md
+++ b/.sessions/2026-06-25-profile-card-attachment-fix.md
@@ -1,30 +1,90 @@
 # 2026-06-25 — Profile hero-card attachment round-trip fix
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — both transitions fixed, 3 regression tests green, full CI mirror green
+> (12528 passed) + arch 0. BUG-0025 recorded FIXED (root).
 
 > **Run type:** `routine · dispatch` — scheduled dispatch fire, no work order. Took the next
 > bugs-first slice spotted during orientation (Q-0166 drift/bug-on-sight).
 
-**Branch:** `claude/funny-franklin-hu26rl` (off `main` @ #1462).
+**Branch:** `claude/funny-franklin-hu26rl` (off `main` @ #1462). **PR #1463.**
 
-## What I'm about to do (intentions)
+## What shipped (BUG-0025)
 
-Fix a real, paired UX bug on the **`/myprofile` H1 hero-card image** navigation, found while
-auditing the visual card-engine H3 adoption tail:
+Fixed a real, paired UX bug on the **`/myprofile` H1 hero-card image** — the card ↔ self-service
+editor round-trip mishandled the rendered image attachment:
 
-- **`views/profile/profile_view.py` — `manage` ("⚙️ Manage settings")** does
-  `edit_message(embed=editor.build_embed(), view=editor)` with **no `attachments`**, so Discord
-  retains the profile hero-card image: it lingers as a stray image under the (image-less) settings
-  editor.
-- **`views/profile/editor.py` — `back_to_card` ("◀ Back to card")** navigates back with
-  `build_profile_embed` (a plain embed, no `set_image`) and **no re-attach**, so the round-trip
-  loses the hero card — the returned panel shows the embed without its designed image (and any
-  stray attachment from the step above dangles).
+- **`views/profile/profile_view.py` — `manage` ("⚙️ Manage settings")** did
+  `edit_message(embed=editor.build_embed(), view=editor)` with **no `attachments`**. Discord retains
+  the prior attachment when the arg is omitted, so the profile hero card lingered as a **stray image**
+  under the (image-less) settings editor. → now passes `attachments=[]` to clear it.
+- **`views/profile/editor.py` — `back_to_card` ("◀ Back to card")** rebuilt the panel from
+  `build_profile_embed` (plain embed, no `set_image`) with **no re-attach**, **losing the hero card**
+  on the return leg. → now re-renders the full card via `build_profile_card` and re-attaches the file
+  (`attachments=[file]`, or `[]` on a Pillow-less host), mirroring `ProfileHomeView.refresh`.
 
-Both transitions must manage `attachments` explicitly, matching the canonical pattern already used
-by `ProfileHomeView.refresh` and every other image-card hub (mining `character_hub`/`gear_panel`,
-`role_menu_view`): re-render + re-attach when there is a card, pass `attachments=[]` to clear it.
-The bug is isolated to the profile views (the other hubs already do it right).
+**Root cause:** these were the only two `edit_message` calls in the profile views that omitted
+`attachments`. Every other image-card hub (`refresh`, mining `character_hub`/`gear_panel`,
+`role_menu_view`) already passes it explicitly — so the bug was isolated to the profile editor
+navigation; no wider sweep needed (I checked the other hubs, they're correct).
 
-Plan: fix both transitions, add tests pinning the attachment behaviour on each, record the bug in
-`docs/health/bug-book.md`. CI mirror green + arch 0 before flipping the card.
+**Stays-fixed guard (same PR):** 3 regression tests asserting the `attachments=` payload on each
+transition (all fail against pre-fix behaviour):
+- `test_profile_card.py::test_manage_clears_the_hero_card_when_opening_the_editor`
+- `test_profile_editor.py::test_back_to_card_rerenders_and_reattaches_the_hero_card`
+- `test_profile_editor.py::test_back_to_card_clears_attachments_when_renderer_unavailable`
+
+Docs: BUG-0025 entry (FIXED root) in `docs/health/bug-book.md`.
+
+### ⚑ Flagged for maintainer / known limits
+
+- **Not live-verified** (no Discord boot here): the fix follows the same `attachments=` contract the
+  rest of the codebase already uses and is unit-pinned, so confidence is high, but a live click-through
+  of `/myprofile` → Manage settings → Back to card would confirm the image now persists correctly.
+
+## 💡 Session idea
+
+**A `views`-layer lint: every `edit_message` whose embed carries a hero card must pass `attachments`
+explicitly.** This bug class (omit `attachments` → Discord silently keeps/strands the old attachment)
+is invisible to mypy and to the existing checks — it only shows live. A small AST check in
+`scripts/check_architecture.py` (or a dedicated `check_attachment_hygiene.py`) could flag any
+`interaction.response.edit_message(...)` / `message.edit(...)` in a view that omits `attachments`
+when an image-card render helper is in scope. Disposable/unverified per Q-0105; would have caught
+BUG-0025 statically. Captured here for a later slice (not built this run — wanted the fix landed
+first).
+
+## ⟲ Previous-session review
+
+Previous run (#1460-band, the ticket AI one-click-confirm follow-up) did the right thing: it shipped
+a clean event-seam confirm flow and, in its own review, flagged that the *prior* session made a
+user-facing interaction-model decision unilaterally — a genuinely useful self-audit. What it (and the
+whole recent burst of "ship the next feature") arguably missed is exactly what this run picked up:
+the H1 visual-card showpiece had a visible navigation bug sitting un-noticed while newer cards were
+being added. **System improvement:** the card-engine rollout has been additive-fast but light on
+*navigation* regression coverage — the session idea above (an attachment-hygiene lint) is the
+structural fix so the next card hub can't reintroduce this class. The workflow itself (born-red card,
+auto-merge, context-map-on-edit) worked smoothly.
+
+## ⟳ Doc audit (Q-0104)
+
+- BUG-0025 recorded in the bug book with its stays-fixed guard named (root fix, not deferred).
+- No new owner decision; no new doc file → no `check_docs` reachability change.
+- current-state recently-shipped left untouched (merged-PRs-only; the next session reconciles #1463).
+- Claim file `claude__funny-franklin-hu26rl.md` deleted at close (below).
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1463 — fix(profile): preserve the `/myprofile` hero-card image across editor navigation
+- **Class:** fix (contained, reversible, test-covered) → self-merge on green (Q-0113)
+- **⚑ Self-initiated:** none beyond picking the slice — a bug-on-sight fix (Q-0166), no invented
+  feature, no idea→plan promotion this run.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none (merge auto-deploys; the fix is live on next deploy)
+
+## Context delta
+
+The bug was found by auditing the visual card-engine H3 adoption tail in `S1-bot.md`. The "profile/
+rank hubs are the next `help_nav_card` adopters" note there is **separate** from this fix — the
+profile card is reached via `!myprofile`/`/myprofile` directly (no Help-hub nav entry), so it isn't
+a `help_nav_card` adopter; this fix is about plain `attachments` hygiene on its own editor nav. Left
+that S1 bullet as-is.

--- a/disbot/views/profile/editor.py
+++ b/disbot/views/profile/editor.py
@@ -180,12 +180,19 @@ class ProfileEditorHomeView(BaseView):
         interaction: discord.Interaction,
         _button: discord.ui.Button,
     ) -> None:
-        from views.profile.profile_view import ProfileHomeView, build_profile_embed
+        from views.profile.profile_view import ProfileHomeView, build_profile_card
 
         card = ProfileHomeView(self._author, self._guild_id)
+        # Re-render the full hero card and re-attach it, mirroring
+        # ``ProfileHomeView.refresh`` — going back to the card must restore its
+        # designed image, not return a plain embed (and never leave a stray
+        # attachment). ``build_profile_card`` returns ``file is None`` on a
+        # Pillow-less host, where ``attachments=[]`` keeps the embed-only state.
+        embed, file = await build_profile_card(self._author, self._guild_id)
         await interaction.response.edit_message(
-            embed=await build_profile_embed(self._author, self._guild_id),
+            embed=embed,
             view=card,
+            attachments=[file] if file is not None else [],
         )
 
 

--- a/disbot/views/profile/profile_view.py
+++ b/disbot/views/profile/profile_view.py
@@ -308,7 +308,11 @@ class ProfileHomeView(BaseView):
         from views.profile.editor import ProfileEditorHomeView
 
         editor = ProfileEditorHomeView(self._author, self._guild_id)
+        # The editor has no hero image, so clear the card explicitly — otherwise
+        # Discord keeps the prior attachment and the profile card lingers as a
+        # stray image under the settings panel (same contract as ``refresh``).
         await interaction.response.edit_message(
             embed=editor.build_embed(),
             view=editor,
+            attachments=[],
         )

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,6 +23,33 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
+## BUG-0025 — `/myprofile` hero-card image stranded/lost across the editor round-trip — FIXED (root)
+
+- **Symptom (found 2026-06-25 by code inspection during the visual card-engine H3 adoption audit;
+  not a live report, but a visible defect on the H1 showpiece card):** opening **⚙️ Manage settings**
+  from the `/myprofile` card and coming back via **◀ Back to card** mishandles the rendered hero-card
+  image. Going *in*, the profile card image lingers as a stray attachment under the (image-less)
+  settings editor; coming *back*, the returned panel shows a plain embed without its designed hero
+  card.
+- **Root cause:** two `interaction.response.edit_message(...)` calls in the profile views omitted the
+  `attachments` argument. Discord **retains** the prior message attachments when `attachments` is not
+  passed on an edit, so (1) `ProfileHomeView.manage` left the card image attached under an editor that
+  never references it, and (2) `editor.back_to_card` rebuilt the panel from `build_profile_embed` (a
+  plain embed, no `set_image`) without re-attaching the file — losing the hero card on the return leg.
+  Every other image-card hub (`ProfileHomeView.refresh`, mining `character_hub`/`gear_panel`,
+  `role_menu_view`) already passes `attachments` explicitly; the profile editor navigation was the one
+  place that forgot the canonical pattern.
+- **Fix (this PR):** both transitions now manage `attachments` explicitly — `manage` clears the card
+  (`attachments=[]`) when opening the image-less editor, and `back_to_card` re-renders the full card
+  via `build_profile_card` and re-attaches the file (`attachments=[file]`, or `[]` on a Pillow-less
+  host). The round-trip card → editor → card now preserves the hero image, with no stray attachment.
+- **Stays-fixed guard (same PR):** `tests/unit/views/test_profile_card.py::
+  test_manage_clears_the_hero_card_when_opening_the_editor` and `tests/unit/views/test_profile_editor.py::
+  test_back_to_card_rerenders_and_reattaches_the_hero_card` /
+  `test_back_to_card_clears_attachments_when_renderer_unavailable` assert the `attachments=` payload on
+  each transition; all three fail against the pre-fix behaviour.
+- **Status:** FIXED (root) 2026-06-25 (dispatch run).
+
 ## BUG-0024 — `test_generated_at_is_deterministic_not_wall_clock` flaky under `pytest -n auto` (real-clock dependent) — FIXED (root)
 
 - **Symptom (observed 2026-06-22, in a full `check_quality.py --full` run during the Q-0195

--- a/docs/owner/claims/claude__funny-franklin-hu26rl.md
+++ b/docs/owner/claims/claude__funny-franklin-hu26rl.md
@@ -1,0 +1,1 @@
+ - `claude/funny-franklin-hu26rl` · **fix profile hero-card attachment round-trip** — `manage`/`back_to_card` drop or strand the `/myprofile` image card · `disbot/views/profile/profile_view.py` `disbot/views/profile/editor.py` · 2026-06-25 · PR pending

--- a/docs/owner/claims/claude__funny-franklin-hu26rl.md
+++ b/docs/owner/claims/claude__funny-franklin-hu26rl.md
@@ -1,1 +1,0 @@
- - `claude/funny-franklin-hu26rl` · **fix profile hero-card attachment round-trip** — `manage`/`back_to_card` drop or strand the `/myprofile` image card · `disbot/views/profile/profile_view.py` `disbot/views/profile/editor.py` · 2026-06-25 · PR pending

--- a/tests/unit/views/test_profile_card.py
+++ b/tests/unit/views/test_profile_card.py
@@ -219,6 +219,31 @@ async def test_view_is_owner_locked():
 
 
 # ---------------------------------------------------------------------------
+# Card ↔ editor navigation — hero-image attachment hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manage_clears_the_hero_card_when_opening_the_editor():
+    """Opening the (image-less) editor must drop the card, not strand it.
+
+    Discord keeps the prior attachment when ``attachments`` is omitted on an
+    edit, so the profile hero image would linger as a stray image under the
+    settings panel. ``manage`` passes ``attachments=[]`` to clear it.
+    """
+    view = ProfileHomeView(_fake_user(user_id=1), guild_id=99)
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1),
+        response=SimpleNamespace(edit_message=AsyncMock()),
+    )
+
+    await view.manage.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    assert interaction.response.edit_message.await_args.kwargs["attachments"] == []
+
+
+# ---------------------------------------------------------------------------
 # Read-only invariant — no mutation pipeline import (AST pin)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/views/test_profile_editor.py
+++ b/tests/unit/views/test_profile_editor.py
@@ -143,6 +143,57 @@ def test_home_empty_state_when_no_registrants():
 
 
 # ---------------------------------------------------------------------------
+# Back to card — re-render + re-attach the hero image (mirrors refresh)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_back_to_card_rerenders_and_reattaches_the_hero_card():
+    """Returning to the card must restore its designed image, not a plain embed.
+
+    ``back_to_card`` re-renders the full card via ``build_profile_card`` and
+    re-attaches the rendered file — the same contract as ``ProfileHomeView``'s
+    refresh — so the round-trip card → editor → card keeps the hero image.
+    """
+    view = ProfileEditorHomeView(_fake_user(), 99)
+    sentinel_embed = SimpleNamespace()
+    sentinel_file = SimpleNamespace()  # stand-in for a discord.File
+    interaction = _interaction()
+
+    with patch(
+        "views.profile.profile_view.build_profile_card",
+        new=AsyncMock(return_value=(sentinel_embed, sentinel_file)),
+    ):
+        await view.back_to_card.callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["embed"] is sentinel_embed
+    assert kwargs["attachments"] == [sentinel_file]
+
+
+@pytest.mark.asyncio
+async def test_back_to_card_clears_attachments_when_renderer_unavailable():
+    """On a Pillow-less host the card file is ``None`` → ``attachments=[]``.
+
+    This both keeps the embed-only state and clears any stray attachment, so
+    the fallback never leaves a dangling image.
+    """
+    view = ProfileEditorHomeView(_fake_user(), 99)
+    sentinel_embed = SimpleNamespace()
+    interaction = _interaction()
+
+    with patch(
+        "views.profile.profile_view.build_profile_card",
+        new=AsyncMock(return_value=(sentinel_embed, None)),
+    ):
+        await view.back_to_card.callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["embed"] is sentinel_embed
+    assert kwargs["attachments"] == []
+
+
+# ---------------------------------------------------------------------------
 # One pipeline call per action (mock-spy)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

A real, paired UX bug on the **`/myprofile` H1 hero-card image** (the visual card engine's first
feature card), found while auditing the H3 adoption tail. The profile card ↔ self-service editor
round-trip mishandles the image attachment:

- **`manage` ("⚙️ Manage settings")** opens the editor with
  `edit_message(embed=..., view=...)` and **no `attachments`** → Discord retains the prior
  attachment, so the profile hero-card image **lingers as a stray image** under the (image-less)
  settings editor.
- **`back_to_card` ("◀ Back to card")** returns via `build_profile_embed` (a plain embed, no
  `set_image`) with **no re-attach** → the round-trip **loses the hero card**; the returned panel
  shows the embed without its designed image.

Both transitions now manage `attachments` explicitly, matching the canonical pattern already used by
`ProfileHomeView.refresh` and every other image-card hub (mining `character_hub`/`gear_panel`,
`role_menu_view`): re-render + re-attach the card on the way back, clear it (`attachments=[]`) on
the way into the image-less editor. The bug was isolated to the profile views — the other hubs
already do this right, so no wider sweep was needed.

## Changes
- `disbot/views/profile/profile_view.py` — `manage` clears the stray card (`attachments=[]`).
- `disbot/views/profile/editor.py` — `back_to_card` re-renders the full hero card via
  `build_profile_card` and re-attaches it (Pillow-less fallback → `attachments=[]`).
- Tests pinning both transitions.
- `docs/health/bug-book.md` — BUG entry (FIXED, this PR).

Class: **fix**. Contained, reversible, test-covered. CI mirror green + arch 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ojGR3obaPwCGqgqfLzGaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016ojGR3obaPwCGqgqfLzGaZ)_