### PR TITLE
Project Moon (Limbus) PR 2 — AI grounding path

### DIFF
--- a/.sessions/2026-06-26-projmoon-grounding-path.md
+++ b/.sessions/2026-06-26-projmoon-grounding-path.md
@@ -1,0 +1,24 @@
+# 2026-06-26 — Project Moon (Limbus) grounding path (PR 2)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What I'm about to do
+Empty-fire dispatch. Open bugs are owner-gated/off-repo (BUG-0011 VPS repro · BUG-0019 #1 /
+BUG-0009 owner-design). Next on-plan, owner-directed slice = **Project Moon knowledge-domain
+PR 2** (Slice A item 2, the grounding path), the explicit ▶ Next in S1-bot.md /
+`planning/project-moon-knowledge-domain-plan-2026-06-21.md` (Q-0192).
+
+Wire Limbus structural facts into the AI natural-language stage as grounding, mirroring the BTD6
+grounding seam and keeping the BTD6 path byte-identical:
+- `AITask.PROJMOON_ANSWER` (contracts).
+- Router: `has_limbus_context` → `PROJMOON_ANSWER` (after BTD6, before video).
+- New `services/projmoon_context_service.build()` — resolves named Limbus entities + bounded
+  roster expansion to provenanced grounding fact lines (read-only over `projmoon_data_service`).
+- `natural_language_stage._gather_feature_facts` branch → inject those facts.
+- Offline-unit-tested; **default-preserving** (only Limbus-detected messages change; no BTD6 change).
+
+**Flagged:** touches the gated AI stage — the live model-loop check is the owner's Q-0086 runtime
+walk (the established AI-feature pattern). The prose-faithfulness *validation* guard (§6 "hardest
+risk") is deliberately **deferred** to a follow-up; this slice injects grounding facts only.

--- a/.sessions/2026-06-26-projmoon-grounding-path.md
+++ b/.sessions/2026-06-26-projmoon-grounding-path.md
@@ -1,24 +1,80 @@
 # 2026-06-26 — Project Moon (Limbus) grounding path (PR 2)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What I'm about to do
-Empty-fire dispatch. Open bugs are owner-gated/off-repo (BUG-0011 VPS repro · BUG-0019 #1 /
-BUG-0009 owner-design). Next on-plan, owner-directed slice = **Project Moon knowledge-domain
-PR 2** (Slice A item 2, the grounding path), the explicit ▶ Next in S1-bot.md /
-`planning/project-moon-knowledge-domain-plan-2026-06-21.md` (Q-0192).
+## What this run did
+Empty-fire dispatch (no work order). Open bugs were all owner-gated/off-repo (BUG-0011 VPS repro ·
+BUG-0019 #1 + BUG-0009 owner-design forks), so this run took the next on-plan, owner-directed
+(Q-0192) slice: **Project Moon knowledge-domain PR 2 — the grounding path** (Slice A item 2 of
+`planning/project-moon-knowledge-domain-plan-2026-06-21.md`, the explicit ▶ Next in S1-bot.md).
 
-Wire Limbus structural facts into the AI natural-language stage as grounding, mirroring the BTD6
-grounding seam and keeping the BTD6 path byte-identical:
-- `AITask.PROJMOON_ANSWER` (contracts).
-- Router: `has_limbus_context` → `PROJMOON_ANSWER` (after BTD6, before video).
-- New `services/projmoon_context_service.build()` — resolves named Limbus entities + bounded
-  roster expansion to provenanced grounding fact lines (read-only over `projmoon_data_service`).
-- `natural_language_stage._gather_feature_facts` branch → inject those facts.
-- Offline-unit-tested; **default-preserving** (only Limbus-detected messages change; no BTD6 change).
+Wired the committed Limbus structural facts into the AI natural-language stage as grounding,
+mirroring the BTD6 grounding seam, **default-preserving** (BTD6 path byte-identical):
 
-**Flagged:** touches the gated AI stage — the live model-loop check is the owner's Q-0086 runtime
-walk (the established AI-feature pattern). The prose-faithfulness *validation* guard (§6 "hardest
-risk") is deliberately **deferred** to a follow-up; this slice injects grounding facts only.
+- **`AITask.PROJMOON_ANSWER`** (`core/runtime/ai/contracts.py`).
+- **Router** (`services/ai_task_router.py`): `has_limbus_context` → `PROJMOON_ANSWER`, checked
+  **after** BTD6 (disjoint keyword sets; BTD6 keeps priority) and **before** video.
+- **`services/projmoon_context_service.py`** (new): `build(text)` resolves the named Limbus entities
+  + bounded roster phrases ("list every sinner", "the three damage types") into provenanced,
+  cap-bounded grounding fact lines, read-only over `projmoon_data_service`. Enriches Sinners with
+  their `literary_origin`, Sins with the colour affinity, E.G.O grades with the rank. Ambiguous bare
+  tokens (`he`/`don`/`sang`) excluded so they ride along only via a distinctive alias. Never raises
+  (best-effort grounding).
+- **`natural_language_stage._gather_feature_facts`**: a `PROJMOON_ANSWER` branch injects those facts
+  as `retrieved_facts` (the same seam BTD6/video use).
+- **Eval-coverage partition**: `PROJMOON_ANSWER` acknowledged in `_ACK_UNCOVERED_TASKS` (model-eval
+  case deferred to the runtime walk + faithfulness-guard follow-up).
+
+**Tests (offline, 27 new):** `tests/unit/services/projmoon/test_projmoon_context_service.py` (10:
+per-entity + roster grounding, ambiguous-token exclusion, provenance survival, fact cap,
+determinism, degradation), `tests/unit/services/test_ai_task_router_projmoon.py` (router priority +
+no over-route), `tests/unit/runtime/ai/test_natural_language_stage_projmoon.py` (the
+`_gather_feature_facts` seam). Full CI mirror green (`check_quality.py --full`: 12591+ passed;
+`check_architecture --mode strict`: 0 errors).
+
+## Deliberately deferred (documented in-module + plan)
+- The **prose-faithfulness validation guard** (plan §6 "hardest correctness risk") — this slice
+  injects grounded facts but does not yet post-verify the model reply against them the way
+  `btd6_grounding_service` does. Follow-up slice.
+- The live **Q-0086 runtime walk** (owner) — the gated AI stage now grounds Limbus; confirm a real
+  Limbus Q&A grounds + reads well on both providers.
+- Slice A item 1 (StaticData exact-number ingest); then Slice B (extract the shared
+  `KnowledgeDomain` seam from BTD6 + Limbus).
+
+## ⟲ Previous-session review
+The 2026-06-25 runs (`projmoon-limbus-domain`, `essential-setup-pr2-extras-health`) executed cleanly
+and left a **sharp, turn-key ▶ Next** — PR 1's progress banner named exactly the next slice, its
+files, and the deferral reason, which let this run start building within minutes with no
+re-discovery. That is the handoff discipline working as intended. **One improvement it surfaces:**
+the plan's "reuse the … faithfulness guard" phrasing under-specified that prose faithfulness is a
+*separate, harder* deferral from the grounding-fact injection — a reader could mistake PR 2 for
+"grounding + guard". This run split them explicitly in the module docstring + plan banner + eval
+ack. **System improvement:** when a plan step bundles a cheap part and an expensive part under one
+verb ("reuse X"), the executor should split them in the ▶ Next on landing — captured here as the
+done thing; worth promoting into the dispatch-handoff convention so future bundled steps don't ship
+half-done-looking.
+
+## 💡 Session idea
+**A `services/grounding_format.py` (or `utils/grounding_format.py`) domain-agnostic home for the
+sanitise / cap / provenance helpers.** Right now both BTD6 and projmoon grounding services import
+`utils.btd6.grounding_format` — a projmoon service reaching into a `btd6`-namespaced util is a smell,
+and it's the first concrete evidence (rule-of-three: BTD6 + Limbus) that these helpers are
+*domain-agnostic*. The Slice B `KnowledgeDomain` extraction is the natural moment to lift them out.
+Small, mechanical, removes a cross-domain coupling. Not built this run (Slice B scope); flagged so
+the seam extraction picks it up.
+
+## ⚑ Self-initiated
+none — this is the explicit owner-directed (Q-0192) ▶ Next plan slice, not an invented feature.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PR:** #1467 (born-red → complete; auto-merge armed, merges on green Code Quality).
+- **What shipped:** Project Moon (Limbus) knowledge-domain PR 2 — the AI grounding path.
+- **⚑ Self-initiated:** none.
+- **⚑ Owner-decisions:** none (no new owner decision; executes existing Q-0192).
+- **⚑ Owner-manual-steps:** the **Q-0086 runtime walk** — verify a live Limbus Q&A grounds + reads
+  well on both providers (the gated AI stage now grounds Limbus). Not a deploy step (merge
+  auto-deploys); a behavioural live-verification only.
+- **Bug-book:** no change (open bugs remain owner-gated/off-repo as noted above).

--- a/disbot/core/runtime/ai/contracts.py
+++ b/disbot/core/runtime/ai/contracts.py
@@ -29,6 +29,10 @@ class AITask(str, Enum):
     # M2 — central natural-language orchestrator routes per task.
     BTD6_ANSWER = "btd6.answer"
     GENERAL_NL_ANSWER = "general.nl_answer"
+    # Project Moon (Limbus) knowledge domain — a message that looks like a
+    # Limbus question routes here so the projmoon grounding facts are injected
+    # (the BTD6_ANSWER analogue for KnowledgeDomain instance #1).
+    PROJMOON_ANSWER = "projmoon.answer"
     # M4 — strategy submission review (AI extracts + validates;
     # publishing requires staff confirmation).
     BTD6_STRATEGY_REVIEW = "btd6.strategy_review"

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -953,10 +953,19 @@ async def _gather_bot_knowledge_blocks(
 async def _gather_feature_facts(req: FeatureFactRequest) -> FeatureFactsResult:
     """Hand off to the feature owner for fact retrieval.
 
-    BTD6 routes through btd6_context_service; VIDEO tasks through
-    youtube_context_service (feature-flag gated).  Other tasks return
-    empty facts and the gateway answers from the instruction stack alone.
+    BTD6 routes through btd6_context_service; Project Moon (Limbus) through
+    projmoon_context_service; VIDEO tasks through youtube_context_service
+    (feature-flag gated).  Other tasks return empty facts and the gateway
+    answers from the instruction stack alone.
     """
+    if req.task is AITask.PROJMOON_ANSWER:
+        # Limbus grounding is read-only over committed fixtures (sync, no I/O);
+        # absence of a named entity is routine, so an empty context just lets the
+        # model answer from the instruction stack (same as the GENERAL path).
+        from services import projmoon_context_service
+
+        ctx_pm = projmoon_context_service.build(req.text)
+        return FeatureFactsResult(facts=tuple(ctx_pm.facts))
     if req.task is AITask.BTD6_ANSWER:
         from services import btd6_context_service
 

--- a/disbot/services/ai_task_router.py
+++ b/disbot/services/ai_task_router.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 from core.runtime.ai.contracts import AITask
 from utils.btd6.keywords import BTD6_CONTEXT_KEYWORDS, degree_in_text
+from utils.projmoon.keywords import has_limbus_context
 
 _YOUTUBE_URL_RE = re.compile(
     r"(?:https?://)?(?:www\.)?(?:youtube\.com/(?:watch\?v=|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})",
@@ -375,6 +376,17 @@ def classify(
             route="btd6.answer",
             confidence=0.6,
             via_conversation_cue=via_cue,
+        )
+    # Project Moon (Limbus) — checked AFTER BTD6 (BTD6 keywords never collide
+    # with the distinctive Limbus tokens) so a Limbus question reaches the
+    # projmoon grounding path. ``has_limbus_context`` is curated to avoid
+    # over-routing (no bare Sin/status words), so this is a low-false-positive
+    # route; standalone non-Limbus chatter stays general.
+    if has_limbus_context(message_text or ""):
+        return RoutedTask(
+            task=AITask.PROJMOON_ANSWER,
+            route="projmoon.answer",
+            confidence=0.6,
         )
     url_count = _count_youtube_urls(message_text or "")
     if url_count >= 2:

--- a/disbot/services/projmoon_context_service.py
+++ b/disbot/services/projmoon_context_service.py
@@ -1,0 +1,216 @@
+"""Project Moon (Limbus) → AI grounding context.
+
+The :func:`build` entry point is the projmoon analogue of
+:func:`services.btd6_context_service.build`: it resolves the distinctive Limbus
+entities named in a message to provenanced, length-bounded grounding fact lines
+that the AI instruction stack injects as ``retrieved_facts``. Read-only over the
+committed structural fixtures (:mod:`services.projmoon_data_service`); no I/O, no
+DB, no live state — every fact is a patch-stable structural/lore statement.
+
+This is **Slice A item 2** of the Project Moon knowledge-domain plan
+(``docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md``, Q-0192): the
+grounding path. It deliberately stays tiny. Two later lanes build on it:
+
+* the StaticData *exact-number* ingest (Slice A item 1) appends more facts here;
+* the shared ``KnowledgeDomain`` seam (Slice B) folds this + the BTD6 context
+  service onto one renderer — at which point the BTD6 grounding-format helpers
+  reused below (:mod:`utils.btd6.grounding_format`) move to a domain-agnostic home.
+
+What is **not** here yet (deliberate, documented): the prose-faithfulness
+*validation* guard (the plan's §6 "hardest correctness risk"). This slice injects
+grounded facts; it does not yet post-verify the model's reply against them the way
+``btd6_grounding_service`` does for BTD6. A Limbus reply therefore grounds on these
+facts but is not refused for ungrounded prose — that guard is a follow-up slice.
+
+Layering: ``services`` may import ``utils``; this module imports only
+``services.projmoon_data_service`` and ``utils`` helpers, never core / cogs / views.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from services import projmoon_data_service
+from utils.btd6.grounding_format import sanitise
+
+# Hard upper bound on a single grounding line, before the provenance suffix is
+# reserved. Limbus lore lines are richer than the BTD6 default (240), so allow a
+# little more room; ``sanitise`` truncates the body so provenance always survives.
+_FACT_TEXT_CAP = 400
+
+# Cap on the number of facts a single message can pull, so a roster query (e.g.
+# "list every sinner") can't drown the model context. 12 Sinners + a couple of
+# named extras fit comfortably.
+_MAX_FACTS = 16
+
+# Short, honest provenance — the committed structural fixtures, not a live scrape.
+_PROVENANCE = "Limbus Company structural data (committed fixture)"
+
+# Ambiguous bare tokens that are ordinary English (or common Discord chatter) and
+# must NOT match on their own — they ride along only when a distinctive longer
+# alias / canonical matches (mirrors ``utils.projmoon.keywords`` curation: "don" /
+# "sang" resolve via "Don Quixote" / "Yi Sang", and the E.G.O grade "HE" via
+# "he grade", never the bare word).
+_AMBIGUOUS_BARE_TOKENS: frozenset[str] = frozenset({"he", "don", "sang"})
+
+# Distinctive group phrases that pull a whole entity-kind roster as grounding.
+# Conservative on purpose — only clearly list-/group-shaped phrasing, never a bare
+# singular (a single named entity grounds through the per-entity match instead).
+_ROSTER_TRIGGERS: dict[str, tuple[str, ...]] = {
+    "sinner": (
+        "sinners",
+        "all sinners",
+        "the sinners",
+        "every sinner",
+        "12 sinners",
+        "twelve sinners",
+        "list of sinners",
+    ),
+    "sin": (
+        "seven sins",
+        "7 sins",
+        "the sins",
+        "all sins",
+        "sin affinities",
+        "sin affinity",
+    ),
+    "damage_type": (
+        "damage types",
+        "all damage types",
+        "three damage types",
+        "the damage types",
+    ),
+    "ego_grade": (
+        "ego grades",
+        "e.g.o grades",
+        "all ego grades",
+        "the ego grades",
+        "ego grade list",
+    ),
+    "status": (
+        "status effects",
+        "all statuses",
+        "status keywords",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ProjmoonContext:
+    """Retrieved Limbus facts ready for the instruction stack.
+
+    Mirrors :class:`services.btd6_context_service.BTD6Context` so the shared
+    ``KnowledgeDomain`` seam (Slice B) can fold the two onto one renderer.
+    """
+
+    facts: tuple[str, ...]
+    source_summary: str = _PROVENANCE
+    confidence: float = 0.6
+
+
+def _normalise(text: str) -> str:
+    r"""Lower-case, replace every non-word run with a single space, pad with
+    spaces so whole-token containment (``f" {token} "``) is punctuation-safe.
+
+    ``\w`` keeps Unicode letters (so accented Sinner names survive casefold).
+    """
+    folded = re.sub(r"[^\w]+", " ", text.casefold()).strip()
+    return f" {folded} "
+
+
+def _match_tokens(entry: projmoon_data_service.LimbusEntry) -> tuple[str, ...]:
+    """The whole-token keys an entry may match on (canonical + aliases),
+    casefolded, with the ambiguous bare tokens removed.
+    """
+    tokens = (entry.canonical.casefold(), *entry.aliases)
+    return tuple(
+        token
+        for token in dict.fromkeys(tokens)
+        if token and token not in _AMBIGUOUS_BARE_TOKENS
+    )
+
+
+def _matched_entries(text: str) -> list[projmoon_data_service.LimbusEntry]:
+    """Every distinct Limbus entry named as a whole token in ``text``.
+
+    Deterministic: returns entries in canonical dataset order (kind order, then
+    file order), never message order, so a fixed message always grounds the same.
+    """
+    needle = _normalise(text)
+    matched: list[projmoon_data_service.LimbusEntry] = []
+    for entry in projmoon_data_service.all_entries():
+        for token in _match_tokens(entry):
+            if f" {token} " in needle:
+                matched.append(entry)
+                break
+    return matched
+
+
+def _rostered_kinds(text: str) -> list[str]:
+    """Entity kinds whose whole roster a group/list phrase in ``text`` requests."""
+    needle = _normalise(text)
+    kinds: list[str] = []
+    for kind, triggers in _ROSTER_TRIGGERS.items():
+        if any(f" {_normalise(trigger).strip()} " in needle for trigger in triggers):
+            kinds.append(kind)
+    return kinds
+
+
+def _body(entry: projmoon_data_service.LimbusEntry) -> str:
+    """Compose the grounding body for one entry, enriched per kind."""
+    base = f"{entry.canonical}: {entry.description}"
+    if entry.entity_kind == "sinner":
+        origin = entry.extra.get("literary_origin")
+        if isinstance(origin, dict) and origin.get("work") and origin.get("author"):
+            base = f"{base} (literary origin: {origin['work']} by {origin['author']})"
+    elif entry.entity_kind == "sin":
+        color = entry.extra.get("color")
+        if color:
+            base = f"{entry.canonical} ({color} Sin affinity): {entry.description}"
+    elif entry.entity_kind == "ego_grade":
+        rank = entry.extra.get("rank")
+        if rank:
+            base = (
+                f"{entry.canonical} (E.G.O grade, rank {rank}/5): {entry.description}"
+            )
+    return base
+
+
+def _grounding_line(entry: projmoon_data_service.LimbusEntry) -> str:
+    """``<body> (source: Limbus Company structural data ...)`` — provenance is
+    reserved out of the cap so it can never be truncated away.
+    """
+    suffix = f" (source: {_PROVENANCE})"
+    budget = max(1, _FACT_TEXT_CAP - len(suffix))
+    return f"{sanitise(_body(entry), cap=budget)}{suffix}"
+
+
+def build(text: str) -> ProjmoonContext:
+    """Return the Limbus grounding facts for ``text``.
+
+    Combines per-entity matches with bounded roster expansion, de-duplicates by
+    entry id (preserving canonical dataset order), and caps at :data:`_MAX_FACTS`.
+    Never raises: a fixture-load fault degrades to an empty context so the reply
+    path proceeds unchanged (the model answers from the instruction stack alone).
+    """
+    try:
+        entries: list[projmoon_data_service.LimbusEntry] = list(_matched_entries(text))
+        roster_kinds = _rostered_kinds(text)
+        if roster_kinds:
+            seen_ids = {entry.id for entry in entries}
+            for kind in projmoon_data_service.entity_kinds():
+                if kind not in roster_kinds:
+                    continue
+                for entry in projmoon_data_service.get_entries(kind):
+                    if entry.id not in seen_ids:
+                        entries.append(entry)
+                        seen_ids.add(entry.id)
+    except Exception:  # noqa: BLE001 — grounding is best-effort; never break reply
+        return ProjmoonContext(facts=())
+
+    facts = tuple(_grounding_line(entry) for entry in entries[:_MAX_FACTS])
+    return ProjmoonContext(facts=facts)
+
+
+__all__ = ["ProjmoonContext", "build"]

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -124,11 +124,16 @@
   follow-on SHIPPED 2026-06-25** (dispatch run, PR #1456): each of the 12 Sinners now carries its
   canonical **`literary_origin`** (the work + author it is drawn from — Faust→Goethe, Outis→Homer,
   Gregor→Kafka, …), rendered in the `!pm` detail card + a new **Origins** cross-reference view
-  (`!pm origins` + a panel button). Still read-only/offline. ▶ **Next: PR 2** —
-  wire `AITask.PROJMOON_ANSWER` + grounding into `core/runtime/ai/natural_language_stage.py` (reuse the
-  tag/cap/provenance render + faithfulness guard), **flagged for a Q-0086 runtime walk** (touches the
-  gated AI stage). Then Slice B = extract the shared `KnowledgeDomain` seam from BTD6 + Limbus + exact
-  StaticData numbers ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
+  (`!pm origins` + a panel button). Still read-only/offline. **PR 2 — the GROUNDING PATH — SHIPPED
+  2026-06-26** (dispatch run, PR #1467): a Limbus-looking message now routes to the new
+  **`AITask.PROJMOON_ANSWER`** (`ai_task_router` → `has_limbus_context`, after BTD6 / before video) and a
+  thin `services/projmoon_context_service.build()` injects provenanced Limbus grounding facts (named
+  entities + bounded roster queries) into `natural_language_stage._gather_feature_facts` —
+  default-preserving (BTD6 path byte-identical), offline-unit-tested. ▶ **Next:** the live **Q-0086
+  runtime walk** (owner — confirm a real Limbus Q&A grounds well on both providers) + the projmoon
+  **faithfulness guard** follow-up + Slice A item 1 (StaticData exact-number ingest); then **Slice B** =
+  extract the shared `KnowledgeDomain` seam from BTD6 + Limbus
+  ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
 - **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover
   (PR 1 foundation shipped; [plan](../planning/botsite-react-spa-migration-plan-2026-06-20.md)).
 

--- a/docs/owner/claims/claude-funny-franklin-1f76uv.md
+++ b/docs/owner/claims/claude-funny-franklin-1f76uv.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-1f76uv` · scope: Project Moon (Limbus) knowledge-domain **PR 2 — the grounding path** · area: `disbot/services/projmoon_context_service.py` (new), `disbot/core/runtime/ai/{contracts.py,natural_language_stage.py}`, `disbot/services/ai_task_router.py`, tests · 2026-06-26

--- a/docs/owner/claims/claude-funny-franklin-1f76uv.md
+++ b/docs/owner/claims/claude-funny-franklin-1f76uv.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-1f76uv` · scope: Project Moon (Limbus) knowledge-domain **PR 2 — the grounding path** · area: `disbot/services/projmoon_context_service.py` (new), `disbot/core/runtime/ai/{contracts.py,natural_language_stage.py}`, `disbot/services/ai_task_router.py`, tests · 2026-06-26

--- a/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
+++ b/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
@@ -82,8 +82,23 @@ argument: generalising from a single example tends to produce the wrong abstract
 > source each Sinner is drawn from: Faust→Goethe, Outis→Homer's *Odyssey*, Gregor→Kafka, Rodion→
 > Dostoevsky, …), validated by `projmoon_data_service`, exposed via a typed `sinner_origins()` accessor,
 > and surfaced in the `!pm` detail card + a new **Origins** cross-reference embed (`!pm origins` + a
-> browse-panel button). Read-only/offline, no AI hot-path change. **PR 2 (the grounding path) is still
-> the next slice** (needs the Q-0086 runtime walk).
+> browse-panel button). Read-only/offline, no AI hot-path change.
+
+> **▶ Progress (2026-06-26 dispatch run, PR #1467): Slice A item 2 — the GROUNDING PATH — SHIPPED.**
+> A message that looks like a Limbus question now routes to the new **`AITask.PROJMOON_ANSWER`**
+> (`ai_task_router.classify` → `has_limbus_context`, checked after BTD6 / before video), and a thin
+> **`services/projmoon_context_service.build()`** resolves the named Limbus entities + bounded roster
+> queries into provenanced grounding fact lines that `natural_language_stage._gather_feature_facts`
+> injects as `retrieved_facts` — the BTD6 grounding seam, mirrored. **Default-preserving:** only
+> Limbus-detected messages change; the BTD6 path stays byte-identical (its faithfulness guard / refusal
+> floor are unchanged and never fire for projmoon). Offline-unit-tested (27 tests: router priority,
+> per-entity + roster grounding, ambiguous-bare-token exclusion, provenance survival, the fact cap, the
+> `_gather_feature_facts` seam). **Deliberately deferred (documented in-module):** the prose-faithfulness
+> *validation* guard (the §6 "hardest correctness risk") — this slice injects grounded facts but does
+> **not** yet post-verify the reply against them. **▶ Next:** (a) the live **Q-0086 runtime walk** (owner —
+> the gated AI stage now grounds Limbus; confirm a real Limbus Q&A grounds + reads well on both
+> providers); (b) the projmoon **faithfulness guard** follow-up; (c) Slice A item 1 — the StaticData
+> exact-number ingest; then **Slice B** — extract the shared `KnowledgeDomain` seam from BTD6 + Limbus.
 
 **Slice A (next session, 2–3 PRs):**
 1. **Ingestion:** a `scripts/fetch_pm_limbus.py` that parses the **StaticData identity JSON** (clean,

--- a/tests/evals/test_eval_coverage.py
+++ b/tests/evals/test_eval_coverage.py
@@ -73,6 +73,13 @@ _ACK_UNCOVERED_TASKS = frozenset(
         "MODERATION_ASSIST",
         "PLATFORM_EXPLAIN_CONSISTENCY",
         "PLATFORM_EXPLAIN_STATUS",
+        # Project Moon (Limbus) grounding path (PR 2, 2026-06-26): the grounding
+        # FACT-building is covered by tests/unit/services/projmoon/ + the router /
+        # _gather_feature_facts unit pins. The live model-eval case is deferred to
+        # the Q-0086 runtime walk + the projmoon faithfulness-guard follow-up
+        # (the BTD6-style answer verification this slice does not yet add), so it
+        # is acknowledged here to keep the task surface exactly partitioned.
+        "PROJMOON_ANSWER",
         "SETTINGS_EXPLAIN",
         "SETTINGS_PROPOSE",
         "SETUP_EXPLAIN",

--- a/tests/unit/runtime/ai/test_natural_language_stage_projmoon.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage_projmoon.py
@@ -1,0 +1,50 @@
+"""Seam pin: PROJMOON_ANSWER routes feature-fact gathering to projmoon grounding.
+
+Project Moon knowledge-domain PR 2 (Slice A item 2). ``_gather_feature_facts``
+must hand a ``PROJMOON_ANSWER`` turn to ``projmoon_context_service`` and return
+its grounded facts, so they flow into the instruction stack's ``retrieved_facts``.
+A non-Limbus general turn must still gather nothing (default-preserving).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from core.runtime.ai import natural_language_stage as stage  # noqa: E402
+from core.runtime.ai.contracts import AITask  # noqa: E402
+from core.runtime.ai.feature_facts import FeatureFactRequest  # noqa: E402
+
+
+def _req(task: AITask, text: str) -> FeatureFactRequest:
+    return FeatureFactRequest(
+        task=task,
+        text=text,
+        guild_id=1,
+        channel_id=2,
+        author_id=3,
+        message_id=4,
+    )
+
+
+@pytest.mark.asyncio
+async def test_projmoon_task_gathers_limbus_grounding_facts() -> None:
+    result = await stage._gather_feature_facts(
+        _req(AITask.PROJMOON_ANSWER, "tell me about Faust in limbus"),
+    )
+    assert result.facts
+    assert any(f.startswith("Faust:") for f in result.facts)
+
+
+@pytest.mark.asyncio
+async def test_general_task_still_gathers_no_facts() -> None:
+    result = await stage._gather_feature_facts(
+        _req(AITask.GENERAL_NL_ANSWER, "tell me about Faust in limbus"),
+    )
+    assert result.facts == ()

--- a/tests/unit/services/projmoon/test_projmoon_context_service.py
+++ b/tests/unit/services/projmoon/test_projmoon_context_service.py
@@ -1,0 +1,100 @@
+"""Tests for the Limbus → AI grounding context (``projmoon_context_service``).
+
+Project Moon knowledge-domain PR 2 (Slice A item 2). The service turns the
+committed Limbus fixtures into provenanced grounding fact lines that the AI
+instruction stack injects. These pins cover per-entity matching, bounded roster
+expansion, the ambiguous-bare-token exclusion, provenance survival, the fact cap,
+and graceful degradation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import projmoon_context_service as svc  # noqa: E402
+
+
+def _joined(text: str) -> str:
+    return "\n".join(svc.build(text).facts)
+
+
+def test_named_sinner_is_grounded_with_origin() -> None:
+    facts = svc.build("tell me about Faust in limbus").facts
+    assert any(f.startswith("Faust:") for f in facts)
+    joined = "\n".join(facts)
+    assert "Goethe" in joined  # the literary origin is folded into the fact
+    assert "source: Limbus Company structural data" in joined
+
+
+def test_ego_grade_is_grounded_with_rank() -> None:
+    facts = svc.build("what is the ZAYIN grade").facts
+    assert any("E.G.O grade, rank 1/5" in f for f in facts)
+
+
+def test_sin_is_grounded_with_affinity_colour() -> None:
+    # "wrath" alone wouldn't route, but the context service is given the text
+    # directly — it should still ground the Sin with its colour affinity.
+    facts = svc.build("limbus wrath affinity").facts
+    assert any(f.startswith("Wrath (Red Sin affinity):") for f in facts)
+
+
+def test_roster_query_expands_to_the_whole_kind() -> None:
+    facts = svc.build("list every sinner in limbus").facts
+    # all 12 Sinners ground (12 <= the 16-fact cap)
+    assert len(facts) == 12
+    joined = "\n".join(facts)
+    for name in ("Yi Sang", "Faust", "Don Quixote", "Heathcliff", "Outis"):
+        assert f"{name}:" in joined
+
+
+def test_damage_types_roster() -> None:
+    facts = svc.build("what are the three damage types").facts
+    joined = "\n".join(facts)
+    for dmg in ("Slash:", "Pierce:", "Blunt:"):
+        assert dmg in joined
+
+
+def test_ambiguous_bare_tokens_do_not_match() -> None:
+    # "he" / "don" / "sang" must not pull the HE grade / Don Quixote / Yi Sang.
+    assert svc.build("he won the match").facts == ()
+    assert svc.build("don't do that").facts == ()
+    assert svc.build("i sang loudly").facts == ()
+
+
+def test_distinctive_alias_still_matches_those_entities() -> None:
+    # the ambiguous *bare* token is excluded, but a distinctive alias/canonical
+    # still grounds the same entity.
+    assert "Don Quixote:" in _joined("about don quixote")
+    assert "Yi Sang:" in _joined("about yi sang")
+    assert any("rank 3/5" in f for f in svc.build("the HE grade explained").facts)
+
+
+def test_provenance_is_never_truncated_away() -> None:
+    for fact in svc.build("list every sinner and the three damage types").facts:
+        assert fact.endswith("(committed fixture))")
+        assert len(fact) <= svc._FACT_TEXT_CAP
+
+
+def test_fact_count_is_capped() -> None:
+    # every roster at once would exceed the cap; the result is bounded.
+    facts = svc.build(
+        "list every sinner, the seven sins, all damage types, the ego grades, "
+        "and all statuses",
+    ).facts
+    assert len(facts) <= svc._MAX_FACTS
+
+
+def test_empty_and_non_limbus_text_grounds_nothing() -> None:
+    assert svc.build("").facts == ()
+    assert svc.build("what is the weather today").facts == ()
+
+
+def test_facts_are_deterministic_for_a_fixed_message() -> None:
+    assert svc.build("faust and heathcliff").facts == svc.build(
+        "faust and heathcliff",
+    ).facts

--- a/tests/unit/services/test_ai_task_router_projmoon.py
+++ b/tests/unit/services/test_ai_task_router_projmoon.py
@@ -1,0 +1,64 @@
+"""Router pin: Limbus questions route to PROJMOON_ANSWER (the grounding path).
+
+Project Moon knowledge-domain PR 2 (Slice A item 2,
+``docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md``). A message
+carrying a distinctive Limbus token must route to ``AITask.PROJMOON_ANSWER`` so
+``projmoon_context_service`` facts are injected — but BTD6 keeps priority, and
+ordinary chatter stays general (the curation that keeps the route low-noise).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from core.runtime.ai.contracts import AITask  # noqa: E402
+from services import ai_task_router  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "tell me about Limbus Company",
+        "who is Faust in limbus?",
+        "what does the ZAYIN grade mean?",
+        "list every sinner",
+        "explain E.G.O grades",
+        "what is a mirror dungeon?",
+        "how does Heathcliff work",
+        "is Don Quixote good",
+    ],
+)
+def test_limbus_questions_route_to_projmoon(text: str) -> None:
+    routed = ai_task_router.classify(text)
+    assert routed.task is AITask.PROJMOON_ANSWER
+    assert routed.route == "projmoon.answer"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # bare ambiguous English / sin words must NOT route to projmoon
+        "he is the boss of this server",
+        "don't be like that",
+        "i sang a song yesterday",
+        "what time is it",
+        "pride comes before a fall",
+    ],
+)
+def test_ordinary_chatter_does_not_route_to_projmoon(text: str) -> None:
+    routed = ai_task_router.classify(text)
+    assert routed.task is AITask.GENERAL_NL_ANSWER
+
+
+def test_btd6_keeps_priority_over_projmoon() -> None:
+    # A message that names both a BTD6 entity and a Limbus token routes to BTD6
+    # (BTD6 is checked first; the two keyword sets are disjoint in practice).
+    routed = ai_task_router.classify("compare the dart monkey to a limbus sinner")
+    assert routed.task is AITask.BTD6_ANSWER


### PR DESCRIPTION
**Born-red** (in-progress session card) — see `.sessions/2026-06-26-projmoon-grounding-path.md`.

Project Moon knowledge-domain **PR 2 — the grounding path** (Slice A item 2 of
`planning/project-moon-knowledge-domain-plan-2026-06-21.md`, owner-directed Q-0192). Wires the
committed Limbus structural facts into the AI natural-language stage as grounding, mirroring the
BTD6 grounding seam.

- `AITask.PROJMOON_ANSWER` + router (`has_limbus_context` → `PROJMOON_ANSWER`, after BTD6, before video).
- New `services/projmoon_context_service.build()` — resolves named Limbus entities + bounded roster
  expansion to provenanced grounding fact lines (read-only over `projmoon_data_service`).
- `natural_language_stage._gather_feature_facts` branch injects those facts.

**Default-preserving:** only Limbus-detected messages change; the BTD6 path stays byte-identical.
Offline-unit-tested. **Flagged:** touches the gated AI stage → the live model-loop verification is
the owner's Q-0086 runtime walk (established AI-feature pattern). The prose-faithfulness *validation*
guard (plan §6 "hardest risk") is deferred to a follow-up; this slice injects grounding facts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167WhNzywKXFPJRHUwpTnXP)_