### PR TITLE
BTD6 live eval: grade answers semantically (fix grader false-negatives)

### DIFF
--- a/.sessions/2026-06-27-btd6-eval-semantic-grader.md
+++ b/.sessions/2026-06-27-btd6-eval-semantic-grader.md
@@ -1,0 +1,70 @@
+# 2026-06-27 — BTD6 live eval: semantic grading (fix false-negatives) + honest limits
+
+> **Status:** `complete`
+
+**Run type:** owner-directed (owner ran the live eval, pasted the scorecard)
+
+## What this run did
+
+The owner ran the new `suite: btd6` live eval against a real Anthropic key. The scorecard read 2/12 —
+but **the replies were almost all correct**; my grader was wrong. It graded the *live* (paraphrased)
+answer by substring-matching the *grounded-fact wording* (`"lead does not resist glue"`), which the model
+restates in its own words. That's the right check for the offline grounding layer (we control the fact
+text) but a false-negative machine for the live layer.
+
+**Fix (PR — eval-only, no `disbot/` change):**
+
+1. `GroundingProbe` gains a `rubric` — the correctness criterion for the LIVE answer. `expect`/`forbid`
+   still grade the offline layer (substrings of the grounded *facts*); `rubric`/`forbid` grade the live
+   layer.
+2. `btd6_live_path._grade` is now async and judges each reply **semantically** with the same
+   `llm_judge` the golden set uses (refusal or a known wrong claim still hard-fails). So the live
+   scorecard now reflects whether the *answer* is right, not whether it echoes the fact's wording.
+3. Documented two honest limits surfaced by the run:
+   - **DB-backed workflow answers can't run in CI.** `_invoke_gateway` degrades the DB-resolved
+     orchestration profile, so round-cash "cash on round N" questions (which need that profile to engage
+     the workflow) refuse in a DB-less run. The corpus deliberately covers interaction/immunity/damage
+     questions, not round-cash.
+
+## Real findings reported to the owner (not silently changed)
+
+The fixed eval surfaced a **genuine** issue worth its own decision, not a quiet patch:
+
+- **Over-refusal on "how do I deal with a DDT"** (and, in the golden set, round-cash / elite-Lych-HP /
+  despo-cost / bomb-MOAB). The faithfulness guard rejects the model's answer when it names towers/numbers
+  not in the grounded facts, then serves the deterministic refusal. For "deal with a DDT" the model wants
+  to recommend towers the grounding doesn't carry → refusal. Two fix paths, both focused follow-ups: (a)
+  enrich the interaction grounding with VERIFIED tower recommendations (derive from the dump's capability
+  data — needs a careful verification pass; it's the tower-specifics I deliberately kept out), or (b)
+  loosen the guard to allow known BTD6 tower *entity names* (riskier — it's the bot's anti-hallucination
+  seam). Reported for an owner decision rather than rushed.
+- A couple of **golden rubrics look stale** (e.g. `knowledge.btd6_lead` expects "Sharp Shots lets Dart
+  pop Lead" — Sharp Shots is +pierce, not lead-popping). Flagged, not touched (pre-existing golden set).
+
+## ⚑ Self-initiated
+
+None unprompted — owner ran the eval and asked (implicitly) for it to be trustworthy. The grader fix is
+the direct response; the over-refusal is reported, not silently changed (it's a guard/grounding decision).
+
+## 💡 Session idea (Q-0089)
+
+*A `--show-replies` flag that dumps every live reply + its grounded facts to a file*, so triaging a live
+fail is "read the reply + what it was given," not a re-run. The runner already holds both. Routed as an
+idea.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (the faithful live path, #1490) was right to reuse production internals — that's exactly
+why this run could trust the *replies* and locate the bug in the *grader*. What it missed: it carried the
+`expect`/`forbid` substrings straight from the offline layer into the live grader without re-checking that
+a paraphrased answer would match — a grader should be designed against *the thing it grades*. Lesson
+applied: offline grades facts (exact), live grades answers (semantic); never share a matcher across the
+two. The faithful path also surfaced a real product signal (over-refusal) the offline layer never could —
+evidence the live layer earns its cost.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_docs`/`check_consistency` green. Homed: the grading method + the DB-workflow limitation in the
+`btd6_live_path` docstring + `tests/evals/README.md`. The over-refusal finding is captured here + reported
+to the owner in-chat; if the owner picks a fix path it becomes a router decision + a plan. Ledger: next
+reconciliation pass.

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -67,7 +67,12 @@ questions at once," because both layers key off the bot's REAL retrieval
   So a result here is **what a live Discord user would get** — not an
   approximation. The only things not reproduced are Discord I/O and the decision
   audit (neither changes the answer text). It tests the provider in
-  `AI_DEFAULT_PROVIDER`.
+  `AI_DEFAULT_PROVIDER`. Replies are graded **semantically** by `llm_judge`
+  against each probe's `rubric` (the model paraphrases, so substring-matching the
+  fact wording gives false negatives); a refusal or a known wrong claim is a fail.
+  **Limitation:** answers that depend on the DB-resolved round-cash *workflow*
+  can't be reproduced in a DB-less CI run, so the corpus covers
+  interaction/immunity/damage-type questions, not "cash on round N".
 
 Grow it by adding a `GroundingProbe` to `btd6_corpus.py` (it feeds both layers).
 The verified human-readable corpus is `docs/btd6/qa-accuracy-corpus-2026-06-27.md`.

--- a/tests/evals/btd6_corpus.py
+++ b/tests/evals/btd6_corpus.py
@@ -26,14 +26,23 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class GroundingProbe:
-    """One corpus question + what its REAL grounding must / must not contain."""
+    """One corpus question + how to judge it at each layer.
+
+    ``expect``/``forbid`` grade the OFFLINE layer (substrings of the grounded
+    *facts*, whose wording we control). ``rubric``/``forbid`` grade the LIVE
+    layer (the model's *paraphrased* answer, judged semantically) — a live answer
+    states the right thing in its own words, so substring-matching the fact text
+    against it gives false negatives.
+    """
 
     question: str
     # Substrings that must appear (case-insensitive) in the joined grounded
     # facts — the answer-bearing fact the bot retrieves for this question.
     expect: tuple[str, ...]
+    # The correctness criterion for the LIVE model answer (LLM-as-judge rubric).
+    rubric: str = ""
     # Substrings that must NOT appear — a known wrong claim (e.g. the live
-    # screenshot's "lead resists glue"). Optional.
+    # screenshot's "lead resists glue"). Checked at BOTH layers.
     forbid: tuple[str, ...] = ()
     note: str = ""
 
@@ -47,60 +56,114 @@ GROUNDING_PROBES: tuple[GroundingProbe, ...] = (
     GroundingProbe(
         question="can glue strike and avenger deal with DDTs",
         expect=("lead does not resist glue", "moab glue", "status effect"),
+        rubric=(
+            "Must say glue is a STATUS effect that ignores damage-type immunity "
+            "(so Lead does NOT resist glue), and that affecting MOAB-class bloons "
+            "like DDTs needs MOAB Glue. It may also note Glue Strike only debuffs "
+            "/ doesn't pop. PASS as long as it never claims Lead resists/blocks "
+            "glue."
+        ),
         forbid=("lead resists glue", "lead is immune to glue"),
         note="screenshot #2 — the 'Lead resists glue' hallucination",
     ),
     GroundingProbe(
         question="can ice monkey slow ddts",
         expect=("cold", "lead", "cold snap"),
+        rubric=(
+            "Must say base Ice Monkey CANNOT slow/freeze DDTs because its effect "
+            "is Cold-based and blocked by the Lead property, AND name a crosspath "
+            "that fixes it (Cold Snap, or Embrittlement). Failing to name the "
+            "crosspath fix is a FAIL."
+        ),
         note="screenshot #3 — ice is cold-based, blocked by lead; Cold Snap fixes it",
     ),
     GroundingProbe(
         question="does glue work on lead bloons",
         expect=("lead does not resist glue",),
+        rubric=(
+            "Must answer YES — glue works on Lead bloons because glue is a status "
+            "effect that ignores damage-type immunity. FAIL if it says Lead "
+            "resists or is immune to glue."
+        ),
         forbid=("lead resists glue",),
     ),
     # --- damage-type interactions --------------------------------------------
     GroundingProbe(
         question="what damage can pop lead bloons",
         expect=("needs explosion, fire, plasma, glacier, acid",),
+        rubric=(
+            "Must list damage types that pop Lead — Explosion, Fire, Plasma, "
+            "Glacier, Acid, and/or Normal — and NOT offer Sharp, Cold, Shatter, "
+            "or Energy as able to pop Lead."
+        ),
         note="the lead pop-guide 'needs' clause is grounded",
     ),
     GroundingProbe(
         question="can you pop purple bloons with plasma",
         expect=("energy, plasma, fire, and frigid damage cannot pop purple",),
+        rubric="Must answer NO — Purple bloons are immune to Plasma damage.",
     ),
     GroundingProbe(
         question="can a bomb shooter pop black bloons",
         expect=("explosion damage cannot pop black",),
+        rubric=(
+            "Must answer NO — a base Bomb Shooter deals Explosion damage, which "
+            "is blocked by the Black property."
+        ),
     ),
     GroundingProbe(
         question="does sharp damage pop lead",
         expect=("sharp, shatter, cold, and energy damage cannot pop lead",),
+        rubric="Must answer NO — Lead bloons are immune to Sharp damage.",
     ),
     GroundingProbe(
         question="how do I deal with a DDT",
         expect=("camo detection", "fire, plasma, normal, acid, or glacier"),
+        rubric=(
+            "Must say a DDT needs CAMO DETECTION plus a damage type that is not "
+            "blocked by Lead+Black — i.e. Fire, Plasma, Normal, Acid, or Glacier "
+            "(NOT Sharp, Cold, Energy, or Explosion). PASS if it conveys the "
+            "camo-detection + non-blocked-damage requirement, even without naming "
+            "specific towers."
+        ),
         forbid=("ddts are immune to glue", "lead resists glue"),
     ),
     GroundingProbe(
         question="can glacier damage pop lead",
         expect=("unlike plain cold",),
+        rubric=(
+            "Must answer YES — Glacier damage CAN pop Lead bloons. (Noting that "
+            "plain Cold cannot is a plus but not required for a pass.)"
+        ),
         note="Glacier is the cold variant that DOES pop lead",
     ),
     # --- bloon immunities (game-sourced) -------------------------------------
     GroundingProbe(
         question="what is a DDT immune to",
         expect=("immune to sharp, shatter, cold, energy, explosion",),
+        rubric=(
+            "Must state a DDT is immune to Sharp, Shatter, Cold, Energy, and "
+            "Explosion damage (it has Lead + Black). Naming all five is required; "
+            "omitting one is a FAIL."
+        ),
     ),
     GroundingProbe(
         question="what is a zebra bloon immune to",
         expect=("explosion", "cold"),
+        rubric=(
+            "Must state a Zebra bloon is immune to BOTH Explosion AND Cold "
+            "damage (Black + White). Naming only one is a FAIL."
+        ),
         note="Zebra = Black + White → both",
     ),
     GroundingProbe(
         question="what is a purple bloon immune to",
         expect=("energy", "plasma", "fire"),
+        rubric=(
+            "Must state a Purple bloon is immune to Energy, Plasma, and Fire "
+            "damage (Frigid too is acceptable). Missing any of Energy/Plasma/Fire "
+            "is a FAIL."
+        ),
     ),
 )
 

--- a/tests/evals/btd6_live_path.py
+++ b/tests/evals/btd6_live_path.py
@@ -16,15 +16,22 @@ the same order, so a result here is what a real Discord user would get:
    deterministic refusal. A hallucinated reply is rejected here exactly as live.
 
 The ONLY things not reproduced are Discord I/O and the decision audit (neither
-changes the answer text) and the pre-model deterministic list/roster floors
-(checked below for completeness). It reuses production internals on purpose —
-that is what keeps it from drifting away from live behaviour. Keep the order in
+changes the answer text). It reuses production internals on purpose — that is
+what keeps it from drifting away from live behaviour. Keep the order in
 :func:`run_live` in step with ``AINaturalLanguageStage.process``.
 
-Runs in CI with no DB (``_invoke_gateway`` degrades the DB-backed bits and, with
-no API key, returns a deterministic non-answer); with a real key + a configured
-provider it produces the genuine live reply. Opt-in/paid, via
-``scripts/run_evals.py --btd6``.
+Grading is semantic: each reply is judged by the same ``llm_judge`` the golden
+set uses, against the probe's ``rubric`` (the model paraphrases, so substring
+matching the grounded-fact wording gives false negatives). A refusal or a known
+wrong claim is a fail.
+
+**Known limitation — DB-backed workflow answers.** ``_invoke_gateway`` degrades
+the DB-backed bits when no DB is present, so questions whose live answer depends
+on the round-cash *workflow* (which only engages under a DB-resolved orchestration
+profile) can't be reproduced in a DB-less CI run — they will refuse. The corpus
+therefore covers interaction / immunity / damage-type questions (no DB workflow),
+not "cash on round N" questions. Run with a real key + ``AI_DEFAULT_PROVIDER``
+set; opt-in/paid via ``scripts/run_evals.py --btd6``.
 """
 
 from __future__ import annotations
@@ -174,19 +181,31 @@ class LiveOutcome:
     detail: str
 
 
-def _grade(probe: GroundingProbe, result: LiveResult) -> tuple[bool, str]:
+async def _grade(probe: GroundingProbe, result: LiveResult) -> tuple[bool, str]:
+    """Grade the LIVE reply: refusal/degrade → fail; a known wrong claim → fail;
+    otherwise judge correctness SEMANTICALLY (the model paraphrases, so a
+    substring match against the grounded-fact wording gives false negatives —
+    that was the original mis-grade). Uses the same LLM-as-judge the golden set
+    uses, against the probe's rubric.
+    """
     if result.degraded:
         return False, f"degraded ({result.provider})"
-    low = result.reply.lower()
     if result.handled_by == "refused":
         return False, "live bot REFUSED (guard rejected the model's answer)"
-    missing = [s for s in probe.expect if s.lower() not in low]
-    if missing:
-        return False, f"missing: {missing[0]!r}"
+    low = result.reply.lower()
     bad = [s for s in probe.forbid if s.lower() in low]
     if bad:
         return False, f"stated wrong claim: {bad[0]!r}"
-    return True, result.handled_by
+    if not probe.rubric:
+        # No rubric → fall back to the offline-style substring check.
+        missing = [s for s in probe.expect if s.lower() not in low]
+        return (not missing), (
+            result.handled_by if not missing else f"missing {missing[0]!r}"
+        )
+    from tests.evals.graders import llm_judge
+
+    grade = await llm_judge(probe.rubric)(SimpleNamespace(text=result.reply))
+    return grade.passed, (result.handled_by if grade.passed else grade.detail)
 
 
 async def run_btd6_live_suite() -> list[LiveOutcome]:
@@ -205,7 +224,7 @@ async def run_btd6_live_suite() -> list[LiveOutcome]:
                 None,
                 None,
             )
-        passed, detail = _grade(probe, result)
+        passed, detail = await _grade(probe, result)
         outcomes.append(LiveOutcome(probe, result, passed, detail))
     return outcomes
 


### PR DESCRIPTION
## Why

You ran `suite: btd6` against a real Anthropic key — the scorecard read **2/12**, but the replies were
**almost all correct**. My grader was wrong: it substring-matched the *live, paraphrased* answer against
the **grounded-fact wording** (`"lead does not resist glue"`), which the model restates in its own words
(*"glue is a status effect, so it ignores Lead's damage immunities"* — correct, but no literal match).
That's the right check for the *offline grounding* layer (we control the fact text) but a false-negative
machine for the live answer.

## Fix (eval-only — no `disbot/` change)

- `GroundingProbe` gains a `rubric` (the correctness criterion for the LIVE answer). `expect`/`forbid`
  still grade the offline layer; `rubric`/`forbid` grade the live layer.
- `btd6_live_path._grade` is now async and judges each reply **semantically** with the same `llm_judge`
  the golden set uses. A refusal or a known wrong claim (`forbid`) still hard-fails.
- Documented a real limit the run exposed: `_invoke_gateway` degrades the DB-resolved orchestration
  profile in a DB-less CI run, so round-cash "cash on round N" answers (which need that profile to engage
  the workflow) can't be reproduced — the corpus covers interaction/immunity/damage questions, not
  round-cash.

## Genuine findings reported (not silently patched)

The fixed eval surfaces a real issue worth your call, so I'm reporting it rather than rushing a change:

- **Over-refusal** on `how do I deal with a DDT` (and, in the golden set, round-cash / elite-Lych /
  despo / bomb-MOAB). The faithfulness guard rejects the model's answer when it names towers/numbers not
  in the grounded facts, then serves the deterministic refusal. Two focused fix paths — enrich grounding
  with VERIFIED tower recs, or loosen the guard to allow known tower entity names (riskier) — your call.
- A couple of **golden rubrics look stale** (e.g. `knowledge.btd6_lead` expects "Sharp Shots lets Dart
  pop Lead" — it doesn't; Sharp Shots is +pierce). Flagged, untouched.

Tests: 140 `tests/evals/` pass with no keys; `check_quality --check-only` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PznCdhdV59y79932VKCj4g)_