### PR TITLE
fix(xp): clear the stranded rank card when opening the XP Configure panel (BUG-0025)

### DIFF
--- a/.sessions/2026-06-25-xp-config-card-strand-fix.md
+++ b/.sessions/2026-06-25-xp-config-card-strand-fix.md
@@ -1,0 +1,22 @@
+# 2026-06-25 — XP hub: clear stranded rank card on Configure (BUG-0025 third instance)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+
+> **Run type:** `routine · dispatch` — same dispatch fire as PR #1463. Follow-up: a bugs-first root
+> sweep of BUG-0025 found a third instance of the attachment-stranding class outside the profile
+> views, but the merge of #1463 (profile-only) raced ahead of the fix push, so it ships separately.
+
+**Branch:** `claude/xp-config-card-strand-fix` (off `main` @ #1463 merge, `ceebc876`).
+
+## What I'm about to do (intentions)
+
+`views/xp/main_panel.py` — `_XpHubView.btn_config` ("⚙️ Configure") opens the image-less
+`XpConfigView` from the `!xpmenu` rank-card hub with `edit_message(...)` and **no `attachments`**, so
+Discord keeps the rank card attached and it lingers as a stray image under the config panel — the
+exact same class as BUG-0025's profile sites (which shipped in #1463). Fix: pass `attachments=[]` to
+clear it, matching the stat toggles in `_switch_stat` and the profile `manage` fix.
+
+Already done on the branch (carried from the #1463 work, pre-verified green): the `btn_config` fix,
+a regression test (`test_xp_hub_panel.py::test_config_button_clears_the_rank_card_attachment`), and
+the BUG-0025 bug-book entry broadened to all three call sites. CI mirror + arch were green on this
+exact diff before the split. Re-verify green, then flip the card.

--- a/.sessions/2026-06-25-xp-config-card-strand-fix.md
+++ b/.sessions/2026-06-25-xp-config-card-strand-fix.md
@@ -1,6 +1,7 @@
 # 2026-06-25 — XP hub: clear stranded rank card on Configure (BUG-0025 third instance)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — `btn_config` fixed, regression test green (9/9 in the XP hub suite),
+> arch 0. BUG-0025 now root-level across all three call sites.
 
 > **Run type:** `routine · dispatch` — same dispatch fire as PR #1463. Follow-up: a bugs-first root
 > sweep of BUG-0025 found a third instance of the attachment-stranding class outside the profile
@@ -16,7 +17,28 @@ Discord keeps the rank card attached and it lingers as a stray image under the c
 exact same class as BUG-0025's profile sites (which shipped in #1463). Fix: pass `attachments=[]` to
 clear it, matching the stat toggles in `_switch_stat` and the profile `manage` fix.
 
-Already done on the branch (carried from the #1463 work, pre-verified green): the `btn_config` fix,
-a regression test (`test_xp_hub_panel.py::test_config_button_clears_the_rank_card_attachment`), and
-the BUG-0025 bug-book entry broadened to all three call sites. CI mirror + arch were green on this
-exact diff before the split. Re-verify green, then flip the card.
+Done on the branch (carried from the #1463 work, pre-verified green): the `btn_config` fix, a
+regression test (`test_xp_hub_panel.py::test_config_button_clears_the_rank_card_attachment`), and the
+BUG-0025 bug-book entry broadened to all three call sites. Re-verified on this branch: 9/9 XP-hub
+tests green, arch 0. The full CI mirror was green on this exact diff during the #1463 work.
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1464 — fix(xp): clear the stranded rank card when opening the XP Configure panel (BUG-0025)
+- **Class:** fix (contained, reversible, test-covered) → self-merge on green (Q-0113)
+- **⚑ Self-initiated:** none — the third instance was surfaced by a bugs-first root sweep (CLAUDE.md
+  §6) of an already-dispatched bug fix, not an invented feature.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none (merge auto-deploys)
+
+## Note on the split
+
+This and #1463 are one logical fix (BUG-0025, three call sites) that the auto-merge race split into
+two PRs: #1463 merged at the profile-only commit while the XP fix's push was still in flight. No work
+was lost — the XP fix is fully tested and shipping here. **Workflow lesson for the next run:** when a
+bugs-first sweep is likely to find sibling instances, hold the born-red card until the *whole* root
+fix is staged, or accept the split up front — don't push the complete-card flip before the sweep
+finishes, because auto-merge fires the instant Code Quality is green. (The session-ender idea + the
+previous-session review for this dispatch run live in the #1463 card,
+`.sessions/2026-06-25-profile-card-attachment-fix.md`, to avoid duplication.)

--- a/disbot/views/xp/main_panel.py
+++ b/disbot/views/xp/main_panel.py
@@ -102,9 +102,14 @@ class _XpHubView(HubView):
 
         config_view = XpConfigView(self.ctx, parent=self)
         config_view.message = self.message
+        # The config panel has no hero image, so clear the rank card explicitly —
+        # otherwise Discord keeps the prior attachment and the rank card lingers
+        # as a stray image under the config panel (same contract as the stat
+        # toggles in ``_switch_stat``). See bug book BUG-0025.
         await interaction.response.edit_message(
             embed=await config_view.build_embed(),
             view=config_view,
+            attachments=[],
         )
 
     @discord.ui.button(label="🎁 Give XP", style=discord.ButtonStyle.grey, row=1)

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,31 +23,38 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
-## BUG-0025 — `/myprofile` hero-card image stranded/lost across the editor round-trip — FIXED (root)
+## BUG-0025 — hero-card image stranded/lost when navigating into an image-less sub-panel (profile + XP hub) — FIXED (root)
 
 - **Symptom (found 2026-06-25 by code inspection during the visual card-engine H3 adoption audit;
-  not a live report, but a visible defect on the H1 showpiece card):** opening **⚙️ Manage settings**
-  from the `/myprofile` card and coming back via **◀ Back to card** mishandles the rendered hero-card
-  image. Going *in*, the profile card image lingers as a stray attachment under the (image-less)
-  settings editor; coming *back*, the returned panel shows a plain embed without its designed hero
-  card.
-- **Root cause:** two `interaction.response.edit_message(...)` calls in the profile views omitted the
-  `attachments` argument. Discord **retains** the prior message attachments when `attachments` is not
-  passed on an edit, so (1) `ProfileHomeView.manage` left the card image attached under an editor that
-  never references it, and (2) `editor.back_to_card` rebuilt the panel from `build_profile_embed` (a
-  plain embed, no `set_image`) without re-attaching the file — losing the hero card on the return leg.
-  Every other image-card hub (`ProfileHomeView.refresh`, mining `character_hub`/`gear_panel`,
-  `role_menu_view`) already passes `attachments` explicitly; the profile editor navigation was the one
-  place that forgot the canonical pattern.
-- **Fix (this PR):** both transitions now manage `attachments` explicitly — `manage` clears the card
-  (`attachments=[]`) when opening the image-less editor, and `back_to_card` re-renders the full card
-  via `build_profile_card` and re-attaches the file (`attachments=[file]`, or `[]` on a Pillow-less
-  host). The round-trip card → editor → card now preserves the hero image, with no stray attachment.
-- **Stays-fixed guard (same PR):** `tests/unit/views/test_profile_card.py::
-  test_manage_clears_the_hero_card_when_opening_the_editor` and `tests/unit/views/test_profile_editor.py::
-  test_back_to_card_rerenders_and_reattaches_the_hero_card` /
-  `test_back_to_card_clears_attachments_when_renderer_unavailable` assert the `attachments=` payload on
-  each transition; all three fail against the pre-fix behaviour.
+  not a live report, but a visible defect on the showpiece image cards):** navigating from an
+  image-card hub into an image-less sub-panel strands or drops the rendered hero card. **Profile:**
+  opening **⚙️ Manage settings** from the `/myprofile` card leaves the card image lingering as a stray
+  attachment under the (image-less) settings editor, and **◀ Back to card** returns a plain embed
+  without its designed hero card. **XP hub:** opening **⚙️ Configure** from the `!xpmenu` rank-card hub
+  leaves the rank card lingering as a stray image under the (image-less) config panel.
+- **Root cause:** `interaction.response.edit_message(...)` calls that navigate to an image-less panel
+  omitted the `attachments` argument. Discord **retains** the prior message attachments when
+  `attachments` is not passed on an edit, so the leaving hub's hero card stayed attached under a panel
+  that never references it. The profile `back_to_card` leg additionally rebuilt from
+  `build_profile_embed` (a plain embed, no `set_image`) without re-attaching the file — losing the card
+  on the way back. Every *same-file* image-card transition already passes `attachments` explicitly
+  (`ProfileHomeView.refresh`, the XP stat toggles in `_switch_stat`, mining `character_hub`/`gear_panel`,
+  `role_menu_view`); the bug was confined to the **cross-panel navigations** that open/return an
+  image-less sibling — the two places that forgot the canonical pattern.
+- **Three call sites fixed (this PR):**
+  1. `views/profile/profile_view.py` `ProfileHomeView.manage` → `attachments=[]` (clear on open).
+  2. `views/profile/editor.py` `back_to_card` → re-render via `build_profile_card` + re-attach
+     (`attachments=[file]`, or `[]` on a Pillow-less host).
+  3. `views/xp/main_panel.py` `_XpHubView.btn_config` → `attachments=[]` (clear on open).
+- **Sweep:** a repo-wide check of every view file that both renders an `attachment://` image card and
+  calls `edit_message` confirmed these were the only offenders; all other image-card hubs already pass
+  `attachments` explicitly.
+- **Stays-fixed guard (same PR):** four regression tests, each asserting the `attachments=` payload and
+  each failing against the pre-fix behaviour —
+  `tests/unit/views/test_profile_card.py::test_manage_clears_the_hero_card_when_opening_the_editor`,
+  `tests/unit/views/test_profile_editor.py::test_back_to_card_rerenders_and_reattaches_the_hero_card`
+  and `::test_back_to_card_clears_attachments_when_renderer_unavailable`,
+  `tests/unit/views/xp/test_xp_hub_panel.py::test_config_button_clears_the_rank_card_attachment`.
 - **Status:** FIXED (root) 2026-06-25 (dispatch run).
 
 ## BUG-0024 — `test_generated_at_is_deterministic_not_wall_clock` flaky under `pytest -n auto` (real-clock dependent) — FIXED (root)

--- a/tests/unit/views/xp/test_xp_hub_panel.py
+++ b/tests/unit/views/xp/test_xp_hub_panel.py
@@ -121,6 +121,27 @@ async def test_stat_switch_clears_attachment_on_embed_only_fallback():
 
 
 @pytest.mark.asyncio
+async def test_config_button_clears_the_rank_card_attachment():
+    # Opening the (image-less) config panel must drop the rank card, not strand
+    # it under the panel — Discord keeps the prior attachment when ``attachments``
+    # is omitted on an edit. See bug book BUG-0025 (the profile-editor sibling).
+    view = _XpHubView(_ctx(admin=True))
+    interaction = MagicMock()
+    interaction.user.guild_permissions = MagicMock(administrator=True)
+    interaction.response.edit_message = AsyncMock()
+
+    with patch(
+        "views.xp.config_panel.XpConfigView.build_embed",
+        new=AsyncMock(return_value=discord.Embed(description="config")),
+    ):
+        await view.btn_config.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["attachments"] == []
+
+
+@pytest.mark.asyncio
 async def test_build_embed_stays_embed_only():
     # ``build_embed`` is the config-panel back-navigation path (XpConfigView →
     # parent.build_embed()); it must not touch the image-card seam — that path


### PR DESCRIPTION
## What & why

Follow-up to #1463. A **bugs-first root sweep** of BUG-0025 (the hero-card attachment-stranding class
fixed for the profile views in #1463) found a **third instance** outside the profile code:

- **`views/xp/main_panel.py` — `_XpHubView.btn_config` ("⚙️ Configure")** opens the image-less
  `XpConfigView` from the `!xpmenu` rank-card hub with `edit_message(...)` and **no `attachments`**.
  Discord retains the prior attachment when the arg is omitted, so the **rank card lingers as a stray
  image** under the (image-less) config panel.

Fix: pass `attachments=[]` to clear it, matching the stat toggles in `_switch_stat` and the profile
`manage` fix. This makes BUG-0025 genuinely root-level — all three call sites (profile `manage`,
profile `back_to_card`, XP `btn_config`) now manage `attachments` explicitly.

> The merge of #1463 (profile-only) raced ahead of this fix's push, so it ships as its own PR rather
> than being folded into #1463.

## Changes
- `disbot/views/xp/main_panel.py` — `btn_config` clears the stray card (`attachments=[]`).
- `tests/unit/views/xp/test_xp_hub_panel.py` — regression test
  (`test_config_button_clears_the_rank_card_attachment`), fails against pre-fix behaviour.
- `docs/health/bug-book.md` — BUG-0025 broadened to all three call sites.

Class: **fix**. Contained, reversible, test-covered. Full CI mirror + arch 0 verified on this exact
diff (during the #1463 work, before the merge split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ojGR3obaPwCGqgqfLzGaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016ojGR3obaPwCGqgqfLzGaZ)_