### PR TITLE
BTD6 eval: anchor coverage guard + distractor negative-anchor guard

### DIFF
--- a/.sessions/2026-06-26-btd6-eval-anchor-coverage.md
+++ b/.sessions/2026-06-26-btd6-eval-anchor-coverage.md
@@ -1,21 +1,89 @@
 # Session — 2026-06-26 · BTD6 eval-anchor coverage + distractor negative-anchor guard
 
-> **Status:** `in-progress` — born-red card (Q-0133). Run type: routine · dispatch.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
 
-## What this run is doing
+## What this run did
 
-Empty-fire dispatch → advancing the **S2 BTD6 ▶ "Anchor-tooling follow-ons (offline, self-mergeable)"**
-lane that the #1458/#1460 anchor runs explicitly teed up. Two additive slices on
-`tests/evals/test_btd6_grounding_anchors.py`:
+Empty-fire dispatch → advanced the **S2 BTD6 ▶ "Anchor-tooling follow-ons (offline, self-mergeable)"**
+lane the #1458/#1460 anchor runs explicitly teed up. Both follow-ons shipped as additive, offline,
+test-layer slices on `tests/evals/test_btd6_grounding_anchors.py` (no runtime / `disbot/` change, no DB,
+no AI hot-path).
 
-1. **Eval-anchor coverage guard** — inventory every *significant* (≥ $1,000) numeric token in the BTD6
-   eval cases' rubrics + fixtures and assert each is either anchored (an `Anchor`/`FixtureAnchor`) or on
-   a documented allowlist of distractors + user-inputs. A future rubric/fixture edit that introduces a
-   new dollar/HP **truth** without anchoring it then fails CI. The ≥ $1,000 threshold drops structural
-   noise (round numbers, tiers, crosspath digits, the "6" in BTD6) so the report isn't noisy.
-2. **Distractor negative-anchor guard** — pin that each documented distractor ($71,315.20, $107,164.60)
-   stays *distinct from the truth(s)* the case asserts, so a data re-seed can't silently collapse a
-   case's discrimination (the wrong answer coinciding with the right one). Where the distractor IS a
-   derivable wrong computation (standard-set range given as the ABR answer), pin that too.
+**PR #1466 — anchor coverage guard + distractor negative-anchor guard.**
 
-Offline, no DB, no AI hot-path, no runtime/`disbot/` change — pure test-layer correctness tooling.
+1. **Eval-anchor coverage guard.** Inventories every **significant (≥ $1,000)** numeric token across each
+   BTD6 case's rubrics + fixtures and asserts each is either **anchored** (an `Anchor`/`FixtureAnchor`
+   re-derives it) or on a curated `_UNANCHORED_ALLOWLIST` of **distractors + user-inputs** (each with a
+   one-line reason). A future rubric/fixture edit that introduces a new dollar/HP *truth* without an
+   anchor now fails CI instead of leaving an un-guarded "truth" the golden set grades against. The
+   ≥ $1,000 significance threshold drops structural noise (round numbers, boss tiers, crosspath digits,
+   the "6" in BTD6) so the report isn't noisy — the #1458 "allowlisting distractors + user-inputs"
+   requirement. BTD6 case scope is derived from the case-id convention (a new BTD6 case is auto-in-scope).
+   Includes a no-dead-entries guard (every allowlisted number must still be a present, *unanchored*
+   significant number) + a non-empty-scope guard.
+2. **Distractor negative-anchor guard.** `DISTRACTOR_NEGATIVE_ANCHORS` pins each documented distractor
+   ($71,315.20 BUG-0004, $107,164.60 BUG-0010, the five standard-Lych-as-elite HP values) **distinct
+   from the truth(s) its case asserts** — so a data re-seed can't silently collapse a case's
+   discrimination (the rejected "wrong" answer coinciding with the right one). For the one distractor
+   that IS a derivable wrong computation ($107,164.60 = the standard-set range given as the ABR answer),
+   a `derive_alias` pins it to `round_cash(25,83,'default')` so the cross-roundset confusion stays
+   exactly reproducible. Plus a rubric-presence guard (the distractor must still be rejected by the
+   rubric) and a real-case guard.
+
+Curation note: $71,315.20 is **not** cleanly derivable (the true from-round-1 cumulative is $70,665.20) —
+a genuine hallucination, so it carries no alias and is guarded only by distinctness from both case
+truths; only $107,164.60 (right calc, wrong roundset) earns an alias.
+
+## Verification
+- New tests: +23 (file 62 → 85 anchor tests). `check_quality.py --full` GREEN (**12566 passed**, 48
+  skipped, 2 xfailed). `check_architecture --mode strict` exit 0 (pre-existing baseview WARNs only,
+  unrelated). `--check-only` all green (black/isort/ruff/check_docs/check_consistency).
+- **Non-vacuity proven:** emptying the allowlist makes the coverage guard flag the Lych distractors;
+  forcing a truth == distractor makes the distinctness guard fire — both verified to fail against the
+  drift they exist to catch (the guard-the-guard discipline already in this file).
+
+## 💡 Session idea (Q-0089)
+*A negative-anchor for the **un-anchored user-input** figures too.* Today the coverage allowlist marks
+user-supplied numbers (20000 / 26932 / 5443) as "input, not a data-derived truth" — but nothing pins that
+a future dataset change can't make one of those *accidentally* become a derivable figure that then reads
+as a truth (the mirror of the distractor risk). A tiny extension — assert each allowlisted *user-input*
+stays NOT reproducible from any standard accessor for its case's rounds — would close the symmetric gap.
+Low value today (inputs are arbitrary), but it generalises the "a re-seed can't silently change what a
+number *means*" invariant the negative anchors started. Genuinely tied to today's allowlist edit, not
+filler; recorded here, not promoted (the distractor side was the higher-value half and is done).
+
+## ⟲ Previous-session review (Q-0102)
+The previous run (2026-06-25 Project Moon Sinner literary origins) did its best work in **honest
+scoping**: it built only the cleanly-offline Slice A and explicitly deferred the gated AI-grounding PR 2
+rather than half-forcing it — and its Q-0102 note nailed a real, recurring cost: an autonomous run burns
+orient-time discovering which ▶ Next startables are offline vs. needs-live-bot, because the per-sector
+files don't tag them. **This run is more evidence for that note:** I again spelunked S1 (setup PR 3b,
+Project Moon PR 2, botsite cutover all needs-live-bot/owner-gated) before finding S2's *explicitly
+tagged* "(offline, self-mergeable)" lane — which is exactly why I could move fast on it. **System
+improvement it confirms:** S2 already uses the `(offline, self-mergeable)` tag on its ▶ items and it
+worked perfectly as a dispatch signal; the cheap, high-leverage move is to **propagate that same tag to
+every ▶ Next startable in the S1/S3/S5 sector files** (and have `dispatch_menu.py --unattended` read it
+directly). The prior run flagged it; this run is the second occurrence — per its own "worth a router
+DISCUSS block if it recurs once more" bar, that threshold is now met. Left as a routed observation here
+(not a unilateral CLAUDE.md/router edit in an unattended run).
+
+## Doc audit (Q-0104)
+S2 sector ▶ anchor-tooling-follow-ons bullet de-staled to "both shipped 2026-06-26 (PR #1466)". Ledger:
+`check_current_state_ledger --strict` reports 22 merges newer than the #1441 marker — **benign
+newest-merge lag** (Q-0166; recon due at #1470, the docs-reconciliation routine's lane, not a manual
+dispatch's — Q-0124), no older-than-marker drift. `check_docs --strict` + `check_consistency` green. No
+owner decision this run (executes the S2 P1-1 lane the prior anchor runs queued). Claim file deleted at
+close.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What shipped:** **PR #1466** — BTD6 eval-anchor **coverage guard** (every ≥ $1,000 rubric/fixture
+  number anchored-or-allowlisted, distractors + user-inputs documented) + **distractor negative-anchor
+  guard** (each documented distractor pinned distinct from its case's truths; the one derivable
+  distractor aliased to its wrong-roundset computation); +23 tests; S2 sector de-staled.
+- **⚑ Self-initiated:** none — this is the S2 BTD6 ▶ "Anchor-tooling follow-ons" lane the #1458/#1460
+  anchor runs explicitly queued; advanced via an empty-fire dispatch.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (test-only; no data/seed step; merge auto-deploys nothing runtime).
+- **Bug-book:** none fixed (BUG-0009 newest-towers data-gated, BUG-0011 needs VPS repro, BUG-0019 #1
+  awaits an owner behavior decision — all stay OPEN).

--- a/.sessions/2026-06-26-btd6-eval-anchor-coverage.md
+++ b/.sessions/2026-06-26-btd6-eval-anchor-coverage.md
@@ -1,0 +1,21 @@
+# Session — 2026-06-26 · BTD6 eval-anchor coverage + distractor negative-anchor guard
+
+> **Status:** `in-progress` — born-red card (Q-0133). Run type: routine · dispatch.
+
+## What this run is doing
+
+Empty-fire dispatch → advancing the **S2 BTD6 ▶ "Anchor-tooling follow-ons (offline, self-mergeable)"**
+lane that the #1458/#1460 anchor runs explicitly teed up. Two additive slices on
+`tests/evals/test_btd6_grounding_anchors.py`:
+
+1. **Eval-anchor coverage guard** — inventory every *significant* (≥ $1,000) numeric token in the BTD6
+   eval cases' rubrics + fixtures and assert each is either anchored (an `Anchor`/`FixtureAnchor`) or on
+   a documented allowlist of distractors + user-inputs. A future rubric/fixture edit that introduces a
+   new dollar/HP **truth** without anchoring it then fails CI. The ≥ $1,000 threshold drops structural
+   noise (round numbers, tiers, crosspath digits, the "6" in BTD6) so the report isn't noisy.
+2. **Distractor negative-anchor guard** — pin that each documented distractor ($71,315.20, $107,164.60)
+   stays *distinct from the truth(s)* the case asserts, so a data re-seed can't silently collapse a
+   case's discrimination (the wrong answer coinciding with the right one). Where the distractor IS a
+   derivable wrong computation (standard-set range given as the ABR answer), pin that too.
+
+Offline, no DB, no AI hot-path, no runtime/`disbot/` change — pure test-layer correctness tooling.

--- a/docs/current-state/S2-btd6.md
+++ b/docs/current-state/S2-btd6.md
@@ -38,12 +38,15 @@
   gate, design-for-review; needs prod creds).
 - **Anchor-tooling follow-ons** (offline, self-mergeable) — *(the range-cash + projected-total figures
   AND the #855 MOAB-class bonuses +15/+30/+99 are now anchored, #1460 above — the BTD6 knowledge/
-  grounding cases are anchor-complete for every cleanly-derivable truth)*: #1458's **eval-anchor
-  coverage report** (inventory every numeric
-  token in `cases.py` rubrics + fixtures; report which lack an Anchor/FixtureAnchor, allowlisting
-  distractors + user-inputs so it isn't noisy) · a **distractor negative-anchor guard** (pin that each
-  documented distractor — $71,315.20, $107,164.60 — stays *un*-derivable, so a data change can't make
-  the case silently stop guarding its confusion).
+  grounding cases are anchor-complete for every cleanly-derivable truth; **the eval-anchor coverage
+  report + distractor negative-anchor guard both shipped 2026-06-26, PR #1466**)*: the **coverage
+  guard** now inventories every significant (≥ $1,000) rubric/fixture number per BTD6 case and asserts
+  it is anchored or on a documented distractor/user-input allowlist (a new dollar/HP truth left
+  unanchored fails CI); the **distractor negative-anchor guard** pins each documented distractor
+  ($71,315.20, $107,164.60, the standard-Lych-as-elite HP) distinct from the truths its case asserts (a
+  re-seed can't silently collapse a case's discrimination), and pins the standard-set-range alias for
+  the one derivable distractor. ▶ remaining anchor-tooling tail: none cleanly offline — the live
+  `llm_judge` battery (below) is the next BTD6 correctness step.
 
 **Gate:** the broad AI/BTD6 feature-expansion gate (stability + provider/provenance + caching + AI
 config) still applies — see [`../current-state.md`](../current-state.md) § Gates / blocked work.

--- a/docs/owner/claims/claude-funny-franklin-nar20j.md
+++ b/docs/owner/claims/claude-funny-franklin-nar20j.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-nar20j` · scope: S2 BTD6 anchor-tooling follow-ons (offline, self-mergeable) — eval-anchor coverage report + distractor negative-anchor guard · area `tests/evals/test_btd6_grounding_anchors.py` · 2026-06-26

--- a/docs/owner/claims/claude-funny-franklin-nar20j.md
+++ b/docs/owner/claims/claude-funny-franklin-nar20j.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-nar20j` · scope: S2 BTD6 anchor-tooling follow-ons (offline, self-mergeable) — eval-anchor coverage report + distractor negative-anchor guard · area `tests/evals/test_btd6_grounding_anchors.py` · 2026-06-26

--- a/tests/evals/test_btd6_grounding_anchors.py
+++ b/tests/evals/test_btd6_grounding_anchors.py
@@ -522,3 +522,282 @@ def test_modified_economy_is_advertised_as_a_guarded_gap():
     assert (
         "double cash" in note and "not applied" in note
     ), f"modified_economy must name the unsupported math as NOT applied; got: {note!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Anchor-coverage report — every *significant* number a BTD6 case asserts must
+# be accounted for: either it is anchored (an Anchor/FixtureAnchor re-derives it)
+# or it is on the curated allowlist below (a distractor the rubric tells the judge
+# to REJECT, or a user-supplied input restated in the rubric). A rubric/fixture
+# edit that introduces a NEW dollar/HP *truth* without anchoring it then fails CI
+# here, instead of silently leaving an un-guarded "truth" the eval grades against.
+#
+# Why a significance threshold: a rubric is full of structural small integers —
+# round numbers (60, 68, 25, 83), boss tiers (1-5), crosspath digits (0/4/1), the
+# "6" in "BTD6", the "2" in "multiply by 2". None of those are data-derived truths,
+# and listing them would drown the real figures in noise (the #1458 "so it isn't
+# noisy" requirement). Every actual asserted truth/distractor/input in these
+# economy + HP cases is >= $1,000 (smallest real truth: Navarch's $3,200 income),
+# so the threshold cleanly separates the figures worth accounting for from the
+# structural noise. Sub-$1,000 asserted truths are rare in this domain and fall
+# outside this report by design (documented, tunable via _SIGNIFICANCE_THRESHOLD).
+# --------------------------------------------------------------------------- #
+_SIGNIFICANCE_THRESHOLD = 1000.0
+
+# Every BTD6 case id this coverage report governs (the knowledge.* / grounding.*
+# BTD6 cases). Derived from the case list so a new BTD6 case is automatically in
+# scope (and a structural rename is caught by the real-case guard below).
+_BTD6_CASE_IDS: tuple[str, ...] = tuple(
+    cid
+    for cid in _CASES_BY_ID
+    if cid.startswith("knowledge.btd6") or cid.startswith("grounding.btd6")
+)
+
+# Significant non-anchored numbers, per case, each with WHY it is not anchored.
+# Two allowed reasons (the #1458 spec): a *distractor* (the rubric rejects it) or
+# a *user-input* (a figure the prompt supplies, restated in the rubric — not a
+# data-derived truth, so a data-drift guard over it would be meaningless). A value
+# here that becomes a real derivable truth should move to ANCHORS instead.
+_UNANCHORED_ALLOWLIST: dict[str, dict[float, str]] = {
+    "knowledge.btd6_round_cash_by_round_projection": {
+        20000.0: "user-input: the stated starting cash ('20K by round 50')",
+    },
+    "knowledge.btd6_round_cash_r_shorthand_bug_0004": {
+        26932.0: "user-input: the stated cash held after r53",
+        71315.2: "distractor: BUG-0004 from-round-1 cumulative mislabel (truth $56,318.70)",
+    },
+    "knowledge.btd6_abr_range_cash_bug_0010": {
+        5443.0: "user-input: the stated starting cash ('started with 5443')",
+        107164.6: "distractor: BUG-0010 standard-set range given as the ABR answer",
+    },
+    "knowledge.btd6_elite_lych_hp_bug_0002": {
+        14000.0: "distractor: STANDARD Lych T1 HP presented as the elite value",
+        52500.0: "distractor: STANDARD Lych T2 HP presented as the elite value",
+        220000.0: "distractor: STANDARD Lych T3 HP presented as the elite value",
+        525000.0: "distractor: STANDARD Lych T4 HP presented as the elite value",
+        2100000.0: "distractor: STANDARD Lych T5 HP presented as the elite value",
+    },
+    "knowledge.btd6_despo_bulk_cost_bug_0003": {
+        10041.0: "distractor: '10 041' misread as the quantity 10,041 (truth: ten 0-4-1)",
+    },
+}
+
+
+def _case_numbers(case: object) -> set[float]:
+    """All numeric tokens a case asserts — rubric numbers plus every fixture
+    number across its ``tool_results`` (the two places a truth can be baked)."""
+    nums = set(_rubric_numbers(getattr(case, "grader", None)))
+    for tool_name in getattr(case, "tool_results", {}) or {}:
+        nums |= _fixture_numbers(case, tool_name)
+    return nums
+
+
+def _significant_numbers(case: object) -> set[float]:
+    """The case's asserted numbers worth accounting for (>= the threshold)."""
+    return {n for n in _case_numbers(case) if n >= _SIGNIFICANCE_THRESHOLD}
+
+
+def _anchored_numbers(case_id: str) -> set[float]:
+    """Every number anchored for ``case_id`` (Anchor + FixtureAnchor)."""
+    return {round(a.expected, 2) for a in ANCHORS if a.case_id == case_id} | {
+        round(a.expected, 2) for a in FIXTURE_ANCHORS if a.case_id == case_id
+    }
+
+
+def test_btd6_case_scope_is_non_empty():
+    """Guard the guard: the BTD6 case-id scope must actually match cases, so a
+    case-id convention change can't silently empty the whole coverage report."""
+    assert _BTD6_CASE_IDS, (
+        "no knowledge.btd6*/grounding.btd6* eval cases matched — the coverage "
+        "report would be vacuous; update _BTD6_CASE_IDS to the current convention."
+    )
+
+
+def test_anchor_coverage_allowlist_references_only_real_cases():
+    """A stale allowlist entry (renamed/removed case) is itself drift — fail loudly."""
+    missing = sorted(set(_UNANCHORED_ALLOWLIST) - set(_CASES_BY_ID))
+    assert not missing, (
+        f"Coverage allowlist references eval case id(s) that no longer exist: "
+        f"{missing}. Update _UNANCHORED_ALLOWLIST to the current case ids."
+    )
+
+
+@pytest.mark.parametrize("case_id", _BTD6_CASE_IDS)
+def test_every_significant_btd6_number_is_anchored_or_allowlisted(case_id: str):
+    """Coverage: every >= $1,000 figure a BTD6 case asserts is either anchored
+    (re-derived from the dataset) or an explicitly allowlisted distractor / input.
+
+    An un-accounted-for figure is the failure this exists to catch — a rubric or
+    fixture edit that introduced a new dollar/HP *truth* the golden set now grades
+    against with nothing re-deriving it. Resolve it by adding an Anchor (if it is a
+    derivable truth) or an _UNANCHORED_ALLOWLIST entry (a distractor / user-input)."""
+    case = _CASES_BY_ID[case_id]
+    significant = _significant_numbers(case)
+    accounted = _anchored_numbers(case_id) | set(_UNANCHORED_ALLOWLIST.get(case_id, {}))
+    unaccounted = sorted(significant - accounted)
+    assert not unaccounted, (
+        f"{case_id}: significant asserted number(s) {unaccounted} are neither "
+        f"anchored nor allowlisted. Add an Anchor (if derivable from the dataset) "
+        f"or an _UNANCHORED_ALLOWLIST entry (distractor / user-input). "
+        f"(significant={sorted(significant)}, anchored={sorted(_anchored_numbers(case_id))})"
+    )
+
+
+@pytest.mark.parametrize("case_id", sorted(_UNANCHORED_ALLOWLIST))
+def test_allowlisted_numbers_are_present_and_unanchored(case_id: str):
+    """No dead allowlist entries: each allowlisted number must still be asserted by
+    its case AND not already anchored (else it belongs in ANCHORS, not here). Stops
+    the allowlist from silently masking a number a later edit removed or anchored."""
+    significant = _significant_numbers(_CASES_BY_ID[case_id])
+    anchored = _anchored_numbers(case_id)
+    for value, reason in _UNANCHORED_ALLOWLIST[case_id].items():
+        assert value in significant, (
+            f"{case_id}: allowlisted {value} ({reason}) is no longer a significant "
+            f"asserted number — remove the stale allowlist entry. "
+            f"(significant={sorted(significant)})"
+        )
+        assert value not in anchored, (
+            f"{case_id}: allowlisted {value} ({reason}) is also anchored — drop the "
+            f"allowlist entry; the Anchor already accounts for it."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Distractor negative-anchors — the inverse of the truth anchors above. A BTD6
+# case earns its keep by REJECTING a specific wrong number; the case only stays
+# discriminating while that wrong number stays *wrong*. A data re-seed that made a
+# distractor coincide with the truth would silently gut the case (the wrong answer
+# becoming a right one) with nothing to notice. These pin that each documented
+# distractor stays distinct from the truth(s) the case asserts — and, where the
+# distractor is itself a derivable *wrong computation* (a right calculation on the
+# wrong roundset), that it keeps reproducing exactly, so the confusion the case
+# guards against stays a real, live confusion.
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class DistractorNegativeAnchor:
+    case_id: str
+    distractor: float  # the number the rubric tells the judge to REJECT
+    reason: str  # where the distractor comes from / why it tempts the model
+    must_differ_from: tuple[Callable[[], float], ...]  # truths it must NOT equal
+    derive_alias: Callable[[], float] | None = None  # the wrong computation it IS
+
+
+DISTRACTOR_NEGATIVE_ANCHORS: tuple[DistractorNegativeAnchor, ...] = (
+    # BUG-0004 — "$71,315.20" was the model's from-round-1 cumulative mislabel.
+    # It is NOT cleanly derivable (the actual cumulative rounds 1-70 is $70,665.20),
+    # so it has no alias; the guard pins that it stays distinct from BOTH truths the
+    # case asserts (the $29,386.70 range AND the $56,318.70 projected total).
+    DistractorNegativeAnchor(
+        "knowledge.btd6_round_cash_r_shorthand_bug_0004",
+        71315.2,
+        "BUG-0004 from-round-1 cumulative mislabel presented as the user's total",
+        (_range_cash(54, 70), _projected_total(26932, 54, 70)),
+    ),
+    # BUG-0010 — "$107,164.60" is the STANDARD-set range over rounds 25-83 given as
+    # the ABR answer. It IS a derivable wrong computation (right range, wrong
+    # roundset), so the alias pins it to the standard range, and must_differ_from
+    # pins it apart from the real ABR truth ($113,872.30).
+    DistractorNegativeAnchor(
+        "knowledge.btd6_abr_range_cash_bug_0010",
+        107164.6,
+        "BUG-0010 standard-set range over r25-83 given as the ABR answer",
+        (_range_cash(25, 83, "abr"),),
+        derive_alias=_range_cash(25, 83, "default"),
+    ),
+    # BUG-0002 — the STANDARD Lych per-tier HP presented as the ELITE values. Each
+    # standard tier must stay strictly below (i.e. distinct from) its elite tier, or
+    # the "standard given as elite" confusion the case rejects would evaporate.
+    DistractorNegativeAnchor(
+        "knowledge.btd6_elite_lych_hp_bug_0002",
+        14000.0,
+        "standard Lych T1 HP presented as the elite value",
+        (_elite_lych_tier(1),),
+    ),
+    DistractorNegativeAnchor(
+        "knowledge.btd6_elite_lych_hp_bug_0002",
+        52500.0,
+        "standard Lych T2 HP presented as the elite value",
+        (_elite_lych_tier(2),),
+    ),
+    DistractorNegativeAnchor(
+        "knowledge.btd6_elite_lych_hp_bug_0002",
+        220000.0,
+        "standard Lych T3 HP presented as the elite value",
+        (_elite_lych_tier(3),),
+    ),
+    DistractorNegativeAnchor(
+        "knowledge.btd6_elite_lych_hp_bug_0002",
+        525000.0,
+        "standard Lych T4 HP presented as the elite value",
+        (_elite_lych_tier(4),),
+    ),
+    DistractorNegativeAnchor(
+        "knowledge.btd6_elite_lych_hp_bug_0002",
+        2100000.0,
+        "standard Lych T5 HP presented as the elite value",
+        (_elite_lych_tier(5),),
+    ),
+)
+
+
+def test_distractor_negative_anchor_table_references_only_real_cases():
+    """A stale negative anchor (renamed/removed case) is itself drift — fail loudly."""
+    missing = sorted({a.case_id for a in DISTRACTOR_NEGATIVE_ANCHORS} - set(_CASES_BY_ID))
+    assert not missing, (
+        f"Distractor negative anchor(s) reference eval case id(s) that no longer "
+        f"exist: {missing}. Update DISTRACTOR_NEGATIVE_ANCHORS to the current ids."
+    )
+
+
+@pytest.mark.parametrize(
+    "anchor", DISTRACTOR_NEGATIVE_ANCHORS, ids=lambda a: f"{a.case_id}:{a.distractor}"
+)
+def test_distractor_stays_distinct_from_the_truth(anchor: DistractorNegativeAnchor):
+    """The core negative guard: the rejected number must not equal any truth the
+    case asserts. If a data re-seed collapses the gap, the case stops discriminating
+    and this fails — surfacing the silent loss instead of letting the eval pass a
+    now-correct 'wrong' answer."""
+    for derive in anchor.must_differ_from:
+        truth = round(derive(), 2)
+        assert round(anchor.distractor, 2) != truth, (
+            f"{anchor.case_id}: distractor {anchor.distractor} ({anchor.reason}) now "
+            f"equals a derived truth ({truth}). The data drifted so the case's "
+            f"'wrong' answer is now correct — the case no longer discriminates. "
+            f"Re-examine the case and the dataset."
+        )
+
+
+@pytest.mark.parametrize(
+    "anchor", DISTRACTOR_NEGATIVE_ANCHORS, ids=lambda a: f"{a.case_id}:{a.distractor}"
+)
+def test_distractor_is_still_rejected_by_the_rubric(anchor: DistractorNegativeAnchor):
+    """The distractor must still be named in the case's rubric — a rubric edit that
+    dropped the explicit rejection would leave the negative anchor guarding a
+    confusion the golden set no longer tests."""
+    asserted = _rubric_numbers(_CASES_BY_ID[anchor.case_id].grader)
+    assert round(anchor.distractor, 2) in asserted, (
+        f"{anchor.case_id}: distractor {anchor.distractor} ({anchor.reason}) is no "
+        f"longer present in the rubric — the case stopped rejecting it. Re-add the "
+        f"rejection or remove this negative anchor (rubric numbers: {sorted(asserted)})."
+    )
+
+
+@pytest.mark.parametrize(
+    "anchor",
+    [a for a in DISTRACTOR_NEGATIVE_ANCHORS if a.derive_alias is not None],
+    ids=lambda a: f"{a.case_id}:{a.distractor}",
+)
+def test_distractor_alias_reproduces_the_wrong_computation(
+    anchor: DistractorNegativeAnchor,
+):
+    """For a distractor that IS a derivable wrong computation (right calc, wrong
+    roundset), pin that it keeps reproducing — so the documented confusion stays a
+    live, exactly-reproducible one and a data change to the wrong-roundset figure is
+    noticed rather than silently making the distractor stop matching."""
+    assert anchor.derive_alias is not None  # narrowed by the parametrize filter
+    derived = round(anchor.derive_alias(), 2)
+    assert derived == round(anchor.distractor, 2), (
+        f"{anchor.case_id}: the wrong computation behind distractor "
+        f"{anchor.distractor} ({anchor.reason}) now yields {derived}. The distractor "
+        f"no longer reproduces from the dataset — re-derive it or update the case."
+    )


### PR DESCRIPTION
**S2 BTD6 ▶ "Anchor-tooling follow-ons (offline, self-mergeable)"** — the two slices the #1458/#1460 anchor runs teed up. Pure test-layer correctness tooling on `tests/evals/test_btd6_grounding_anchors.py`; no runtime / `disbot/` change, no DB, no AI hot-path.

### Slice 1 — eval-anchor coverage guard
Inventories every **significant (≥ $1,000)** numeric token across the BTD6 eval cases' rubrics + fixtures and asserts each is either **anchored** (an `Anchor`/`FixtureAnchor`) or on a documented **allowlist of distractors + user-inputs**. A future rubric/fixture edit that introduces a new dollar/HP **truth** without anchoring it now fails CI. The ≥ $1,000 significance threshold drops structural noise (round numbers, tiers, crosspath digits, the "6" in BTD6) so the report isn't noisy — matching #1458's "allowlisting distractors + user-inputs so it isn't noisy".

### Slice 2 — distractor negative-anchor guard
Pins that each documented distractor (`$71,315.20`, `$107,164.60`, the standard-Lych-as-elite figures) stays **distinct from the truth(s)** the case asserts, so a data re-seed can't silently collapse a case's discrimination (the wrong answer coinciding with the right one). Where a distractor IS a derivable wrong computation (standard-set range given as the ABR answer = `$107,164.60`), that alias is pinned too.

Status (born-red → ready) is driven by the session card per Q-0133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WE98bKa6S45UgBAo1W4qPz)_