### PR TITLE
S3: wire ▶ Next freshness guard into the /session-close gate

### DIFF
--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -102,6 +102,7 @@ python3.10 scripts/check_docs.py --strict
 python3.10 scripts/check_session_log.py --strict      # Q-0089 idea + Q-0102 review present
 python3.10 scripts/check_current_state_ledger.py --strict  # merged PRs are in the ledger
 python3.10 scripts/check_plan_code_drift.py            # Q-0181: a plan-badged doc whose code already shipped? rebadge -> historical
+python3.10 scripts/check_sector_next_freshness.py     # a per-sector ▶ Next pointing at a SHIPPED (historical) plan? re-point it (Q-0166)
 python3.10 scripts/check_reconciliation_due.py        # Q-0107: is a 30th-PR docs/planning pass due? (cadence 30, Q-0134)
 python3.10 scripts/check_quality.py --check-only
 ```
@@ -122,7 +123,10 @@ flags a merged PR, **verify its #number against live GitHub** then add it to
 `check_plan_code_drift` flags a **STRONG** candidate whose work your session shipped, **verify the
 deliverables exist (don't trust the heuristic blindly), then rebadge that plan `historical`** — badge
 + a SHIPPED banner + move its row in `planning/README.md` — per
-`docs/operations/ground-truth-audit-protocol.md`.
+`docs/operations/ground-truth-audit-protocol.md`. If `check_sector_next_freshness` flags a sector,
+its **`▶ Next` links a SHIPPED (`historical`) plan** — re-point that `▶ Next` item at buildable work
+(and preserve the shipped provenance in the sector's Recently-shipped) so the next dispatch run isn't
+steered into rebuilding finished work (Q-0166 fix-on-sight).
 
 **Documentation audit (Q-0104) — the judgment half.** The checks above are the automated
 half. Also ask yourself: *"is anything important from this session captured only in chat?"*

--- a/.sessions/2026-06-26-sessionclose-freshness-wiring.md
+++ b/.sessions/2026-06-26-sessionclose-freshness-wiring.md
@@ -1,0 +1,16 @@
+# 2026-06-26 — Wire ▶ Next freshness guard into /session-close
+
+> **Status:** `in-progress`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/franklin-sessionclose-freshness`
+
+## What I'm about to do
+Second slice of this dispatch run. PR #1476 shipped `check_sector_next_freshness.py`
+(a guard for ▶ Next pointers at SHIPPED plans) but **a guard nobody runs is useless** —
+it had no invocation site, so a stale pointer could still sit unguarded between the
+30-PR recon passes (the S3 pointer #1476 fixed had been live 3 days).
+
+This slice operationalizes it: add it to the `/session-close` Step-4 quality gate +
+a remediation note, so every session re-checks ▶ Next freshness on the way out. This is
+option (a) — the "smaller, surer win" — from #1476's session idea. Skill/orientation
+edit only (not CLAUDE.md / hooks / settings — those stay read-only to an autonomous run).

--- a/.sessions/2026-06-26-sessionclose-freshness-wiring.md
+++ b/.sessions/2026-06-26-sessionclose-freshness-wiring.md
@@ -1,16 +1,61 @@
 # 2026-06-26 — Wire ▶ Next freshness guard into /session-close
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Run type:** routine · dispatch
-> **Branch:** `claude/franklin-sessionclose-freshness`
+> **Branch:** `claude/franklin-sessionclose-freshness` · **PR:** #1477
 
-## What I'm about to do
-Second slice of this dispatch run. PR #1476 shipped `check_sector_next_freshness.py`
-(a guard for ▶ Next pointers at SHIPPED plans) but **a guard nobody runs is useless** —
-it had no invocation site, so a stale pointer could still sit unguarded between the
-30-PR recon passes (the S3 pointer #1476 fixed had been live 3 days).
+## What was done
+Second slice of this dispatch run, completing the first. PR #1476 (merged) shipped
+`scripts/check_sector_next_freshness.py` (flags a per-sector `▶ Next` linking a SHIPPED /
+`historical` plan) but gave it **no invocation site** — a guard nobody runs is useless. A
+stale pointer could still sit unguarded between the 30-PR reconciliation passes (the S3
+pointer #1476 fixed had been live 3 days before this run caught it by hand).
 
-This slice operationalizes it: add it to the `/session-close` Step-4 quality gate +
-a remediation note, so every session re-checks ▶ Next freshness on the way out. This is
-option (a) — the "smaller, surer win" — from #1476's session idea. Skill/orientation
-edit only (not CLAUDE.md / hooks / settings — those stay read-only to an autonomous run).
+- Added `check_sector_next_freshness.py` to the `/session-close` **Step-4 quality gate**
+  (`.claude/skills/session-close/SKILL.md`) + a one-line remediation note (re-point the
+  flagged `▶ Next` at buildable work, preserve the shipped provenance, Q-0166 fix-on-sight).
+- This is option (a) — the "smaller, surer win" — from #1476's session idea: every session
+  now re-checks `▶ Next` freshness on the way out, instead of relying on the 30-PR cadence.
+- Skill/orientation-only edit (not CLAUDE.md / hooks / settings — read-only to an autonomous
+  run, Q-0106).
+
+## Decisions recorded
+none.
+
+## Left open / next session
+- Nothing open for this slice.
+- The *other* half of #1476's idea (option (b): roadmap Now/Next bullets carry plan links so
+  `dispatch_menu.py` can suppress a shipped lane at the dispatch pick) needs a roadmap-
+  convention change first — left as a future idea, not started.
+
+## Verification
+- `python3.10 scripts/check_sector_next_freshness.py` → OK on live main (post-#1476 merge).
+- `python3.10 scripts/check_docs.py --strict` → all checks passed (skill file is reachable
+  docs; no structural break).
+
+## 💡 Session idea (Q-0089)
+The `/session-close` Step-4 gate is now a hand-maintained list of `check_*` invocations that
+has grown to ~7 entries — and it's drifted before (a checker exists but isn't wired into any
+gate, exactly the gap this slice closed). Idea: a tiny meta-check `check_session_close_gate.py`
+that greps `scripts/check_*.py` for the Q-0105 "run … from the docs-reconciliation routine /
+session close" provenance phrasing and asserts each such checker is actually referenced in
+`SKILL.md`'s Step-4 block — so a guard authored "to be run at close" can't silently lack an
+invocation site (the meta-version of the bug this slice fixed). Small, offline, on the same seam.
+
+## ⟲ Previous-session review (Q-0102)
+The previous slice (this run's own #1476) was solid — it found a real bug, fixed it at the
+root, and built the class-level guard with tests. What it **missed** (and I caught only because
+I kept going): it shipped the guard with **no caller**, which is the same failure mode as the
+drift it guards against — a thing that exists but nobody runs. The system improvement that
+surfaced and is now acted on: **a checker is not "done" until it has an invocation site** (a
+CI step, a hook, or a /session-close gate entry). The Q-0089 idea above proposes machine-
+enforcing exactly that, so the next "I built a guard" slice can't repeat the omission.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PR:** #1477
+- **⚑ Self-initiated:** wiring `check_sector_next_freshness` into `/session-close` — the
+  completing half of #1476's self-initiated guard; no dispatch/owner ask (Q-0172), flagged
+  for owner review/revert.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none

--- a/docs/owner/claims/claude-franklin-sessionclose-freshness.md
+++ b/docs/owner/claims/claude-franklin-sessionclose-freshness.md
@@ -1,1 +1,0 @@
-- branch `claude/franklin-sessionclose-freshness` · scope: wire check_sector_next_freshness into /session-close gate · area: .claude/skills/session-close/ · 2026-06-26

--- a/docs/owner/claims/claude-franklin-sessionclose-freshness.md
+++ b/docs/owner/claims/claude-franklin-sessionclose-freshness.md
@@ -1,0 +1,1 @@
+- branch `claude/franklin-sessionclose-freshness` · scope: wire check_sector_next_freshness into /session-close gate · area: .claude/skills/session-close/ · 2026-06-26


### PR DESCRIPTION
## What (autonomous dispatch run — slice 2, follow-on to #1476)

#1476 shipped `scripts/check_sector_next_freshness.py` (flags a per-sector `▶ Next` linking a SHIPPED/`historical` plan) but gave it **no invocation site** — a guard nobody runs is useless. A stale pointer could still sit unguarded between the 30-PR reconciliation passes (the S3 pointer #1476 fixed had been live 3 days).

This slice **operationalizes** it: adds the guard to the `/session-close` Step-4 quality gate + a remediation note, so every session re-checks `▶ Next` freshness on the way out. This is option (a) — the "smaller, surer win" — from #1476's session idea.

## Changes
- `.claude/skills/session-close/SKILL.md` — add `check_sector_next_freshness.py` to the Step-4 gate command list + a one-line remediation note (re-point the flagged `▶ Next`, preserve provenance, Q-0166).

Skill/orientation-only edit (not CLAUDE.md / hooks / settings — those stay read-only to an autonomous run). Born-red card; flips to `complete` on green.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bjb6pXdk2p9vhFH8PvivB)_