### PR TITLE
BTD6 QA-accuracy corpus wired into the evals (offline grounding test + live action suite)

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -23,6 +23,14 @@ on:
           - openai
           - anthropic
         default: both
+      suite:
+        description: Which cases to run
+        type: choice
+        options:
+          - golden          # the standard capability golden set
+          - btd6            # ONLY the BTD6 QA-accuracy corpus (real grounding)
+          - golden+btd6     # both
+        default: golden+btd6
       threshold:
         description: Pass-rate threshold (0-1), informational only
         type: string
@@ -52,12 +60,22 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PROVIDER: ${{ inputs.provider }}
+          SUITE: ${{ inputs.suite }}
           THRESHOLD: ${{ inputs.threshold }}
         run: |
+          # Translate the suite picker into run_evals flags. The BTD6 corpus is
+          # grounded with the bot's REAL btd6_context_service.build() facts, so a
+          # pass means the bot's own retrieval answers the question.
+          SUITE_FLAGS=""
+          case "$SUITE" in
+            btd6)        SUITE_FLAGS="--btd6 --category btd6_grounding" ;;
+            golden+btd6) SUITE_FLAGS="--btd6" ;;
+            *)           SUITE_FLAGS="" ;;   # golden only
+          esac
           {
-            echo '### AI eval scorecard'
+            echo "### AI eval scorecard (suite: ${SUITE})"
             echo ''
             echo '```text'
-            python scripts/run_evals.py --provider "$PROVIDER" --threshold "$THRESHOLD" || true
+            python scripts/run_evals.py --provider "$PROVIDER" --threshold "$THRESHOLD" $SUITE_FLAGS || true
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.sessions/2026-06-27-btd6-eval-corpus-action.md
+++ b/.sessions/2026-06-27-btd6-eval-corpus-action.md
@@ -1,0 +1,60 @@
+# 2026-06-27 — BTD6 QA corpus wired into the evals (offline grounding test + live action suite)
+
+> **Status:** `complete`
+
+**Run type:** owner-directed (follow-up to PR #1487)
+
+## What this run did
+
+Owner asked: *"update the evals action so I can test all these questions at once — would that be
+trustworthy? does the evals have access to the stored data?"* Honest finding: the eval **harness probes
+the model with hand-canned `tool_results` + a generic system prompt — it does NOT touch
+`btd6_context_service.build()`**, so naively dumping the corpus in would test the model in a vacuum, not
+the bot's retrieval. Made it trustworthy by keying both new layers off the bot's REAL grounding.
+
+**PR — BTD6 QA-accuracy corpus in the eval system.**
+
+1. **`tests/evals/btd6_corpus.py`** — the machine-readable corpus (`GROUNDING_PROBES`): each question +
+   the answer-bearing fact its real grounding must contain (`expect`) and the known wrong claim it must
+   not (`forbid`). One source feeding both layers.
+2. **`tests/evals/test_btd6_qa_corpus.py`** — the **offline, deterministic, creds-free** layer: runs each
+   question through the real `build()` and asserts the fact is grounded. Runs every PR. This is the
+   trustworthy "all at once" check — it proves the stored data is accessible + correct per question with
+   no model variance.
+3. **`scripts/run_evals.py --btd6`** + **`.github/workflows/ai-evals.yml` `suite:` picker** — the
+   **live, paid** layer: builds one `EvalCase` per question whose system prompt is the question's real
+   `build()` facts, then grades the model's phrased answer. Because the grounding is the bot's own, a
+   pass means "with the facts our bot actually retrieves, the model answers right" — not "answers from
+   perfect hand-fed context."
+4. Docs: `tests/evals/README.md` + the corpus doc explain the offline-vs-live trust split.
+
+CI: `check_quality --check-only` green; the offline corpus test + the eval harness/coverage tests pass
+(34) with no API keys.
+
+## ⚑ Self-initiated
+
+None unprompted — owner-directed ("update the evals action"). The offline grounding layer is the
+trustworthy implementation of "test all these questions at once."
+
+## 💡 Session idea (Q-0089)
+
+*Promote `test_btd6_qa_corpus.py` into a tiny reusable `grounding_probe` fixture other knowledge domains
+reuse (Project Moon already has the same build()/guard shape).* The offline "does the real pipeline
+ground the answer-bearing fact?" pattern is domain-agnostic; a shared probe helper would let the next
+knowledge domain get an accuracy corpus for free. Routed as an idea (Project Moon's corpus would be the
+first reuse), not built here.
+
+## ⟲ Previous-session review (Q-0102)
+
+The immediately-prior work (PR #1487, this session's first half) shipped the interaction grounding +
+corpus but left the corpus as a **human-readable doc only** — the owner's very next question ("can I test
+these at once?") shows a doc isn't enough; a corpus wants a machine half wired into CI. Good that #1487's
+corpus doc was structured enough to lift directly into `GROUNDING_PROBES`. **Workflow improvement
+(applied):** an accuracy corpus should ship with its offline probe test in the same arc, so "verified
+once" becomes "verified every PR" without a follow-up ask.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_docs`/`check_consistency` green. New facts homed: the eval trust-model in `tests/evals/README.md`
++ the testing section in the corpus doc. No new owner decision to route. Ledger: this PR is added by the
+next reconciliation pass (merged-only convention).

--- a/docs/btd6/qa-accuracy-corpus-2026-06-27.md
+++ b/docs/btd6/qa-accuracy-corpus-2026-06-27.md
@@ -174,10 +174,24 @@ gap — add a trigger token / alias to `btd6_interaction_service` or a row to
 `damage_types.json` (and a cross-check stays green because the table is validated against
 the game-sourced `immune_to` data).
 
+## Testing the whole corpus at once
+
+This corpus is wired into the eval system as `tests/evals/btd6_corpus.py` (the machine half),
+keyed off the bot's REAL `btd6_context_service.build()` grounding:
+
+- **Offline, free, every PR** — `python3.10 -m pytest tests/evals/test_btd6_qa_corpus.py` asserts
+  each question grounds its answer-bearing fact. This is the trustworthy "all at once" check; it
+  proves the stored data is accessible + correct per question with no model variance.
+- **Live, paid, opt-in** — the *AI Evals* GitHub Action (**suite: btd6**), or
+  `RUN_EVALS=1 … python3.10 scripts/run_evals.py --btd6 --category btd6_grounding`. Each case's
+  prompt is the question's real grounded facts, so it grades the model's *phrasing given the bot's
+  own retrieval* — not hand-fed context.
+
 ## Open follow-ups (next sessions)
 
-- **Live `llm_judge` battery** (creds-gated): confirm the model actually *uses* these
-  grounded interaction facts in its replies (the offline grounding half is what shipped here).
+- **Broaden the live `llm_judge` battery** (creds-gated): the `--btd6` corpus now confirms the model
+  answers from the real grounding; extend it with `llm_judge` rubric cases for strategy/opinion
+  questions the offline layer can't assert.
 - **Newer-tower coverage** (Desperado, Mermonkey): the dump has them; spot-check that
   interaction questions about their damage types ground correctly.
 - **Hero costs** are absent from `heroes.json` — wiki-only for now; a future data pass

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -78,7 +78,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--category",
         default=None,
-        help="run only one category (e.g. tool_use)",
+        help="run only one category (e.g. tool_use, btd6_grounding)",
+    )
+    parser.add_argument(
+        "--btd6",
+        action="store_true",
+        help="also run the BTD6 QA-accuracy corpus (tests/evals/btd6_corpus.py), "
+        "grounded with the REAL btd6_context_service.build() facts — so it tests "
+        "the bot's own retrieval, not hand-fed context. Combine with "
+        "--category btd6_grounding to run ONLY the BTD6 corpus.",
     )
     parser.add_argument(
         "--smoke",
@@ -113,14 +121,24 @@ def main(argv: list[str] | None = None) -> int:
     from tests.evals.harness import run_suite
     from tests.evals.smoke import SMOKE_MATRIX_VERSION
 
-    cases = [c for c in CASES if args.category in (None, c.category)]
+    all_cases = list(CASES)
+    if args.btd6:
+        # Build BTD6 cases from the REAL grounding pipeline (one build() per
+        # question), so the live model sees exactly what production retrieves.
+        from tests.evals.btd6_corpus import live_cases
+
+        all_cases += asyncio.run(live_cases())
+
+    cases = [c for c in all_cases if args.category in (None, c.category)]
     if not cases:
         print(f"No cases match category {args.category!r}.")
         return 2
 
+    btd6_note = " · BTD6 corpus grounded via real build()" if args.btd6 else ""
     print(
         f"Eval record — golden set v{GOLDEN_SET_VERSION} "
-        f"(live) · smoke matrix v{SMOKE_MATRIX_VERSION} (offline, run --smoke)",
+        f"(live) · smoke matrix v{SMOKE_MATRIX_VERSION} (offline, run --smoke)"
+        f"{btd6_note}",
     )
     card = asyncio.run(run_suite(cases, providers=providers))
     print(card.render())

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -45,3 +45,25 @@ rubric).
 Append an `EvalCase` to `CASES` in `cases.py`. Grow the set from real failures —
 when someone reports a bad answer, add it here so it becomes a permanent
 regression probe.
+
+## BTD6 QA-accuracy corpus (grounded with the REAL pipeline)
+
+`cases.py` probes the model with **hand-canned** `tool_results` — it tests the
+model in isolation, NOT the bot's BTD6 data pipeline. The BTD6 corpus
+(`btd6_corpus.py`) is different and is the trustworthy way to "test all the BTD6
+questions at once," because both layers key off the bot's REAL retrieval
+(`btd6_context_service.build()`):
+
+- **Offline, deterministic, free, every PR** — `test_btd6_qa_corpus.py` runs each
+  corpus question through `build()` and asserts the answer-bearing fact is
+  grounded (and the known wrong claim is not). This proves the stored data is
+  accessible and correct per question, with no API keys and no model variance.
+- **Live, paid, opt-in** — `run_evals.py --btd6` (or the **suite: btd6** dropdown
+  in the *AI Evals* Action) builds one `EvalCase` per question whose system
+  prompt is the question's **real `build()` facts**, then grades the model's
+  phrased answer. Because the grounding is the bot's own, a pass means "with the
+  facts our bot actually retrieves, the model answers correctly" — not "the model
+  can answer from perfect hand-fed context."
+
+Grow it by adding a `GroundingProbe` to `btd6_corpus.py` (it feeds both layers).
+The verified human-readable corpus is `docs/btd6/qa-accuracy-corpus-2026-06-27.md`.

--- a/tests/evals/btd6_corpus.py
+++ b/tests/evals/btd6_corpus.py
@@ -1,0 +1,167 @@
+"""BTD6 QA accuracy corpus — the machine-readable half of
+``docs/btd6/qa-accuracy-corpus-2026-06-27.md``.
+
+Two layers, both keyed off the SAME real grounding the production AI path uses
+(``services.btd6_context_service.build``), so a pass means the *bot's own*
+retrieved facts answer the question — not that a model can answer from perfect
+hand-fed context:
+
+* :data:`GROUNDING_PROBES` + ``test_btd6_qa_corpus.py`` — the **offline**,
+  deterministic, creds-free layer. For each question it asserts the answer-bearing
+  fact is actually grounded (``expect``) and the known wrong claim never is
+  (``forbid``). This is the trustworthy "test all these questions at once" check:
+  it runs the real retrieval pipeline, needs no API keys, and runs on every PR.
+
+* :func:`live_cases` — the **live** layer for ``scripts/run_evals.py --btd6``
+  (paid, opt-in). It injects each question's real ``build()`` facts into the
+  model prompt (mirroring production, where facts enter the instruction stack)
+  and grades the phrased answer. Same facts as the offline layer, so the only
+  extra thing it tests is whether the model *phrases* a faithful answer.
+
+Grow both from real misses: when a BTD6 answer is reported wrong, add a probe
+here so it becomes a permanent regression.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tests.evals.graders import all_of, contains, not_contains
+from tests.evals.harness import EvalCase
+
+from core.runtime.ai.contracts import AITask
+
+
+@dataclass(frozen=True)
+class GroundingProbe:
+    """One corpus question + what its REAL grounding must / must not contain."""
+
+    question: str
+    # Substrings that must appear (case-insensitive) in the joined grounded
+    # facts — the answer-bearing fact the bot retrieves for this question.
+    expect: tuple[str, ...]
+    # Substrings that must NOT appear — a known wrong claim (e.g. the live
+    # screenshot's "lead resists glue"). Optional.
+    forbid: tuple[str, ...] = ()
+    note: str = ""
+
+
+# Every probe's `expect` is a fact the curated data + the interaction layer
+# ground deterministically (verified against the dump). These are the
+# error-prone interaction questions from the live screenshots plus the core
+# bloon/immunity facts. Numbers/immunities trace to the game-sourced dump.
+GROUNDING_PROBES: tuple[GroundingProbe, ...] = (
+    # --- the live screenshot misses ------------------------------------------
+    GroundingProbe(
+        question="can glue strike and avenger deal with DDTs",
+        expect=("lead does not resist glue", "moab glue", "status effect"),
+        forbid=("lead resists glue", "lead is immune to glue"),
+        note="screenshot #2 — the 'Lead resists glue' hallucination",
+    ),
+    GroundingProbe(
+        question="can ice monkey slow ddts",
+        expect=("cold", "lead", "cold snap"),
+        note="screenshot #3 — ice is cold-based, blocked by lead; Cold Snap fixes it",
+    ),
+    GroundingProbe(
+        question="does glue work on lead bloons",
+        expect=("lead does not resist glue",),
+        forbid=("lead resists glue",),
+    ),
+    # --- damage-type interactions --------------------------------------------
+    GroundingProbe(
+        question="what damage can pop lead bloons",
+        expect=("needs explosion, fire, plasma, glacier, acid",),
+        note="the lead pop-guide 'needs' clause is grounded",
+    ),
+    GroundingProbe(
+        question="can you pop purple bloons with plasma",
+        expect=("energy, plasma, fire, and frigid damage cannot pop purple",),
+    ),
+    GroundingProbe(
+        question="can a bomb shooter pop black bloons",
+        expect=("explosion damage cannot pop black",),
+    ),
+    GroundingProbe(
+        question="does sharp damage pop lead",
+        expect=("sharp, shatter, cold, and energy damage cannot pop lead",),
+    ),
+    GroundingProbe(
+        question="how do I deal with a DDT",
+        expect=("camo detection", "fire, plasma, normal, acid, or glacier"),
+        forbid=("ddts are immune to glue", "lead resists glue"),
+    ),
+    GroundingProbe(
+        question="can glacier damage pop lead",
+        expect=("unlike plain cold",),
+        note="Glacier is the cold variant that DOES pop lead",
+    ),
+    # --- bloon immunities (game-sourced) -------------------------------------
+    GroundingProbe(
+        question="what is a DDT immune to",
+        expect=("immune to sharp, shatter, cold, energy, explosion",),
+    ),
+    GroundingProbe(
+        question="what is a zebra bloon immune to",
+        expect=("explosion", "cold"),
+        note="Zebra = Black + White → both",
+    ),
+    GroundingProbe(
+        question="what is a purple bloon immune to",
+        expect=("energy", "plasma", "fire"),
+    ),
+)
+
+
+# --- live-eval grading rubrics (one per probe id, keyed by question) ---------
+# The live model must state the same correct fact in prose. Kept lenient
+# (contains/not_contains on the key token) so model phrasing variance doesn't
+# cause false fails — the strict assertion is the offline grounding layer.
+_LIVE_FORBID_GLOBAL = ("lead resists glue", "lead is immune to glue")
+
+
+def _grounding_block(facts: list[str]) -> str:
+    """Wrap real grounded facts the way the production instruction stack frames
+    them: an untrusted-data block the model must answer FROM, not from memory.
+    """
+    body = "\n".join(facts) if facts else "(no grounded facts retrieved)"
+    return (
+        "You are SuperBot answering a Bloons TD 6 question. Answer ONLY from the "
+        "grounded BTD6 facts below — do not add facts from memory, and if the "
+        "facts do not cover it, say so. Keep it short.\n\n"
+        "<grounded_btd6_facts>\n"
+        f"{body}\n"
+        "</grounded_btd6_facts>"
+    )
+
+
+async def live_cases() -> list[EvalCase]:
+    """Build live EvalCases whose grounding is the REAL ``build()`` output.
+
+    Async because it calls the production grounding pipeline once per probe.
+    Each case grades the model's phrased answer with lenient contains/not_contains
+    over the same expect/forbid the offline layer asserts — so the live layer
+    tests *phrasing faithfulness given the real facts*, nothing hand-fed.
+    """
+    from services import btd6_context_service
+
+    cases: list[EvalCase] = []
+    for i, probe in enumerate(GROUNDING_PROBES):
+        ctx = await btd6_context_service.build(probe.question)
+        graders = [contains(s) for s in probe.expect[:1]]  # at least the headline fact
+        graders += [not_contains(s) for s in (*probe.forbid, *_LIVE_FORBID_GLOBAL)]
+        cases.append(
+            EvalCase(
+                id=f"btd6_corpus.{i:02d}",
+                category="btd6_grounding",
+                user_message=probe.question,
+                task=AITask.GENERAL_NL_ANSWER,
+                system_prompt=_grounding_block(list(ctx.facts)),
+                grader=all_of(*graders),
+                max_output_tokens=400,
+            ),
+        )
+    return cases
+
+
+__all__ = ["GROUNDING_PROBES", "GroundingProbe", "live_cases"]

--- a/tests/evals/test_btd6_qa_corpus.py
+++ b/tests/evals/test_btd6_qa_corpus.py
@@ -1,0 +1,41 @@
+"""Offline BTD6 QA-accuracy corpus check — the trustworthy "test all the
+questions at once" layer.
+
+For every :data:`GROUNDING_PROBES` entry this runs the REAL production grounding
+(``btd6_context_service.build``) and asserts the answer-bearing fact is grounded
+(``expect``) and the known wrong claim is not (``forbid``). It needs no API keys
+and runs on every PR, so it proves — deterministically — that the bot retrieves
+the right stored data for each corpus question. (The live model phrasing is the
+separate paid ``scripts/run_evals.py --btd6`` layer.)
+"""
+
+from __future__ import annotations
+
+import pytest
+from tests.evals.btd6_corpus import GROUNDING_PROBES
+
+from services import btd6_context_service
+
+
+@pytest.mark.parametrize("probe", GROUNDING_PROBES, ids=lambda p: p.question)
+async def test_corpus_question_grounds_its_answer(probe):
+    ctx = await btd6_context_service.build(probe.question)
+    blob = "\n".join(ctx.facts).lower()
+
+    for needle in probe.expect:
+        assert needle.lower() in blob, (
+            f"{probe.question!r}: expected grounded fact containing {needle!r}"
+            f"{' — ' + probe.note if probe.note else ''}.\nGrounded:\n" + blob
+        )
+    for bad in probe.forbid:
+        assert bad.lower() not in blob, (
+            f"{probe.question!r}: grounding must NOT contain {bad!r} "
+            f"(a known wrong claim)."
+        )
+
+
+def test_corpus_is_nontrivial():
+    """Guard against the corpus being silently emptied."""
+    assert len(GROUNDING_PROBES) >= 10
+    # Every probe names at least one expected fact.
+    assert all(p.expect for p in GROUNDING_PROBES)


### PR DESCRIPTION
## Why

Follow-up to #1487. You asked to *test all the BTD6 questions at once* and whether that would be
trustworthy — *"does the evals have access to the data we stored?"*

**Honest finding:** by default, **no**. The eval harness probes the model with hand-canned
`tool_results` + a generic system prompt — it never calls `btd6_context_service.build()`. So naively
dumping the corpus into it would test the *model in a vacuum*, not the bot's retrieval. A green there
would prove nothing about our data.

## What this does — both layers key off the bot's REAL grounding

1. **`tests/evals/btd6_corpus.py`** — `GROUNDING_PROBES`: each question + the answer-bearing fact its
   grounding must contain (`expect`) and the known wrong claim it must not (`forbid`). One source feeds
   both layers below.
2. **`tests/evals/test_btd6_qa_corpus.py`** — the **offline, deterministic, creds-free** layer. Runs
   each question through the real `build()` and asserts the fact is grounded. **Runs on every PR.** This
   is the trustworthy "all at once" check: it proves the stored data is accessible + correct per
   question, with no API keys and no model variance.
3. **`scripts/run_evals.py --btd6`** + **`ai-evals.yml` `suite:` picker** (`golden` / `btd6` /
   `golden+btd6`) — the **live, paid** layer. Builds one case per question whose system prompt is that
   question's **real `build()` facts**, then grades the model's phrased answer. A pass means "with the
   facts our bot actually retrieves, the model answers correctly" — not "from perfect hand-fed context."
4. Docs: `tests/evals/README.md` + the corpus doc explain the offline-vs-live trust split.

## Trustworthiness, plainly

- **Offline layer: fully trustworthy.** It *is* the production retrieval pipeline; deterministic; free.
  This is the one to rely on for "are these questions answerable from our data?"
- **Live layer: trustworthy for phrasing**, because the grounding is the bot's own — but it makes real
  paid API calls and has normal model-output variance, so read its scorecard, don't gate on it.

Tests: offline corpus (13 probes) + eval harness/coverage all pass with no API keys; `check_quality
--check-only` green. No `disbot/` runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PznCdhdV59y79932VKCj4g)_