### PR TITLE
S3 mechanism: guard sector ▶ Next freshness + fix S3 stale pointer

### DIFF
--- a/.sessions/2026-06-26-sector-next-freshness-guard.md
+++ b/.sessions/2026-06-26-sector-next-freshness-guard.md
@@ -1,21 +1,78 @@
 # 2026-06-26 — Sector ▶ Next freshness guard (S3 mechanism)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Run type:** routine · dispatch
-> **Branch:** `claude/funny-franklin-867vhz`
+> **Branch:** `claude/funny-franklin-867vhz` · **PR:** #1476
 
-## What I'm about to do
-Autonomous dispatch fire (no work order). S2's offline anchor tail is exhausted (needs prod
-creds); the cleanest offline, self-mergeable slice is S3 self-improving-engine mechanism work.
+## What I did
+Autonomous dispatch fire (no work order). S2's offline anchor tail is exhausted (remaining
+BTD6 correctness needs prod creds); the cleanest offline, self-mergeable slice was S3
+self-improving-engine mechanism work.
 
-While orienting I hit a real drift class: `docs/current-state/S3-ai-memory.md` ▶ Next lists
-"Consistency-linter AI-nav PR 1" linking a plan that is already **SHIPPED / `historical`**
-(#1376). A ▶ Next that points at finished work misdirects the next dispatch run to rebuild it.
+While orienting I hit a real drift class: `docs/current-state/S3-ai-memory.md` ▶ Next listed
+**"Consistency-linter AI-nav PR 1"** linking `ai-panel-inplace-navigation-plan-2026-06-19.md`,
+a plan already **`historical` / SHIPPED** (#1376). A `▶ Next` that points at finished work
+steers the *next* dispatch run into rebuilding shipped work — the exact mis-step this run
+nearly made before I cross-checked the plan's status.
 
-Slice (S3):
-1. `scripts/check_sector_next_freshness.py` — read-only stdlib guard that flags any
-   `▶ Next` item in `docs/current-state/S*.md` linking a `historical`-status plan.
-2. Fix the live S3 stale pointer (Q-0166 fix-on-sight).
-3. Tests under `tests/unit/scripts/`.
+Shipped:
+1. **`scripts/check_sector_next_freshness.py`** — read-only stdlib guard (Q-0105 disposable
+   header). Scans each `docs/current-state/S*.md`, isolates the `▶ Next` section(s), extracts
+   `../planning/*.md` links, and flags any whose plan `Status:` is `historical`. Scoped to the
+   ▶ Next section only, so Recently-shipped / pass-record `historical` links don't false-positive.
+   Not CI-wired (ask-first per the autonomy boundary) — run by hand / from the recon routine.
+2. **Fixed the live S3 instance** (Q-0166 fix-on-sight): dropped the stale shipped pointer from
+   S3 ▶ Next; preserved the shipped provenance as a Recently-shipped line (the `edit_in_place`
+   rule graduated warn→error, #1375).
+3. **`tests/unit/scripts/test_check_sector_next_freshness.py`** — 7 tests: live ground-truth
+   (`run() == []` after the fix), section-scope isolation, link extraction, historical-flagging,
+   buildable-not-flagged, missing-plan-not-flagged.
 
-CI mirror + arch strict must be green before flipping this card to `complete`.
+## Verification
+- `python3.10 scripts/check_sector_next_freshness.py` → OK (5 sector files clean after the fix).
+- `python3.10 scripts/check_quality.py --check-only` → all checks passed (check_docs +
+  check_consistency green).
+- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors (only pre-existing
+  `views/` WARNs, none from this change — it touches scripts/docs/tests only).
+- `python3.10 -m pytest tests/unit/scripts tests/unit/docs -q` → **1078 passed**.
+- Doc audit: `check_current_state_ledger --strict` (3 dashboard-refresh PRs newer than marker
+  #1472 = benign lag, recorded by the next recon at #1500); `check_docs --strict` clean.
+
+## Handoff — next dispatch
+- This slice is complete and self-contained. No remaining sub-steps.
+- **S2** offline BTD6 anchor tail is exhausted — the next BTD6 correctness step (live `llm_judge`
+  battery + absence-guard Layer B) is **creds-gated / owner-paced**, not an autonomous slice.
+- **S3** next offline-buildable: the **bot self-test walker** eval harness, or the **Hermes
+  bug-triage write**. (`procedures→skills Batch 2` touches CLAUDE.md restructuring — I left it
+  for a session with the owner live, given CLAUDE.md is read-only to an autonomous run, Q-0106.)
+- **S1** offline-buildable: H3 card-engine incremental adoption (next card-bearing hubs set
+  `help_nav_card` in their hook) — but several S1 ▶ Next items are blocked on running-bot
+  verification; pick the offline ones.
+- Remark for a later review: **CodeGraph up** (52525 nodes, build clean); Grimp not exercised
+  this run. No arch warning I could retire (all pre-existing `views/` lifecycle WARNs).
+
+## 💡 Session idea (Q-0089)
+Pair this freshness guard with the existing `scripts/dispatch_menu.py`: when the resolver
+surfaces a sector's first ▶ startable item, it could call `check_sector_next_freshness`'s
+`plan_status()` to **suppress** any item linking a `historical` plan from the dispatch pick —
+turning the guard from a *detector* into an *active filter* so a stale ▶ Next can never be
+dispatched even before a human re-points it. (Captured here; small, on the dispatch seam.)
+
+## ⟲ Previous-session review (Q-0102)
+The prior runs (projmoon grounding + faithfulness guard, #1467/#1469/#1470) were strong —
+they shipped the cross-domain over-route guard *and* a one-line-registration recipe for the
+next domain, which is exactly the "leave the next session better-equipped" bar. What they
+**missed**: each shipped its arc but none re-checked the *sector ▶ Next pointers* for staleness
+on the way out — the S3 stale pointer this run found had been live since #1376 (2026-06-23),
+three days unguarded. **System improvement surfaced:** the per-sector ▶ Next layer had no
+freshness guard at all (the recon routine only reconciles every 30 PRs) — this run's
+`check_sector_next_freshness.py` closes that gap; consider running it from `/session-close`.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PR:** #1476
+- **⚑ Self-initiated:** `check_sector_next_freshness.py` — an S3 mechanism guard I originated
+  (no dispatch/owner ask) after spotting the S3 stale-pointer drift; idea→build is open
+  (Q-0172), flagged here for owner review/revert.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none

--- a/.sessions/2026-06-26-sector-next-freshness-guard.md
+++ b/.sessions/2026-06-26-sector-next-freshness-guard.md
@@ -52,11 +52,17 @@ Shipped:
   this run. No arch warning I could retire (all pre-existing `views/` lifecycle WARNs).
 
 ## 💡 Session idea (Q-0089)
-Pair this freshness guard with the existing `scripts/dispatch_menu.py`: when the resolver
-surfaces a sector's first ▶ startable item, it could call `check_sector_next_freshness`'s
-`plan_status()` to **suppress** any item linking a `historical` plan from the dispatch pick —
-turning the guard from a *detector* into an *active filter* so a stale ▶ Next can never be
-dispatched even before a human re-points it. (Captured here; small, on the dispatch seam.)
+Turn the freshness guard from a *detector* into an *active filter* on the dispatch seam — but
+note the real shape (verified this run, so the next session isn't misled): `dispatch_menu.py`
+resolves from **`roadmap.md` § By sector**, whose Now/Next bullets are short labels with **no
+plan links**, while this guard scans the **`current-state/S*.md` ▶ Next** links. They're
+different sources. So the clean version is *either* (a) wire the guard into `/session-close`
+so every session re-checks ▶ Next freshness on the way out (cheap, high-leverage — closes the
+"3 days unguarded" gap), *or* (b) have the roadmap Now/Next bullets carry the same plan link
+their current-state twin does, then a shared `plan_status()` can suppress a shipped lane from
+the dispatch pick. (a) is the smaller, surer win; (b) needs a roadmap-convention change first.
+A direct cross-script import is ruled out — `dispatch_menu.py`'s header pins the single-file
+standalone convention (factor a shared module only when a third consumer appears).
 
 ## ⟲ Previous-session review (Q-0102)
 The prior runs (projmoon grounding + faithfulness guard, #1467/#1469/#1470) were strong —

--- a/.sessions/2026-06-26-sector-next-freshness-guard.md
+++ b/.sessions/2026-06-26-sector-next-freshness-guard.md
@@ -1,0 +1,21 @@
+# 2026-06-26 — Sector ▶ Next freshness guard (S3 mechanism)
+
+> **Status:** `in-progress`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/funny-franklin-867vhz`
+
+## What I'm about to do
+Autonomous dispatch fire (no work order). S2's offline anchor tail is exhausted (needs prod
+creds); the cleanest offline, self-mergeable slice is S3 self-improving-engine mechanism work.
+
+While orienting I hit a real drift class: `docs/current-state/S3-ai-memory.md` ▶ Next lists
+"Consistency-linter AI-nav PR 1" linking a plan that is already **SHIPPED / `historical`**
+(#1376). A ▶ Next that points at finished work misdirects the next dispatch run to rebuild it.
+
+Slice (S3):
+1. `scripts/check_sector_next_freshness.py` — read-only stdlib guard that flags any
+   `▶ Next` item in `docs/current-state/S*.md` linking a `historical`-status plan.
+2. Fix the live S3 stale pointer (Q-0166 fix-on-sight).
+3. Tests under `tests/unit/scripts/`.
+
+CI mirror + arch strict must be green before flipping this card to `complete`.

--- a/docs/current-state/S3-ai-memory.md
+++ b/docs/current-state/S3-ai-memory.md
@@ -21,11 +21,11 @@
   one-file-per-claim (`scripts/check_lane_overlap.py` reads the directory; `check_stale_claims.py`
   GC) + `current-state.md` → per-sector files. Justified by `tools/sim/claim_layout_sim.py`.
 - **Lane-overlap claim-scan** (#1223) and the **repo-consistency-linter** (back-button /
-  edit-in-place rules, #1189) mechanisms.
+  edit-in-place rules, #1189) mechanisms; the linter's **`edit_in_place` rule graduated
+  warn→error** (#1375) once the `views/ai/` in-place-nav migration cleared its last findings
+  ([plan, now historical](../planning/ai-panel-inplace-navigation-plan-2026-06-19.md)).
 
 **▶ Next startable:**
-- **Consistency-linter AI-nav PR 1**
-  ([plan](../planning/ai-panel-inplace-navigation-plan-2026-06-19.md)).
 - **procedures→skills Batch 2**
   ([plan](../planning/procedures-to-skills-conversion-plan-2026-06-17.md)).
 - The **bot self-test walker** eval harness (pairs with S1 P1-1) · the **Hermes bug-triage** write.

--- a/docs/owner/claims/claude-funny-franklin-867vhz.md
+++ b/docs/owner/claims/claude-funny-franklin-867vhz.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-867vhz` · scope: S3 mechanism — sector ▶ Next freshness guard + fix S3 stale pointer · area: scripts/, docs/current-state/, tests/unit/scripts/ · 2026-06-26

--- a/docs/owner/claims/claude-funny-franklin-867vhz.md
+++ b/docs/owner/claims/claude-funny-franklin-867vhz.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-867vhz` · scope: S3 mechanism — sector ▶ Next freshness guard + fix S3 stale pointer · area: scripts/, docs/current-state/, tests/unit/scripts/ · 2026-06-26

--- a/scripts/check_sector_next_freshness.py
+++ b/scripts/check_sector_next_freshness.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3.10
+"""Flag per-sector ``▶ Next`` items that point at already-shipped plans.
+
+Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch):
+- Why: ``docs/current-state/S*.md`` are the *freshness* layer — the dispatch routine
+  reads a sector's ``▶ Next startable`` to pick the next slice. When a ``▶ Next`` item
+  links a plan that has already shipped (its ``Status:`` is ``historical``), the routine
+  is steered to rebuild finished work. This is exactly the mis-step the 2026-06-26
+  dispatch run nearly made: S3's ▶ Next listed "Consistency-linter AI-nav PR 1" linking
+  ``ai-panel-inplace-navigation-plan-2026-06-19.md``, which had been SHIPPED in #1376.
+  The reconciliation routine reconciles ``current-state.md`` every 30 PRs, but the
+  *per-sector* ▶ Next pointers had no machine guard against this drift class.
+- Added: 2026-06-26 (autonomous dispatch run, S3 mechanism). **Unverified** — confirm its
+  output against ground truth over a few sessions before trusting it. **Delete this script
+  if it proves noisy/unreliable over multiple sessions**; it is a disposable convenience
+  guard, not load-bearing. It is intentionally NOT wired into CI (ask-first per the
+  autonomy boundary) — run it by hand or from the docs-reconciliation routine.
+
+What it checks (read-only; exits 1 on any finding, 0 when clean):
+- For each ``docs/current-state/S*.md`` sector file, isolate the ``▶ Next`` section(s)
+  (a bold heading line beginning ``**▶ Next`` up to the next sibling ``**...**`` heading).
+- Extract every ``../planning/<file>.md`` link inside that section.
+- Read the linked plan's ``Status:`` marker; flag any whose status is ``historical``
+  (the convention's "initiative complete / shipped" state) — a ▶ Next must point at
+  *buildable* work, never a finished plan.
+
+The scoping to the ▶ Next section is deliberate: a sector's *Recently shipped* list and a
+docs sector's pass-record links are legitimately ``historical`` and must not false-positive.
+
+Usage::
+
+    python3.10 scripts/check_sector_next_freshness.py            # report + exit code
+    python3.10 scripts/check_sector_next_freshness.py --quiet     # exit code only
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SECTOR_DIR = REPO_ROOT / "docs" / "current-state"
+PLANNING_DIR = REPO_ROOT / "docs" / "planning"
+
+# Statuses that mean "this plan is done — do not dispatch against it as new work".
+SHIPPED_STATUSES = frozenset({"historical"})
+
+# A bold section heading line (``**Label...**``) — NOT a ``- **bullet:**`` list item,
+# which starts with ``- ``. Used to find the ▶ Next section and its end boundary.
+_SECTION_HEADING = re.compile(r"^\*\*(.+?)\*\*")
+_NEXT_HEADING = re.compile(r"^\*\*▶\s*Next")
+# A relative link to a planning doc, from a current-state/ file (``../planning/<file>``).
+_PLAN_LINK = re.compile(r"\]\(\.\./planning/([A-Za-z0-9._-]+\.md)")
+# The plan's status marker, e.g. ``> **Status:** `historical` — ...``.
+_STATUS = re.compile(r"Status:\*\*\s*`([a-z-]+)`")
+
+
+def _read(path: Path) -> str:
+    """Return the file text, or an empty string if it does not exist."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def next_sections(text: str) -> list[str]:
+    """Return the text of every ``▶ Next`` section in a sector file.
+
+    A section starts at a line matching ``**▶ Next...**`` and ends at the next
+    sibling bold heading (another ``**...**`` line that is not a ``- **`` bullet),
+    a ``## `` heading, or end-of-file.
+    """
+    lines = text.splitlines()
+    sections: list[str] = []
+    buf: list[str] | None = None
+    for line in lines:
+        if _NEXT_HEADING.match(line):
+            if buf is not None:
+                sections.append("\n".join(buf))
+            buf = [line]
+            continue
+        if buf is not None:
+            # End the section at the next sibling heading.
+            if line.startswith("## ") or (
+                _SECTION_HEADING.match(line) and not _NEXT_HEADING.match(line)
+            ):
+                sections.append("\n".join(buf))
+                buf = None
+                continue
+            buf.append(line)
+    if buf is not None:
+        sections.append("\n".join(buf))
+    return sections
+
+
+def plan_status(plan_file: str) -> str | None:
+    """Return the lowercase status of a planning doc, or ``None`` if unreadable."""
+    text = _read(PLANNING_DIR / plan_file)
+    if not text:
+        return None
+    m = _STATUS.search(text)
+    return m.group(1) if m else None
+
+
+def check_sector_file(path: Path) -> list[str]:
+    """Return the list of stale-pointer findings for one sector file."""
+    findings: list[str] = []
+    text = _read(path)
+    if not text:
+        return findings
+    seen: set[str] = set()
+    for section in next_sections(text):
+        for plan_file in _PLAN_LINK.findall(section):
+            if plan_file in seen:
+                continue
+            seen.add(plan_file)
+            status = plan_status(plan_file)
+            if status in SHIPPED_STATUSES:
+                findings.append(
+                    f"{path.name}: ▶ Next links '{plan_file}' whose plan Status is "
+                    f"`{status}` (shipped/complete) — re-point ▶ Next at buildable work "
+                    f"(Q-0166 fix-on-sight).",
+                )
+    return findings
+
+
+def run() -> list[str]:
+    """Run the check over every sector file and return the combined findings."""
+    if not SECTOR_DIR.is_dir():
+        return [f"cannot read sector dir {SECTOR_DIR}"]
+    findings: list[str] = []
+    for path in sorted(SECTOR_DIR.glob("S*.md")):
+        findings += check_sector_file(path)
+    return findings
+
+
+def main() -> int:
+    """CLI entry point: print findings and return an exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress output; return exit code only",
+    )
+    args = parser.parse_args()
+
+    findings = run()
+    if findings:
+        if not args.quiet:
+            print("check_sector_next_freshness: FAIL — ▶ Next points at shipped work:")
+            for f in findings:
+                print(f"  - {f}")
+        return 1
+    if not args.quiet:
+        n = len(sorted(SECTOR_DIR.glob("S*.md")))
+        print(
+            f"check_sector_next_freshness: OK — {n} sector files, "
+            f"no ▶ Next item points at a shipped (`historical`) plan ✓",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_sector_next_freshness.py
+++ b/tests/unit/scripts/test_check_sector_next_freshness.py
@@ -1,0 +1,106 @@
+"""check_sector_next_freshness flags ▶ Next pointers at shipped (historical) plans."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).parents[3]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "check_sector_next_freshness",
+        _REPO / "scripts" / "check_sector_next_freshness.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+csf = _load()
+
+
+# --------------------------------------------------------------------------- live
+def test_live_sectors_have_no_shipped_next_pointer():
+    """Ground truth (Q-0105): the real sector files pass after the S3 fix."""
+    assert csf.run() == []
+
+
+def test_main_exits_zero_and_reports_ok(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["check_sector_next_freshness.py"])
+    assert csf.main() == 0
+    assert "OK" in capsys.readouterr().out
+
+
+# ------------------------------------------------------------------- section scope
+_SECTOR = """\
+# S9 — fixture
+
+**Recently shipped (this sector):**
+- A thing ([plan](../planning/done-plan.md)).
+
+**▶ Next startable:**
+- Build the live thing ([plan](../planning/live-plan.md)).
+
+**Note:**
+- trailing ([plan](../planning/note-plan.md)).
+"""
+
+
+def test_next_sections_isolates_only_the_next_block():
+    sections = csf.next_sections(_SECTOR)
+    assert len(sections) == 1
+    body = sections[0]
+    assert "live-plan.md" in body
+    # Recently-shipped and the trailing Note must be outside the ▶ Next section.
+    assert "done-plan.md" not in body
+    assert "note-plan.md" not in body
+
+
+def test_plan_link_extraction():
+    assert csf._PLAN_LINK.findall("see ](../planning/foo-bar_2026.md) end") == [
+        "foo-bar_2026.md",
+    ]
+
+
+# ----------------------------------------------------------------- finding logic
+def _write_fixture(tmp_path, monkeypatch, sector_body: str, plans: dict[str, str]):
+    sector_dir = tmp_path / "current-state"
+    planning_dir = tmp_path / "planning"
+    sector_dir.mkdir()
+    planning_dir.mkdir()
+    (sector_dir / "S9-fix.md").write_text(sector_body, encoding="utf-8")
+    for name, status in plans.items():
+        (planning_dir / name).write_text(
+            f"# Plan\n\n> **Status:** `{status}` — fixture.\n", encoding="utf-8"
+        )
+    monkeypatch.setattr(csf, "SECTOR_DIR", sector_dir)
+    monkeypatch.setattr(csf, "PLANNING_DIR", planning_dir)
+
+
+def test_flags_next_pointer_to_historical_plan(tmp_path, monkeypatch):
+    _write_fixture(
+        tmp_path,
+        monkeypatch,
+        _SECTOR,
+        {"live-plan.md": "historical", "done-plan.md": "historical"},
+    )
+    findings = csf.run()
+    assert len(findings) == 1
+    assert "live-plan.md" in findings[0]
+    # The Recently-shipped historical link is NOT flagged (scope correctness).
+    assert all("done-plan.md" not in f for f in findings)
+
+
+def test_does_not_flag_buildable_plan(tmp_path, monkeypatch):
+    _write_fixture(tmp_path, monkeypatch, _SECTOR, {"live-plan.md": "plan"})
+    assert csf.run() == []
+
+
+def test_missing_plan_file_is_not_flagged(tmp_path, monkeypatch):
+    """An unreadable/absent plan yields status None — no false positive."""
+    _write_fixture(tmp_path, monkeypatch, _SECTOR, {})
+    assert csf.run() == []


### PR DESCRIPTION
## What (autonomous dispatch run — S3 self-improving-engine mechanism)

No work order this fire; S2's offline anchor tail is exhausted (remaining BTD6 correctness needs prod creds). While orienting I hit a real drift class: `docs/current-state/S3-ai-memory.md` ▶ Next listed **"Consistency-linter AI-nav PR 1"** linking a plan (`ai-panel-inplace-navigation-plan-2026-06-19.md`) that is already **`historical` / SHIPPED** (#1376). A `▶ Next` that points at finished work misdirects the *next* dispatch run into rebuilding shipped work — the exact mis-step this run nearly made.

## Changes
1. **`scripts/check_sector_next_freshness.py`** — read-only stdlib guard (Q-0105 disposable header). Flags any `▶ Next` item in `docs/current-state/S*.md` that links a `historical`-status plan. Scoped to the `▶ Next` section only, so Recently-shipped / pass-record links don't false-positive.
2. **Fix the live S3 instance** — drop the stale shipped pointer from S3's ▶ Next (Q-0166 fix-on-sight).
3. **Tests** under `tests/unit/scripts/`.

Born-red session card; flips to `complete` when CI mirror + arch-strict are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bjb6pXdk2p9vhFH8PvivB)_