### PR TITLE
Project Moon (Limbus) answer-faithfulness guard

### DIFF
--- a/.sessions/2026-06-26-projmoon-faithfulness-guard.md
+++ b/.sessions/2026-06-26-projmoon-faithfulness-guard.md
@@ -1,0 +1,33 @@
+# 2026-06-26 — Project Moon (Limbus) faithfulness guard (S1)
+
+> **Status:** `in-progress`
+
+## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
+
+Empty scheduled fire, **zero open PRs**. Per the routine: advance the next **▶ startable**
+plan slice. The Project Moon knowledge-domain plan's ▶ Next item (b) is **the projmoon
+faithfulness guard follow-up** — the §6 "hardest correctness risk". PR #1467 (Slice A item 2)
+shipped the Limbus grounding *injection* path but deliberately deferred the prose-faithfulness
+*validation* guard: a `PROJMOON_ANSWER` reply grounds on the injected facts but is **not**
+verified against them the way `btd6_grounding_service.validate_btd6_reply` verifies BTD6 replies.
+This slice closes that gap — offline-verifiable, default-preserving (only Limbus-detected
+messages route to `PROJMOON_ANSWER`).
+
+## Plan
+
+1. New `disbot/services/projmoon_grounding_service.py` — `validate_projmoon_reply(reply, facts)`
+   mirroring the BTD6 name-guard: reuse the domain-agnostic `utils.btd6.name_guard` matchers,
+   index the **distinctive** Limbus proper names (the 12 Sinners + the E.G.O grade names),
+   skip the common-English categories (Sins / damage types / statuses). Names-only — Limbus
+   exact numbers aren't ingested yet (Slice A item 1).
+2. Wire a `PROJMOON_ANSWER` faithfulness block into `natural_language_stage.py` parallel to the
+   BTD6 one: reject → regenerate-once with a do-not-state constraint → floor to a deterministic
+   projmoon refusal.
+3. Offline unit tests (the guard logic + the name-index discipline + the wiring).
+
+## Status checklist
+- [ ] `projmoon_grounding_service` + name index + tests
+- [ ] NL-stage `PROJMOON_ANSWER` guard wiring + deterministic refusal
+- [ ] CI mirror green + arch strict 0 errors
+- [ ] De-stale the project-moon plan + S1 sector doc
+- [ ] Session enders (idea / prev-review / doc audit / run-report footer)

--- a/.sessions/2026-06-26-projmoon-faithfulness-guard.md
+++ b/.sessions/2026-06-26-projmoon-faithfulness-guard.md
@@ -1,6 +1,6 @@
 # 2026-06-26 — Project Moon (Limbus) faithfulness guard (S1)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
 
@@ -13,21 +13,104 @@ verified against them the way `btd6_grounding_service.validate_btd6_reply` verif
 This slice closes that gap — offline-verifiable, default-preserving (only Limbus-detected
 messages route to `PROJMOON_ANSWER`).
 
-## Plan
+## What shipped (PR #1469)
 
-1. New `disbot/services/projmoon_grounding_service.py` — `validate_projmoon_reply(reply, facts)`
-   mirroring the BTD6 name-guard: reuse the domain-agnostic `utils.btd6.name_guard` matchers,
-   index the **distinctive** Limbus proper names (the 12 Sinners + the E.G.O grade names),
-   skip the common-English categories (Sins / damage types / statuses). Names-only — Limbus
-   exact numbers aren't ingested yet (Slice A item 1).
-2. Wire a `PROJMOON_ANSWER` faithfulness block into `natural_language_stage.py` parallel to the
-   BTD6 one: reject → regenerate-once with a do-not-state constraint → floor to a deterministic
-   projmoon refusal.
-3. Offline unit tests (the guard logic + the name-index discipline + the wiring).
+**New `disbot/services/projmoon_grounding_service.py`** — the projmoon analogue of
+`btd6_grounding_service.validate_btd6_reply`:
+- `validate_projmoon_reply(reply, facts)` reuses the domain-agnostic, stdlib-only
+  `utils.btd6.name_guard` matchers **and the shared `GroundingResult` dataclass** (so Slice B's
+  `KnowledgeDomain` seam folds the two grounding services with no contract change).
+- `_name_index()` indexes the **distinctive** Limbus proper names — the 12 Sinners (canonicals +
+  aliases, `build_matchers` filters the generic short ones) + the four non-ambiguous E.G.O grade
+  letters (ZAYIN/TETH/WAW/ALEPH, "HE" excluded as the pronoun) and their "<x> grade" multi-word
+  aliases. It **skips** the common-English categories (Sins `Wrath`…, damage types `Slash`…,
+  statuses `Burn`…) so ordinary prose never false-positives — mirroring BTD6's
+  hero/boss-vs-generic discipline.
+- **Names-only** — Limbus *exact numbers* aren't ingested yet (Slice A item 1), so there is no
+  numeric grounding, unlike BTD6.
+- `build_grounding_constraint()` + `no_data_refusal()` — the retry constraint + the deterministic,
+  never-model-prose Limbus refusal string.
+
+**NL-stage wiring** (`core/runtime/ai/natural_language_stage.py`) — a `PROJMOON_ANSWER`
+faithfulness block parallel to the BTD6 one: reject → regenerate-once with a do-not-state
+constraint → floor to the deterministic refusal (`_send_projmoon_refusal`), auditing
+`denied`/`GROUNDING_FAILED` (or `degraded`/`PROVIDER_UNAVAILABLE` if the retry degrades).
+
+**Posture divergence from BTD6 (documented in-module):** a verifier *exception* fails **open**
+(projmoon faithfulness is additive hardening, not a hard numeric safety floor — a verifier bug
+must not refuse a legitimate, lower-stakes Limbus answer); a genuine unsupported-name finding
+fails **closed**.
+
+**Default-preserving:** only `PROJMOON_ANSWER` replies (already Limbus-routed) enter the guard;
+the BTD6 / general paths are byte-identical.
+
+## Verification
+- `tests/unit/services/projmoon/test_projmoon_grounding_service.py`: **12 passed** (name-index
+  discipline, grounded/unsupported verdicts, common-category exclusion, ambiguous-`he` exclusion,
+  fail-open-on-error, constraint/refusal strings).
+- `tests/unit/runtime/ai/test_natural_language_stage.py` projmoon block: **4 passed** (grounded
+  served · unsupported-name refused after retry · regenerate-once rescue · degraded-retry stays
+  PROVIDER_UNAVAILABLE).
+- Registered the new `_reset_for_tests` hook in `tests/_isolation.py` (PER_FILE) — fixes the
+  `test_every_reset_hook_is_classified` invariant.
+- Full CI mirror `python3.10 scripts/check_quality.py --full`: **12608 passed, 48 skipped,
+  2 xfailed** (green after the isolation registration; the one earlier failure was exactly that
+  unclassified hook).
+- `check_architecture.py --mode strict`: **0 errors** (49 known warnings, none touched).
+- Doc audit: `check_current_state_ledger.py --strict` exit 0 (benign newest-merge lag only,
+  25 PRs newer than marker #1441 — the recon pass records them); `check_docs.py --strict` green.
 
 ## Status checklist
-- [ ] `projmoon_grounding_service` + name index + tests
-- [ ] NL-stage `PROJMOON_ANSWER` guard wiring + deterministic refusal
-- [ ] CI mirror green + arch strict 0 errors
-- [ ] De-stale the project-moon plan + S1 sector doc
-- [ ] Session enders (idea / prev-review / doc audit / run-report footer)
+- [x] `projmoon_grounding_service` + name index + 12 service tests
+- [x] NL-stage `PROJMOON_ANSWER` guard wiring + deterministic refusal + 4 wiring tests
+- [x] `tests/_isolation.py` registration (reset-hook invariant)
+- [x] CI mirror green + arch strict 0 errors
+- [x] De-stale the project-moon plan + S1 sector doc
+- [x] Session enders (idea / prev-review / doc audit / run-report footer)
+
+## 💡 Session idea (Q-0089)
+
+**A `name_guard`-style faithfulness guard is a *reusable domain primitive*, not a per-domain
+copy.** Building the projmoon guard, I deliberately reused `utils.btd6.name_guard` and the shared
+`GroundingResult` — but the *index-building discipline* ("distinctive proper names single-token,
+common-English categories multi-word-only") was hand-re-implemented in both
+`btd6_grounding_service._name_index` and `projmoon_grounding_service._name_index`. When Slice B
+extracts the `KnowledgeDomain` seam, that discipline should become a single
+`build_domain_name_index(domain)` helper that takes a per-domain "distinctive kinds" vs "generic
+kinds" partition — so registering a third reference domain (Library of Ruina) is a *data*
+declaration, not another bespoke index builder. Captured as the natural shape for Slice B's
+shared renderer. *(Not promoted to a separate idea file — it's an implementation note on the
+already-planned Slice B, recorded here + in the plan's §3 generalisation table.)*
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (PR #1458, the BTD6 fixture-drift anchor guard) did something genuinely right and
+worth repeating: when it found the *remaining* unanchored rubric figures were **not cleanly
+reproducible** (a naive `round_cash` lands ~$10 off; `$71,315.20` is a BUG-0004 distractor), it
+**did not anchor them blindly** — it documented why and left a handoff, honoring CLAUDE.md Q-0120
+("a guard that asserts a wrong truth is worse than no guard"). That restraint is exactly the
+instinct I leaned on here: the projmoon guard is **names-only and skips the common-English
+categories** rather than over-indexing for coverage — a guard that floored "this deals slash
+damage" on the word *slash* would be worse than no guard. **System improvement it surfaces:** both
+runs independently re-derived the same "distinctive vs generic token" discipline by reading the
+BTD6 code — that's the duplication my session idea above flags. The workflow would be better with a
+**single documented `name_guard` usage recipe** (in `docs/subsystems/ai.md` or the helper-policy)
+so the next domain author doesn't re-derive it from the BTD6 source each time. Small, real, not
+filler.
+
+## 📤 Run report
+
+- **Did:** built the Project Moon (Limbus) answer-faithfulness guard — post-verify `PROJMOON_ANSWER`
+  replies against the injected grounding facts · **Outcome:** shipped
+- **Shipped:** #1469 — `projmoon_grounding_service` (name-guard reuse, Sinner/E.G.O index,
+  common-category exclusion) + NL-stage `PROJMOON_ANSWER` reject→retry→refusal wiring + 16 offline
+  tests; closes Slice A follow-up (b) / plan §6 hardest-risk item
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (the live Q-0086 Limbus runtime walk remains an owner step from
+  PR #1467 — not newly created here; the guard is offline-verified)
+- **⚑ Self-initiated:** none (dispatched-plan ▶ Next item (b))
+- **↪ Next:** S1 Project Moon — the live **Q-0086 runtime walk** (owner) + Slice A item 1 (the
+  StaticData exact-number ingest, the deferred fragile lane) → then **Slice B** = extract the shared
+  `KnowledgeDomain` seam from BTD6 + Limbus (fold the two grounding services; lift the duplicated
+  name-index discipline into one `build_domain_name_index` helper — see this run's session idea).

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -765,6 +765,87 @@ class AINaturalLanguageStage:
                     ctx.metadata["handled_by"] = STAGE_NAME
                     return StageResult(short_circuit=True)
 
+        # ---- Project Moon (Limbus) faithfulness guard -----------------------
+        # A PROJMOON_ANSWER reply must not state distinctive Limbus proper names
+        # (the 12 Sinners, the E.G.O grades) absent from the grounded payload
+        # injected by ``projmoon_context_service``. Reject + regenerate once with
+        # a do-not-state constraint, then floor to a deterministic refusal.
+        # Names-only — Limbus exact numbers aren't ingested yet (Slice A item 1).
+        # Default-preserving: only PROJMOON_ANSWER replies (already Limbus-routed)
+        # enter here; the BTD6 / general paths above are untouched.
+        if routed.task is AITask.PROJMOON_ANSWER:
+            from services import projmoon_grounding_service
+
+            pm_verdict = projmoon_grounding_service.validate_projmoon_reply(
+                reply_text,
+                facts=tuple(feature.facts),
+            )
+            if not pm_verdict.grounded:
+                async with _maybe_typing(message.channel):
+                    response = await _invoke_gateway(
+                        stack,
+                        built,
+                        ctx,
+                        ledger=ledger,
+                        grounding_constraint=(
+                            projmoon_grounding_service.build_grounding_constraint(
+                                pm_verdict,
+                            )
+                        ),
+                    )
+                pm_retry_text = redact_text((response.text or "").strip()).value
+                pm_retry_verdict = (
+                    projmoon_grounding_service.validate_projmoon_reply(
+                        pm_retry_text,
+                        facts=tuple(feature.facts),
+                    )
+                    if pm_retry_text
+                    else None
+                )
+                if (
+                    pm_retry_text
+                    and pm_retry_verdict is not None
+                    and pm_retry_verdict.grounded
+                ):
+                    logger.info(
+                        "projmoon_faithfulness: retry_rescued route=%s",
+                        routed.route,
+                    )
+                    reply_text = pm_retry_text
+                else:
+                    logger.warning(
+                        "projmoon_faithfulness: blocked route=%s names=%s "
+                        "retry_attempted=True retry_rescued=False degraded=%s",
+                        routed.route,
+                        list(pm_verdict.offending_names),
+                        response.degraded,
+                    )
+                    await _send_projmoon_refusal(message)
+                    if response.degraded:
+                        pm_decision = "degraded"
+                        pm_reason = PolicyDenialReason.PROVIDER_UNAVAILABLE
+                    else:
+                        pm_decision = "denied"
+                        pm_reason = PolicyDenialReason.GROUNDING_FAILED
+                    await ai_decision_audit_service.record(
+                        guild_id=guild_id,
+                        channel_id=channel_id,
+                        category_id=category_id,
+                        user_id=user_id,
+                        message_id=message.id,
+                        task=routed.task.value,
+                        route=routed.route,
+                        decision=pm_decision,
+                        reason_code=pm_reason,
+                        policy_snapshot_hash=decision.policy_snapshot_hash,
+                        instruction_profile_ids=list(stack.instruction_profile_ids)
+                        or None,
+                        provider=response.provider or None,
+                        model=response.model or None,
+                    )
+                    ctx.metadata["handled_by"] = STAGE_NAME
+                    return StageResult(short_circuit=True)
+
         from core.runtime.ai import response_renderer_registry
 
         # A registered renderer may raise (bad render_context, embed
@@ -1118,6 +1199,24 @@ async def _send_btd6_refusal(message: discord.Message) -> None:
     except discord.HTTPException:
         logger.warning(
             "btd6_faithfulness: refusal send failed for message=%s",
+            getattr(message, "id", None),
+            exc_info=True,
+        )
+
+
+async def _send_projmoon_refusal(message: discord.Message) -> None:
+    """Send the deterministic Project Moon (Limbus) refusal as a reply."""
+    from services import projmoon_grounding_service
+
+    try:
+        await message.channel.send(
+            projmoon_grounding_service.no_data_refusal(),
+            allowed_mentions=discord.AllowedMentions.none(),
+            reference=message.to_reference(fail_if_not_exists=False),
+        )
+    except discord.HTTPException:
+        logger.warning(
+            "projmoon_faithfulness: refusal send failed for message=%s",
             getattr(message, "id", None),
             exc_info=True,
         )

--- a/disbot/services/projmoon_grounding_service.py
+++ b/disbot/services/projmoon_grounding_service.py
@@ -1,0 +1,202 @@
+"""Project Moon (Limbus) answer-faithfulness verifier.
+
+The projmoon analogue of :func:`services.btd6_grounding_service.validate_btd6_reply`:
+a ``PROJMOON_ANSWER`` reply must not state distinctive Limbus proper names absent
+from the grounded payload (the facts injected by
+:mod:`services.projmoon_context_service`). The natural-language stage calls
+:func:`validate_projmoon_reply` after the model answers; an unsupported name
+triggers a single regenerate-with-constraint, then the deterministic refusal floor.
+
+This realises **Slice A follow-up (b)** of the Project Moon knowledge-domain plan
+(``docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md``, Q-0192) — the
+prose-faithfulness *validation* guard the plan's §6 calls "the hardest correctness
+risk". PR #1467 (Slice A item 2) injected grounded facts but deliberately deferred
+this verify step; this module closes that gap.
+
+Design notes:
+
+* **Names-only.** Limbus *exact numbers* aren't ingested yet (Slice A item 1 — the
+  StaticData dump), so there is no numeric grounding here, unlike the BTD6 path. The
+  committed fixtures are structural/lore prose; the realistic confabulation a guard
+  can catch is **misattributing a known Sinner / E.G.O grade**, not inventing a
+  numeric stat.
+* **Common-word discipline.** Only the *distinctive* proper names are indexed: the
+  12 Sinners and the four non-ambiguous E.G.O grade letters. The Sins (``Wrath`` …),
+  damage types (``Slash`` …) and statuses (``Burn`` …) are ordinary English words,
+  so — exactly like BTD6's bloon colours / generic tower words — they are **not**
+  single-token matched (a reply that says "this deals slash damage" must never be
+  refused for the word "slash"). This mirrors
+  :func:`services.btd6_grounding_service._name_index`.
+* **Reuses** the domain-agnostic, stdlib-only :mod:`utils.btd6.name_guard` matchers
+  and the shared :class:`services.btd6_grounding_service.GroundingResult` dataclass —
+  so when the shared ``KnowledgeDomain`` seam (Slice B) lands, this module and the
+  BTD6 grounding service fold onto one renderer with no contract change.
+
+Layering: ``services`` may import ``utils`` and sibling services; this module imports
+only :mod:`services.projmoon_data_service`, :mod:`services.btd6_grounding_service`
+(for the shared result type), :mod:`core.runtime.ai.contracts`, and ``utils`` —
+never cogs / views.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from core.runtime.ai.contracts import PolicyDenialReason
+from services import projmoon_data_service
+from services.btd6_grounding_service import GroundingResult
+from utils.btd6 import name_guard
+
+logger = logging.getLogger("bot.services.projmoon_grounding")
+
+# E.G.O grade canonicals that are distinctive Hebrew-letter tokens safe to match
+# whole-word. "HE" is excluded — it is the ordinary English pronoun (the same
+# ambiguous-bare-token curation ``projmoon_context_service`` applies); it grounds
+# only via its multi-word "he grade" alias.
+_AMBIGUOUS_EGO_CANONICALS: frozenset[str] = frozenset({"he"})
+
+_index_lock = threading.Lock()
+_NAME_INDEX: name_guard.NameMatchers | None = None
+
+
+def _name_index() -> name_guard.NameMatchers:
+    """Memoized Limbus proper-name matchers built from the committed fixtures.
+
+    Discipline (mirrors :func:`btd6_grounding_service._name_index`):
+
+    * **Sinners** — distinctive proper names; feed every canonical + alias to
+      :func:`name_guard.build_matchers`, which keeps single-word forms at the
+      router's length thresholds (so "Faust"/"Gregor" match whole-word while the
+      generic short aliases "don"/"ish"/"sang" are filtered out) and multi-word
+      forms ("Don Quixote", "Yi Sang") as substring phrases.
+    * **E.G.O grades** — the four non-ambiguous letters (ZAYIN/TETH/WAW/ALEPH) as
+      single tokens, plus the "<grade> grade" aliases as multi-word phrases.
+    * **Sins / damage types / statuses** — ordinary English words, **skipped**
+      entirely (single-token matching them would false-positive on normal prose).
+
+    Never raises: a fixture-load fault yields an empty index so the guard passes
+    (fail-open on a *load* error — see :func:`validate_projmoon_reply`).
+    """
+    global _NAME_INDEX
+    if _NAME_INDEX is not None:
+        return _NAME_INDEX
+    with _index_lock:
+        if _NAME_INDEX is not None:
+            return _NAME_INDEX
+
+        canonicals: set[str] = set()
+        aliases: set[str] = set()
+        try:
+            for entry in projmoon_data_service.get_entries("sinner"):
+                canonicals.add(entry.canonical)
+                aliases.update(entry.aliases)
+            for entry in projmoon_data_service.get_entries("ego_grade"):
+                if entry.canonical.casefold() not in _AMBIGUOUS_EGO_CANONICALS:
+                    canonicals.add(entry.canonical)
+                # The "<x> grade" aliases are distinctive multi-word phrases.
+                aliases.update(alias for alias in entry.aliases if " " in alias)
+        except Exception:
+            logger.warning(
+                "projmoon_grounding: fixtures unavailable; using empty name index",
+                exc_info=True,
+            )
+            return name_guard.NameMatchers(multi=frozenset(), single=frozenset())
+
+        index = name_guard.build_matchers(canonicals, aliases)
+        _NAME_INDEX = index
+        return index
+
+
+def _reset_for_tests() -> None:
+    """Clear the memoized name index (call alongside ``projmoon_data_service.reset_cache``)."""
+    global _NAME_INDEX
+    with _index_lock:
+        _NAME_INDEX = None
+
+
+def validate_projmoon_reply(
+    answer_text: str,
+    *,
+    facts: tuple[str, ...] = (),
+) -> GroundingResult:
+    """Verify a model-authored Limbus reply against the grounded payload.
+
+    Trusted haystack = the injected grounding ``facts``. A reply is grounded when
+    every indexed Limbus proper name it states is present in the haystack. Names
+    only — Limbus exact numbers aren't grounded yet.
+
+    On a real unsupported-name finding the result is *not grounded* so the caller
+    floors to the refusal (fail closed on a genuine miss). On an internal verifier
+    error the result is *grounded* (fail open): a verifier bug must not turn a
+    legitimate, lower-stakes Limbus answer into a refusal — unlike the BTD6 numeric
+    path, projmoon faithfulness is additive hardening, not a hard safety floor.
+    """
+    try:
+        matchers = _name_index()
+        haystack = " ".join(facts)
+
+        allowed_names = name_guard.names_present(haystack, matchers)
+        answer_names = name_guard.names_present(answer_text, matchers)
+        offending_names = tuple(sorted(answer_names - allowed_names))
+
+        if not offending_names:
+            return GroundingResult(
+                grounded=True,
+                reason_code=PolicyDenialReason.NONE.value,
+                used_fact_keys=(),
+            )
+        return GroundingResult(
+            grounded=False,
+            reason_code=PolicyDenialReason.GROUNDING_FAILED.value,
+            used_fact_keys=(),
+            notes=("entity_name_unsupported",),
+            offending_names=offending_names,
+        )
+    except Exception:
+        logger.warning(
+            "projmoon_grounding: validate_projmoon_reply raised; failing open",
+            exc_info=True,
+        )
+        return GroundingResult(
+            grounded=True,
+            reason_code=PolicyDenialReason.NONE.value,
+            used_fact_keys=(),
+            notes=("verifier_error",),
+        )
+
+
+def build_grounding_constraint(verdict: GroundingResult) -> str:
+    """A do-not-state constraint appended to the system prompt on the retry."""
+    detail = (
+        "names not in the data: " + ", ".join(verdict.offending_names)
+        if verdict.offending_names
+        else "unsupported Limbus claims"
+    )
+    return (
+        "GROUNDING CORRECTION: your previous reply contained "
+        f"{detail}. Do NOT state these. Use only Project Moon (Limbus) names "
+        "present in the provided data. If the data does not support an answer, "
+        "say you don't have that information."
+    )
+
+
+def no_data_refusal() -> str:
+    """Deterministic Project Moon refusal — never model prose.
+
+    The single source for the floor string so every projmoon grounding refusal
+    reads the same. Never raises.
+    """
+    return (
+        "I don't have verified Project Moon (Limbus) details to answer that "
+        "confidently. I won't state Sinner or E.G.O facts I can't ground in my "
+        "data — try asking about a specific Sinner (e.g. Faust, Don Quixote) or "
+        "one of the E.G.O grades."
+    )
+
+
+__all__ = [
+    "build_grounding_constraint",
+    "no_data_refusal",
+    "validate_projmoon_reply",
+]

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -129,10 +129,14 @@
   **`AITask.PROJMOON_ANSWER`** (`ai_task_router` → `has_limbus_context`, after BTD6 / before video) and a
   thin `services/projmoon_context_service.build()` injects provenanced Limbus grounding facts (named
   entities + bounded roster queries) into `natural_language_stage._gather_feature_facts` —
-  default-preserving (BTD6 path byte-identical), offline-unit-tested. ▶ **Next:** the live **Q-0086
-  runtime walk** (owner — confirm a real Limbus Q&A grounds well on both providers) + the projmoon
-  **faithfulness guard** follow-up + Slice A item 1 (StaticData exact-number ingest); then **Slice B** =
-  extract the shared `KnowledgeDomain` seam from BTD6 + Limbus
+  default-preserving (BTD6 path byte-identical), offline-unit-tested. **Faithfulness guard SHIPPED
+  2026-06-26** (dispatch run, PR #1469): `services/projmoon_grounding_service.py` post-verifies a
+  `PROJMOON_ANSWER` reply against the injected facts (the projmoon analogue of `validate_btd6_reply`,
+  reusing `utils.btd6.name_guard` + the shared `GroundingResult`) — indexes the distinctive Sinner /
+  E.G.O names, skips the common-English categories, reject → regenerate-once → deterministic Limbus
+  refusal; offline-unit-tested. ▶ **Next:** the live **Q-0086 runtime walk** (owner — confirm a real
+  Limbus Q&A grounds well on both providers) + Slice A item 1 (StaticData exact-number ingest); then
+  **Slice B** = extract the shared `KnowledgeDomain` seam from BTD6 + Limbus
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
 - **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover
   (PR 1 foundation shipped; [plan](../planning/botsite-react-spa-migration-plan-2026-06-20.md)).

--- a/docs/owner/claims/claude-funny-franklin-8za1rx.md
+++ b/docs/owner/claims/claude-funny-franklin-8za1rx.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-8za1rx` · scope: Project Moon (Limbus) faithfulness guard · area: `disbot/services/projmoon_grounding_service.py` (new) + `disbot/core/runtime/ai/natural_language_stage.py` + tests · 2026-06-26

--- a/docs/owner/claims/claude-funny-franklin-8za1rx.md
+++ b/docs/owner/claims/claude-funny-franklin-8za1rx.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-8za1rx` · scope: Project Moon (Limbus) faithfulness guard · area: `disbot/services/projmoon_grounding_service.py` (new) + `disbot/core/runtime/ai/natural_language_stage.py` + tests · 2026-06-26

--- a/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
+++ b/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
@@ -100,6 +100,23 @@ argument: generalising from a single example tends to produce the wrong abstract
 > providers); (b) the projmoon **faithfulness guard** follow-up; (c) Slice A item 1 — the StaticData
 > exact-number ingest; then **Slice B** — extract the shared `KnowledgeDomain` seam from BTD6 + Limbus.
 
+> **▶ Progress (2026-06-26 dispatch run, PR #1469): Slice A follow-up (b) — the FAITHFULNESS GUARD —
+> SHIPPED.** Closes the §6 "hardest correctness risk" deferred by PR #1467. New
+> **`services/projmoon_grounding_service.py`** is the projmoon analogue of
+> `btd6_grounding_service.validate_btd6_reply`: it reuses the domain-agnostic `utils.btd6.name_guard`
+> matchers and the shared `GroundingResult` dataclass (so Slice B's seam folds them with no contract
+> change), indexes the **distinctive** Limbus proper names (the 12 Sinners + the ZAYIN/TETH/WAW/ALEPH
+> E.G.O grades) and **skips** the common-English categories (Sins / damage types / statuses) so ordinary
+> prose never false-positives — mirroring BTD6's hero/boss-vs-generic discipline. **Names-only** (Limbus
+> exact numbers aren't ingested yet — item c). Wired into `natural_language_stage` as a `PROJMOON_ANSWER`
+> block parallel to the BTD6 one (reject → regenerate-once with a do-not-state constraint → floor to a
+> deterministic, never-model-prose Limbus refusal). **Posture divergence from BTD6 (documented):** a
+> verifier *exception* fails **open** (projmoon faithfulness is additive hardening, not a hard numeric
+> safety floor); a genuine unsupported-name finding fails **closed**. Default-preserving (BTD6 / general
+> paths byte-identical); offline-unit-tested (12 service tests + 4 NL-stage wiring tests). **▶ Next:**
+> (a) the live **Q-0086 runtime walk** (owner); (c) Slice A item 1 — the StaticData exact-number ingest;
+> then **Slice B** — extract the shared `KnowledgeDomain` seam from BTD6 + Limbus.
+
 **Slice A (next session, 2–3 PRs):**
 1. **Ingestion:** a `scripts/fetch_pm_limbus.py` that parses the **StaticData identity JSON** (clean,
    bounded — Identities + Sinners + E.G.O index) into committed JSON under

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -103,6 +103,7 @@ PER_FILE_RESET_HOOKS: dict[str, str] = {
     "services.btd6_grounding_service": "grounding cache; wired in BTD6 grounding tests",
     "services.btd6_source_parser": "parser cache; wired in BTD6 parser tests",
     "services.btd6_version_announce": "bus subscriber; wired in announce tests",
+    "services.projmoon_grounding_service": "name-index cache; wired in projmoon grounding tests",
     "services.customization_catalogue": "catalogue cache; wired in customization tests",
     "services.diagnostics_service": "import-populated provider registry; wired in diagnostics tests",
     "services.paragon_service": "paragon cache; wired in paragon tests",

--- a/tests/unit/runtime/ai/test_natural_language_stage.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage.py
@@ -1876,6 +1876,126 @@ async def test_btd6_meta_question_serves_answerability_summary(
 
 
 # ---------------------------------------------------------------------------
+# Project Moon (Limbus) faithfulness guard (Slice A follow-up b)
+# ---------------------------------------------------------------------------
+
+
+def _route_projmoon(monkeypatch):
+    from core.runtime.ai import natural_language_stage as mod
+
+    monkeypatch.setattr(
+        mod.ai_task_router,
+        "classify",
+        lambda _t, **_kw: SimpleNamespace(
+            task=AITask.PROJMOON_ANSWER, route="projmoon.answer"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_projmoon_grounded_answer_is_served(monkeypatch, stub_services):
+    """A Limbus reply that names only grounded Sinners is served unchanged."""
+    from services import ai_gateway
+
+    _route_projmoon(monkeypatch)
+    _stub_facts(monkeypatch, ("Faust: a steady, cerebral Sinner.",))
+
+    async def fake_execute(_request):
+        return _make_response(text="Faust is one of the twelve Sinners.")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> tell me about Faust in limbus"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert _sent_text(msg) == "Faust is one of the twelve Sinners."
+    assert stub_services[-1]["decision"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_projmoon_unsupported_name_is_refused(monkeypatch, stub_services):
+    """A reply that drifts to an ungrounded Sinner is floored to the deterministic
+    Limbus refusal after the constrained retry still misses."""
+    from services import ai_gateway
+
+    _route_projmoon(monkeypatch)
+    _stub_facts(monkeypatch, ("Faust: a steady, cerebral Sinner.",))
+
+    # Both the first reply and the retry name Heathcliff (never grounded).
+    async def fake_execute(_request):
+        return _make_response(text="Actually Heathcliff is the strongest Sinner.")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> who is the best limbus sinner"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    sent = _sent_text(msg)
+    assert "Heathcliff" not in sent  # the ungrounded reply is NOT served
+    assert "Project Moon" in sent  # the deterministic refusal floor
+    assert stub_services[-1]["decision"] == "denied"
+    assert stub_services[-1]["reason_code"] is PolicyDenialReason.GROUNDING_FAILED
+
+
+@pytest.mark.asyncio
+async def test_projmoon_regenerate_once_rescues(monkeypatch, stub_services):
+    """First reply ungrounded, the constrained retry grounded → served."""
+    from services import ai_gateway
+
+    _route_projmoon(monkeypatch)
+    _stub_facts(monkeypatch, ("Faust: a steady, cerebral Sinner.",))
+
+    texts = iter(
+        ["Heathcliff is the answer.", "Faust is a cerebral, steady Sinner."]
+    )
+
+    async def fake_execute(_request):
+        return _make_response(text=next(texts))
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> tell me about Faust"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert _sent_text(msg) == "Faust is a cerebral, steady Sinner."
+    assert stub_services[-1]["decision"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_projmoon_degraded_retry_stays_provider_unavailable(
+    monkeypatch, stub_services
+):
+    """An ungrounded first reply whose retry degrades stays PROVIDER_UNAVAILABLE —
+    a provider outage on retry must never be misclassified as a grounding miss."""
+    from services import ai_gateway
+
+    _route_projmoon(monkeypatch)
+    _stub_facts(monkeypatch, ("Faust: a steady, cerebral Sinner.",))
+
+    responses = iter(
+        [
+            _make_response(text="Heathcliff is the best.", degraded=False),
+            _make_response(text=None, degraded=True, model=""),
+        ]
+    )
+
+    async def fake_execute(_request):
+        return next(responses)
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> who is the best limbus sinner"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert stub_services[-1]["decision"] == "degraded"
+    assert stub_services[-1]["reason_code"] is PolicyDenialReason.PROVIDER_UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
 # BUG-0019 #2 — @everyone / @here must NOT read as a direct personal ping.
 #
 # discord.py's ``ClientUser.mentioned_in`` returns True on

--- a/tests/unit/services/projmoon/test_projmoon_grounding_service.py
+++ b/tests/unit/services/projmoon/test_projmoon_grounding_service.py
@@ -1,0 +1,155 @@
+"""Tests for the Limbus answer-faithfulness verifier (``projmoon_grounding_service``).
+
+Project Moon knowledge-domain Slice A follow-up (b) — the prose-faithfulness
+validation guard (plan §6). These pins cover the name-index discipline (distinctive
+Sinners + E.G.O letters in, common-English categories out), the grounded /
+unsupported verdicts, the fail-open-on-error posture, and the constraint / refusal
+string helpers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+import pytest  # noqa: E402
+
+from services import projmoon_context_service as ctx_svc  # noqa: E402
+from services import projmoon_grounding_service as svc  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_index() -> None:
+    svc._reset_for_tests()
+    yield
+    svc._reset_for_tests()
+
+
+def _grounded_facts(text: str) -> tuple[str, ...]:
+    """The real grounding facts the context service would inject for ``text``."""
+    return ctx_svc.build(text).facts
+
+
+# --- distinctive proper names: caught when unsupported -----------------------
+
+
+def test_unsupported_sinner_name_is_not_grounded() -> None:
+    # Facts ground Faust only; a reply that drifts to Heathcliff is unsupported.
+    facts = _grounded_facts("tell me about Faust in limbus")
+    verdict = svc.validate_projmoon_reply(
+        "Faust is steady, and Heathcliff hits hard too.",
+        facts=facts,
+    )
+    assert not verdict.grounded
+    assert "heathcliff" in verdict.offending_names
+    assert "entity_name_unsupported" in verdict.notes
+
+
+def test_supported_sinner_name_is_grounded() -> None:
+    facts = _grounded_facts("tell me about Faust in limbus")
+    verdict = svc.validate_projmoon_reply(
+        "Faust is one of the twelve Sinners.",
+        facts=facts,
+    )
+    assert verdict.grounded
+    assert verdict.offending_names == ()
+
+
+def test_multiword_sinner_name_matches_as_phrase() -> None:
+    facts = _grounded_facts("who is Faust")  # no Don Quixote here
+    verdict = svc.validate_projmoon_reply(
+        "Don Quixote charges in with a lance.",
+        facts=facts,
+    )
+    assert not verdict.grounded
+    assert "don quixote" in verdict.offending_names
+
+
+def test_roster_facts_ground_every_sinner_named() -> None:
+    facts = _grounded_facts("list every sinner in limbus")
+    verdict = svc.validate_projmoon_reply(
+        "The roster includes Faust, Heathcliff, Outis and Gregor.",
+        facts=facts,
+    )
+    assert verdict.grounded
+
+
+# --- common-English categories are NOT single-token matched ------------------
+
+
+def test_sin_and_status_words_are_not_offending() -> None:
+    # No grounding facts at all; ordinary English words that happen to be Sin /
+    # status / damage-type names must never be treated as proper-name evidence.
+    verdict = svc.validate_projmoon_reply(
+        "Pride and wrath can make you slash out in a fit of gloom and burn bridges.",
+        facts=(),
+    )
+    assert verdict.grounded, verdict.offending_names
+
+
+def test_ambiguous_ego_he_is_not_matched_bare() -> None:
+    # "HE" the E.G.O grade is excluded; the pronoun "he" must not offend.
+    verdict = svc.validate_projmoon_reply(
+        "If he wants a strong unit, he should look around.",
+        facts=(),
+    )
+    assert verdict.grounded
+
+
+def test_distinctive_ego_letter_is_caught() -> None:
+    # ALEPH is a distinctive token; unsupported it offends.
+    verdict = svc.validate_projmoon_reply(
+        "That is an ALEPH grade E.G.O.",
+        facts=(),
+    )
+    assert not verdict.grounded
+    assert "aleph" in verdict.offending_names
+
+
+# --- robustness --------------------------------------------------------------
+
+
+def test_empty_reply_grounds() -> None:
+    assert svc.validate_projmoon_reply("", facts=()).grounded
+
+
+def test_fails_open_on_internal_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> None:
+        raise RuntimeError("index build exploded")
+
+    monkeypatch.setattr(svc, "_name_index", _boom)
+    verdict = svc.validate_projmoon_reply("Heathcliff is unsupported here", facts=())
+    # A verifier *bug* must not refuse a legitimate Limbus answer (fail open).
+    assert verdict.grounded
+    assert "verifier_error" in verdict.notes
+
+
+def test_name_index_skips_common_categories() -> None:
+    index = svc._name_index()
+    # Sinners present, common-word categories absent from the single-token set.
+    assert "faust" in index.single
+    assert "gregor" in index.single
+    for ordinary in ("wrath", "pride", "slash", "burn", "bleed", "charge", "he"):
+        assert ordinary not in index.single
+
+
+# --- helper strings ----------------------------------------------------------
+
+
+def test_grounding_constraint_lists_offending_names() -> None:
+    verdict = svc.validate_projmoon_reply(
+        "Heathcliff is great", facts=_grounded_facts("Faust")
+    )
+    constraint = svc.build_grounding_constraint(verdict)
+    assert "GROUNDING CORRECTION" in constraint
+    assert "heathcliff" in constraint
+
+
+def test_no_data_refusal_is_deterministic_prose() -> None:
+    text = svc.no_data_refusal()
+    assert "Project Moon" in text
+    assert text == svc.no_data_refusal()  # stable


### PR DESCRIPTION
## What

Closes the documented gap in the Project Moon (Limbus) knowledge domain: PR #1467 (Slice A item 2)
shipped the Limbus grounding **injection** path but deliberately deferred the prose-faithfulness
**validation** guard — the plan's §6 "hardest correctness risk". A `PROJMOON_ANSWER` reply currently
grounds on the injected facts but is never verified against them.

This PR adds the projmoon analogue of `btd6_grounding_service.validate_btd6_reply`:

- **New `services/projmoon_grounding_service.py`** — `validate_projmoon_reply(reply, facts)` reusing
  the domain-agnostic `utils.btd6.name_guard` matchers. Indexes the **distinctive** Limbus proper
  names (the 12 Sinners + the E.G.O grade names ZAYIN/TETH/WAW/ALEPH), and **skips** the
  common-English categories (Sins / damage types / statuses) so ordinary prose never false-positives —
  mirroring the BTD6 hero/boss-vs-generic discipline. Names-only (Limbus exact numbers aren't ingested
  yet — Slice A item 1).
- **NL-stage wiring** — a `PROJMOON_ANSWER` faithfulness block parallel to the BTD6 one: reject →
  regenerate-once with a do-not-state constraint → floor to a deterministic, never-model-prose refusal.
- **Default-preserving**: only Limbus-detected messages route to `PROJMOON_ANSWER`; the BTD6 / general
  paths are byte-identical.

## Tracker

`docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md` (Q-0192) — Slice A follow-up (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwqhBAcWSuL9oGCnfTNsyS)_