### PR TITLE
BTD6 evals: faithful "exactly live" answer-path replay

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -54,26 +54,31 @@ jobs:
       - name: Run evals
         env:
           RUN_EVALS: "1"
-          # The LLM-as-judge uses the default-routed provider; pin it to
-          # Claude so grading is consistent across both candidate providers.
-          AI_DEFAULT_PROVIDER: anthropic
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PROVIDER: ${{ inputs.provider }}
           SUITE: ${{ inputs.suite }}
           THRESHOLD: ${{ inputs.threshold }}
         run: |
-          # Translate the suite picker into run_evals flags. The BTD6 corpus is
-          # grounded with the bot's REAL btd6_context_service.build() facts, so a
-          # pass means the bot's own retrieval answers the question.
+          # Map the suite picker → run_evals flags. The BTD6 corpus replays the
+          # REAL production answer path (router → grounding → instruction stack →
+          # gateway → faithfulness guard), so its result is the live answer. It
+          # tests the provider in AI_DEFAULT_PROVIDER; the golden set's LLM judge
+          # also keys off it, so default it to Claude for grading consistency and
+          # only switch it when running the BTD6 suite alone against one provider.
           SUITE_FLAGS=""
+          DEFAULT_PROVIDER="anthropic"
           case "$SUITE" in
-            btd6)        SUITE_FLAGS="--btd6 --category btd6_grounding" ;;
+            btd6)
+              SUITE_FLAGS="--btd6-only"
+              [ "$PROVIDER" != "both" ] && DEFAULT_PROVIDER="$PROVIDER"
+              ;;
             golden+btd6) SUITE_FLAGS="--btd6" ;;
             *)           SUITE_FLAGS="" ;;   # golden only
           esac
+          export AI_DEFAULT_PROVIDER="$DEFAULT_PROVIDER"
           {
-            echo "### AI eval scorecard (suite: ${SUITE})"
+            echo "### AI eval scorecard (suite: ${SUITE}; BTD6 live provider: ${DEFAULT_PROVIDER})"
             echo ''
             echo '```text'
             python scripts/run_evals.py --provider "$PROVIDER" --threshold "$THRESHOLD" $SUITE_FLAGS || true

--- a/.sessions/2026-06-27-btd6-eval-live-path.md
+++ b/.sessions/2026-06-27-btd6-eval-live-path.md
@@ -1,0 +1,63 @@
+# 2026-06-27 — BTD6 evals: faithful "exactly live" answer-path replay
+
+> **Status:** `complete`
+
+**Run type:** owner-directed (follow-up to PR #1488)
+
+## What this run did
+
+Owner wanted the eval action to give *"exactly the results that a live test would give."* PR #1488's
+live layer injected the real grounding into a simplified prompt (good, but not the live system prompt or
+the faithfulness guard). This run closes that gap: a faithful replay of the **real production answer
+path**, reusing production internals so there's no approximation and minimal drift.
+
+**PR — `tests/evals/btd6_live_path.py`.**
+
+- `run_live(question)` replays one question through the SAME components the live
+  `AINaturalLanguageStage` uses, in the same order: real `ai_task_router.classify` → real
+  `btd6_context_service.build` grounding → real `ai_instruction_service.assemble` instruction stack →
+  real `natural_language_stage._invoke_gateway` (tools, orchestration, round-cash workflow, ledger) →
+  real `validate_btd6_reply` guard + `_build_grounding_constraint` regenerate-once → real
+  `_btd6_no_data_refusal`. Pre-model deterministic floors are checked too. **Zero production code
+  change** — it reuses the internals, which is what keeps it from drifting.
+- `run_btd6_live_suite()` + `render_live_report()` grade every corpus probe's final live reply.
+- `scripts/run_evals.py --btd6` / `--btd6-only` run it; the *AI Evals* action **suite: btd6** maps to
+  `--btd6-only` and points `AI_DEFAULT_PROVIDER` at the chosen provider (the one the live path tests).
+- Replaced #1488's approximation (`live_cases`) with this; the **offline** grounding test
+  (`test_btd6_qa_corpus.py`) is unchanged + gained a wiring guard that runs `run_live` offline (degrades,
+  never raises) on every PR.
+
+Why faithful + safe: `_invoke_gateway` is DB-safe (it degrades the DB-backed bits and, with no key,
+returns a deterministic non-answer), so the path runs in CI; with a real key it produces the genuine
+live reply. Verified offline: the whole path executes without raising; the only non-reproduced parts are
+Discord I/O + the audit log, neither of which changes the answer text.
+
+CI: `check_quality --check-only` green; all 140 `tests/evals/` pass with no API keys.
+
+## ⚑ Self-initiated
+
+None unprompted — owner asked for exactly-live fidelity. Chose the reuse-internals replay over a
+hot-path refactor specifically to avoid touching the bot's riskiest code while still being faithful.
+
+## 💡 Session idea (Q-0089)
+
+*Add a `--diff` mode to the live suite that prints, per probe, the grounded facts vs the model's reply
+side by side.* When a live BTD6 answer fails, the fastest triage is "did the fact ground, and did the
+model use it?" — the replay already has both in hand. Routed as an idea, not built (keeps this PR
+focused on the faithful path itself).
+
+## ⟲ Previous-session review (Q-0102)
+
+PR #1488 was right to ship the offline layer first (it's the trustworthy core) but shipped a live layer
+I *described* to the owner as an approximation — and the very next ask was "make it exactly live." Lesson
+applied this run: when the deliverable is "test like production," reach for **reusing the production
+seam** first, not a parallel re-implementation — the reuse is both more faithful and less code. The one
+residual is drift risk (the replay mirrors `process`'s order); mitigated with a cross-reference note +
+the offline wiring guard, but a future shared-seam extraction in `natural_language_stage` would remove it
+entirely (noted, not done — it touches the hot path).
+
+## 🧾 Doc audit (Q-0104)
+
+`check_docs`/`check_consistency` green. Homed: the faithful-path explanation in `tests/evals/README.md`
++ the corpus doc testing section (both updated from "approximation" to "real production path"). No new
+owner decision to route. Ledger: added by the next reconciliation pass (merged-only convention).

--- a/docs/btd6/qa-accuracy-corpus-2026-06-27.md
+++ b/docs/btd6/qa-accuracy-corpus-2026-06-27.md
@@ -183,15 +183,17 @@ keyed off the bot's REAL `btd6_context_service.build()` grounding:
   each question grounds its answer-bearing fact. This is the trustworthy "all at once" check; it
   proves the stored data is accessible + correct per question with no model variance.
 - **Live, paid, opt-in** — the *AI Evals* GitHub Action (**suite: btd6**), or
-  `RUN_EVALS=1 … python3.10 scripts/run_evals.py --btd6 --category btd6_grounding`. Each case's
-  prompt is the question's real grounded facts, so it grades the model's *phrasing given the bot's
-  own retrieval* — not hand-fed context.
+  `RUN_EVALS=1 … python3.10 scripts/run_evals.py --btd6-only`. This replays each question through the
+  **REAL production answer path** (`tests/evals/btd6_live_path.py`): real router → real grounding → real
+  instruction stack → real gateway call → real faithfulness guard + regenerate-once + refusal. The
+  result is **what a live Discord user would get** (only Discord I/O + the audit log are skipped). It
+  tests the provider set in `AI_DEFAULT_PROVIDER`.
 
 ## Open follow-ups (next sessions)
 
-- **Broaden the live `llm_judge` battery** (creds-gated): the `--btd6` corpus now confirms the model
-  answers from the real grounding; extend it with `llm_judge` rubric cases for strategy/opinion
-  questions the offline layer can't assert.
+- **Broaden the live corpus** with strategy/opinion questions graded by `llm_judge` rubrics (the
+  exact-fact `expect`/`forbid` grading suits the interaction/data class; open-ended advice needs a
+  rubric judge).
 - **Newer-tower coverage** (Desperado, Mermonkey): the dump has them; spot-check that
   interaction questions about their damage types ground correctly.
 - **Hero costs** are absent from `heroes.json` — wiki-only for now; a future data pass

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -83,10 +83,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--btd6",
         action="store_true",
-        help="also run the BTD6 QA-accuracy corpus (tests/evals/btd6_corpus.py), "
-        "grounded with the REAL btd6_context_service.build() facts — so it tests "
-        "the bot's own retrieval, not hand-fed context. Combine with "
-        "--category btd6_grounding to run ONLY the BTD6 corpus.",
+        help="also run the BTD6 QA-accuracy corpus through the REAL production "
+        "answer path (router → grounding → instruction assembly → gateway → "
+        "faithfulness guard), so a result is what a live Discord user would get. "
+        "Uses the configured default provider (set AI_DEFAULT_PROVIDER).",
+    )
+    parser.add_argument(
+        "--btd6-only",
+        action="store_true",
+        help="run ONLY the BTD6 live corpus (skip the capability golden set).",
     )
     parser.add_argument(
         "--smoke",
@@ -109,45 +114,70 @@ def main(argv: list[str] | None = None) -> int:
     os.environ.setdefault("AI_ENABLED", "1")
     os.environ.setdefault("AI_TOOLS_ENABLED", "1")
 
-    providers = _build_providers(args.provider)
-    if not providers:
-        print(
-            "No usable providers — set OPENAI_API_KEY and/or ANTHROPIC_API_KEY "
-            "for the providers you selected.",
+    run_btd6 = args.btd6 or args.btd6_only
+    overall_ok = True
+
+    # --- BTD6 live corpus — the REAL production answer path -----------------
+    # Replays each corpus question through router → grounding → instruction
+    # assembly → gateway → faithfulness guard, against the configured default
+    # provider (AI_DEFAULT_PROVIDER), so a result is the live answer.
+    if run_btd6:
+        from tests.evals.btd6_live_path import (
+            live_suite_available,
+            render_live_report,
+            run_btd6_live_suite,
         )
-        return 2
 
-    from tests.evals.cases import CASES, GOLDEN_SET_VERSION
-    from tests.evals.harness import run_suite
-    from tests.evals.smoke import SMOKE_MATRIX_VERSION
+        if not live_suite_available():
+            print(
+                "BTD6 live corpus needs a provider key (OPENAI_API_KEY / "
+                "ANTHROPIC_API_KEY) and AI_DEFAULT_PROVIDER set to that provider.",
+            )
+            return 2
+        outcomes = asyncio.run(run_btd6_live_suite())
+        print(render_live_report(outcomes))
+        passed = sum(1 for o in outcomes if o.passed)
+        rate = passed / len(outcomes) if outcomes else 0.0
+        btd6_ok = rate >= args.threshold
+        overall_ok = overall_ok and btd6_ok
+        print(
+            f"\n{'PASS' if btd6_ok else 'FAIL'} — BTD6 live {rate:.0%} "
+            f"(threshold {args.threshold:.0%})",
+        )
 
-    all_cases = list(CASES)
-    if args.btd6:
-        # Build BTD6 cases from the REAL grounding pipeline (one build() per
-        # question), so the live model sees exactly what production retrieves.
-        from tests.evals.btd6_corpus import live_cases
+    # --- capability golden set — per-provider A/B ---------------------------
+    if not args.btd6_only:
+        providers = _build_providers(args.provider)
+        if not providers:
+            print(
+                "No usable providers — set OPENAI_API_KEY and/or ANTHROPIC_API_KEY "
+                "for the providers you selected.",
+            )
+            return 2
 
-        all_cases += asyncio.run(live_cases())
+        from tests.evals.cases import CASES, GOLDEN_SET_VERSION
+        from tests.evals.harness import run_suite
+        from tests.evals.smoke import SMOKE_MATRIX_VERSION
 
-    cases = [c for c in all_cases if args.category in (None, c.category)]
-    if not cases:
-        print(f"No cases match category {args.category!r}.")
-        return 2
+        cases = [c for c in CASES if args.category in (None, c.category)]
+        if not cases:
+            print(f"No cases match category {args.category!r}.")
+            return 2
 
-    btd6_note = " · BTD6 corpus grounded via real build()" if args.btd6 else ""
-    print(
-        f"Eval record — golden set v{GOLDEN_SET_VERSION} "
-        f"(live) · smoke matrix v{SMOKE_MATRIX_VERSION} (offline, run --smoke)"
-        f"{btd6_note}",
-    )
-    card = asyncio.run(run_suite(cases, providers=providers))
-    print(card.render())
-    ok = card.pass_rate >= args.threshold
-    print(
-        f"\n{'PASS' if ok else 'FAIL'} — overall {card.pass_rate:.0%} "
-        f"(threshold {args.threshold:.0%})",
-    )
-    return 0 if ok else 1
+        print(
+            f"Eval record — golden set v{GOLDEN_SET_VERSION} "
+            f"(live) · smoke matrix v{SMOKE_MATRIX_VERSION} (offline, run --smoke)",
+        )
+        card = asyncio.run(run_suite(cases, providers=providers))
+        print(card.render())
+        golden_ok = card.pass_rate >= args.threshold
+        overall_ok = overall_ok and golden_ok
+        print(
+            f"\n{'PASS' if golden_ok else 'FAIL'} — golden {card.pass_rate:.0%} "
+            f"(threshold {args.threshold:.0%})",
+        )
+
+    return 0 if overall_ok else 1
 
 
 if __name__ == "__main__":

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -59,11 +59,17 @@ questions at once," because both layers key off the bot's REAL retrieval
   grounded (and the known wrong claim is not). This proves the stored data is
   accessible and correct per question, with no API keys and no model variance.
 - **Live, paid, opt-in** — `run_evals.py --btd6` (or the **suite: btd6** dropdown
-  in the *AI Evals* Action) builds one `EvalCase` per question whose system
-  prompt is the question's **real `build()` facts**, then grades the model's
-  phrased answer. Because the grounding is the bot's own, a pass means "with the
-  facts our bot actually retrieves, the model answers correctly" — not "the model
-  can answer from perfect hand-fed context."
+  in the *AI Evals* Action) replays each question through the **REAL production
+  answer path** (`btd6_live_path.run_live`): the real router, the real
+  `btd6_context_service.build` grounding, the real `ai_instruction_service.assemble`
+  instruction stack, the real `natural_language_stage._invoke_gateway` call, and
+  the real `validate_btd6_reply` faithfulness guard + regenerate-once + refusal.
+  So a result here is **what a live Discord user would get** — not an
+  approximation. The only things not reproduced are Discord I/O and the decision
+  audit (neither changes the answer text). It tests the provider in
+  `AI_DEFAULT_PROVIDER`.
 
 Grow it by adding a `GroundingProbe` to `btd6_corpus.py` (it feeds both layers).
 The verified human-readable corpus is `docs/btd6/qa-accuracy-corpus-2026-06-27.md`.
+`btd6_live_path.py` reuses production internals on purpose — keep `run_live` in
+step with `AINaturalLanguageStage.process`.

--- a/tests/evals/btd6_corpus.py
+++ b/tests/evals/btd6_corpus.py
@@ -1,35 +1,27 @@
 """BTD6 QA accuracy corpus — the machine-readable half of
 ``docs/btd6/qa-accuracy-corpus-2026-06-27.md``.
 
-Two layers, both keyed off the SAME real grounding the production AI path uses
-(``services.btd6_context_service.build``), so a pass means the *bot's own*
-retrieved facts answer the question — not that a model can answer from perfect
-hand-fed context:
+One shared table (:data:`GROUNDING_PROBES`) feeds two layers, both keyed off the
+bot's REAL retrieval so a pass means the *bot's own* facts answer the question —
+not that a model can answer from perfect hand-fed context:
 
-* :data:`GROUNDING_PROBES` + ``test_btd6_qa_corpus.py`` — the **offline**,
-  deterministic, creds-free layer. For each question it asserts the answer-bearing
-  fact is actually grounded (``expect``) and the known wrong claim never is
+* ``test_btd6_qa_corpus.py`` — the **offline**, deterministic, creds-free layer.
+  For each question it asserts the answer-bearing fact is actually grounded by
+  ``btd6_context_service.build`` (``expect``) and the known wrong claim is not
   (``forbid``). This is the trustworthy "test all these questions at once" check:
-  it runs the real retrieval pipeline, needs no API keys, and runs on every PR.
+  real retrieval pipeline, no API keys, runs on every PR.
 
-* :func:`live_cases` — the **live** layer for ``scripts/run_evals.py --btd6``
-  (paid, opt-in). It injects each question's real ``build()`` facts into the
-  model prompt (mirroring production, where facts enter the instruction stack)
-  and grades the phrased answer. Same facts as the offline layer, so the only
-  extra thing it tests is whether the model *phrases* a faithful answer.
+* ``btd6_live_path.run_btd6_live_suite`` (via ``scripts/run_evals.py --btd6``) —
+  the **live** layer. It replays each question through the REAL production answer
+  path (router → grounding → instruction assembly → gateway → faithfulness guard)
+  and grades the reply, so a result is what a live Discord user would get.
 
-Grow both from real misses: when a BTD6 answer is reported wrong, add a probe
-here so it becomes a permanent regression.
+Grow both from real misses: when a BTD6 answer is reported wrong, add a probe.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-from tests.evals.graders import all_of, contains, not_contains
-from tests.evals.harness import EvalCase
-
-from core.runtime.ai.contracts import AITask
 
 
 @dataclass(frozen=True)
@@ -113,55 +105,4 @@ GROUNDING_PROBES: tuple[GroundingProbe, ...] = (
 )
 
 
-# --- live-eval grading rubrics (one per probe id, keyed by question) ---------
-# The live model must state the same correct fact in prose. Kept lenient
-# (contains/not_contains on the key token) so model phrasing variance doesn't
-# cause false fails — the strict assertion is the offline grounding layer.
-_LIVE_FORBID_GLOBAL = ("lead resists glue", "lead is immune to glue")
-
-
-def _grounding_block(facts: list[str]) -> str:
-    """Wrap real grounded facts the way the production instruction stack frames
-    them: an untrusted-data block the model must answer FROM, not from memory.
-    """
-    body = "\n".join(facts) if facts else "(no grounded facts retrieved)"
-    return (
-        "You are SuperBot answering a Bloons TD 6 question. Answer ONLY from the "
-        "grounded BTD6 facts below — do not add facts from memory, and if the "
-        "facts do not cover it, say so. Keep it short.\n\n"
-        "<grounded_btd6_facts>\n"
-        f"{body}\n"
-        "</grounded_btd6_facts>"
-    )
-
-
-async def live_cases() -> list[EvalCase]:
-    """Build live EvalCases whose grounding is the REAL ``build()`` output.
-
-    Async because it calls the production grounding pipeline once per probe.
-    Each case grades the model's phrased answer with lenient contains/not_contains
-    over the same expect/forbid the offline layer asserts — so the live layer
-    tests *phrasing faithfulness given the real facts*, nothing hand-fed.
-    """
-    from services import btd6_context_service
-
-    cases: list[EvalCase] = []
-    for i, probe in enumerate(GROUNDING_PROBES):
-        ctx = await btd6_context_service.build(probe.question)
-        graders = [contains(s) for s in probe.expect[:1]]  # at least the headline fact
-        graders += [not_contains(s) for s in (*probe.forbid, *_LIVE_FORBID_GLOBAL)]
-        cases.append(
-            EvalCase(
-                id=f"btd6_corpus.{i:02d}",
-                category="btd6_grounding",
-                user_message=probe.question,
-                task=AITask.GENERAL_NL_ANSWER,
-                system_prompt=_grounding_block(list(ctx.facts)),
-                grader=all_of(*graders),
-                max_output_tokens=400,
-            ),
-        )
-    return cases
-
-
-__all__ = ["GROUNDING_PROBES", "GroundingProbe", "live_cases"]
+__all__ = ["GROUNDING_PROBES", "GroundingProbe"]

--- a/tests/evals/btd6_live_path.py
+++ b/tests/evals/btd6_live_path.py
@@ -1,0 +1,246 @@
+"""Faithful "exactly live" BTD6 eval — replays the REAL production answer path.
+
+The standard harness probes the model with a hand-built prompt. This runner
+instead drives the *same components the live ``AINaturalLanguageStage`` uses*, in
+the same order, so a result here is what a real Discord user would get:
+
+1. ``ai_task_router.classify`` — the real router (so a mis-route shows up).
+2. ``btd6_context_service.build`` — the real grounding facts.
+3. ``ai_instruction_service.assemble`` — the real instruction stack (system
+   prompt + payload), not a hand-written one.
+4. ``natural_language_stage._invoke_gateway`` — the real gateway call (tools,
+   orchestration policy, round-cash workflow, ledger) against the configured
+   provider.
+5. ``btd6_grounding_service.validate_btd6_reply`` + ``_build_grounding_constraint``
+   — the real faithfulness guard with the real regenerate-once, then the real
+   deterministic refusal. A hallucinated reply is rejected here exactly as live.
+
+The ONLY things not reproduced are Discord I/O and the decision audit (neither
+changes the answer text) and the pre-model deterministic list/roster floors
+(checked below for completeness). It reuses production internals on purpose —
+that is what keeps it from drifting away from live behaviour. Keep the order in
+:func:`run_live` in step with ``AINaturalLanguageStage.process``.
+
+Runs in CI with no DB (``_invoke_gateway`` degrades the DB-backed bits and, with
+no API key, returns a deterministic non-answer); with a real key + a configured
+provider it produces the genuine live reply. Opt-in/paid, via
+``scripts/run_evals.py --btd6``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from tests.evals.btd6_corpus import GROUNDING_PROBES, GroundingProbe
+
+from core.runtime.ai.contracts import AIScope, AITask
+
+# Fixed fake identity (mirrors the harness): no real guild/DB is touched.
+_EVAL_GUILD_ID = 1
+_EVAL_ACTOR_ID = 1
+_EVAL_CHANNEL_ID = 1
+
+
+@dataclass(frozen=True)
+class LiveResult:
+    question: str
+    task: str
+    reply: str
+    handled_by: str  # model | model_regenerated | refused | floor:<kind> | degraded
+    degraded: bool
+    provider: str | None
+    model: str | None
+
+
+async def run_live(question: str) -> LiveResult:
+    """Replay one question through the real production answer path."""
+    from core.runtime.ai import natural_language_stage as nls
+    from core.runtime.ai.redaction import redact_text
+    from services import (
+        ai_context_service,
+        ai_instruction_service,
+        ai_task_router,
+        btd6_context_service,
+        btd6_grounding_service,
+    )
+
+    routed = ai_task_router.classify(question)
+
+    # Pre-model deterministic floors the stage serves WITHOUT the model. For the
+    # interaction/knowledge corpus these rarely fire, but checking them keeps the
+    # replay honest (a list/roster question is answered deterministically, live).
+    for floor in (
+        btd6_context_service.deterministic_btd6_list_reply,
+        btd6_context_service.deterministic_bloon_roster_reply,
+        btd6_context_service.deterministic_bloon_modifier_reply,
+    ):
+        try:
+            text = floor(question)
+        except Exception:  # noqa: BLE001 — a floor must never break the replay
+            text = None
+        if text:
+            return LiveResult(
+                question,
+                routed.task.value,
+                text,
+                f"floor:{floor.__name__}",
+                False,
+                "deterministic",
+                None,
+            )
+
+    ctx = await btd6_context_service.build(question)
+    facts = tuple(ctx.facts)
+    stack = await ai_instruction_service.assemble(
+        guild_id=_EVAL_GUILD_ID,
+        user_message=question,
+        profile_ids=(),
+        retrieved_facts=list(facts),
+        recent_turns=[],
+        bot_user_id=None,
+        bot_knowledge_blocks=[],
+    )
+    built = ai_context_service.build(
+        task=routed.task,
+        guild_id=_EVAL_GUILD_ID,
+        actor_id=_EVAL_ACTOR_ID,
+        channel_id=_EVAL_CHANNEL_ID,
+        correlation_id=uuid.uuid4().hex,
+        scope=AIScope.USER,
+    )
+    # _invoke_gateway only reads `.message`/`.bot` off the pipeline ctx (via
+    # getattr) to bind server-introspection tools; a stub with both None gives
+    # the same toolset a DM-less knowledge question gets.
+    stub_ctx = SimpleNamespace(message=None, bot=None)
+    ledger: list[str] = []
+
+    response = await nls._invoke_gateway(stack, built, stub_ctx, ledger=ledger)
+    reply = redact_text((response.text or "").strip()).value
+    handled = "model"
+
+    # The real BTD6 faithfulness guard + regenerate-once + refusal.
+    if routed.task is AITask.BTD6_ANSWER or (
+        routed.task is AITask.GENERAL_NL_ANSWER
+        and btd6_grounding_service.general_path_should_verify(question, reply)
+    ):
+        verdict = btd6_grounding_service.validate_btd6_reply(
+            reply,
+            facts=facts,
+            tool_results=tuple(ledger),
+            task=routed.task,
+        )
+        if not verdict.grounded:
+            response = await nls._invoke_gateway(
+                stack,
+                built,
+                stub_ctx,
+                ledger=ledger,
+                grounding_constraint=nls._build_grounding_constraint(verdict),
+            )
+            retry = redact_text((response.text or "").strip()).value
+            retry_ok = (
+                retry
+                and btd6_grounding_service.validate_btd6_reply(
+                    retry,
+                    facts=facts,
+                    tool_results=tuple(ledger),
+                    task=routed.task,
+                ).grounded
+            )
+            if retry_ok:
+                reply, handled = retry, "model_regenerated"
+            else:
+                reply, handled = nls._btd6_no_data_refusal(), "refused"
+
+    return LiveResult(
+        question,
+        routed.task.value,
+        reply,
+        handled,
+        response.degraded,
+        response.provider,
+        response.model,
+    )
+
+
+@dataclass
+class LiveOutcome:
+    probe: GroundingProbe
+    result: LiveResult
+    passed: bool
+    detail: str
+
+
+def _grade(probe: GroundingProbe, result: LiveResult) -> tuple[bool, str]:
+    if result.degraded:
+        return False, f"degraded ({result.provider})"
+    low = result.reply.lower()
+    if result.handled_by == "refused":
+        return False, "live bot REFUSED (guard rejected the model's answer)"
+    missing = [s for s in probe.expect if s.lower() not in low]
+    if missing:
+        return False, f"missing: {missing[0]!r}"
+    bad = [s for s in probe.forbid if s.lower() in low]
+    if bad:
+        return False, f"stated wrong claim: {bad[0]!r}"
+    return True, result.handled_by
+
+
+async def run_btd6_live_suite() -> list[LiveOutcome]:
+    """Replay every corpus probe through the live path and grade the reply."""
+    outcomes: list[LiveOutcome] = []
+    for probe in GROUNDING_PROBES:
+        try:
+            result = await run_live(probe.question)
+        except Exception as exc:  # noqa: BLE001 — one bad probe must not abort
+            result = LiveResult(
+                probe.question,
+                "error",
+                f"<error: {exc}>",
+                "error",
+                True,
+                None,
+                None,
+            )
+        passed, detail = _grade(probe, result)
+        outcomes.append(LiveOutcome(probe, result, passed, detail))
+    return outcomes
+
+
+def render_live_report(outcomes: list[LiveOutcome]) -> str:
+    passed = sum(1 for o in outcomes if o.passed)
+    total = len(outcomes)
+    provider = next((o.result.provider for o in outcomes if o.result.provider), "?")
+    lines = [
+        "",
+        "BTD6 live-path scorecard (real grounding + assemble + gateway + guard)",
+        "=" * 68,
+        f"provider: {provider}   {passed}/{total} passed "
+        f"({(100.0 * passed / total) if total else 0:.0f}%)",
+        "",
+    ]
+    for o in outcomes:
+        mark = "✓" if o.passed else "✗"
+        lines.append(f"  {mark} [{o.result.handled_by:>17}] {o.probe.question}")
+        if not o.passed:
+            lines.append(f"      → {o.detail}")
+            lines.append(f"      reply: {o.result.reply[:140]}")
+    return "\n".join(lines)
+
+
+def live_suite_available() -> bool:
+    """A real provider key must be present for the live suite to mean anything."""
+    return bool(os.getenv("OPENAI_API_KEY") or os.getenv("ANTHROPIC_API_KEY"))
+
+
+__all__ = [
+    "LiveOutcome",
+    "LiveResult",
+    "render_live_report",
+    "run_btd6_live_suite",
+    "run_live",
+    "live_suite_available",
+]

--- a/tests/evals/test_btd6_qa_corpus.py
+++ b/tests/evals/test_btd6_qa_corpus.py
@@ -39,3 +39,22 @@ def test_corpus_is_nontrivial():
     assert len(GROUNDING_PROBES) >= 10
     # Every probe names at least one expected fact.
     assert all(p.expect for p in GROUNDING_PROBES)
+
+
+async def test_live_path_wiring_runs_offline():
+    """The faithful live path (router → grounding → assemble → gateway → guard)
+    must run end-to-end without raising even with no DB and no API key — it just
+    degrades. This guards the wiring on every PR; the paid run needs real keys.
+    """
+    from tests.evals.btd6_live_path import run_live
+
+    result = await run_live("can glue strike deal with DDTs")
+    # No API key in CI → a degraded, non-crashing result through the real path.
+    assert result.question
+    assert result.task  # the real router classified it
+    assert result.handled_by in {
+        "model",
+        "model_regenerated",
+        "refused",
+        "degraded",
+    } or result.handled_by.startswith("floor:")


### PR DESCRIPTION
## Why

Follow-up to #1488. You asked for the eval action to give *"exactly the results that a live test would
give."* #1488's live layer injected the real grounding into a *simplified* prompt — good, but not the
live system prompt and not the faithfulness guard. This closes that gap.

## What this does — replays the REAL production answer path

`tests/evals/btd6_live_path.py::run_live(question)` drives the **same components the live
`AINaturalLanguageStage` uses, in the same order**, with **zero `disbot/` change** (it reuses the
internals, which is what keeps it from drifting):

1. `ai_task_router.classify` — the real router (a mis-route shows up).
2. `btd6_context_service.build` — the real grounding facts.
3. `ai_instruction_service.assemble` — the real instruction stack (system prompt + payload).
4. `natural_language_stage._invoke_gateway` — the real gateway call (tools, orchestration policy,
   round-cash workflow, ledger) against the configured provider.
5. `btd6_grounding_service.validate_btd6_reply` + `_build_grounding_constraint` — the real faithfulness
   guard with the real **regenerate-once**, then the real deterministic refusal.

Pre-model deterministic floors are checked too. **The only things not reproduced are Discord I/O and the
decision-audit log — neither changes the answer text.** So a result here is what a live Discord user
gets.

## How to run

- **Action:** *AI Evals (manual)* → **suite: btd6** (pick the `provider` to test its live answers).
- **CLI:** `RUN_EVALS=1 ANTHROPIC_API_KEY=… AI_DEFAULT_PROVIDER=anthropic python3.10 scripts/run_evals.py --btd6-only`

## Safety / fidelity notes

- `_invoke_gateway` is DB-safe — it degrades the DB-backed bits and, with no key, returns a deterministic
  non-answer — so the path runs in CI. A new offline test runs `run_live` every PR to guard the wiring
  (it degrades, never raises); the paid run needs real keys.
- One residual: the replay mirrors `process`'s orchestration order (drift risk), mitigated by a
  cross-reference note + the wiring guard. A future shared-seam extraction in `natural_language_stage`
  would remove it entirely — noted as follow-up, not done here (it touches the hottest path).

Tests: all 140 `tests/evals/` pass with no API keys; `check_quality --check-only` green. The offline
grounding corpus (`test_btd6_qa_corpus.py`) is unchanged and remains the trustworthy free layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PznCdhdV59y79932VKCj4g)_