### PR TITLE
AI routing: guard the cross-domain detector-disjointness invariant (Project Moon prep)

### DIFF
--- a/.sessions/2026-06-26-cross-domain-routing-disjoint-guard.md
+++ b/.sessions/2026-06-26-cross-domain-routing-disjoint-guard.md
@@ -1,0 +1,33 @@
+# 2026-06-26 — Cross-domain AI-routing disjointness guard (S1 / Project Moon prep)
+
+> **Status:** `in-progress`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/funny-franklin-8s9r5j`
+
+## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
+
+Empty scheduled fire. The Project Moon knowledge-domain arc (Q-0192) is the active S1
+program; Slice A (grounding path + faithfulness guard) shipped through #1469. The plan's
+remaining ▶ Next items are **owner-gated** (the live Q-0086 runtime walk), **fragile-unattended**
+(Slice A item 1 — the StaticData exact-number ingest, which poisons grounding if sourced
+wrong), or **Slice B** (the risky gated BTD6 seam refactor that wants a runtime-verified
+session). The clean, safe, offline-buildable slice both of the last two runs' session ideas
+flagged is the **cross-domain `has_*_context` over-route harness**.
+
+It guards a **currently-unguarded invariant**: `ai_task_router.classify` routes BTD6 first,
+then Limbus, on the bare comment *"BTD6 keywords never collide with the distinctive Limbus
+tokens"* — asserted, never tested. The two detectors even use **different match semantics**
+(`has_btd6_context` is a substring scan; `has_limbus_context` is word-boundary), so a future
+keyword-set edit could silently make a Limbus question route to BTD6 (starving projmoon) or a
+BTD6 phrase trip the Limbus detector. This run pins that invariant with a registry-driven
+guard so the next domain (LoR / LobCorp) is a one-line registration, not a re-derivation.
+
+## Plan
+- `tests/unit/runtime/ai/test_domain_routing_disjoint.py` — a registry-driven harness:
+  per-domain representative corpora route to exactly that domain's `AITask`; structural
+  token-disjointness between the substring-keyword domain and the word-boundary domains.
+- A short **domain-detector curation recipe** in the ai folio (the prev-review system
+  improvement) so the invariant + the "distinctive vs generic token" discipline has a
+  durable home instead of living in two code comments.
+
+## Verification (to fill at close)

--- a/.sessions/2026-06-26-cross-domain-routing-disjoint-guard.md
+++ b/.sessions/2026-06-26-cross-domain-routing-disjoint-guard.md
@@ -1,33 +1,131 @@
 # 2026-06-26 — Cross-domain AI-routing disjointness guard (S1 / Project Moon prep)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Run type:** routine · dispatch
-> **Branch:** `claude/funny-franklin-8s9r5j`
+> **Branch:** `claude/funny-franklin-8s9r5j` · **PR:** #1470
 
 ## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
 
 Empty scheduled fire. The Project Moon knowledge-domain arc (Q-0192) is the active S1
 program; Slice A (grounding path + faithfulness guard) shipped through #1469. The plan's
-remaining ▶ Next items are **owner-gated** (the live Q-0086 runtime walk), **fragile-unattended**
-(Slice A item 1 — the StaticData exact-number ingest, which poisons grounding if sourced
-wrong), or **Slice B** (the risky gated BTD6 seam refactor that wants a runtime-verified
-session). The clean, safe, offline-buildable slice both of the last two runs' session ideas
-flagged is the **cross-domain `has_*_context` over-route harness**.
+remaining ▶ Next items are all genuinely blocked for an unattended dispatch run:
+**owner-gated** (the live Q-0086 runtime walk), **fragile-unattended** (Slice A item 1 —
+the StaticData exact-number ingest, which poisons grounding if sourced wrong), or **Slice B**
+(the gated BTD6-grounding seam refactor the plan §4 explicitly flags as wanting a
+*runtime-verified* session). The clean, safe, offline-buildable slice both of the last two
+runs' session ideas flagged is the **cross-domain over-route harness**.
 
 It guards a **currently-unguarded invariant**: `ai_task_router.classify` routes BTD6 first,
 then Limbus, on the bare comment *"BTD6 keywords never collide with the distinctive Limbus
 tokens"* — asserted, never tested. The two detectors even use **different match semantics**
 (`has_btd6_context` is a substring scan; `has_limbus_context` is word-boundary), so a future
 keyword-set edit could silently make a Limbus question route to BTD6 (starving projmoon) or a
-BTD6 phrase trip the Limbus detector. This run pins that invariant with a registry-driven
-guard so the next domain (LoR / LobCorp) is a one-line registration, not a re-derivation.
+BTD6 phrase trip the Limbus detector.
 
-## Plan
-- `tests/unit/runtime/ai/test_domain_routing_disjoint.py` — a registry-driven harness:
-  per-domain representative corpora route to exactly that domain's `AITask`; structural
-  token-disjointness between the substring-keyword domain and the word-boundary domains.
-- A short **domain-detector curation recipe** in the ai folio (the prev-review system
-  improvement) so the invariant + the "distinctive vs generic token" discipline has a
-  durable home instead of living in two code comments.
+## What shipped (PR #1470)
 
-## Verification (to fill at close)
+- **`tests/unit/runtime/ai/test_domain_routing_disjoint.py`** — a registry-driven harness.
+  A `DomainRoute` registry (`DOMAINS`) declares each domain's detector, expected `AITask`,
+  distinctive tokens, and clean sample questions; **adding a domain is one registration**.
+  It pins three properties:
+  1. **Routing** — each domain's clean samples route to its task.
+  2. **Detector disjointness (root guard)** — no domain's distinctive tokens trip any *other*
+     domain's detector, across **every ordered pair** and both match semantics. This is the
+     structural form of the router's comment — a future collision fails CI.
+  3. **Priority is a total order** — when two domains could claim a phrase, the earlier
+     (BTD6) wins; pinned with a phrase both detectors genuinely fire on.
+  Plus a "claimed only by its own detector" check (the literal "at most one domain claims
+  each phrase") and a neutral-chatter → general corpus. 12 tests.
+- **Detector-curation recipe** in [`docs/subsystems/ai.md`](../docs/subsystems/ai.md)
+  § "Adding a knowledge domain" — the durable home for the "distinctive vs generic token"
+  + cross-domain disjointness discipline that was re-derived from BTD6 source twice (the
+  prev-review's flagged system improvement). Points the next domain author at the guard.
+
+**Offline, no runtime behaviour change** — only a test + docs + the plan/S1 progress trail.
+De-risks Slice B's seam extraction without touching the gated BTD6 hot path.
+
+## Verification
+
+- `python3.10 -m pytest tests/unit/runtime/ai/test_domain_routing_disjoint.py` → **12 passed**.
+- `python3.10 scripts/check_quality.py --full` → **All checks passed** (12621 passed, 48
+  skipped, 2 xfailed).
+- `check_architecture.py --mode strict` → **0 errors** (49 pre-existing warnings, none new).
+- `check_docs.py --strict` → green; `check_current_state_ledger.py` → benign newest-merge lag
+  only (the recon pass records it).
+
+## Status checklist
+- [x] Registry-driven disjointness harness (12 tests, all 3 properties)
+- [x] Detector-curation recipe in the ai folio
+- [x] De-stale the project-moon plan + S1 sector doc (progress trail)
+- [x] CI mirror green + arch strict 0 errors
+- [x] Session enders (idea / prev-review / doc audit / run-report footer)
+
+## Decisions made alone
+
+- **Shipped one coherent PR, not a forced second slice.** The routine biases toward 2–3
+  slices, but the remaining Project Moon ▶ items are owner-gated / fragile-data / gated-runtime
+  (above), and the obvious adjacent refactor (`build_domain_name_index` folding the two
+  `_name_index` builders) belongs to Slice B per the plan §3/§5 — doing it now would touch
+  groundedness-critical gated code against the plan's stated "runtime-verified session"
+  sequencing, purely to hit a slice count. That's the wrong trade; this is an honest natural
+  boundary, not a lazy single-PR stop. Flagged here for ratification.
+
+## 💡 Session idea (Q-0089)
+
+**Promote the `DomainRoute` registry from the test into a runtime source of truth.** Today the
+router hand-codes the domain check order (BTD6 → Limbus → video) and each domain's detector wiring
+inline in `classify`, while the test's `DOMAINS` registry independently lists the same domains +
+priority. When Slice B extracts the `KnowledgeDomain` seam, the router's domain dispatch could be
+**driven by an ordered registry of `KnowledgeDomain` instances** (each carrying its detector +
+task + priority), and this test's registry would then *assert against the real one* rather than
+duplicate it — so the priority order and detector set have exactly one home, and registering LoR
+is a single `KnowledgeDomain(...)` that the router, the grounding guard, and this harness all read.
+(Genuinely believe in it — it's the natural endpoint of the over-route guard once the seam exists,
+and it closes the last "two lists of domains" drift gap.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (PR #1469, the projmoon faithfulness guard) did the right thing twice: it
+**reused** `utils.btd6.name_guard` + `GroundingResult` instead of copying, and it deliberately
+kept the guard **names-only / common-category-skipping** rather than over-indexing for coverage
+(a guard that floored "deals slash damage" on *slash* would be worse than none). Its own session
+idea + prev-review both flagged that the "distinctive vs generic token" discipline was being
+**re-derived from BTD6 source each time** and wanted a documented recipe — this run acted on
+exactly that (the ai-folio recipe) and added the missing *cross-domain* half (the disjointness
+guard the faithfulness work assumed but never tested). **System improvement it surfaces (acted
+on):** the recipe + registry harness together turn "read BTD6 source and re-derive the rules"
+into "register a domain and let the guard cover it." One thing still open for the next run: the
+two `_name_index` builders remain literal duplicates — the right fix is the `build_domain_name_index`
+helper, but it correctly belongs to Slice B's seam extraction, not a premature standalone refactor.
+
+## Context delta
+- **Needed but not pointed to:** that `ai_task_router.classify` encodes the domain priority order
+  *and* the disjointness assumption only as an inline comment — found by reading the router, not
+  routed to by any folio. Now documented in the ai folio § "Adding a knowledge domain".
+- **Pointed to but didn't need:** the bug-book full read (`bug-book.md` is 950 lines) — the
+  rootfix-backlog checker (`check_bug_book_rootfix_backlog.py`) answered "what's actionable?" in
+  one line; the two open entries (BUG-0009 data-gated, BUG-0019 owner-decision) were both blocked,
+  so the deep read wasn't load-bearing this run.
+- **Discovered by hand:** the "distinctive vs generic token" curation discipline lived only in
+  `btd6_grounding_service._name_index` / `projmoon_grounding_service._name_index` comments +
+  `utils/*/keywords.py` docstrings — now has a durable home in the ai folio.
+
+## 📤 Run report
+
+- **Did:** built the cross-domain AI-routing disjointness guard — a registry-driven harness pinning
+  the previously-untested router invariant that BTD6 and Limbus detectors never collide · **Outcome:** shipped
+- **Shipped:** #1470 — `tests/unit/runtime/ai/test_domain_routing_disjoint.py` (12 tests: routing ·
+  token disjointness across every domain pair · priority total-order) + an ai-folio detector-curation
+  recipe; de-risks Slice B without touching the gated BTD6 hot path
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (offline test + docs; a merge auto-deploys, though nothing runtime
+  changed). The live Q-0086 Limbus runtime walk remains an owner step carried from PR #1467 — not new here.
+- **⚑ Self-initiated:** the over-route guard — chosen on an *empty* dispatch fire. Executes an
+  already-owner-approved program (Q-0192) + a session-idea flagged by the last two runs, not a fresh
+  idea→plan promotion; flagged here since no work order named it.
+- **↪ Next:** S1 Project Moon — the live **Q-0086 runtime walk** (owner) + Slice A item 1 (the
+  StaticData exact-number ingest, the deferred fragile lane) → then **Slice B** = extract the shared
+  `KnowledgeDomain` seam from BTD6 + Limbus (fold the two `_name_index` builders into one
+  `build_domain_name_index`; consider driving the router's domain dispatch off a runtime registry the
+  new harness asserts against — see this run's session idea).

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -134,7 +134,12 @@
   `PROJMOON_ANSWER` reply against the injected facts (the projmoon analogue of `validate_btd6_reply`,
   reusing `utils.btd6.name_guard` + the shared `GroundingResult`) — indexes the distinctive Sinner /
   E.G.O names, skips the common-English categories, reject → regenerate-once → deterministic Limbus
-  refusal; offline-unit-tested. ▶ **Next:** the live **Q-0086 runtime walk** (owner — confirm a real
+  refusal; offline-unit-tested. **Slice B *prep* — cross-domain over-route guard SHIPPED 2026-06-26**
+  (dispatch run, PR #1470): a registry-driven harness
+  (`tests/unit/runtime/ai/test_domain_routing_disjoint.py`) pins the previously-untested router invariant
+  *"BTD6 keywords never collide with the distinctive Limbus tokens"* (routing · token disjointness across
+  every domain pair · priority total-order) + a detector-curation recipe in the ai folio, so the next
+  domain (LoR / LobCorp) is a one-line registration. ▶ **Next:** the live **Q-0086 runtime walk** (owner — confirm a real
   Limbus Q&A grounds well on both providers) + Slice A item 1 (StaticData exact-number ingest); then
   **Slice B** = extract the shared `KnowledgeDomain` seam from BTD6 + Limbus
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).

--- a/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
+++ b/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
@@ -117,6 +117,20 @@ argument: generalising from a single example tends to produce the wrong abstract
 > (a) the live **Q-0086 runtime walk** (owner); (c) Slice A item 1 — the StaticData exact-number ingest;
 > then **Slice B** — extract the shared `KnowledgeDomain` seam from BTD6 + Limbus.
 
+> **▶ Progress (2026-06-26 dispatch run, PR #1470): Slice B *prep* — the CROSS-DOMAIN OVER-ROUTE GUARD —
+> SHIPPED.** The over-route harness flagged by PR #1453 / #1469's session ideas. `ai_task_router.classify`
+> checks BTD6 then Limbus on the bare comment *"BTD6 keywords never collide with the distinctive Limbus
+> tokens"* — asserted, never tested, and the two detectors don't even share match semantics
+> (`has_btd6_context` is a substring scan; `has_limbus_context` is word-boundary). New
+> **`tests/unit/runtime/ai/test_domain_routing_disjoint.py`** is a registry-driven guard pinning three
+> properties (routing · token disjointness across every ordered domain pair · priority total-order) so the
+> next reference domain (LoR / LobCorp) is a one-line `DOMAINS` registration, not a re-derivation from
+> source. Paired with a durable **detector-curation recipe** in the [ai folio](../subsystems/ai.md)
+> § "Adding a knowledge domain" (the "distinctive vs generic token" + cross-domain disjointness discipline
+> that was re-derived from source twice). Offline, **no runtime behaviour change** — de-risks Slice B's
+> seam extraction without touching the gated BTD6 hot path. **▶ Next unchanged:** (a) the live
+> **Q-0086 runtime walk** (owner); (c) Slice A item 1 — StaticData numbers; then **Slice B** proper.
+
 **Slice A (next session, 2–3 PRs):**
 1. **Ingestion:** a `scripts/fetch_pm_limbus.py` that parses the **StaticData identity JSON** (clean,
    bounded — Identities + Sinners + E.G.O index) into committed JSON under

--- a/docs/subsystems/ai.md
+++ b/docs/subsystems/ai.md
@@ -35,6 +35,34 @@ scoped tools (including owner-gated diagnostics). Source:
   refactor the orchestration choke point). See `docs/ai/ai-guard-coverage-map.md` and
   `docs/btd6/btd6-derived-value-groundedness-finding.md`.
 
+### Adding a knowledge domain — detector curation recipe
+
+A knowledge domain (BTD6, Project Moon/Limbus, future LoR/LobCorp) routes through a
+curated `has_<domain>_context(text)` detector (`utils/<domain>/keywords.py`) that
+`services.ai_task_router.classify` checks in a fixed **priority order** (BTD6 first,
+then Limbus). Two disciplines keep this multi-domain router correct — both were
+re-derived from source twice before being written down here:
+
+- **Distinctive vs generic tokens.** A detector / name-index keyword list must carry
+  only *distinctive* proper-noun tokens. Ordinary English words a domain happens to use
+  — bloon colours (`red`/`blue`), the Limbus Sins (`pride`/`wrath`), damage types
+  (`slash`), statuses (`burn`) — are **excluded** as bare single tokens; they enter the
+  faithfulness name-index (`btd6_grounding_service._name_index` /
+  `projmoon_grounding_service._name_index`) only as **multi-word phrases** or via the
+  resolver. Routing or flooring on a generic word over-triggers on normal chat.
+- **Cross-domain disjointness.** The router relies on each domain's distinctive tokens
+  being **inert to every other domain's detector** — in both directions and across the
+  match-semantics gap (`has_btd6_context` is a substring scan; `has_limbus_context` is a
+  word-boundary regex). When two domains could both claim a phrase, the **earlier domain
+  in the priority order wins** (the documented tie-break).
+
+**Guard:** `tests/unit/runtime/ai/test_domain_routing_disjoint.py` is the registry-driven
+harness that pins all three properties (routing · token disjointness · priority order).
+**Adding a domain is a one-line `DOMAINS` registration there** (detector, expected task,
+distinctive tokens, sample questions) — do not re-derive the discipline; register and let
+the guard cover it. (Slice B of the Project Moon program folds the per-domain name-index
+builders into one shared `KnowledgeDomain` helper — until then this recipe is the contract.)
+
 ## Current state
 
 - **Production-readiness map (verified 2026-06-12):**

--- a/tests/unit/runtime/ai/test_domain_routing_disjoint.py
+++ b/tests/unit/runtime/ai/test_domain_routing_disjoint.py
@@ -1,0 +1,194 @@
+"""Cross-domain AI-routing disjointness guard (the over-route harness).
+
+`services.ai_task_router.classify` checks knowledge domains in a fixed priority
+order — BTD6 first, then Project Moon (Limbus) — on the bare premise, stated only
+in a code comment, that *"BTD6 keywords never collide with the distinctive Limbus
+tokens"*. That premise was **asserted but never tested**, and the two detectors do
+not even share match semantics: :func:`utils.btd6.keywords.has_btd6_context` is a
+**substring** scan, while :func:`utils.projmoon.keywords.has_limbus_context` is a
+**word-boundary** regex. A future keyword-set edit could therefore silently make a
+Limbus question route to BTD6 (starving the projmoon grounding path) or a BTD6
+phrase trip the Limbus detector — with no test to catch it.
+
+This module is the **registry-driven over-route harness** flagged by two consecutive
+Project Moon dispatch runs' session ideas (PR #1453 / PR #1469 logs). It pins three
+properties of the multi-domain router so the next reference domain (Library of Ruina,
+Lobotomy Corporation, …) is a one-line :data:`DOMAINS` registration, not a
+re-derivation from source:
+
+1. **Routing** — each domain's clean, single-domain sample questions route to exactly
+   that domain's :class:`AITask`.
+2. **Detector disjointness (the root guard)** — no domain's distinctive tokens trip
+   any *other* domain's context detector, in **both** directions and across **all**
+   domain pairs. This is the structural form of the router's comment.
+3. **Priority is a total order** — when more than one domain could claim a phrase, the
+   earlier domain in the documented priority order wins (BTD6 over Limbus), so adding a
+   domain can never silently reorder an existing route.
+
+Adding a domain: append a :class:`DomainRoute` to :data:`DOMAINS` (detector, the task a
+clean question routes to, the bare distinctive tokens the detector keys on, and a few
+single-domain sample questions). All three guards then cover it automatically.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from core.runtime.ai.contracts import AITask  # noqa: E402
+from services import ai_task_router  # noqa: E402
+from utils.btd6.keywords import BTD6_CONTEXT_KEYWORDS, has_btd6_context  # noqa: E402
+from utils.projmoon.keywords import (  # noqa: E402
+    LIMBUS_CONTEXT_KEYWORDS,
+    has_limbus_context,
+)
+
+
+@dataclass(frozen=True)
+class DomainRoute:
+    """One knowledge domain's routing contract, as the harness sees it.
+
+    ``name`` — display name (test ids).
+    ``detector`` — the curated ``has_<domain>_context`` predicate.
+    ``expected_task`` — the task a clean single-domain question routes to.
+    ``distinctive_tokens`` — the bare tokens the detector keys on (its keyword list);
+      every one must be inert to every *other* domain's detector.
+    ``sample_questions`` — clean, single-domain phrasings (no foreign-domain token).
+    """
+
+    name: str
+    detector: Callable[[str], bool]
+    expected_task: AITask
+    distinctive_tokens: tuple[str, ...]
+    sample_questions: tuple[str, ...]
+
+
+# Priority order MATTERS: it mirrors the order `ai_task_router.classify` checks the
+# domains (BTD6 first, then Limbus). The priority test below relies on this order.
+DOMAINS: tuple[DomainRoute, ...] = (
+    DomainRoute(
+        name="btd6",
+        detector=has_btd6_context,
+        expected_task=AITask.BTD6_ANSWER,
+        distinctive_tokens=BTD6_CONTEXT_KEYWORDS,
+        sample_questions=(
+            "how much does a dart monkey cost",
+            "what is the best hero in btd6",
+            "explain the moab class bloons",
+            "how much cash do i get on round 40",
+            "is obyn good for chimps",
+            "what does a banana farm earn",
+        ),
+    ),
+    DomainRoute(
+        name="limbus",
+        detector=has_limbus_context,
+        expected_task=AITask.PROJMOON_ANSWER,
+        distinctive_tokens=LIMBUS_CONTEXT_KEYWORDS,
+        sample_questions=(
+            "tell me about Limbus Company",
+            "who is Heathcliff",
+            "what does the ZAYIN grade mean",
+            "list every sinner",
+            "explain E.G.O grades",
+            "what is a mirror dungeon",
+        ),
+    ),
+)
+
+# Ordinary chatter that must stay general — claimed by no domain detector.
+_NEUTRAL_CHATTER: tuple[str, ...] = (
+    "what time is the event tonight",
+    "can you help me set up the server",
+    "i sang a song at karaoke yesterday",
+    "pride comes before a fall",
+    "he is the new moderator here",
+    "what's the weather like",
+)
+
+
+def _domain_id(domain: DomainRoute) -> str:
+    return domain.name
+
+
+@pytest.mark.parametrize("domain", DOMAINS, ids=_domain_id)
+def test_sample_questions_route_to_their_domain(domain: DomainRoute) -> None:
+    """Every clean single-domain question routes to that domain's task."""
+    for question in domain.sample_questions:
+        routed = ai_task_router.classify(question)
+        assert routed.task is domain.expected_task, (
+            f"{domain.name!r} sample {question!r} routed to "
+            f"{routed.task.value!r}, expected {domain.expected_task.value!r}"
+        )
+
+
+@pytest.mark.parametrize("domain", DOMAINS, ids=_domain_id)
+def test_sample_questions_are_claimed_only_by_their_own_detector(
+    domain: DomainRoute,
+) -> None:
+    """A clean single-domain phrasing trips at most its own context detector.
+
+    The literal "at most one domain claims each phrase" property — a sample that
+    other detectors also claim is an over-route waiting to happen.
+    """
+    for question in domain.sample_questions:
+        claimants = [d.name for d in DOMAINS if d.detector(question)]
+        assert claimants in ([domain.name], []), (
+            f"{domain.name!r} sample {question!r} is claimed by {claimants} — "
+            "a clean single-domain phrasing must trip at most its own detector"
+        )
+
+
+def test_distinctive_tokens_do_not_trip_another_domains_detector() -> None:
+    """The root guard: each domain's tokens are inert to every other detector.
+
+    This is the structural form of the router's comment ("BTD6 keywords never
+    collide with the distinctive Limbus tokens"), generalised to every ordered
+    domain pair and both match semantics (BTD6 substring vs Limbus word-boundary).
+    A future keyword-set edit that introduces a collision fails here.
+    """
+    collisions: list[str] = []
+    for source in DOMAINS:
+        for other in DOMAINS:
+            if other is source:
+                continue
+            for token in source.distinctive_tokens:
+                if other.detector(token):
+                    collisions.append(
+                        f"{source.name} token {token!r} trips the {other.name} detector"
+                    )
+    assert not collisions, "cross-domain detector collisions:\n  " + "\n  ".join(
+        collisions
+    )
+
+
+@pytest.mark.parametrize("text", _NEUTRAL_CHATTER)
+def test_neutral_chatter_is_claimed_by_no_domain(text: str) -> None:
+    """Ordinary chatter trips no domain detector and routes general."""
+    claimants = [d.name for d in DOMAINS if d.detector(text)]
+    assert not claimants, f"neutral {text!r} wrongly claimed by {claimants}"
+    routed = ai_task_router.classify(text)
+    assert routed.task is AITask.GENERAL_NL_ANSWER
+
+
+def test_priority_is_a_total_order_earlier_domain_wins() -> None:
+    """When a phrase carries tokens from two domains, the earlier domain wins.
+
+    Pins the documented tie-break (BTD6 is checked before Limbus) so adding a
+    domain can never silently reorder an existing route. The phrase names a BTD6
+    entity AND a Limbus token; it must route BTD6 by priority, not projmoon.
+    """
+    routed = ai_task_router.classify("compare the dart monkey to a limbus sinner")
+    assert routed.task is AITask.BTD6_ANSWER
+    # Both detectors genuinely fire on this phrase — i.e. the test exercises the
+    # tie-break, not a case where only one detector matched.
+    assert has_btd6_context("compare the dart monkey to a limbus sinner")
+    assert has_limbus_context("compare the dart monkey to a limbus sinner")


### PR DESCRIPTION
## What & why

`ai_task_router.classify` checks BTD6 first, then Limbus (Project Moon), on the bare
comment *"BTD6 keywords never collide with the distinctive Limbus tokens"* — an
**invariant that is asserted but never tested**. The two detectors even use different
match semantics (`has_btd6_context` = substring scan; `has_limbus_context` =
word-boundary regex), so a future keyword-set edit could silently make a Limbus question
route to BTD6 (starving the projmoon grounding path) or a BTD6 phrase trip the Limbus
detector. As the knowledge-domain program adds LoR / LobCorp, this collision class only
grows.

This PR is the **cross-domain over-route harness** both recent dispatch runs' session
ideas flagged ([PR #1453 log], [PR #1469 log]) — a registry-driven guard with teeth so
the next domain is a one-line registration, not a re-derivation from source.

## Scope (offline, default-preserving — no runtime behaviour change)

- A registry-driven disjointness harness: per-domain representative corpora route to
  exactly that domain's `AITask`, plus a structural token-disjointness check between the
  substring-keyword domain (BTD6) and the word-boundary domains (Limbus).
- A durable **domain-detector curation recipe** in the ai folio so the "distinctive vs
  generic token" discipline + this routing invariant has one home instead of two code
  comments.

Part of the Project Moon knowledge-domain program (Q-0192); de-risks Slice B without
touching the gated BTD6 hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XU1wZesQPzotgpNDv5HdXY)_