### PR TITLE
docs+tooling: per-sector offline-fit startability tags (self-maintaining dispatch signal)

### DIFF
--- a/.sessions/2026-06-27-startability-offline-fit-tags.md
+++ b/.sessions/2026-06-27-startability-offline-fit-tags.md
@@ -1,29 +1,96 @@
 # 2026-06-27 — Per-sector offline-fit startability tags (workflow improvement)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What this run is about to do
+## What this run did
 
-Empty-fire dispatch. Acting on the **twice-flagged** self-audit observation (Q-0102 notes in the
-2026-06-25 and 2026-06-26 session logs): only the **S2** per-sector live-state file tags its ▶ Next
-startable items with an offline-fit phrase (`(offline, self-mergeable)`), and that tag worked as a
-fast dispatch signal — but S1/S3/S5 don't carry it, so every autonomous dispatch run (this one
-included) burns orient-time discovering which ▶ startables are offline-verifiable vs. needs-live-bot
-vs. owner-gated. The previous run's review reached the "route it if it recurs once more" bar.
+Empty-fire dispatch. Acted on a **twice-flagged** self-audit observation (the Q-0102 reviews in the
+2026-06-25 and 2026-06-26 session logs, which reached the "route it if it recurs once more" bar): only
+the **S2** per-sector live-state file tagged its `▶ Next` startable items with an offline-fit phrase, and
+that worked as a fast dispatch signal — but S1/S3/S5 didn't, so every autonomous dispatch run (this one
+included — I confirmed it firsthand) burned orient-time rediscovering which startables are
+offline-verifiable vs. needs-live-bot vs. owner-gated. Built the fix end-to-end as one coherent
+docs+tooling PR (no runtime / `disbot/` change).
 
-**Plan (offline, self-mergeable):**
-1. Standardize a small per-item offline-fit tag vocabulary on the per-sector live-state files'
-   `▶ Next` startable items — `[offline]` / `[needs-live-bot]` / `[owner]` — matching S2's proven
-   inline-phrase model, and apply it to S1/S3/S5 (S2 already carries the prose; S4 is the
-   docs/reconciliation sector with a cadence-gated ▶ Next).
-2. Add a disposable, NOT-CI-wired checker (`scripts/check_startability_tags.py`, Q-0105 header +
-   kill-switch) that asserts every sector live-state file's `▶ Next` block carries at least one
-   recognized offline-fit tag — so the convention can't silently drift back out.
-3. Tests for the checker in `tests/unit/scripts/`.
-4. Document the convention in `docs/repo-sector-map.md` next to the existing unattended-fit tag.
-5. Record the rule-level proposal as a router DISCUSS block (owner review) — not a unilateral
-   CLAUDE.md/router rule edit in an unattended run.
+**PR #1482 — the offline-fit startability tag system.**
 
-⚑ Self-initiated (Q-0172): yes — promoting the self-audit observation to a built improvement.
+**Slice 1 — the tag convention + checker.**
+1. A small per-item offline-fit tag vocabulary — `[offline]` (offline-verifiable + self-mergeable) /
+   `[needs-live-bot]` (needs a running bot / runtime creds to verify) / `[owner]` (needs an owner
+   decision/action) — applied to every `▶ Next` item across `docs/current-state/S1-bot.md`,
+   `S2-btd6.md`, `S3-ai-memory.md`, `S5-ops.md`, each with a one-line legend under the heading. S4 is
+   exempt (its `▶ Next` is a cadence-gated reconciliation pass, not a buildable menu). A tag reflects an
+   arc's *next actionable* step (a shipped arc whose next move is a live walk is `[needs-live-bot]`).
+2. `scripts/check_startability_tags.py` (Q-0105 provenance header + kill-switch, **not** CI-wired —
+   ask-first) asserts each non-exempt sector's `▶ Next` block carries ≥1 recognized tag, so the
+   convention can't silently drift back out. Presence check, not a brittle per-bullet parse.
+3. Documented the convention in `docs/repo-sector-map.md` § "the offline-fit startability tag", next to
+   the existing sector-level unattended-fit tag.
+
+**Slice 2 — wired it into the dispatch tool (closes the loop / Q-0207 option (c)).**
+`scripts/dispatch_menu.py --unattended` now reads each buildable sector's live-state file and surfaces a
+new **"Concrete [offline] items"** section — the actual item to build per sector — so an empty-fire run
+never needs to open the sector file by hand (the exact friction the 2026-06-26 review described). S5
+(all `[owner]`) and S4 (exempt) correctly produce no offline pick.
+
+Recorded the **rule-level** question (bless the convention as standing / leave disposable / fold into
+the tool) as router **Q-0207 (DISCUSS)** rather than self-editing CLAUDE.md.
+
+## Verification
+- New tests: `tests/unit/scripts/test_check_startability_tags.py` (11, incl. guard-the-guard:
+  removing a tag makes the checker fail) + 5 added to `test_dispatch_menu.py` (the offline-pick parsing
+  reads the live S1/S2/S3 files, S5 has none, label-strip, block-stops-at-next-heading, the summary
+  surfaces the new section). `check_quality.py --full` GREEN. `check_startability_tags.py` OK (4 sectors
+  tagged, S4 exempt). Arch unaffected (no `disbot/` change).
+
+## 💡 Session idea (Q-0089)
+*Tag the roadmap's per-sector `▶ Now/Next` items with the same `[offline]`/`[needs-live-bot]`/`[owner]`
+vocabulary, not just the current-state sector files.* Today the roadmap carries a **sector-level**
+unattended-fit tag (🟢/🟡/🔵/🟠) and the current-state files now carry **item-level** offline-fit tags —
+two homes, slightly different vocabularies. A future slice could unify them: one tag vocabulary, applied
+once at item granularity on the roadmap (the dispatch source of truth), with the current-state files
+linking rather than restating (the one-fact-one-home rule). Low urgency — the two layers don't conflict
+today, and dispatch_menu now bridges them — but it would remove the dual-vocabulary seam. Genuinely tied
+to this run's edit, not filler.
+
+## ⟲ Previous-session review (Q-0102)
+The previous run (2026-06-26 BTD6 eval-anchor coverage) did its best work in **disciplined
+guard-the-guard verification** — it proved its new coverage/distractor guards non-vacuous by emptying the
+allowlist and forcing a truth==distractor, confirming each fails against the drift it exists to catch. I
+mirrored that here (the checker's `test_missing_tag_fails`). Its Q-0102 note is **what this run executed**:
+it flagged that autonomous runs burn orient-time finding offline lanes and recommended propagating S2's
+offline-fit tag — this run is the third occurrence and the build of that exact fix. **System improvement
+this surfaces:** the self-audit loop worked as designed — a friction flagged twice, then built — but the
+gap was *latency*: the observation sat for two runs as a routed note before a run acted on it. A cheap
+upgrade would be for the Q-0102 ender to **promote a twice-flagged observation into the bug-book or a
+`docs/ideas/` entry on the second occurrence** (not just re-note it in prose), so the next empty-fire run
+finds it as a concrete startable rather than re-deriving it. Routed as an observation here, not a
+unilateral rule edit.
+
+## Doc audit (Q-0104)
+The four sector live-state files + `repo-sector-map.md` are the durable homes of the convention; Q-0207
+is the durable home of the rule-level question. `check_current_state_ledger --strict` lag is benign
+newest-merge lag (recon is the docs-reconciliation routine's lane at #1500, not a manual dispatch's —
+Q-0124). `check_docs --strict` + `check_consistency` green. No ledger/Recently-shipped edit needed (this
+PR ships no new merged-PR fact yet; the next session/recon records #1482). Claim file deleted at close.
+
+## 📤 Run report
+- **Did:** built the per-sector offline-fit startability tag system (tags + checker + map doc + router
+  Q) and wired it into `dispatch_menu --unattended`. · **Outcome:** shipped
+- **Shipped:** #1482 — `[offline]`/`[needs-live-bot]`/`[owner]` tags on S1/S2/S3/S5 ▶ Next items +
+  `check_startability_tags.py` + `repo-sector-map.md` convention + dispatch_menu "Concrete [offline]
+  items" section; +16 tests.
+- **Run type:** routine · dispatch
+- **⚑ Owner decisions needed:** Q-0207 (DISCUSS) — bless the offline-fit tag convention as standing /
+  leave it disposable / fold it fully into dispatch_menu (agent rec: bless + the dispatch_menu wiring,
+  already built).
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** yes — promoted the twice-flagged self-audit observation (Q-0102 notes) into a
+  built workflow improvement (PR #1482), no dispatch or owner ask; flagged here + routed as Q-0207.
+- **↪ Next:** the sector ▶ Next offline-fit tags are now the fast dispatch signal — an empty-fire run can
+  run `python3.10 scripts/dispatch_menu.py --unattended` and build a listed **Concrete [offline] item**
+  directly (S1 Fishing open-world / Project Moon Slice A·B · S3 self-test walker harness). Bug-book:
+  BUG-0009 newest-towers data-gated, BUG-0011 needs VPS repro, BUG-0019 #1 awaits an owner behavior
+  decision — all stay OPEN.

--- a/.sessions/2026-06-27-startability-offline-fit-tags.md
+++ b/.sessions/2026-06-27-startability-offline-fit-tags.md
@@ -1,0 +1,29 @@
+# 2026-06-27 — Per-sector offline-fit startability tags (workflow improvement)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What this run is about to do
+
+Empty-fire dispatch. Acting on the **twice-flagged** self-audit observation (Q-0102 notes in the
+2026-06-25 and 2026-06-26 session logs): only the **S2** per-sector live-state file tags its ▶ Next
+startable items with an offline-fit phrase (`(offline, self-mergeable)`), and that tag worked as a
+fast dispatch signal — but S1/S3/S5 don't carry it, so every autonomous dispatch run (this one
+included) burns orient-time discovering which ▶ startables are offline-verifiable vs. needs-live-bot
+vs. owner-gated. The previous run's review reached the "route it if it recurs once more" bar.
+
+**Plan (offline, self-mergeable):**
+1. Standardize a small per-item offline-fit tag vocabulary on the per-sector live-state files'
+   `▶ Next` startable items — `[offline]` / `[needs-live-bot]` / `[owner]` — matching S2's proven
+   inline-phrase model, and apply it to S1/S3/S5 (S2 already carries the prose; S4 is the
+   docs/reconciliation sector with a cadence-gated ▶ Next).
+2. Add a disposable, NOT-CI-wired checker (`scripts/check_startability_tags.py`, Q-0105 header +
+   kill-switch) that asserts every sector live-state file's `▶ Next` block carries at least one
+   recognized offline-fit tag — so the convention can't silently drift back out.
+3. Tests for the checker in `tests/unit/scripts/`.
+4. Document the convention in `docs/repo-sector-map.md` next to the existing unattended-fit tag.
+5. Record the rule-level proposal as a router DISCUSS block (owner review) — not a unilateral
+   CLAUDE.md/router rule edit in an unattended run.
+
+⚑ Self-initiated (Q-0172): yes — promoting the self-audit observation to a built improvement.

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -45,7 +45,10 @@
   broadcast table. [design](../planning/casino-poker-design-2026-06-22.md).
 
 **▶ Next startable (one of):**
-- **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
+*(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
+creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
+§ "the offline-fit startability tag". A tag reflects the arc's *next actionable* step.)*
+- `[needs-live-bot]` **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
   (owner-directed, 2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow
   (**7 steps**: what kind of server is this · greet · moderators · block spam · choose a log channel ·
   reward active members · help desk + summary). Each step applies immediately (direct lane) through an
@@ -67,7 +70,7 @@
   "currently most of it does not do anything") + delete the now-dead service code; **heavier, needs
   live-bot verification.** Tracker:
   [`planning/setup-wizard-restructure-plan-2026-06-24.md`](../planning/setup-wizard-restructure-plan-2026-06-24.md).
-- **✅ Consolidation / discoverability audit — COMPLETE (owner-directed, 2026-06-23).** All five goals
+- `[needs-live-bot]` **✅ Consolidation / discoverability audit — COMPLETE (owner-directed, 2026-06-23).** All five goals
   shipped and CI-guarded where possible. Staging brief + per-cog rubric:
   [`planning/consolidation-discoverability-audit-brief-2026-06-23.md`](../planning/consolidation-discoverability-audit-brief-2026-06-23.md).
   - **Every command findable + buttonized** — per-command reachability guard (#1370); gap cogs closed
@@ -105,7 +108,7 @@
     [vision](../ideas/visual-card-engine-vision-2026-06-23.md) ·
     [seam idea](../ideas/help-nav-attachment-seam-2026-06-24.md) · the
     `channel-deployed-component` roles primitive (idea, not yet built).
-- **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value
+- `[offline]` **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔
   deepwater toggle + boat-only species + tougher deep minigame — are all done)* — remaining:
   the literal §5 **shore-cap-at-12 rebalance** (owner balance call, flagged in #1340) ·
@@ -115,7 +118,7 @@
   **open-world expansion**
   ([plan](../planning/fishing-open-world-expansion-plan-2026-06-18.md) Phase 2+: the
   boat-as-structure / travel-timer / destinations layer).
-- **Project Moon (Limbus) — runtime PR 1 SHIPPED 2026-06-25** (dispatch run, PR #1453): a standalone
+- `[offline]` **Project Moon (Limbus) — runtime PR 1 SHIPPED 2026-06-25** (dispatch run, PR #1453): a standalone
   **Limbus knowledge domain** — committed structural/lore facts (`disbot/data/projmoon/limbus/`: 12
   Sinners · 7 Sins · 3 damage types · 5 E.G.O grades · status keywords, provenance-tagged), a typed
   `services/projmoon_data_service.py` (loader + resolver), `utils/projmoon/keywords.py`
@@ -143,8 +146,9 @@
   Limbus Q&A grounds well on both providers) + Slice A item 1 (StaticData exact-number ingest); then
   **Slice B** = extract the shared `KnowledgeDomain` seam from BTD6 + Limbus
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
-- **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover
-  (PR 1 foundation shipped; [plan](../planning/botsite-react-spa-migration-plan-2026-06-20.md)).
+- `[offline]` **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover
+  (PR 1 foundation shipped; [plan](../planning/botsite-react-spa-migration-plan-2026-06-20.md)). *(The
+  build/serve code is offline + self-mergeable like PR 1; the domain cutover itself is `[owner]`.)*
 
 **In flight (don't duplicate):** Starboard PR 2 (#1270) config polish · botsite React-SPA
 migration **PR 1** (#1305 — runnable data-fed React app + `/site-data.json`; foundation).

--- a/docs/current-state/S2-btd6.md
+++ b/docs/current-state/S2-btd6.md
@@ -32,11 +32,14 @@
   to run `seed-data`" manual step.**
 
 **▶ Next startable:**
-- Decode-status ⭐ item 3 (buff/zone tail, demand-driven) + item 4 (maintainer live spot-check).
-- **P1-1 live `llm_judge` battery** (the model actually using the grounded facts — creds-gated; the
+*(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
+creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
+§ "the offline-fit startability tag".)*
+- `[owner]` Decode-status ⭐ item 3 (buff/zone tail, demand-driven) + item 4 (maintainer live spot-check).
+- `[needs-live-bot]` **P1-1 live `llm_judge` battery** (the model actually using the grounded facts — creds-gated; the
   offline grounding half now shipped, above) + absence-guard **Layer B** (the negative-existential
   gate, design-for-review; needs prod creds).
-- **Anchor-tooling follow-ons** (offline, self-mergeable) — *(the range-cash + projected-total figures
+- `[offline]` **Anchor-tooling follow-ons** (offline, self-mergeable) — *(the range-cash + projected-total figures
   AND the #855 MOAB-class bonuses +15/+30/+99 are now anchored, #1460 above — the BTD6 knowledge/
   grounding cases are anchor-complete for every cleanly-derivable truth; **the eval-anchor coverage
   report + distractor negative-anchor guard both shipped 2026-06-26, PR #1466**)*: the **coverage

--- a/docs/current-state/S3-ai-memory.md
+++ b/docs/current-state/S3-ai-memory.md
@@ -26,9 +26,14 @@
   ([plan, now historical](../planning/ai-panel-inplace-navigation-plan-2026-06-19.md)).
 
 **▶ Next startable:**
-- **procedures→skills Batch 2**
+*(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
+creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
+§ "the offline-fit startability tag".)*
+- `[offline]` **procedures→skills Batch 2**
   ([plan](../planning/procedures-to-skills-conversion-plan-2026-06-17.md)).
-- The **bot self-test walker** eval harness (pairs with S1 P1-1) · the **Hermes bug-triage** write.
+- `[offline]` The **bot self-test walker** eval harness (pairs with S1 P1-1) — the harness scaffold is
+  offline-buildable; `[owner]` the **Hermes bug-triage** write side stays gated on the VPS write scope
+  (Q-0121).
 
 **Note:** S3 runtime depth is self-initiated mechanism work; the old `needs-hermes-review` review gate
 is **retired** (Q-0197) — every PR now auto-merges on green CI. A fresh idea may be promoted

--- a/docs/current-state/S5-ops.md
+++ b/docs/current-state/S5-ops.md
@@ -23,10 +23,13 @@
   elsewhere).
 
 **▶ Next (owner / Hermes-executed):**
-- **Website two-site split rollout** — v1 is code-complete + reviewed; what remains is the
+*(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
+creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
+§ "the offline-fit startability tag". S5 is the executor outlier — most items are owner/Hermes-run.)*
+- `[owner]` **Website two-site split rollout** — v1 is code-complete + reviewed; what remains is the
   owner-paced rollout (provision `botsite/` + submissions DB, domain cutover)
   ([handoff](../operations/website-split-next-steps-2026-06-19.md)).
-- Two **security-review-gated** slices: control-panel migration · live status aggregator.
+- `[owner]` Two **security-review-gated** slices: control-panel migration · live status aggregator.
 
 **Control-plane truth:** see [`../current-state.md`](../current-state.md) § Gates / blocked work —
 that section is a pure pointer to the canonical control-plane table (copying its verdict drifted

--- a/docs/owner/claims/claude-funny-franklin-q6cvco.md
+++ b/docs/owner/claims/claude-funny-franklin-q6cvco.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-q6cvco` · scope: per-sector offline-fit startability tagging · area: docs/current-state/S*.md + scripts/check_startability_tags.py + tests · 2026-06-27

--- a/docs/owner/claims/claude-funny-franklin-q6cvco.md
+++ b/docs/owner/claims/claude-funny-franklin-q6cvco.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-q6cvco` · scope: per-sector offline-fit startability tagging · area: docs/current-state/S*.md + scripts/check_startability_tags.py + tests · 2026-06-27

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7519,3 +7519,40 @@ default, optionally paired with **option 3**. Option 1 only if the owner wants i
 
 **Home:** this Q-block (canonical) + `.sessions/2026-06-25-stale-claim-detector.md`. Related: **Q-0195**
 (one-file-per-claim), **Q-0166** (drift-on-sight), **Q-0105** (disposable-tool posture).
+
+---
+
+### Q-0207 — DISCUSS: make the per-item offline-fit startability tag a standing convention (2026-06-27)
+
+> **PROPOSED — surfaced (and partially built) this session, after a twice-flagged self-audit.** The
+> *implementation* (the tags on the sector files + a disposable checker + the map doc) is docs/tooling I
+> have free rein on (Q-0105) and shipped this run; **this Q-block is only the rule-level question** —
+> should the convention be codified/blessed, or left as a disposable guard? It routes here rather than
+> self-editing CLAUDE.md (the binding-rule channel). Owner is the live reviewer when present; else it waits.
+
+**Context:** two consecutive empty-fire dispatch runs' Q-0102 reviews (the 2026-06-25 and 2026-06-26
+session logs) flagged the same friction: only **S2**'s per-sector live-state file tagged its `▶ Next`
+startable items with an offline-fit phrase, and that worked as a fast dispatch signal — but S1/S3/S5
+didn't, so each autonomous run burned orient-time rediscovering which startables are offline-verifiable
+vs. needs-live-bot vs. owner-gated. The 2026-06-26 review explicitly noted "second occurrence → meets the
+router-DISCUSS bar." This run is the third, and confirmed it firsthand (I again spelunked S1's arc bullets
+to find the offline lanes).
+
+**What this run already built (reversible docs/tooling, no rule change):** a per-item tag vocabulary —
+`[offline]` / `[needs-live-bot]` / `[owner]` — applied to every `▶ Next` item in S1/S2/S3/S5 (S4 exempt:
+docs/reconciliation sector); `scripts/check_startability_tags.py` (Q-0105 disposable, **not** CI-wired)
+asserting each non-exempt sector's `▶ Next` block carries ≥1 recognized tag; and the convention documented
+in `repo-sector-map.md` § "the offline-fit startability tag", next to the existing unattended-fit tag.
+
+**Open question for the owner:** (a) **bless it** as a standing convention (keep the tags + guard, maybe
+graduate the checker to a Stop-hook advisory or a warn-only CI step later); (b) **leave it disposable** —
+keep it only while it proves useful, delete on the Q-0105 kill-switch if it drifts; or (c) **fold it into
+`dispatch_menu.py`** so the empty-fire pick reads the per-item tag directly instead of a human/agent
+reading the sector file (the 2026-06-26 review's suggestion). *Agent recommendation:* **(a) + (c)** — the
+signal is cheap, already paid for, and directly cuts every future dispatch run's orient cost; wiring it
+into `dispatch_menu --unattended` is the natural next slice.
+
+**Home:** this Q-block (canonical) + `.sessions/2026-06-27-startability-offline-fit-tags.md` +
+`repo-sector-map.md` (durable home of the convention). Related: **Q-0143** (startability tag), **#1285 /
+Q-0172** (unattended-fit tag — the sector-level sibling), **Q-0102** (the self-audit loop that surfaced
+it), **Q-0105** (disposable-tool posture).

--- a/docs/repo-sector-map.md
+++ b/docs/repo-sector-map.md
@@ -179,6 +179,28 @@ layers) are 🟢 `auto`, while the **headline** lanes the empty-fire runs anchor
 tag stops a run from missing the auto-buildable per-sector work. Provenance: #1285 (Q-0172, promoting
 #1274's surfaced fix).*
 
+### Which *item* is offline — the offline-fit startability tag
+The unattended-fit tag above lives on the roadmap and tags one lane **per sector**. But a dispatch run
+that picks a sector then opens that sector's **live-state file**
+([`current-state/S<n>.md`](current-state/README.md)), which lists *several* `▶ Next` startable items —
+and those items differ in what verifying them costs. Two consecutive empty-fire runs' Q-0102 reviews
+(the 2026-06-25 / 2026-06-26 session logs) found that **S2** already annotated its items with an
+offline-fit phrase and it worked as a fast signal, while S1/S3/S5 didn't — so each run re-discovered, by
+hand, which item was offline. So every `▶ Next` item in a sector live-state file carries one **offline-fit
+tag** — the per-item analogue of the sector-level unattended-fit tag:
+
+- **`[offline]`** — offline-verifiable **and** self-mergeable by a Claude-in-repo run (the ideal
+  empty-fire pick — maps to 🟢 `auto`).
+- **`[needs-live-bot]`** — needs a running bot / runtime creds to *verify* (maps to 🔵 `live`).
+- **`[owner]`** — needs an owner decision or action (a balance call, a rollout, a security review,
+  externally-sourced data).
+
+A tag reflects an arc's **next actionable step** (an arc whose code is shipped but whose next move is a
+live walk is `[needs-live-bot]`). `scripts/check_startability_tags.py` (Q-0105 disposable guard, not
+CI-wired) requires at least one recognized tag in each non-exempt sector's `▶ Next` block, so the
+convention can't silently drift back out; **S4** (the docs/reconciliation sector — its `▶ Next` is a
+cadence-gated pass, not a buildable menu) is exempt.
+
 **What this map does *not* do:** it does not wire Hermes. Turning a phone message into a `/fire`
 dispatch — and moving the night executor off GitHub cron onto the always-on Hermes VPS — is **Q-0137
 Thread 1** (owner-undecided). The actions above map onto the existing routine fleet documented in

--- a/scripts/check_startability_tags.py
+++ b/scripts/check_startability_tags.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3.10
+"""Assert every per-sector live-state file tags its ▶ Next startables with an offline-fit tag.
+
+Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch):
+- Why: the per-sector live-state files (``docs/current-state/S*.md``) list each sector's
+  ``▶ Next startable`` items. **S2** annotated those items with an offline-fit phrase
+  ("(offline, self-mergeable)") and two consecutive dispatch runs' Q-0102 reviews (the
+  2026-06-25 and 2026-06-26 session logs) found that tag worked as a fast dispatch signal —
+  while S1/S3/S5 lacked it, so each empty-fire run burned orient-time rediscovering which
+  startables are offline-verifiable vs. needs-live-bot vs. owner-gated. This checker makes the
+  now-standardized per-item offline-fit tag (``[offline]`` / ``[needs-live-bot]`` / ``[owner]``)
+  a machine-checked convention so it can't silently drift back out.
+- Added: 2026-06-27 (dispatch run, self-initiated per Q-0172). **Unverified** — confirm its
+  output against the sector files over a few sessions before trusting it. **Delete this script
+  if it proves noisy/unreliable over multiple sessions**; it is a disposable convenience guard,
+  read-only, not load-bearing. It is intentionally **NOT wired into CI** (that is ask-first per
+  the autonomy boundary) — run it by hand or from the docs-reconciliation routine.
+
+The check (read-only; exits 1 on any violation, 0 when clean): each non-exempt
+``docs/current-state/S<n>.md`` file's ``▶ Next`` startable bullet block contains at least one
+recognized offline-fit tag. It is deliberately a **presence** check, not a rigid per-bullet
+parse — the sector files are rich prose and a per-bullet parser would be brittle; presence
+catches the real failure (a sector file that gives a dispatch run no offline-fit guidance at all).
+
+Usage::
+
+    python3.10 scripts/check_startability_tags.py            # report + exit code
+    python3.10 scripts/check_startability_tags.py --quiet     # exit code only
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STATE_DIR = REPO_ROOT / "docs" / "current-state"
+
+# The per-item offline-fit tag vocabulary (documented in repo-sector-map.md §
+# "the offline-fit startability tag"). Orthogonal to the ▶/⛔/👤 startability glyph
+# (may-begin) and to dispatch_menu's sector-level unattended-fit (can-finish-and-merge);
+# this one answers, per ▶ item, "what does verifying it require?".
+RECOGNIZED_TAGS = ("[offline]", "[needs-live-bot]", "[owner]")
+
+# S4 is the documentation/reconciliation sector: its ▶ Next is a cadence-gated docs pass
+# (auto-triggered by the reconciliation routine), not a menu of buildable startables, so it
+# carries no per-item offline-fit tag by design.
+EXEMPT_SECTORS = {"S4"}
+
+_SECTOR_FILE = re.compile(r"^S(\d)\b")
+_NEXT_HEADING = re.compile(r"^\*\*▶ Next\b")
+_BOLD_HEADING = re.compile(r"^\*\*[^*].*:\*\*")
+
+
+def _read(path: Path) -> str:
+    """Return the file text, or an empty string if it does not exist."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def sector_files() -> list[Path]:
+    """Return the per-sector live-state files (``S<n>.md``), excluding the README."""
+    return sorted(
+        p for p in STATE_DIR.glob("S*.md") if _SECTOR_FILE.match(p.stem) is not None
+    )
+
+
+def next_block(text: str) -> str | None:
+    """Return the ``▶ Next`` startable bullet block, or ``None`` if there is no heading.
+
+    The block runs from the ``**▶ Next…:**`` heading line up to (but not including) the next
+    bold section heading line (``**Something:**`` at line start) or end of file. Bullets start
+    with ``-`` and the italic legend line starts with ``*(`` — neither terminates the block, so
+    only a sibling section heading ends it.
+    """
+    lines = text.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if _NEXT_HEADING.match(line)),
+        None,
+    )
+    if start is None:
+        return None
+    out = [lines[start]]
+    for line in lines[start + 1 :]:
+        if _BOLD_HEADING.match(line):
+            break
+        out.append(line)
+    return "\n".join(out)
+
+
+def sector_id(path: Path) -> str:
+    """Return the ``S<n>`` id from a sector file stem (``S4-docs`` → ``S4``)."""
+    m = _SECTOR_FILE.match(path.stem)
+    return f"S{m.group(1)}" if m else path.stem
+
+
+def check_file(path: Path) -> list[str]:
+    """Return violation strings for one sector file (empty when clean)."""
+    if sector_id(path) in EXEMPT_SECTORS:
+        return []
+    text = _read(path)
+    if not text:
+        return [f"{path.name}: unreadable or empty."]
+    block = next_block(text)
+    if block is None:
+        return [
+            f"{path.name}: no '**▶ Next…:**' startable heading found "
+            f"(every active sector lists its next startables).",
+        ]
+    if not any(tag in block for tag in RECOGNIZED_TAGS):
+        return [
+            f"{path.name}: the ▶ Next block carries no offline-fit tag "
+            f"(tag each item with one of {', '.join(RECOGNIZED_TAGS)} — see "
+            f"repo-sector-map.md § 'the offline-fit startability tag').",
+        ]
+    return []
+
+
+def run() -> list[str]:
+    """Run the check over every sector file and return combined violation strings."""
+    files = sector_files()
+    if not files:
+        return [f"no S<n>.md files found in {STATE_DIR}"]
+    errors: list[str] = []
+    for path in files:
+        errors += check_file(path)
+    return errors
+
+
+def main() -> int:
+    """CLI entry point: print violations and return an exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress output; return exit code only",
+    )
+    args = parser.parse_args()
+
+    errors = run()
+    if errors:
+        if not args.quiet:
+            print("check_startability_tags: FAIL — sector ▶ Next tagging drift:")
+            for err in errors:
+                print(f"  - {err}")
+        return 1
+    if not args.quiet:
+        checked = [
+            sector_id(p) for p in sector_files() if sector_id(p) not in EXEMPT_SECTORS
+        ]
+        print(
+            "check_startability_tags: OK — "
+            f"{len(checked)} sectors tagged ({', '.join(checked)}); "
+            f"{', '.join(sorted(EXEMPT_SECTORS))} exempt ✓",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dispatch_menu.py
+++ b/scripts/dispatch_menu.py
@@ -34,6 +34,18 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ROADMAP = REPO_ROOT / "docs" / "roadmap.md"
+STATE_DIR = REPO_ROOT / "docs" / "current-state"
+
+# The per-item offline-fit tag the per-sector live-state files carry on each ▶ Next item
+# (convention: repo-sector-map.md § "the offline-fit startability tag"; guarded by
+# scripts/check_startability_tags.py). ``[offline]`` = offline-verifiable + self-mergeable —
+# the concrete item an empty-fire run should build. Surfacing it here closes the loop the
+# roadmap's sector-level unattended-fit tag left open: a run gets the actual item to build
+# without opening the sector file by hand (the 2026-06-26 Q-0102 review's friction).
+_OFFLINE_TAG = "[offline]"
+_NEXT_HEADING = re.compile(r"^\*\*▶ Next\b")
+_BOLD_HEADING = re.compile(r"^\*\*[^*].*:\*\*")
+_SECTOR_STEM = re.compile(r"^(S\d)\b")
 
 _SECTOR_HEADING = re.compile(r"^###\s+(S\d)\s+—\s+(.+?)\s+·")
 _BULLET_HEAD = re.compile(r"^- \*\*([^:*]+):\*\*")
@@ -236,6 +248,60 @@ def build_menu(text: str, only: str | None = None) -> list[str]:
     return lines
 
 
+def _sector_file(sid: str) -> Path | None:
+    """Return the per-sector live-state file for ``sid`` (``S2`` → ``S2-btd6.md``)."""
+    matches = sorted(
+        p
+        for p in STATE_DIR.glob(f"{sid}-*.md")
+        if _SECTOR_STEM.match(p.stem) and _SECTOR_STEM.match(p.stem).group(1) == sid
+    )
+    return matches[0] if matches else None
+
+
+def _next_block(text: str) -> str:
+    """Return the ``▶ Next`` block of a sector live-state file (heading → next bold heading)."""
+    lines = text.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if _NEXT_HEADING.match(line)),
+        None,
+    )
+    if start is None:
+        return ""
+    out = [lines[start]]
+    for line in lines[start + 1 :]:
+        if _BOLD_HEADING.match(line):
+            break
+        out.append(line)
+    return "\n".join(out)
+
+
+def _offline_item_label(line: str) -> str:
+    """Short label for an ``[offline]``-tagged ▶ item bullet line."""
+    after = line.split(_OFFLINE_TAG, 1)[1]
+    after = re.sub(r"\]\([^)]*\)", "]", after)  # drop link targets
+    after = after.replace("**", "").replace("[", "").replace("]", "")
+    after = _ITEM_SEP.split(after, maxsplit=1)[0]
+    return after.strip(" *:-—`")[:60].strip()
+
+
+def sector_offline_pick(sid: str) -> str | None:
+    """Return the first ``[offline]`` startable item in a sector's live-state file, or ``None``.
+
+    The concrete answer to "what offline thing do I build in this sector?" — read straight from
+    the per-item offline-fit tag so an empty-fire run skips the by-hand sector-file spelunk.
+    """
+    path = _sector_file(sid)
+    if path is None:
+        return None
+    block = _next_block(_read(path))
+    for line in block.splitlines():
+        if line.lstrip().startswith("-") and _OFFLINE_TAG in line:
+            label = _offline_item_label(line)
+            if label:
+                return label
+    return None
+
+
 def build_unattended_summary(text: str) -> list[str]:
     """Answer one question for a *scheduled empty-fire* run: can I complete-and-merge a lane now?
 
@@ -283,6 +349,18 @@ def build_unattended_summary(text: str) -> list[str]:
     if untagged:
         out.append("?  untagged (roadmap drift — run check_sector_map.py):")
         out.extend(f"   {_fmt(r)}" for r in untagged)
+
+    # Bridge sector → concrete item: read the first [offline]-tagged ▶ item from each buildable
+    # sector's live-state file, so the run gets the actual thing to build, not just the sector.
+    offline_picks = [
+        (rec["sector"], pick)
+        for rec in buildable
+        if (pick := sector_offline_pick(str(rec["sector"]))) is not None
+    ]
+    if offline_picks:
+        out.append("-" * 72)
+        out.append("Concrete [offline] items (from the per-sector live-state files):")
+        out.extend(f"   {sid}: {pick}" for sid, pick in offline_picks)
 
     out.append("-" * 72)
     if by_fit["auto"]:

--- a/tests/unit/scripts/test_check_startability_tags.py
+++ b/tests/unit/scripts/test_check_startability_tags.py
@@ -1,0 +1,128 @@
+"""check_startability_tags asserts each sector ▶ Next block carries an offline-fit tag."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).parents[3]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "check_startability_tags",
+        _REPO / "scripts" / "check_startability_tags.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cst = _load()
+
+
+def test_live_sector_files_are_clean():
+    """The real repo passes (ground-truth verification, Q-0105)."""
+    assert cst.run() == []
+
+
+def test_main_exits_zero_and_reports_ok(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["check_startability_tags.py"])
+    assert cst.main() == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def _block(body: str) -> str:
+    return f"# S9 — test\n\n{body}\n"
+
+
+def test_recognized_tag_passes(tmp_path):
+    path = tmp_path / "S9-test.md"
+    path.write_text(
+        _block("**▶ Next startable:**\n- `[offline]` do a thing.\n"),
+        encoding="utf-8",
+    )
+    assert cst.check_file(path) == []
+
+
+def test_missing_tag_fails(tmp_path):
+    """A ▶ Next block with no offline-fit tag is flagged — the drift the guard exists for."""
+    path = tmp_path / "S9-test.md"
+    path.write_text(
+        _block("**▶ Next startable:**\n- do an untagged thing.\n"),
+        encoding="utf-8",
+    )
+    errors = cst.check_file(path)
+    assert errors and "no offline-fit tag" in errors[0]
+
+
+def test_missing_next_heading_fails(tmp_path):
+    path = tmp_path / "S9-test.md"
+    path.write_text(
+        _block("**Recently shipped:**\n- shipped a thing.\n"), encoding="utf-8"
+    )
+    errors = cst.check_file(path)
+    assert errors and "no '**▶ Next" in errors[0]
+
+
+def test_each_recognized_tag_is_accepted(tmp_path):
+    for tag in cst.RECOGNIZED_TAGS:
+        path = tmp_path / "S9-test.md"
+        path.write_text(
+            _block(f"**▶ Next startable:**\n- `{tag}` an item.\n"),
+            encoding="utf-8",
+        )
+        assert cst.check_file(path) == [], tag
+
+
+def test_block_ends_at_next_section_heading(tmp_path):
+    """A tag in a *sibling* section after ▶ Next does not satisfy the ▶ Next block."""
+    path = tmp_path / "S9-test.md"
+    path.write_text(
+        _block(
+            "**▶ Next startable:**\n- an untagged item.\n\n"
+            "**In flight:**\n- `[offline]` an unrelated tagged item.\n",
+        ),
+        encoding="utf-8",
+    )
+    errors = cst.check_file(path)
+    assert errors and "no offline-fit tag" in errors[0]
+
+
+def test_legend_line_does_not_terminate_the_block(tmp_path):
+    """The italic ``*(legend…)*`` line under the heading stays inside the block."""
+    path = tmp_path / "S9-test.md"
+    path.write_text(
+        _block(
+            "**▶ Next startable:**\n*(offline-fit tags — see the map.)*\n"
+            "- `[needs-live-bot]` an item.\n",
+        ),
+        encoding="utf-8",
+    )
+    assert cst.check_file(path) == []
+
+
+def test_s4_is_exempt(tmp_path):
+    """S4 (docs/reconciliation sector) is exempt — its ▶ Next is a cadence-gated pass."""
+    path = tmp_path / "S4-docs.md"
+    path.write_text(
+        _block("**▶ Next:**\n- next reconciliation pass at the next 30-PR band.\n"),
+        encoding="utf-8",
+    )
+    assert cst.sector_id(path) == "S4"
+    assert cst.check_file(path) == []
+
+
+def test_sector_id_extracts_the_id():
+    assert cst.sector_id(Path("S2-btd6.md")) == "S2"
+    assert cst.sector_id(Path("S5-ops.md")) == "S5"
+
+
+def test_live_real_sector_files_are_all_tagged():
+    """Every non-exempt live sector file individually carries a tag (not just run() aggregate)."""
+    for path in cst.sector_files():
+        if cst.sector_id(path) in cst.EXEMPT_SECTORS:
+            continue
+        assert cst.check_file(path) == [], path.name

--- a/tests/unit/scripts/test_dispatch_menu.py
+++ b/tests/unit/scripts/test_dispatch_menu.py
@@ -190,3 +190,45 @@ def test_unattended_summary_falls_back_when_no_auto_lane():
     joined = "\n".join(lines)
     assert "🟢 auto: none" in joined
     assert "promote an idea" in joined
+
+
+# --- per-item offline-fit picks (read from the per-sector live-state files) -----------
+
+
+def test_offline_item_label_strips_markup_and_links():
+    line = "- `[offline]` **Fishing follow-ups** (turn-key) — remaining: x"
+    assert dm._offline_item_label(line) == "Fishing follow-ups"
+    line2 = "- `[offline]` **[botsite PR 2](../planning/x.md)** — serve the app"
+    assert "botsite PR 2" in dm._offline_item_label(line2)
+
+
+def test_sector_offline_pick_reads_live_files():
+    """The real S1/S2/S3 sector files each surface a concrete [offline] item; S5 has none."""
+    assert dm.sector_offline_pick("S1") is not None
+    assert dm.sector_offline_pick("S2") is not None
+    assert dm.sector_offline_pick("S3") is not None
+    # S5 is the executor outlier — its ▶ Next items are all [owner], so no offline pick.
+    assert dm.sector_offline_pick("S5") is None
+
+
+def test_sector_offline_pick_none_for_unknown_sector():
+    assert dm.sector_offline_pick("S9") is None
+
+
+def test_next_block_stops_at_next_bold_heading():
+    text = (
+        "**▶ Next startable:**\n"
+        "- `[offline]` an item.\n\n"
+        "**In flight:**\n"
+        "- `[offline]` an unrelated item.\n"
+    )
+    block = dm._next_block(text)
+    assert "an item." in block and "unrelated" not in block
+
+
+def test_unattended_summary_lists_concrete_offline_items():
+    text = (_REPO / "docs" / "roadmap.md").read_text(encoding="utf-8")
+    joined = "\n".join(dm.build_unattended_summary(text))
+    assert "Concrete [offline] items" in joined
+    # At least one real sector pick is surfaced.
+    assert "S1:" in joined or "S2:" in joined or "S3:" in joined


### PR DESCRIPTION
## Why

Empty-fire dispatch run. Acts on a **twice-flagged** self-audit observation (the Q-0102 review notes in the 2026-06-25 and 2026-06-26 session logs): only the **S2** per-sector live-state file tags its `▶ Next` startable items with an offline-fit phrase, and that worked as a fast dispatch signal — but S1/S3/S5 don't, so every autonomous dispatch run burns orient-time discovering which startables are offline-verifiable vs. needs-live-bot vs. owner-gated. The previous run reached the "route it if it recurs once more" bar.

## What this PR does (offline, self-mergeable)

1. Standardizes a small per-item offline-fit tag vocabulary on the per-sector live-state files' `▶ Next` startable items — `[offline]` / `[needs-live-bot]` / `[owner]` — matching S2's proven inline model, applied across S1/S2/S3/S5 (S4 = the docs/reconciliation sector, cadence-gated).
2. Adds a disposable, **NOT-CI-wired** checker (`scripts/check_startability_tags.py`, Q-0105 provenance header + kill-switch) asserting every sector live-state file's `▶ Next` block carries at least one recognized offline-fit tag, so the convention can't silently drift back out.
3. Tests for the checker.
4. Documents the convention in `docs/repo-sector-map.md` next to the unattended-fit tag.
5. Records the rule-level proposal as a router DISCUSS block for owner review (not a unilateral rule edit in an unattended run).

Born-red session card flips to `complete` as the final step (Q-0133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNhiGtr1weWeyZny7LAumZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNhiGtr1weWeyZny7LAumZ)_