### PR TITLE
docs(btd6): consolidate the QA-accuracy arc + live-verification checklist

### DIFF
--- a/.sessions/2026-06-27-btd6-session-close-docs.md
+++ b/.sessions/2026-06-27-btd6-session-close-docs.md
@@ -1,0 +1,45 @@
+# 2026-06-27 — BTD6 QA arc: session-close documentation (what shipped + live-test checklist)
+
+> **Status:** `complete`
+
+**Run type:** owner-directed (session close — "document what we did + what's still to test, then end")
+
+## What this run did
+
+Consolidated the day's BTD6 QA-accuracy arc (six merged PRs: #1487 interaction grounding · #1488 evals
+wiring · #1490 faithful live path · #1491 semantic grader · #1492 verified DDT counter grounding) into the
+durable corpus doc, and added an explicit **live-verification checklist** of what still needs a real-key /
+prod test:
+
+- re-run *AI Evals → suite: btd6* after deploy (expect interaction questions pass + the DDT question
+  answers with towers, not a refusal);
+- a live Discord spot-check of the original screenshot questions;
+- the **golden-set over-refusals are NOT fixed** (round-cash partly a DB-less harness limitation; the rest
+  a possible guard/grounding issue — separate scope);
+- a couple of golden rubrics look stale (verify the rubrics, not the bot).
+
+Docs-only; no `disbot/` change.
+
+## ⚑ Self-initiated
+
+None — owner-directed session close.
+
+## 💡 Session idea (Q-0089)
+
+*A tiny `docs/btd6/qa-status.md` "live-test checklist" that the live eval action updates a timestamp on
+when it passes* — so "when did a human last confirm these answer correctly in prod?" is visible, not
+folklore. Routed as an idea.
+
+## ⟲ Previous-session review (Q-0102)
+
+The arc's strength was tight owner-in-the-loop iteration (each PR driven by a screenshot or a pasted
+scorecard) and verify-before-shipping (the wiki/owner-confirmed Sniper check kept a wrong tower rec out).
+The improvement this close-out makes: the per-PR session logs documented each step but a reader had no
+single "what's the live-test status of the whole effort?" view — now the corpus doc has it. Lesson: a
+multi-PR arc deserves a consolidated status doc, not just N session logs.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_docs`/`check_consistency` green. The consolidated arc + live-verification checklist now live in
+`docs/btd6/qa-accuracy-corpus-2026-06-27.md`. All six runtime/eval PRs merged; this is the documentation
+capstone. Ledger: the six PRs are added by the next reconciliation pass (merged-only convention).

--- a/docs/btd6/qa-accuracy-corpus-2026-06-27.md
+++ b/docs/btd6/qa-accuracy-corpus-2026-06-27.md
@@ -189,12 +189,41 @@ keyed off the bot's REAL `btd6_context_service.build()` grounding:
   result is **what a live Discord user would get** (only Discord I/O + the audit log are skipped). It
   tests the provider set in `AI_DEFAULT_PROVIDER`.
 
+## Session arc — what shipped (2026-06-27, all merged)
+
+| PR | What it did |
+|---|---|
+| **#1487** | The root fix: `damage_types.json` + `btd6_interaction_service` ground damage-type ↔ bloon-property INTERACTION facts (the "Lead resists glue" class), cross-checked against the game-sourced `immune_to` data. Plus this corpus + bloon-prose completion. |
+| **#1488** | Corpus wired into the evals: the offline grounding test (`test_btd6_qa_corpus.py`, free, every PR) + the live action suite picker. |
+| **#1490** | The faithful **"exactly live"** runner (`btd6_live_path.py`) — replays the real production answer path (router → grounding → instruction stack → gateway → faithfulness guard). |
+| **#1491** | Fixed the eval grader: live answers are graded **semantically** by `llm_judge` (the model paraphrases — substring-matching the fact wording gave false negatives). |
+| **#1492** | Verified **DDT counter-tower grounding** (`towers_that_can_damage`) so "how do I deal with a DDT" recommends real towers instead of refusing. |
+
+## Live verification checklist — what still needs a real-key / prod test
+
+Everything above is offline-verified (1500+ tests, no creds). These need a real provider key or a live
+bot to confirm, and are **not** done:
+
+- [ ] **Re-run *AI Evals → suite: btd6*** after deploy. Expect: the interaction questions PASS on the
+      semantic grader, and **`how do I deal with a DDT` now answers with towers instead of refusing**
+      (the #1492 fix — not yet re-run live).
+- [ ] **Live Discord spot-check** of the original screenshot questions (glue/avenger/DDT, "can ice slow
+      DDTs") on the real bot — confirm the answers are now correct in production, not just in the eval.
+- [ ] **The golden-set over-refusals are NOT fixed** — `knowledge.btd6_round_cash_*`,
+      `btd6_elite_lych_hp`, `btd6_despo_bulk_cost`, `bomb_middle_path_moab`. Two parts: (a) the
+      round-cash ones partly reflect a **harness limitation** — those answers need a DB-resolved
+      orchestration profile that can't run in a keyless/DB-less eval; (b) the rest may be a real
+      guard-strictness/grounding issue worth its own look. Separate from this session's scope.
+- [ ] **A couple of golden rubrics look stale** (e.g. `knowledge.btd6_lead` expects "Sharp Shots lets
+      Dart pop Lead" — it's +pierce, not lead-popping). Verify + fix the rubrics, not the bot.
+
 ## Open follow-ups (next sessions)
 
-- **Broaden the live corpus** with strategy/opinion questions graded by `llm_judge` rubrics (the
-  exact-fact `expect`/`forbid` grading suits the interaction/data class; open-ended advice needs a
-  rubric judge).
-- **Newer-tower coverage** (Desperado, Mermonkey): the dump has them; spot-check that
-  interaction questions about their damage types ground correctly.
-- **Hero costs** are absent from `heroes.json` — wiki-only for now; a future data pass
-  could add them so cost questions are dump-verified like tower costs.
+- **Generalize the counter grounding** beyond DDT — `towers_that_can_damage` is already general; extend
+  the `_COUNTER_BLOON_FOR` map in `btd6_interaction_service` to camo-lead / the Camo bloon to close the
+  same over-refusal there.
+- **Broaden the live corpus** with strategy/opinion questions graded by `llm_judge` rubrics.
+- **Newer-tower coverage** (Desperado, Mermonkey): the dump has them; spot-check their damage-type
+  interaction questions ground correctly.
+- **Hero costs** are absent from `heroes.json` — wiki-only for now; a future data pass could add them so
+  cost questions are dump-verified like tower costs.


### PR DESCRIPTION
## Why

Session-close documentation. The day's BTD6 QA-accuracy work landed as six PRs; this consolidates them
into the durable corpus doc and adds an explicit **live-verification checklist** of what still needs a
real-key / prod test (so "what's left to confirm" isn't folklore).

## What it adds (docs-only)

- A **session arc table** (#1487 interaction grounding · #1488 evals wiring · #1490 faithful live path ·
  #1491 semantic grader · #1492 verified DDT counter grounding).
- A **live-verification checklist** — the not-yet-done items: re-run *AI Evals → suite: btd6* after
  deploy, a live Discord spot-check of the original screenshot questions, the **still-open golden-set
  over-refusals** (round-cash partly a DB-less harness limitation; the rest a possible guard/grounding
  issue — separate scope), and a couple of **stale golden rubrics** to fix.
- Refreshed the follow-ups (generalize the counter grounding beyond DDT, etc.).

No `disbot/` change; `check_quality --check-only` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PznCdhdV59y79932VKCj4g)_