### PR TITLE
Games-economy observability: faucet/sink per-day timeseries (+ inflation finding)

### DIFF
--- a/.sessions/2026-06-27-economy-flow-timeseries.md
+++ b/.sessions/2026-06-27-economy-flow-timeseries.md
@@ -1,34 +1,115 @@
-# 2026-06-27 — Games-economy observability: faucet/sink timeseries (+ inflation finding)
+# 2026-06-27 — Games-economy observability: per-day faucet/sink trend view
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What this run is doing
+## What this run did
 
-Empty-fire dispatch. The clean offline lanes are thin (BTD6 anchors complete; procedures→skills
-Batch 2 needs a CLAUDE.md self-edit — autonomous-blocked by Q-0106; botsite PR 2 flips the live
-homepage — owner-paced; BUG-0009 newest-towers is data-gated; Project Moon Slice A/B need a network
-datamine or runtime verification; fishing Phase 2 is owner-design-gated). The cleanest genuinely-
-useful offline slice is the **§6 follow-up tail** of the shipped games-economy faucet/sink diagnostic
+Empty-fire dispatch. The clean offline lanes were thin — every other concrete candidate was gated
+for an autonomous run: BTD6 anchors are complete; procedures→skills **Batch 2 needs a `.claude/CLAUDE.md`
+self-edit** (Q-0106 — proposals only in an autonomous run); botsite React **PR 2 flips the live
+homepage** (owner-paced website rollout); **BUG-0009** newest-towers is **data-gated**; Project Moon
+Slice A item 1 needs a **network datamine + runtime verification**, Slice B is a **runtime-verification-
+needing BTD6 refactor**; fishing Phase 2 is **owner-design-gated**. The cleanest genuinely-useful
+offline slice was the **§6 follow-up tail** of the shipped games-economy faucet/sink diagnostic
 ([plan](../planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md), shipped #1044): the
-all-time + windowed *aggregate* view + verdict shipped, but the per-day **trend** and the **inflation
-health-finding** were explicitly "capture, don't build here". Both are read-only / content-free,
-extend shipped work, and serve the owner's stated need (watch whether the mining economy is inflating
-*over time*, not from a single window aggregate).
+all-time + windowed *aggregate* view + verdict shipped, but the per-day **trend** was explicitly
+"capture, don't build here". Read-only, content-free, extends shipped work, serves the owner's stated
+need (watch whether the mining economy is inflating *over time*).
 
-**Slice 1 (PR) — economy-flow timeseries (per-day trend).** A pure DB read fn
-(`economy_flow_daily`, GROUP BY day over `economy_audit_log.occurred_at`) → a typed
-`EconomyFlowTimeseries` service read model → a `!platform economytrend [days]` admin view (per-day
-minted/drained/net table + a dependency-free net-flow sparkline + an overall trend read). Read-only,
-content-free, no migration (rides the existing `occurred_at` column), no new reason.
+**PR #1483 — games-economy per-day faucet/sink trend view.**
 
-**Slice 2 (assessed after Slice 1) — inflation health-finding.** Wire the existing `verdict` into the
-P1-2 health-findings lifecycle (#843) so a sustained "inflating ⚠" surfaces as a persistent operator
-finding manageable via `!platform finding`.
+**Slice 1 (shipped) — the timeseries / trend view.**
+1. `utils/db/economy.economy_flow_daily(guild_id, *, since)` — a pure
+   `GROUP BY (occurred_at AT TIME ZONE 'UTC')::date` read over `economy_audit_log` returning per-day
+   `(day, minted, drained, net, movements)`, oldest-first (deterministic UTC day boundary). The
+   time-series sibling of the shipped `economy_flow_by_reason`; no migration (rides `occurred_at`).
+2. `services/economy_flow_service.build_flow_timeseries` → `EconomyFlowTimeseries` (a `DayFlow` series +
+   totals/ratio + the reused aggregate `verdict` classifier + a first-half-vs-second-half
+   **rising/falling/steady** `_trend` read, noise-tolerant via `_TREND_EPS`). Pure aggregation, no
+   Discord types.
+3. `!platform economytrend [days]` (alias `coinflowtrend`) — a dependency-free unicode net-flow
+   **sparkline** + a recent-days table + a summary line (minted/drained/net/ratio/verdict/trend).
+   Read-only, content-free, admin-gated, beside `!platform economy`.
 
-Also fixing on sight (Q-0166 drift): the roadmap §Games "Now" line still lists **P0-1 wager
-money-safety** as the next implementation session, but its plan is `historical` — EXECUTED in #748.
+**Slice 2 — NOT built (deliberately).** The §6 health-finding (a persistent finding when a guild
+sustains the `inflating ⚠` verdict) is genuinely **design-for-review**: the economy verdict is
+**per-guild** but the `operational_health_findings` store + `record_findings(HealthSnapshot)` seam is
+**guild-agnostic** (no `guild_id` column; fingerprint excludes unbounded identifiers). I sharpened it
+into a turn-key design-for-review handoff in the plan §6 (the three decisions it needs: guild_id in the
+fingerprint vs. a roll-up · the sustained rule · which loop emits it) rather than build it blind in an
+autonomous run.
+
+**Drift fixed on sight (Q-0166):** the roadmap §Games "Now" line listed **P0-1 wager money-safety** as
+the next implementation session, but its plan is `historical` — EXECUTED in #748. Marked shipped (+ the
+settle-once lineage #1444/#1445/#1454).
 
 ## Verification
-*(filled at close)*
+- New tests: `tests/unit/db/test_economy_db_txn.py` (+2: `economy_flow_daily` all-time grouping &
+  windowed filter, query-shape asserted), `tests/unit/services/test_economy_flow_service.py` (+6:
+  timeseries assembly/totals/verdict, empty path, `_trend` rising/falling/steady/n-a + noise-tolerance,
+  `build_flow_timeseries` since/label), `tests/unit/services/test_diagnostic_economy_trend_embed.py`
+  (new, 6: sparkline empty/flat/min-max, day-rows newest-first+cap, embed render + no-activity path).
+- `python3.10 scripts/check_quality.py --full` GREEN (12669 passed; the initial run flagged the
+  expected derived-artifact drift — my new command bumped the live count 448→449, so I re-exported
+  `botsite/data/site.json` + `site/data.js` via `scripts/export_dashboard_data.py`; data.js diff is
+  exactly the new command entry, no sha churn).
+- `python3.10 scripts/check_architecture.py --mode strict` — 0 errors (49 pre-existing warnings, none
+  from this change; the new code is `utils/db` + `services` + `cogs`, layering-clean).
+
+## 💡 Session idea (Q-0089)
+*Give the per-day economy-flow read model a single shared "window → (since, label)" helper.* Right now
+`build_flow_report` (aggregate) and `build_flow_timeseries` (trend) each contain the identical
+`days → since/window_label` block (`datetime.now(utc) - timedelta(days=N)` + the `last N day(s)` label).
+It's only ~6 lines duplicated, but the two are guaranteed to be asked for *together* (an operator who
+looks at the aggregate verdict will want the trend), and a future windowing tweak (e.g. "this calendar
+month") would have to land in both. A tiny private `_resolve_window(days) -> (since, label)` removes
+the duplication and is the obvious extraction point if a third window-based reader appears. Low urgency
+(the two don't conflict today), genuinely tied to this run's edit — captured, not built, to keep the
+shipped slice focused.
+
+## ⟲ Previous-session review (Q-0102)
+The previous run (2026-06-27 offline-fit startability tags) did its best work by **closing the loop it
+identified** — it didn't just tag the sector files, it wired the tags into `dispatch_menu --unattended`
+so the *next* empty-fire run gets a concrete pick without re-deriving it. That paid off **this run**: I
+ran `dispatch_menu --unattended` first and it surfaced the candidate sectors immediately. Its one miss:
+the `Concrete [offline] items` it surfaces are **stale relative to what's actually buildable** — it
+listed "S2: Anchor-tooling follow-ons" as offline, but S2's own file says that tail is "none cleanly
+offline", and it didn't catch that S1's headline offline lanes are mostly shipped/gated. The tags are a
+*presence* signal, not a *freshness* one. **System improvement this surfaces:** the dispatch tool reads
+the tag but not the prose qualifier next to it ("none cleanly offline" / "shipped"); a cheap upgrade is
+for `check_startability_tags.py` to also flag a `[offline]` item whose bullet contains a
+shipped/exhausted marker ("✅", "SHIPPED", "none cleanly offline") as a **stale tag** — so an
+`[offline]` tag can't outlive the work it points at. Routed as an observation here, not a rule edit.
+
+## Doc audit (Q-0104)
+Durable homes updated: the **plan §6** (follow-up #1 SHIPPED + #2 sharpened), the **games folio**
+(`!platform economytrend` documented), and the **roadmap** drift fix. `check_docs --strict` +
+`check_consistency` green (via `check_quality --check-only`). **Recently-shipped NOT edited** — #1483
+isn't merged at write time and the ledger convention is merged-PRs-only; the lag is benign (the next
+session / the #1500 reconciliation records it). `check_current_state_ledger --strict` lag is the same
+benign newest-merge lag (recon is the docs-reconciliation routine's lane, Q-0124). Claim file deleted
+at close.
+
+## 📤 Run report
+- **Did:** built the per-day games-economy faucet/sink **trend** view (db read fn + service timeseries
+  read model + `!platform economytrend` with a sparkline) — the §6 follow-up tail of the shipped #1044
+  diagnostic; fixed the roadmap P0-1 drift on sight; sharpened the §6 health-finding into a turn-key
+  design-for-review handoff. · **Outcome:** shipped (auto-merges on green).
+- **Shipped:** #1483 — `economy_flow_daily` + `build_flow_timeseries`/`EconomyFlowTimeseries` +
+  `!platform economytrend [days]`; +14 tests; roadmap/plan/games-folio de-staled; artifacts re-exported.
+- **Run type:** routine · dispatch
+- **⚑ Owner decisions needed:** none (the §6 health-finding stays design-for-review — captured, not a
+  blocking decision; agent rec when picked up: guild_id in the fingerprint + a sustained ≥N-of-M-days
+  rule, emitted from the daily `HealthMaintenanceCog`).
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** yes — this lane was self-picked from the shipped plan's explicitly-captured §6
+  follow-ups (no dispatch payload, no owner ask); it's a read-only observability extension of shipped
+  work, flagged here per Q-0172.
+- **↪ Next:** the BTD6 grounding-eval offline tail is complete and procedures→skills Batch 2 /
+  botsite PR 2 / Project Moon Slice A·B remain gated for an autonomous run (CLAUDE.md-edit /
+  production-web / network-datamine / runtime-verification respectively). The cleanest *next* offline
+  pick is the **§6 economy-flow health-finding** once its three design questions (above) are decided, or
+  promoting a fresh `docs/ideas/` entry → plan → build (Q-0172). Bug-book: BUG-0009 newest-towers
+  data-gated, BUG-0011 needs a VPS repro, BUG-0019 #1 awaits an owner behavior decision — all stay OPEN.

--- a/.sessions/2026-06-27-economy-flow-timeseries.md
+++ b/.sessions/2026-06-27-economy-flow-timeseries.md
@@ -1,0 +1,34 @@
+# 2026-06-27 — Games-economy observability: faucet/sink timeseries (+ inflation finding)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What this run is doing
+
+Empty-fire dispatch. The clean offline lanes are thin (BTD6 anchors complete; procedures→skills
+Batch 2 needs a CLAUDE.md self-edit — autonomous-blocked by Q-0106; botsite PR 2 flips the live
+homepage — owner-paced; BUG-0009 newest-towers is data-gated; Project Moon Slice A/B need a network
+datamine or runtime verification; fishing Phase 2 is owner-design-gated). The cleanest genuinely-
+useful offline slice is the **§6 follow-up tail** of the shipped games-economy faucet/sink diagnostic
+([plan](../planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md), shipped #1044): the
+all-time + windowed *aggregate* view + verdict shipped, but the per-day **trend** and the **inflation
+health-finding** were explicitly "capture, don't build here". Both are read-only / content-free,
+extend shipped work, and serve the owner's stated need (watch whether the mining economy is inflating
+*over time*, not from a single window aggregate).
+
+**Slice 1 (PR) — economy-flow timeseries (per-day trend).** A pure DB read fn
+(`economy_flow_daily`, GROUP BY day over `economy_audit_log.occurred_at`) → a typed
+`EconomyFlowTimeseries` service read model → a `!platform economytrend [days]` admin view (per-day
+minted/drained/net table + a dependency-free net-flow sparkline + an overall trend read). Read-only,
+content-free, no migration (rides the existing `occurred_at` column), no new reason.
+
+**Slice 2 (assessed after Slice 1) — inflation health-finding.** Wire the existing `verdict` into the
+P1-2 health-findings lifecycle (#843) so a sustained "inflating ⚠" surfaces as a persistent operator
+finding manageable via `!platform finding`.
+
+Also fixing on sight (Q-0166 drift): the roadmap §Games "Now" line still lists **P0-1 wager
+money-safety** as the next implementation session, but its plan is `historical` — EXECUTED in #748.
+
+## Verification
+*(filled at close)*

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-26T09:31:18Z",
+    "generated_at": "2026-06-27T03:11:26Z",
     "build": {
-      "commit": "48cd5a08",
-      "subject": "reconcile band-#1470: born-red session card + claim",
-      "committed_at": "2026-06-26T09:31:18Z"
+      "commit": "50165ff0",
+      "subject": "session: open born-red card — games-economy faucet/sink timeseries (+ inflation finding)",
+      "committed_at": "2026-06-27T03:11:26Z"
     }
   },
   "counts": {
-    "commands": 448,
+    "commands": 449,
     "features": 43,
     "games": 12
   },
@@ -10547,6 +10547,24 @@
       "use_cases": null,
       "examples": [
         "!platform economy [days]"
+      ],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "economytrend",
+      "aliases": [
+        "coinflowtrend"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Per-day coin-flow trend (`!platform economytrend [days]`): the daily",
+      "description": "Per-day coin-flow trend (!platform economytrend [days]): the daily minted/drained/net series + a net sparkline + a rising/falling read, so you can see whether the economy is inflating *over time*, not just at one snapshot. Window N days or omit for all-time. Read-only, content-free.",
+      "use_cases": null,
+      "examples": [
+        "!platform economytrend [days]"
       ],
       "status": "finished",
       "linked_ideas": [],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -1999,6 +1999,23 @@ const COMMANDS = [
     ]
   },
   {
+    "name": "economytrend",
+    "area": "other",
+    "status": "finished",
+    "summary": "Per-day coin-flow trend (`!platform economytrend [days]`): the daily",
+    "description": "Per-day coin-flow trend (!platform economytrend [days]): the daily minted/drained/net series + a net sparkline + a rising/falling read, so you can see whether the economy is inflating *over time*, not just at one snapshot. Window N days or omit for all-time. Read-only, content-free.",
+    "usage": "!economytrend",
+    "aliases": [
+      "coinflowtrend"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [
+      "!platform economytrend [days]"
+    ],
+    "planned": []
+  },
+  {
     "name": "ego",
     "area": "games",
     "status": "in-progress",
@@ -6824,7 +6841,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "48cd5a08",
+    "build": "50165ff0",
     "title": "New public bot website",
     "changes": [
       {
@@ -6836,7 +6853,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "48cd5a08",
+    "build": "50165ff0",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6848,7 +6865,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "48cd5a08",
+    "build": "50165ff0",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-26T23:46:05Z",
+    "generated_at": "2026-06-27T03:11:26Z",
     "build": {
-      "commit": "6aa548c9",
-      "subject": "Merge pull request #1480 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-06-26T23:46:05Z"
+      "commit": "50165ff0",
+      "subject": "session: open born-red card — games-economy faucet/sink timeseries (+ inflation finding)",
+      "committed_at": "2026-06-27T03:11:26Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 54,
-      "commands": 448,
+      "commands": 449,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2545,6 +2545,22 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-06-27-startability-offline-fit-tags.md",
+      "date": "2026-06-27",
+      "title": "2026-06-27 — Per-sector offline-fit startability tags (workflow improvement)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-27-economy-flow-timeseries.md",
+      "date": "2026-06-27",
+      "title": "2026-06-27 — Games-economy observability: faucet/sink timeseries (+ inflation finding)",
+      "status": "in-progress",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-26-sessionclose-freshness-wiring.md",
       "date": "2026-06-26",
       "title": "2026-06-26 — Wire ▶ Next freshness guard into /session-close",
@@ -3006,22 +3022,6 @@
       "title": "2026-06-24 — BTD6 paragon elite-boss damage multiplier",
       "status": "complete",
       "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-24-btd6-ai-floor-coverage-fixes.md",
-      "date": "2026-06-24",
-      "title": "2026-06-24 — BTD6 AI floor coverage: range RBE + paragon elite-boss multiplier",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-24-bot-migration-assistant-plan.md",
-      "date": "2026-06-24",
-      "title": "Session — 2026-06-24 · bot-migration-assistant plan",
-      "status": "complete",
-      "run_type": "",
       "self_initiated": false
     }
   ],
@@ -7786,6 +7786,19 @@
             "coinflow"
           ],
           "brief": "Faucet/sink coin-economy view (`!platform economy [days]`): minted",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "economytrend",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "coinflowtrend"
+          ],
+          "brief": "Per-day coin-flow trend (`!platform economytrend [days]`): the daily",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -30,6 +30,7 @@ from services.diagnostic_embeds import (  # noqa: F401
     build_counting_health_embed,
     build_customization_embed,
     build_economy_flow_embed,
+    build_economy_trend_embed,
     build_findings_embed,
     build_flags_embed,
     build_health_embed,

--- a/disbot/cogs/diagnostic/platform_group.py
+++ b/disbot/cogs/diagnostic/platform_group.py
@@ -322,6 +322,18 @@ class PlatformCommandsMixin(_MixinBase):
 
         await ctx.send(embed=await build_economy_flow_embed(ctx.guild.id, days=days))
 
+    @platform_grp.command(name="economytrend", aliases=["coinflowtrend"])  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_economy_trend(self, ctx, days: int | None = None):
+        """Per-day coin-flow trend (`!platform economytrend [days]`): the daily
+        minted/drained/net series + a net sparkline + a rising/falling read, so
+        you can see whether the economy is inflating *over time*, not just at one
+        snapshot. Window N days or omit for all-time. Read-only, content-free.
+        """
+        from cogs.diagnostic._platform_embeds import build_economy_trend_embed
+
+        await ctx.send(embed=await build_economy_trend_embed(ctx.guild.id, days=days))
+
     @platform_grp.command(name="locks")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_locks(self, ctx, prefix: str = ""):

--- a/disbot/services/diagnostic_embeds.py
+++ b/disbot/services/diagnostic_embeds.py
@@ -1407,6 +1407,116 @@ def _format_flow_rows(rows, limit: int = 12) -> str:
     return "\n".join(lines)
 
 
+# Eight block glyphs for the dependency-free sparkline (low → high). A signed
+# series is mapped over its full min..max range so the zero line sits where the
+# data crosses it — no external charting lib, content-free.
+_SPARK_BLOCKS = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(values: list[int]) -> str:
+    """Render ``values`` as a unicode block sparkline (empty string if none).
+
+    Scaled across the series' own min..max so flat data renders as one mid
+    glyph rather than dividing by zero. Pure text — safe in an embed field.
+    """
+    if not values:
+        return ""
+    lo, hi = min(values), max(values)
+    span = hi - lo
+    if span == 0:
+        return _SPARK_BLOCKS[len(_SPARK_BLOCKS) // 2] * len(values)
+    last = len(_SPARK_BLOCKS) - 1
+    return "".join(_SPARK_BLOCKS[round((v - lo) / span * last)] for v in values)
+
+
+async def build_economy_trend_embed(
+    guild_id: int,
+    *,
+    days: int | None = None,
+) -> discord.Embed:
+    """Build the embed for ``!platform economytrend [days]`` — per-day flow trend.
+
+    The time-series companion to :func:`build_economy_flow_embed`: instead of one
+    window aggregate it shows the **daily** minted / drained / net series (a
+    net-flow sparkline + a recent per-day table) plus a rising/falling/steady
+    read, so an operator can see whether the economy is inflating *over time*,
+    not just at one snapshot.  Content-free — coin totals and counts only, no
+    per-user data (the read model aggregates ``user_id`` away).
+    """
+    from services import economy_flow_service
+
+    ts = await economy_flow_service.build_flow_timeseries(guild_id, days=days)
+
+    verdict_colors = {
+        "inflating ⚠": discord.Color.orange(),
+        "draining": discord.Color.blue(),
+        "balanced": discord.Color.green(),
+        "no activity": discord.Color.light_grey(),
+    }
+    embed = discord.Embed(
+        title="📈 Economy flow trend",
+        description=(
+            f"Per-day coin flow over **{ts.window_label}** "
+            "(aggregated from the economy audit ledger — counts and totals "
+            "only, no per-user data)."
+        ),
+        color=verdict_colors.get(ts.verdict, discord.Color.blurple()),
+    )
+
+    if not ts.days:
+        embed.add_field(
+            name="No activity",
+            value="*(no coin movements recorded for this window)*",
+            inline=False,
+        )
+        return embed
+
+    ratio_text = f"{ts.ratio:.2f}×" if ts.ratio is not None else "—"
+    net_sign = "+" if ts.net >= 0 else "−"
+    embed.add_field(
+        name="Summary",
+        value=(
+            f"minted **{ts.total_minted:,}** · "
+            f"drained **{ts.total_drained:,}**\n"
+            f"net **{net_sign}{abs(ts.net):,}** · "
+            f"mint:drain **{ratio_text}** · "
+            f"verdict **{ts.verdict}** · "
+            f"trend **{ts.trend}**"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name=f"Net per day ({len(ts.days)} day{'s' if len(ts.days) != 1 else ''})",
+        value=f"`{_sparkline([d.net for d in ts.days])}`",
+        inline=False,
+    )
+    embed.add_field(
+        name="Recent days",
+        value=_format_day_rows(ts.days),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Trend = first-half vs second-half mean daily net flow.",
+    )
+    return embed
+
+
+def _format_day_rows(days, limit: int = 14) -> str:
+    """Render the most recent *limit* ``DayFlow`` rows, newest first."""
+    recent = days[-limit:]
+    lines = []
+    for d in reversed(recent):
+        net_sign = "+" if d.net >= 0 else "−"
+        lines.append(
+            f"`{d.day.isoformat()}` "
+            f"🟢 {d.minted:,} · 🔴 {d.drained:,} · "
+            f"net {net_sign}{abs(d.net):,} ({d.movements:,})",
+        )
+    if len(days) > limit:
+        lines.append(f"… and {len(days) - limit} earlier day(s)")
+    return "\n".join(lines)
+
+
 def build_locks_embed(prefix: str = "") -> discord.Embed:
     """Build the embed for ``!platform locks [prefix]``."""
     from services import diagnostics_service

--- a/disbot/services/economy_flow_service.py
+++ b/disbot/services/economy_flow_service.py
@@ -19,7 +19,7 @@ with no Discord types and no ``views`` import. The admin cog renders it.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import NamedTuple
 
 from utils.db import economy as economy_db
@@ -74,6 +74,117 @@ def _classify(ratio: float | None, total_minted: int, total_drained: int) -> str
     if ratio <= _DRAINING_RATIO:
         return "draining"
     return "balanced"
+
+
+class DayFlow(NamedTuple):
+    """One calendar day (UTC) of coin flow: minted / drained / net + movements.
+
+    ``net`` is ``minted - drained`` (signed). ``drained`` is a positive
+    magnitude (coins removed), mirroring :class:`EconomyFlowReport`.
+    """
+
+    day: date
+    minted: int
+    drained: int
+    net: int
+    movements: int
+
+
+class EconomyFlowTimeseries(NamedTuple):
+    """Per-day faucet/sink trend over a window — the time-series sibling.
+
+    ``days`` is oldest-first so it reads left-to-right. The totals/ratio/verdict
+    mirror :class:`EconomyFlowReport` (the whole-window aggregate), and
+    ``trend`` is a coarse read of whether net coin flow is rising (minting
+    pulling ahead of draining over the window), falling, or steady — the signal
+    a single aggregate can't show.
+    """
+
+    days: list[DayFlow]
+    total_minted: int
+    total_drained: int
+    net: int
+    ratio: float | None
+    window_label: str
+    verdict: str
+    trend: str
+
+
+# Below this fraction of the window's net-flow magnitude a half-over-half change
+# is noise, not a trend — keeps a flat economy from reading as "rising/falling".
+_TREND_EPS = 0.15
+
+
+def _trend(daily_nets: list[int]) -> str:
+    """Coarse direction of net coin flow: rising / falling / steady / n/a.
+
+    Compares the mean daily net of the window's first half against its second
+    half. A move smaller than :data:`_TREND_EPS` of the window's magnitude is
+    "steady" (noise-tolerant); fewer than two days is "n/a".
+    """
+    if len(daily_nets) < 2:
+        return "n/a"
+    mid = len(daily_nets) // 2
+    first = daily_nets[:mid] or daily_nets[:1]
+    second = daily_nets[mid:]
+    first_mean = sum(first) / len(first)
+    second_mean = sum(second) / len(second)
+    delta = second_mean - first_mean
+    scale = max(abs(first_mean), abs(second_mean), 1.0)
+    if delta > _TREND_EPS * scale:
+        return "rising ⬆"
+    if delta < -_TREND_EPS * scale:
+        return "falling ⬇"
+    return "steady ➡"
+
+
+async def build_flow_timeseries(
+    guild_id: int,
+    *,
+    days: int | None = None,
+) -> EconomyFlowTimeseries:
+    """Aggregate ``economy_audit_log`` into a per-day faucet/sink trend.
+
+    ``days`` bounds the window to the last *N* days (by audit timestamp);
+    ``None`` is the all-time view. Pure read — no writes, no Discord types.
+    """
+    since: datetime | None = None
+    if days is not None and days > 0:
+        since = datetime.now(timezone.utc) - timedelta(days=days)
+        window_label = f"last {days} day{'s' if days != 1 else ''}"
+    else:
+        window_label = "all time"
+
+    rows = await economy_db.economy_flow_daily(guild_id, since=since)
+    return _assemble_timeseries(rows, window_label)
+
+
+def _assemble_timeseries(
+    rows: list[tuple[date, int, int, int, int]],
+    window_label: str,
+) -> EconomyFlowTimeseries:
+    """Pure assembly from raw ``(day, minted, drained, net, count)`` rows."""
+    day_flows = [
+        DayFlow(day, minted, drained, net, count)
+        for day, minted, drained, net, count in rows
+    ]
+    total_minted = sum(d.minted for d in day_flows)
+    total_drained = sum(d.drained for d in day_flows)
+    net = total_minted - total_drained
+    ratio = (total_minted / total_drained) if total_drained > 0 else None
+    verdict = _classify(ratio, total_minted, total_drained)
+    trend = _trend([d.net for d in day_flows])
+
+    return EconomyFlowTimeseries(
+        days=day_flows,
+        total_minted=total_minted,
+        total_drained=total_drained,
+        net=net,
+        ratio=ratio,
+        window_label=window_label,
+        verdict=verdict,
+        trend=trend,
+    )
 
 
 async def build_flow_report(

--- a/disbot/utils/db/economy.py
+++ b/disbot/utils/db/economy.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from utils.db import pool
 
 if TYPE_CHECKING:
-    from datetime import datetime
+    from datetime import date, datetime
 
     import asyncpg
 
@@ -145,6 +145,56 @@ async def economy_flow_by_reason(
             conn=conn,
         )
     return [(r["reason"], int(r["net"]), int(r["n"])) for r in rows]
+
+
+async def economy_flow_daily(
+    guild_id: int,
+    *,
+    since: datetime | None = None,
+    conn: asyncpg.Connection | None = None,
+) -> list[tuple[date, int, int, int, int]]:
+    """Per-UTC-day ``(day, minted, drained, net, movements)`` over the audit log.
+
+    Pure read — the time-series sibling of :func:`economy_flow_by_reason`.
+    Aggregates ``economy_audit_log`` for one guild into one row per calendar day
+    (UTC, so a day boundary is deterministic regardless of the server timezone):
+    coins minted (sum of positive deltas), coins drained (sum of negative deltas
+    as a positive magnitude), net (signed), and the movement count. ``since``
+    filters by ``occurred_at``; omit for all recorded days. Rows are ordered
+    **oldest-first** so the caller reads them left-to-right as a trend.
+    """
+    if since is None:
+        rows = await pool.fetchall(
+            """SELECT (occurred_at AT TIME ZONE 'UTC')::date              AS day,
+                      COALESCE(SUM(delta) FILTER (WHERE delta > 0), 0)::bigint  AS minted,
+                      COALESCE(SUM(-delta) FILTER (WHERE delta < 0), 0)::bigint AS drained,
+                      SUM(delta)::bigint                                  AS net,
+                      COUNT(*)::bigint                                    AS n
+               FROM economy_audit_log
+               WHERE guild_id=$1
+               GROUP BY day
+               ORDER BY day ASC""",
+            (guild_id,),
+            conn=conn,
+        )
+    else:
+        rows = await pool.fetchall(
+            """SELECT (occurred_at AT TIME ZONE 'UTC')::date              AS day,
+                      COALESCE(SUM(delta) FILTER (WHERE delta > 0), 0)::bigint  AS minted,
+                      COALESCE(SUM(-delta) FILTER (WHERE delta < 0), 0)::bigint AS drained,
+                      SUM(delta)::bigint                                  AS net,
+                      COUNT(*)::bigint                                    AS n
+               FROM economy_audit_log
+               WHERE guild_id=$1 AND occurred_at >= $2
+               GROUP BY day
+               ORDER BY day ASC""",
+            (guild_id, since),
+            conn=conn,
+        )
+    return [
+        (r["day"], int(r["minted"]), int(r["drained"]), int(r["net"]), int(r["n"]))
+        for r in rows
+    ]
 
 
 async def add_coins(user_id: int, guild_id: int, amount: int) -> int:

--- a/docs/owner/claims/claude-funny-franklin-e8jbvj.md
+++ b/docs/owner/claims/claude-funny-franklin-e8jbvj.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-e8jbvj` · games-economy observability §6 follow-ups (faucet/sink timeseries + inflation health-finding) · `disbot/utils/db/economy.py`, `disbot/services/economy_flow_service.py`, `disbot/cogs/diagnostic/`, `disbot/services/diagnostic_embeds.py`, tests · 2026-06-27

--- a/docs/owner/claims/claude-funny-franklin-e8jbvj.md
+++ b/docs/owner/claims/claude-funny-franklin-e8jbvj.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-e8jbvj` · games-economy observability §6 follow-ups (faucet/sink timeseries + inflation health-finding) · `disbot/utils/db/economy.py`, `disbot/services/economy_flow_service.py`, `disbot/cogs/diagnostic/`, `disbot/services/diagnostic_embeds.py`, tests · 2026-06-27

--- a/docs/planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md
+++ b/docs/planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md
@@ -117,9 +117,23 @@ read model aggregates away `user_id`).
 
 ## 6. Follow-ups (capture, don't build here)
 
-- A windowed/timeseries view (coin flow per day) if the audit table carries a timestamp — natural
-  once the all-time view exists.
-- A `diagnostics_health_snapshot`-style finding when the faucet:sink ratio crosses an inflation
-  threshold (ties into the P1-2 health-findings lifecycle, #843) — design-for-review.
+- **✅ A windowed/timeseries view (coin flow per day) — SHIPPED (2026-06-27 dispatch run).** The
+  audit table carries `occurred_at`, so this landed as the per-day **trend** sibling of the aggregate
+  view: `utils.db.economy.economy_flow_daily` (a pure `GROUP BY (occurred_at AT TIME ZONE 'UTC')::date`
+  read), the `economy_flow_service.build_flow_timeseries` → `EconomyFlowTimeseries` read model (per-day
+  `DayFlow` series + totals + a first-half-vs-second-half **rising/falling/steady** trend read), and
+  `!platform economytrend [days]` (a net-flow unicode sparkline + a recent-days table + the verdict).
+  Read-only, content-free, no migration, no new reason.
+- **A health-finding when the faucet:sink ratio sustains an inflation verdict (ties into the P1-2
+  health-findings lifecycle, #843) — STILL design-for-review.** The deliberate open design question
+  (why it wasn't built with the timeseries): the economy verdict is **per-guild**, but the
+  `operational_health_findings` store + `record_findings(HealthSnapshot)` seam is **guild-agnostic**
+  (the fingerprint excludes unbounded identifiers; the store has no `guild_id` column). A turn-key
+  next slice must decide: (a) carry the `guild_id` in the finding's fingerprint + message (so each
+  guild gets a distinct, dedupable finding) vs. a process-wide "some guild is inflating" roll-up; (b)
+  the **sustained** rule (don't fire on one noisy day — e.g. verdict `inflating ⚠` on ≥ N of the last
+  M days, computed off `build_flow_timeseries`); (c) which loop emits it (the daily
+  `HealthMaintenanceCog` is the precedent, but it would need to iterate guilds). Once decided it is a
+  small producer + a wiring into the daily loop; the read model already computes the verdict + trend.
 - Extend faucet coverage when game/daily reward reasons are folded in (the classifier already
   handles them by sign; this is just documentation of the taxonomy).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -490,10 +490,11 @@ provenance schema is implemented.
 Folio: [games](subsystems/games.md) · **Boundary:** ADR-002 (game state not restart-safe —
 accepted, not a target).
 
-- **Now (next implementation session, owner-picked 2026-06-12)** — **P0-1 wager
-  money-safety**: [games-wager-money-safety-plan](planning/games-wager-money-safety-plan-2026-06-12.md)
-  — one audited `game_wager_workflow` composing the existing `economy_service` atomic
-  primitives (escrow→settle/refund, idempotent payouts), failure-injection tests, AST fence.
+- **✅ P0-1 wager money-safety — SHIPPED #748 (2026-06-12, owner-picked).** The audited
+  `services/game_wager_workflow.py` (escrow-at-accept, idempotent settle/payout, all four RPS +
+  blackjack PvP/tournament call-sites migrated, AST fence + failure-injection tests) — plan is
+  `historical`: [games-wager-money-safety-plan](planning/games-wager-money-safety-plan-2026-06-12.md).
+  *(Money-safety lineage continued in the settle-once guards #1444/#1445/#1454.)*
 - **Now (active lane)** — the **mining character platform** (from the
   [mining brainstorm](ideas/mining_exploration_brainstorm.md) §7 vision). Wave-1 chain
   shipped #606–#610 + #624 (explore wiring + equipment seam, persistent Descent, combat

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -300,7 +300,13 @@ also reachable via `!farm` and the Explore world hub.
   transaction: move + loot + fog-mark + wear + the down-dig depth-record bonus); no separate move /
   "Mine here".
 - [games-economy-faucet-sink-diagnostic-plan](../planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md) —
-  read-only economy faucet/sink read model (turn-key).
+  read-only economy faucet/sink read model. **Shipped #1044** (`!platform economy [days]` — the
+  whole-window mint/drain/net/ratio + verdict aggregate) **+ the per-day trend view (2026-06-27):
+  `!platform economytrend [days]`** (`economy_flow_service.build_flow_timeseries` → a daily
+  minted/drained/net series + a net-flow sparkline + a rising/falling/steady read), so an operator can
+  watch inflation *over time*, not just at one snapshot. The §6 health-finding follow-up (a persistent
+  finding when a guild sustains the `inflating ⚠` verdict) stays **design-for-review** (per-guild verdict
+  vs. the guild-agnostic findings store — see the plan §6).
 - [mining-economy-balance-2026-06-22](../planning/mining-economy-balance-2026-06-22.md) — **sim-pinned
   rebalance numbers** for the live grid-Mine faucet (owner: "rewards too large & too frequent"). The
   simulator (`tools/game_sim/mining_economy_sim.py`) quantifies the live faucet at ~7–55× a `!daily`/hr

--- a/tests/unit/db/test_economy_db_txn.py
+++ b/tests/unit/db/test_economy_db_txn.py
@@ -217,3 +217,64 @@ async def test_economy_flow_by_reason_windowed_filters_by_occurred_at():
     flat = " ".join(mock_fetch.await_args.args[0].split())
     assert "occurred_at >= $2" in flat
     assert mock_fetch.await_args.args[1] == (99, since)
+
+
+# ---------------------------------------------------------------------------
+# economy_flow_daily — per-day time-series aggregation (trend view)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_economy_flow_daily_all_time_groups_by_utc_day_no_since():
+    from datetime import date
+
+    with patch(
+        "utils.db.economy.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[
+            {
+                "day": date(2026, 6, 1),
+                "minted": 5000,
+                "drained": 1800,
+                "net": 3200,
+                "n": 40,
+            },
+            {
+                "day": date(2026, 6, 2),
+                "minted": 1200,
+                "drained": 1500,
+                "net": -300,
+                "n": 22,
+            },
+        ],
+    ) as mock_fetch:
+        result = await economy.economy_flow_daily(7)
+
+    flat = " ".join(mock_fetch.await_args.args[0].split())
+    assert "FROM economy_audit_log" in flat
+    assert "GROUP BY day" in flat
+    assert "ORDER BY day ASC" in flat  # oldest-first, read left-to-right
+    assert "AT TIME ZONE 'UTC'" in flat  # deterministic day boundary
+    assert "occurred_at >=" not in flat  # all-time path has no time filter
+    assert mock_fetch.await_args.args[1] == (7,)
+    assert result == [
+        (date(2026, 6, 1), 5000, 1800, 3200, 40),
+        (date(2026, 6, 2), 1200, 1500, -300, 22),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_economy_flow_daily_windowed_filters_by_occurred_at():
+    from datetime import datetime, timezone
+
+    since = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    with patch(
+        "utils.db.economy.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_fetch:
+        await economy.economy_flow_daily(7, since=since)
+
+    flat = " ".join(mock_fetch.await_args.args[0].split())
+    assert "occurred_at >= $2" in flat
+    assert mock_fetch.await_args.args[1] == (7, since)

--- a/tests/unit/services/test_diagnostic_economy_trend_embed.py
+++ b/tests/unit/services/test_diagnostic_economy_trend_embed.py
@@ -1,0 +1,97 @@
+"""The `!platform economytrend` embed + its pure render helpers.
+
+Pins the per-day faucet/sink trend embed (the time-series companion to the
+`!platform economy` aggregate view): the dependency-free unicode sparkline, the
+recent-days table, and that the builder forwards the window to the read model
+and renders the summary/verdict/trend without touching Discord I/O.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import diagnostic_embeds as de
+from services.economy_flow_service import DayFlow, EconomyFlowTimeseries
+
+
+def test_sparkline_empty_is_blank():
+    assert de._sparkline([]) == ""
+
+
+def test_sparkline_flat_series_is_single_mid_glyph_no_div_by_zero():
+    out = de._sparkline([5, 5, 5])
+    assert len(out) == 3
+    assert set(out) == {de._SPARK_BLOCKS[len(de._SPARK_BLOCKS) // 2]}
+
+
+def test_sparkline_maps_min_low_max_high():
+    out = de._sparkline([-100, 0, 100])
+    assert len(out) == 3
+    assert out[0] == de._SPARK_BLOCKS[0]  # min → lowest block
+    assert out[-1] == de._SPARK_BLOCKS[-1]  # max → highest block
+
+
+def test_format_day_rows_is_newest_first_and_caps():
+    days = [DayFlow(date(2026, 6, d), d * 100, d * 10, d * 90, d) for d in range(1, 20)]
+    out = de._format_day_rows(days, limit=14)
+    lines = out.splitlines()
+    # 14 rendered rows newest-first + one "earlier day(s)" line.
+    assert lines[0].startswith("`2026-06-19`")
+    assert "earlier day(s)" in lines[-1]
+
+
+@pytest.mark.asyncio
+async def test_trend_embed_renders_summary_and_series():
+    ts = EconomyFlowTimeseries(
+        days=[
+            DayFlow(date(2026, 6, 1), 5000, 1000, 4000, 40),
+            DayFlow(date(2026, 6, 2), 1000, 1500, -500, 22),
+        ],
+        total_minted=6000,
+        total_drained=2500,
+        net=3500,
+        ratio=2.4,
+        window_label="last 7 days",
+        verdict="inflating ⚠",
+        trend="rising ⬆",
+    )
+    # The builder imports economy_flow_service lazily, so patch at the source.
+    with patch(
+        "services.economy_flow_service.build_flow_timeseries",
+        new_callable=AsyncMock,
+        return_value=ts,
+    ):
+        embed = await de.build_economy_trend_embed(123, days=7)
+
+    blob = (
+        embed.description + " " + " ".join(f"{f.name} {f.value}" for f in embed.fields)
+    )
+    assert "last 7 days" in blob
+    assert "inflating ⚠" in blob
+    assert "rising ⬆" in blob
+    assert "2026-06-01" in blob
+
+
+@pytest.mark.asyncio
+async def test_trend_embed_no_activity_path():
+    ts = EconomyFlowTimeseries(
+        days=[],
+        total_minted=0,
+        total_drained=0,
+        net=0,
+        ratio=None,
+        window_label="all time",
+        verdict="no activity",
+        trend="n/a",
+    )
+    with patch(
+        "services.economy_flow_service.build_flow_timeseries",
+        new_callable=AsyncMock,
+        return_value=ts,
+    ):
+        embed = await de.build_economy_trend_embed(123, days=None)
+    names = [f.name for f in embed.fields]
+    assert "No activity" in names

--- a/tests/unit/services/test_economy_flow_service.py
+++ b/tests/unit/services/test_economy_flow_service.py
@@ -92,9 +92,9 @@ def test_zero_net_reason_is_neither_faucet_nor_sink():
 
 def test_verdict_thresholds():
     # ratio >= 1.5 → inflating
-    assert _assemble(
-        [("f", 200, 1), ("s", -100, 1)], "all time"
-    ).verdict == "inflating ⚠"
+    assert (
+        _assemble([("f", 200, 1), ("s", -100, 1)], "all time").verdict == "inflating ⚠"
+    )
     # ratio <= 0.67 → draining
     assert _assemble([("f", 50, 1), ("s", -100, 1)], "all time").verdict == "draining"
     # in between → balanced
@@ -139,3 +139,88 @@ async def test_build_flow_report_singular_day_label():
     ):
         report = await flow.build_flow_report(42, days=1)
     assert report.window_label == "last 1 day"
+
+
+# ---------------------------------------------------------------------------
+# Time-series (per-day trend) read model
+# ---------------------------------------------------------------------------
+
+from datetime import date  # noqa: E402
+
+from services.economy_flow_service import (  # noqa: E402
+    DayFlow,
+    _assemble_timeseries,
+    _trend,
+)
+
+
+def test_assemble_timeseries_totals_and_verdict():
+    rows = [
+        (date(2026, 6, 1), 5000, 1000, 4000, 40),
+        (date(2026, 6, 2), 1000, 1500, -500, 22),
+    ]
+    ts = _assemble_timeseries(rows, "all time")
+    assert ts.days == [
+        DayFlow(date(2026, 6, 1), 5000, 1000, 4000, 40),
+        DayFlow(date(2026, 6, 2), 1000, 1500, -500, 22),
+    ]
+    assert ts.total_minted == 6000
+    assert ts.total_drained == 2500
+    assert ts.net == 3500
+    assert ts.ratio == pytest.approx(6000 / 2500)
+    assert ts.verdict == "inflating ⚠"  # reuses the aggregate classifier
+    assert ts.window_label == "all time"
+
+
+def test_assemble_timeseries_empty_is_no_activity():
+    ts = _assemble_timeseries([], "all time")
+    assert ts.days == []
+    assert ts.total_minted == 0
+    assert ts.total_drained == 0
+    assert ts.net == 0
+    assert ts.ratio is None
+    assert ts.verdict == "no activity"
+    assert ts.trend == "n/a"  # fewer than two days
+
+
+def test_trend_rising_falling_steady_and_na():
+    assert _trend([]) == "n/a"
+    assert _trend([100]) == "n/a"
+    # second half mean clearly above first half → rising
+    assert _trend([0, 0, 5000, 6000]) == "rising ⬆"
+    # second half mean clearly below first half → falling
+    assert _trend([6000, 5000, 0, 0]) == "falling ⬇"
+    # flat → steady (noise-tolerant)
+    assert _trend([100, 100, 100, 100]) == "steady ➡"
+
+
+def test_trend_small_change_is_steady_not_noise():
+    # A change under the _TREND_EPS fraction of magnitude must not read as a trend.
+    assert _trend([1000, 1000, 1000, 1010]) == "steady ➡"
+
+
+@pytest.mark.asyncio
+async def test_build_flow_timeseries_all_time_passes_no_since():
+    with patch.object(
+        flow.economy_db,
+        "economy_flow_daily",
+        new_callable=AsyncMock,
+        return_value=[(date(2026, 6, 1), 100, 0, 100, 2)],
+    ) as mock_db:
+        ts = await flow.build_flow_timeseries(7, days=None)
+    assert mock_db.await_args.kwargs["since"] is None
+    assert ts.window_label == "all time"
+    assert ts.days[0].day == date(2026, 6, 1)
+
+
+@pytest.mark.asyncio
+async def test_build_flow_timeseries_windowed_passes_since_and_labels():
+    with patch.object(
+        flow.economy_db,
+        "economy_flow_daily",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_db:
+        ts = await flow.build_flow_timeseries(7, days=14)
+    assert mock_db.await_args.kwargs["since"] is not None
+    assert ts.window_label == "last 14 days"


### PR DESCRIPTION
**Born-red dispatch PR** (session card `in-progress` → flipped `complete` as the last step, Q-0133).

## What & why
Empty-fire dispatch. Builds the **§6 follow-up tail** of the shipped games-economy faucet/sink
diagnostic ([plan](../blob/main/docs/planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md),
shipped #1044). The all-time + windowed *aggregate* view + inflating/draining/balanced verdict
shipped; the per-day **trend** and the **inflation health-finding** were explicitly "capture, don't
build here". Both are read-only / content-free (Q-0048 standing lift) and serve the owner's stated
need: watch whether the mining economy is inflating *over time*, not from one window aggregate.

## Slices
- **Slice 1 — economy-flow timeseries (per-day trend).** Pure DB read fn (`economy_flow_daily`,
  GROUP BY day over `economy_audit_log.occurred_at`) → typed `EconomyFlowTimeseries` read model →
  `!platform economytrend [days]` admin view (per-day minted/drained/net table + a dependency-free
  net-flow sparkline + an overall trend read). No migration (rides the existing `occurred_at`),
  no new reason/write.
- **Slice 2 (assessed after Slice 1)** — wire the existing `verdict` into the P1-2 health-findings
  lifecycle (#843) so a sustained "inflating ⚠" surfaces as a persistent operator finding.

Also fixes on sight (Q-0166): the roadmap §Games "Now" line still lists **P0-1 wager money-safety**
as the next session, but its plan is `historical` — EXECUTED in #748.

## Verification
`check_quality.py --full` + `check_architecture.py --mode strict` green (filled in the session card at close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyGkRjEebbEWdYHwPFVwK2)_