### PR TITLE
Reconcile-marker band-consistency guard + fix the #1472→#1470 marker conflation

### DIFF
--- a/.sessions/2026-06-27-reconcile-marker-band-consistency-guard.md
+++ b/.sessions/2026-06-27-reconcile-marker-band-consistency-guard.md
@@ -1,25 +1,88 @@
 # Session — reconcile-marker band-consistency guard (+ marker conflation fix)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> **Status:** `complete`
 > **Run type:** routine · dispatch
 
-## What I'm about to do
+## What shipped (2 slices, one PR #1495)
 
-Promote the freshly-captured idea
-[`reconcile-trigger-band-consistency-guard-2026-06-26`](../docs/ideas/reconcile-trigger-band-consistency-guard-2026-06-26.md)
-into a shipped guard (Q-0172 self-initiated promotion — idea→ship, no dispatch order this fire):
+**Slice 1 — `scripts/check_reconcile_marker.py` + fix the live marker drift.** Promoted the
+freshly-captured idea `reconcile-trigger-band-consistency-guard-2026-06-26` (self-initiated, Q-0172 —
+no dispatch work order this fire). A warn-first, stdlib, disposable (Q-0105) guard that asserts the
+`Last reconciliation pass:** PR #N` marker in `current-state.md` is internally consistent:
+1. **conflation guard (core):** the leading `#N` == the stated "reset to the latest merged PR #R",
+2. **band-boundary:** `band-#M` == `(N // 30) * 30` (mirrors `check_reconciliation_due.STEP`),
+3. **pass-record link exists** on disk.
+Each assertion skips when its clause is absent (robust to format variation). It **caught + fixed the
+live band-#1470 drift**: the 26th pass set the marker to its own PR `#1472` while its parenthetical
+(and the convention "reset to the latest PR") said `#1470` — corrected to `#1470` (cadence math
+unchanged: `1472 // 30 == 1470 // 30 == 49`, next pass still #1500). Critically, the extractor had to
+be made multi-line-aware — the real marker is a 3-line blockquote, so a single-physical-line scan would
+have silently skipped the conflation check (pinned by a regression test). 14 tests; routine-prompt
+pointer added at the "reset the marker" step.
 
-1. **`scripts/check_reconcile_marker.py`** — a warn-first, stdlib, disposable (Q-0105) guard that
-   asserts the `Last reconciliation pass:** PR #N` marker in `current-state.md` is internally
-   consistent: (a) the leading `#N` equals the parenthetical "reset to the latest merged PR #R"
-   value (the conflation guard — the idea's core), (b) the `band-#M` label has `M = (N // 30) * 30`
-   (the cadence boundary), and (c) the linked `reconciliation-pass-*` doc exists on disk. Folds into
-   the existing `check_current_state_ledger` / `check_reconciliation_due` family.
-2. **Fix the live drift it catches** (bugs-first / Q-0166): the 26th pass set the marker to its own
-   PR `#1472` while its parenthetical (and the convention "reset to the latest PR") say `#1470` —
-   correct it to `#1470`.
-3. Tests in `tests/unit/scripts/`; mark the idea shipped; add a discoverability pointer.
+**Slice 2 — de-stale `check_ledger_hygiene.py` for the Q-0195 per-claim-file layout (bugs-first,
+Q-0166).** The shared `docs/owner/active-work.md` claim ledger was retired to a pointer stub when
+claims moved to one-file-per-claim under `docs/owner/claims/` — but the linter still scanned
+active-work.md's "Active claims" section (now absent → no-op) and its docstring still called
+active-work.md the live claim ledger (a lie). Repointed the claim half to scan `docs/owner/claims/*.md`
+and flag a `claude/<branch>` claimed by >1 file (the per-file analogue of a duplicate claim line);
+idea-index dedup half unchanged. Docstring + tests updated; idea `ledger-dedup-linter` → historical.
 
-Why offline-fit: no dispatch work order this fire, most feature lanes are owner/live-bot/design-gated,
-and this is the "leave the next run better-equipped" lane the loop exists for — fully offline,
-test-covered, zero runtime risk.
+**Verification:** `check_quality.py --full` green (12,762 passed); `check_architecture --mode strict` 0;
+both new/changed checkers green report-only AND `--strict`; `check_current_state_ledger --strict`,
+`check_docs --strict`, `check_reconcile_marker --strict` all exit 0.
+
+## ⟲ Previous-session review (Q-0102)
+
+The **band-#1470 reconciliation pass (PR #1472, 2026-06-26)** did the right thing in substance — it
+even flagged this exact marker-conflation class as a Q-0089 idea, which is what I built this run, so
+the self-auditing loop worked as designed. What it *missed*: it then **re-introduced the very drift it
+described** — it wrote its own PR `#1472` as the leading marker number while its own parenthetical said
+"reset to the latest merged PR #1470". The lesson is the one its idea already named: a hand-written
+field that must agree with another hand-written field will drift; capturing the idea isn't enough, the
+*next* pass needs the guard in place before it writes the marker. **System improvement made:** shipped
+the guard (so the next pass's marker is checked) and captured `reconcile-marker-generator-2026-06-27`
+(generate the marker so it can't be mistyped at all) — detect now, prevent next.
+
+## 💡 Session idea (Q-0089)
+
+`reconcile-marker-generator-2026-06-27` — the generate-don't-validate complement to the guard shipped
+this run: a `scripts/set_reconcile_marker.py` that emits the canonical marker line from the
+latest-merged PR + band math, so the agreeing numbers come from one source. Genuinely believed-in
+(same philosophy that beat the migration-renumber treadmill: remove the shared hand-typed value, don't
+just lint it). Idea file + README index entry added.
+
+## 📄 Doc audit (Q-0104)
+
+`check_current_state_ledger --strict` 0 · `check_docs --strict` 0 · the new guard's own `--strict` 0.
+Ledger in sync (newer merges are benign lag past the marker). No drift left uncaptured: the marker fix
++ the de-stale + the idea are all in their durable homes; S3 sector ledger updated with both guards.
+
+## Bug-book
+
+No new runtime bugs; no existing bug-book entries became fixable this run (BUG-0009 / BUG-0011 stay
+OPEN — both need work outside this run's offline lane).
+
+## Handoff / continuation
+
+This run was self-initiated docs-system tooling (no dispatch order). The sector queues are unchanged —
+the next scheduled dispatch should read `docs/current-state.md` ▶ Next action and pick the next
+**▶ startable** sector item. Most S1/S2 feature lanes remain `[owner]` / `[needs-live-bot]` /
+design-gated (Project Moon Slice A item 1 needs the external StaticData dump; absence-guard Layer B is
+review-gated "design-first"; fishing Phase 2 needs owner design calls). The cleanest fully-offline
+follow-on in this tooling lane is the captured `reconcile-marker-generator-2026-06-27` (small).
+
+Remarks for review: CodeGraph available (built clean at session start); Grimp not needed. The
+`check_quality.py --full` run takes ~2m43s — budget for it. No arch warnings introduced (the baseline
+`baseview_inheritance` WARNs are pre-existing).
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **Shipped:** PR #1495 — `check_reconcile_marker.py` (new guard) + live marker `#1472`→`#1470` fix +
+  `check_ledger_hygiene.py` de-stale for Q-0195. 32 checker tests; full suite green.
+- **⚑ Self-initiated:** YES — both slices. Slice 1 promotes idea
+  `reconcile-trigger-band-consistency-guard-2026-06-26` → shipped guard (Q-0172, no dispatch/owner ask);
+  slice 2 is a drift-on-sight de-stale (Q-0166). Owner can review/revert via PR #1495.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (merge auto-deploys; these are dev-tooling/docs, no runtime/data step).

--- a/.sessions/2026-06-27-reconcile-marker-band-consistency-guard.md
+++ b/.sessions/2026-06-27-reconcile-marker-band-consistency-guard.md
@@ -1,0 +1,25 @@
+# Session — reconcile-marker band-consistency guard (+ marker conflation fix)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> **Run type:** routine · dispatch
+
+## What I'm about to do
+
+Promote the freshly-captured idea
+[`reconcile-trigger-band-consistency-guard-2026-06-26`](../docs/ideas/reconcile-trigger-band-consistency-guard-2026-06-26.md)
+into a shipped guard (Q-0172 self-initiated promotion — idea→ship, no dispatch order this fire):
+
+1. **`scripts/check_reconcile_marker.py`** — a warn-first, stdlib, disposable (Q-0105) guard that
+   asserts the `Last reconciliation pass:** PR #N` marker in `current-state.md` is internally
+   consistent: (a) the leading `#N` equals the parenthetical "reset to the latest merged PR #R"
+   value (the conflation guard — the idea's core), (b) the `band-#M` label has `M = (N // 30) * 30`
+   (the cadence boundary), and (c) the linked `reconciliation-pass-*` doc exists on disk. Folds into
+   the existing `check_current_state_ledger` / `check_reconciliation_due` family.
+2. **Fix the live drift it catches** (bugs-first / Q-0166): the 26th pass set the marker to its own
+   PR `#1472` while its parenthetical (and the convention "reset to the latest PR") say `#1470` —
+   correct it to `#1470`.
+3. Tests in `tests/unit/scripts/`; mark the idea shipped; add a discoverability pointer.
+
+Why offline-fit: no dispatch work order this fire, most feature lanes are owner/live-bot/design-gated,
+and this is the "leave the next run better-equipped" lane the loop exists for — fully offline,
+test-covered, zero runtime risk.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -217,7 +217,7 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 >
-> **Last reconciliation pass:** PR #1472 (2026-06-26, twenty-sixth Q-0107 cadence pass, band-#1470 —
+> **Last reconciliation pass:** PR #1470 (2026-06-26, twenty-sixth Q-0107 cadence pass, band-#1470 —
 > [the pass record + next-band queue](planning/reconciliation-pass-2026-06-26-band1470.md); marker reset
 > to the latest merged PR **#1470**). The next
 > **docs-only review + planning reconciliation** is due once merged PRs cross #1500 (every

--- a/docs/current-state/S3-ai-memory.md
+++ b/docs/current-state/S3-ai-memory.md
@@ -10,6 +10,15 @@
 > own; distinct from S4 (the docs content it produces) and S5 (its operation).*
 
 **Recently shipped (this sector):**
+- **Reconcile-marker band-consistency guard** (`scripts/check_reconcile_marker.py`, warn-first,
+  dispatch run 2026-06-27) — asserts the `Last reconciliation pass` marker in `current-state.md` is
+  internally consistent (leading `PR #N` == the stated reset target · `band-#M` == `(N // 30) * 30` ·
+  the linked pass-record doc exists); caught + fixed the live band-#1470 drift (marker read `#1472`,
+  the pass's own PR, vs the reset target `#1470`). Idea `reconcile-trigger-band-consistency-guard`.
+- **`check_ledger_hygiene` de-staled for the Q-0195 per-claim-file layout** (dispatch run 2026-06-27) —
+  the retired shared `active-work.md` claim ledger left the linter's Active-claims scan no-op'ing
+  against a pointer stub; repointed to scan `docs/owner/claims/*.md` and flag a `claude/<branch>`
+  claimed by >1 file.
 - **Settle-once money-safety guard** (`check_consistency` **Rule 6**, warn-first, #1454) — pins the
   settle-once terminal pattern on game-state views (#1444) + blackjack PvP (#1445, shared mixin
   relocated to `utils/`) so a money-paying game can't double-settle without tripping a checker.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -109,13 +109,15 @@ Current broad captures:
   real signal: *how much of the roadmap the autonomous fleet drives vs. how much he steers live* — the core
   "is the workflow self-driving?" metric. Reuses the planned-slice hit-rate tracker's parse. Subsystem: S4/S3 tooling.
 - [`reconcile-trigger-band-consistency-guard-2026-06-26.md`](./reconcile-trigger-band-consistency-guard-2026-06-26.md) —
-  **reconciliation idea (2026-06-26, band-#1470 Q-0089):** the `Last reconciliation pass: PR #N` marker is
-  hand-written and conflates the *reset target* (latest merged PR) with the *pass identity* (the PR the pass
-  shipped as) — the band-#1440 marker wrote `#1441` (a dashboard refresh) where the 25th pass was actually
-  #1443, costing the band-#1470 pass time to disentangle. A warn-first `check_reconcile_marker.py` that asserts
-  the marker is the latest merged PR, the `band-#M` label matches the cadence boundary the trigger issue
-  crossed, and the linked pass doc is the single `plan`-badged one — folds into the ledger-checker parse and
-  catches the conflation at the root. Joins the reconciliation-tooling cluster above. Subsystem: S4/S3 tooling.
+  **✅ SHIPPED 2026-06-27** (`scripts/check_reconcile_marker.py`, dispatch run): the warn-first guard that
+  asserts the `Last reconciliation pass: PR #N` marker is internally consistent (leading `#N` == the stated
+  reset target · `band-#M` == `(N // 30) * 30` · the linked pass doc exists). Caught + fixed the live
+  band-#1470 drift (marker read `#1472`, the pass's own PR, vs the reset target `#1470`). Subsystem: S4/S3 tooling.
+- [`reconcile-marker-generator-2026-06-27.md`](./reconcile-marker-generator-2026-06-27.md) —
+  **reconciliation idea (2026-06-27, Q-0089):** the generate-don't-validate complement to the guard above — a
+  `scripts/set_reconcile_marker.py` that *emits* the canonical marker line from the latest-merged PR + band
+  math (so the agreeing numbers come from one source and can't be mistyped), turning the routine's "reset the
+  marker" step into *run this script*. The guard catches the drift; the generator prevents it. Subsystem: S4/S3 tooling.
 - [`dispatch-menu-suppress-shipped-lanes-2026-06-26.md`](./dispatch-menu-suppress-shipped-lanes-2026-06-26.md) —
   **dispatch-tooling idea (2026-06-26, groomed from the #1477 left-open note):** `check_sector_next_freshness`
   catches a `▶ Next` linking a shipped (`historical`) plan at *session close*; `dispatch_menu.py` has no such

--- a/docs/ideas/ledger-dedup-linter-2026-06-16.md
+++ b/docs/ideas/ledger-dedup-linter-2026-06-16.md
@@ -1,7 +1,11 @@
 # Ledger dedup linter (companion to the merge=union fix)
 
-> **Status:** `ideas` — captured 2026-06-16 (session idea, Q-0089, from the merge=union fix #1003).
-> Source + merged PRs win.
+> **Status:** `historical` — **SHIPPED** `scripts/check_ledger_hygiene.py` (2026-06-19) and
+> **de-staled 2026-06-27** for the Q-0195 per-claim-file restructure: the claim half no longer scans
+> the retired shared `active-work.md` "Active claims" section (now a pointer stub) — it scans the
+> per-file `docs/owner/claims/*.md` directory and flags a `claude/<branch>` claimed by more than one
+> file. The idea-index dedup half is unchanged. Captured 2026-06-16 (session idea, Q-0089, from the
+> merge=union fix #1003). Source + merged PRs win.
 
 ## The gap
 

--- a/docs/ideas/reconcile-marker-generator-2026-06-27.md
+++ b/docs/ideas/reconcile-marker-generator-2026-06-27.md
@@ -1,0 +1,44 @@
+# Idea — generate the reconciliation marker instead of hand-writing it
+
+> **Status:** `ideas` — session idea (2026-06-27, Q-0089, from the dispatch run that shipped
+> `check_reconcile_marker.py`). Lane: S4 (docs system) / S3 (the engine's tooling). Size: small
+> (one stdlib emitter + a routine-prompt wiring line).
+
+## The gap the guard left open
+
+The `Last reconciliation pass:** PR #N (… band-#M … reset to the latest merged PR #R)` marker is
+**hand-written** by every Q-0107 pass. This run shipped `scripts/check_reconcile_marker.py`, which
+*validates* the marker's three internal invariants (N == R, M == (N // 30) * 30, the pass doc
+exists) — but validation is the *detect* half. The drift it caught (the band-#1470 pass wrote its
+own PR #1472 as the marker instead of the reset target #1470) happened because a human/agent typed
+two numbers that must agree, and got one wrong. A guard turns that into a red check the *next* pass
+has to fix; it doesn't stop the pass from emitting the wrong marker in the first place.
+
+## The idea — generate, don't validate
+
+A tiny `scripts/set_reconcile_marker.py` (stdlib, disposable Q-0105) that **emits the canonical
+marker line** from inputs it derives, so the agreeing numbers come from one source and can't drift:
+
+- read the **latest merged PR** the same way `check_reconciliation_due._latest_merged_pr()` does
+  (`git log origin/main`), use it as both the leading `#N` and the `reset to … #R` (they are the
+  same thing by construction),
+- compute `band-#M = (N // STEP) * STEP`,
+- take the ordinal + pass-doc path as args (or derive the ordinal from the existing marker + 1),
+- print the exact marker line (and optionally rewrite it in `current-state.md` in place).
+
+The reconcile routine's "reset the marker" step then becomes *run this script* instead of *hand-edit
+the line* — `check_reconcile_marker.py` stays as the backstop for a marker edited any other way.
+
+## Why it's worth having
+
+- It is the generate-don't-validate complement to the guard (same philosophy as the
+  migration-collision idea's Option 3: remove the shared hand-typed value rather than lint it). The
+  guard catches the drift; the generator prevents it.
+- Cheap, offline, read-only-by-default (print mode), pairs with the existing reconciliation-tooling
+  cluster. → relates `scripts/check_reconcile_marker.py` · `scripts/check_reconciliation_due.py` ·
+  `docs/operations/autonomous-routines.md` (the "reset the marker" step).
+
+## Disposition
+
+Decided-lane, small → execute when the dashboard/tooling lane next has capacity (a few-line emitter +
+a test + the one routine-prompt wiring line).

--- a/docs/ideas/reconcile-trigger-band-consistency-guard-2026-06-26.md
+++ b/docs/ideas/reconcile-trigger-band-consistency-guard-2026-06-26.md
@@ -1,6 +1,15 @@
 # Idea — a `reconcile`-issue ↔ marker band-consistency guard
 
-> **Status:** `ideas` — raised by the band-#1470 Q-0107 reconciliation pass (2026-06-26, Q-0089).
+> **Status:** `ideas` — **SHIPPED 2026-06-27** (dispatch run, self-initiated Q-0172):
+> `scripts/check_reconcile_marker.py` + `tests/unit/scripts/test_check_reconcile_marker.py`. The
+> shipped guard implements the conflation check (assertion 1 below) + the band-boundary check
+> (assertion 2) + the linked-pass-record existence check (assertion 3); it also caught + fixed a live
+> drift (the band-#1470 marker read `PR #1472` — the pass's own PR — instead of the reset target
+> `#1470`). *Not folded into `check_current_state_ledger.py` — kept a standalone disposable (Q-0105)
+> sibling instead, simpler to delete if it proves noisy.* Assertion 1's "latest open/closed reconcile
+> issue" cross-check (below) was **not** built — the marker is self-consistent without a network call,
+> so the guard stays pure-stdlib/offline.
+> Raised by the band-#1470 Q-0107 reconciliation pass (2026-06-26, Q-0089).
 > Lane: S4 (docs system) / S3 (the engine's tooling). Size: small (one stdlib checker + test).
 
 ## The problem

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -210,7 +210,11 @@ STEP 2 — RECONCILE (the Q-0107 pass):
     *cadence half* of the freshness loop — the dispatch routine carries the warn-only `--drift`
     reporter, this routine keeps the artifact fresh without burdening every session.
   - Reset the "Last reconciliation pass: PR #N" marker in current-state.md to the latest PR
-    (the trigger Action keys off it — do not skip).
+    (the trigger Action keys off it — do not skip). #N is the **latest merged PR** (the reset
+    target), NOT the pass's own PR number; keep the leading #N, the `band-#M` label
+    (M = (N // 30) * 30), and the "reset to the latest merged PR #N" parenthetical all the same
+    number. `python3.10 scripts/check_reconcile_marker.py` verifies this consistency (warn-only;
+    `--strict` to gate).
 
 STEP 3 — RUNTIME BUGS YOU NOTICED: do NOT fix them here. Append each to docs/health/bug-book.md
   as a new OPEN entry for the dispatch routine to fix. Stay docs-only.

--- a/docs/owner/claims/claude-funny-franklin-galrnj.md
+++ b/docs/owner/claims/claude-funny-franklin-galrnj.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-galrnj` · reconcile-marker band-consistency guard (`scripts/check_reconcile_marker.py`) + fix the #1472→#1470 marker conflation drift · scope: `scripts/`, `tests/unit/scripts/`, `docs/current-state.md` (marker line), `docs/ideas/`, `docs/operations/` · 2026-06-27

--- a/docs/owner/claims/claude-funny-franklin-galrnj.md
+++ b/docs/owner/claims/claude-funny-franklin-galrnj.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-galrnj` · reconcile-marker band-consistency guard (`scripts/check_reconcile_marker.py`) + fix the #1472→#1470 marker conflation drift · scope: `scripts/`, `tests/unit/scripts/`, `docs/current-state.md` (marker line), `docs/ideas/`, `docs/operations/` · 2026-06-27

--- a/scripts/check_ledger_hygiene.py
+++ b/scripts/check_ledger_hygiene.py
@@ -3,31 +3,38 @@ r"""Ledger-hygiene linter — surface duplicate claim branches / idea-file links
 
 Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch)
 ---------------------------------------------------------------------------
-- Why: PR #1003 put git's ``merge=union`` driver on the two append-only
-  coordination ledgers (``docs/owner/active-work.md`` claim ledger,
-  ``docs/ideas/README.md`` idea index) so concurrent appends from parallel
-  sessions auto-merge instead of conflicting (the #995 livelock, hit 3x). Union's
-  one accepted downside: it never deletes and never dedups, so over time a
-  duplicate claim line or a twice-linked idea file can land and accumulate
-  silently — the convention already *permits* pruning these by hand, but nothing
-  *surfaces* them. This linter is the surface. It pairs with #1003: union keeps
-  the ledgers conflict-free, this keeps them clean. Idea:
+- Why: PR #1003 put git's ``merge=union`` driver on the append-only coordination
+  ledgers so concurrent appends from parallel sessions auto-merge instead of
+  conflicting (the #995 livelock, hit 3x). Union's one accepted downside: it never
+  deletes and never dedups, so over time a duplicate claim or a twice-linked idea
+  file can land and accumulate silently — the convention already *permits* pruning
+  these by hand, but nothing *surfaces* them. This linter is the surface. It pairs
+  with #1003: union keeps the ledgers conflict-free, this keeps them clean. Idea:
   ``docs/ideas/ledger-dedup-linter-2026-06-16.md`` (fleet unit B2).
-- Added: 2026-06-19. **Unverified** — confirm its output against ground truth a
-  few times across sessions before trusting it (the duplicate counts it reports
-  should match a hand grep of the two ledgers). **Delete this script + its test if
-  it proves unreliable / noisy over multiple sessions** — it is a disposable
-  convenience guard (Q-0105), not load-bearing. It is read-only: it never modifies
-  the ledgers it inspects.
+- Added: 2026-06-19. De-staled 2026-06-27 for the **Q-0195 per-claim-file
+  restructure**: the single shared ``docs/owner/active-work.md`` claim ledger was
+  retired (now a pointer stub) in favour of **one file per claim** under
+  ``docs/owner/claims/``, so the old "Active claims section" scan no-op'd against a
+  stub. The claim half now scans the per-file claim directory for a branch claimed
+  by more than one file (the per-file analogue of a duplicate claim line — e.g. a
+  hand-named claim file whose ``claude/<branch>`` collides with another's). The
+  idea-index half is unchanged. Per-file claim *staleness* (a claim left behind after
+  merge) is owned by ``check_stale_claims.py``; lane *overlap* by
+  ``check_lane_overlap.py`` — this stays narrowly the dedup surface.
+- **Unverified** — confirm its output against ground truth a few times across
+  sessions before trusting it (the duplicate counts should match a hand grep).
+  **Delete this script + its test if it proves unreliable / noisy over multiple
+  sessions** — it is a disposable convenience guard (Q-0105), not load-bearing. It
+  is read-only: it never modifies the ledgers it inspects.
 
 Behavior
 --------
-Read-only over two well-structured lists:
+Read-only over two well-structured sources:
 
-* **Active claims** (``active-work.md`` § "Active claims") — flags the same
-  ``\`claude/<branch>\``` appearing twice *within that section*. A branch may
-  legitimately appear once in Active claims and again under "Recently cleared",
-  so the scan is scoped to the Active-claims section only.
+* **Claims** (``docs/owner/claims/*.md``, excluding ``README.md``) — flags the same
+  ``\`claude/<branch>\``` appearing in more than one claim file. One file per claim
+  (Q-0195) makes a duplicate *filename* impossible, but a hand-authored claim file
+  can still name a branch another file already claims; that collision is the dupe.
 * **Idea index** (``ideas/README.md`` § "What lives here") — flags the same
   ``./<file>.md`` linked twice as a top-level **index entry** (a list item that
   opens ``- [\`...\`](./<file>.md)``). Inline cross-references to an idea from
@@ -56,7 +63,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-ACTIVE_WORK = REPO_ROOT / "docs" / "owner" / "active-work.md"
+CLAIMS_DIR = REPO_ROOT / "docs" / "owner" / "claims"
 IDEAS_README = REPO_ROOT / "docs" / "ideas" / "README.md"
 
 # A `claude/<slug>` branch token inside backticks. Slug is lowercase alnum + dashes.
@@ -70,35 +77,23 @@ _INDEX_ENTRY_RE = re.compile(r"^-\s+\[[^\]]*\]\((\./[A-Za-z0-9._-]+\.md)\)")
 _ANY_IDEA_LINK_RE = re.compile(r"\]\((\./[A-Za-z0-9._-]+\.md)\)")
 
 
-def section_body(text: str, heading: str) -> str:
-    """Return the body of the ``## <heading>`` section (up to the next ``## ``).
+def duplicate_claim_branches(claims_dir: Path) -> list[tuple[str, int]]:
+    """``(branch, count)`` for each ``claude/<branch>`` claimed by >1 file in ``claims_dir``.
 
-    Returns "" when the heading is absent. Matching is exact on the heading text
-    after the ``## `` marker (leading/trailing whitespace stripped), so
-    "Active claims" finds ``## Active claims`` but not ``## Recently cleared``.
+    Scans every ``*.md`` claim file (excluding ``README.md``) under the per-file claim
+    directory (Q-0195). A branch is counted **once per file** (a single claim file naming
+    its own branch repeatedly is not a duplicate), so the count is the number of *distinct
+    files* that claim the same branch — a genuine collision needing a manual prune. Sorted
+    by branch for deterministic output. Missing/empty directory → ``[]``.
     """
-    lines = text.splitlines()
-    out: list[str] = []
-    capturing = False
-    for line in lines:
-        if line.startswith("## "):
-            if capturing:
-                break  # reached the next section — stop
-            capturing = line[3:].strip() == heading
+    counts: Counter[str] = Counter()
+    if not claims_dir.is_dir():
+        return []
+    for path in sorted(claims_dir.glob("*.md")):
+        if path.name == "README.md":
             continue
-        if capturing:
-            out.append(line)
-    return "\n".join(out)
-
-
-def duplicate_active_claims(text: str) -> list[tuple[str, int]]:
-    """``(branch, count)`` for each branch appearing >1x in the Active-claims section.
-
-    Sorted by branch for deterministic output. Scans only the Active-claims
-    section so a branch that also appears under "Recently cleared" is not a dupe.
-    """
-    body = section_body(text, "Active claims")
-    counts = Counter(_BRANCH_RE.findall(body))
+        branches = set(_BRANCH_RE.findall(_read(path)))  # once per file
+        counts.update(branches)
     return sorted((b, n) for b, n in counts.items() if n > 1)
 
 
@@ -143,10 +138,10 @@ def main(argv: list[str] | None = None) -> int:
         help="exit 1 when a hard duplicate (claim branch / idea index entry) is found",
     )
     parser.add_argument(
-        "--active-work",
+        "--claims-dir",
         type=Path,
-        default=ACTIVE_WORK,
-        help="path to the claim ledger (default: docs/owner/active-work.md)",
+        default=CLAIMS_DIR,
+        help="path to the per-file claim directory (default: docs/owner/claims/)",
     )
     parser.add_argument(
         "--ideas-readme",
@@ -156,10 +151,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    active_text = _read(args.active_work)
     ideas_text = _read(args.ideas_readme)
 
-    dup_claims = duplicate_active_claims(active_text)
+    dup_claims = duplicate_claim_branches(args.claims_dir)
     dup_entries = duplicate_idea_entries(ideas_text)
     # Advisory-only set: cross-reference dupes that are NOT duplicate index entries.
     entry_links = {link for link, _ in dup_entries}
@@ -172,9 +166,11 @@ def main(argv: list[str] | None = None) -> int:
     hard = bool(dup_claims or dup_entries)
 
     if dup_claims:
-        print("Duplicate Active-claims branches (active-work.md § Active claims):")
+        print("Duplicate claim branches (docs/owner/claims/*.md):")
         for branch, n in dup_claims:
-            print(f"  - `{branch}` appears {n}x — prune the stale duplicate line.")
+            print(
+                f"  - `{branch}` claimed by {n} files — prune the stale duplicate claim.",
+            )
     if dup_entries:
         print("Duplicate idea index entries (ideas/README.md § What lives here):")
         for link, n in dup_entries:

--- a/scripts/check_reconcile_marker.py
+++ b/scripts/check_reconcile_marker.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3.10
+"""Reconcile-marker band-consistency guard — keep the `Last reconciliation pass` marker honest.
+
+The ``Last reconciliation pass:** PR #N`` marker in ``docs/current-state.md`` is hand-written
+by every Q-0107 reconciliation pass, and it conflates two numbers that *look* interchangeable
+but are not:
+
+- the **reset target** — the latest *merged* PR at pass time. ``check_reconciliation_due.py``
+  keys the cadence off it, and ``check_current_state_ledger.py`` treats it as the lag/drift
+  boundary ("everything up to and including #N has been reconciled"). The routine prompt
+  (``docs/operations/autonomous-routines.md``) says reset it to **the latest PR**.
+- the **pass identity** — the PR the docs-only pass itself shipped as.
+
+These drift apart in a recurring micro-way. The band-#1440 pass wrote ``PR #1441`` (correct reset
+target) but its parenthetical claimed #1441 *was* the pass (it shipped as #1443); the band-#1470
+pass wrote ``PR #1472`` (its *own* PR) while its parenthetical said "reset to the latest merged PR
+#1470" — an internal contradiction. Every pass re-writes the marker by hand, so every pass can
+re-introduce the conflation, and the *next* pass re-explains it in prose instead of a checker
+catching it (idea ``reconcile-trigger-band-consistency-guard-2026-06-26``).
+
+This guard asserts three independent, internally-checkable invariants on the marker line. Each
+is **skipped if its clause is absent**, so an older / abbreviated marker format never false-reds:
+
+1. **Conflation guard (the core):** when the line carries "reset to the latest merged PR #R", the
+   leading ``PR #N`` must equal ``R`` — they are the same thing (the reset target), so a leading
+   number that is the pass's own PR is the bug.
+2. **Band-boundary:** a ``band-#M`` label must satisfy ``M == (N // STEP) * STEP`` (the cadence
+   boundary at/under the marker; ``STEP`` mirrors ``check_reconciliation_due.STEP``).
+3. **Pass-record link exists:** the linked ``planning/reconciliation-pass-*.md`` resolves on disk.
+
+Advisory by default (exit 0) like its siblings; ``--strict`` exits 1 on any inconsistency. Pure
+stdlib, like ``check_docs.py``.
+
+Reliability (Q-0105): **unverified** — confirm its flags against the actual marker over a few
+reconciliation passes before trusting it. If it false-positives on a legitimate marker format (or
+misses a real conflation) over multiple sessions, **delete it** — it is a convenience guard for
+the Q-0107 cadence bookkeeping, not load-bearing.
+
+Usage:
+    python3.10 scripts/check_reconcile_marker.py            # advisory report (exit 0)
+    python3.10 scripts/check_reconcile_marker.py --strict   # exit 1 on any inconsistency
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CURRENT_STATE = REPO_ROOT / "docs" / "current-state.md"
+
+# Mirrors ``check_reconciliation_due.STEP`` (the multiple-of-N cadence band, 30 since Q-0134).
+# Kept as a local constant rather than a cross-script import so this guard stays standalone +
+# disposable (scripts/ is not a package); if STEP ever changes, change it in both — they are
+# checked against each other by ``test_step_matches_reconciliation_due``.
+STEP = 30
+
+# The marker, e.g.:
+#   > **Last reconciliation pass:** PR #1470 (2026-06-26, twenty-sixth Q-0107 cadence pass,
+#     band-#1470 — [the pass record + next-band queue](planning/reconciliation-pass-2026-06-26-band1470.md);
+#     marker reset to the latest merged PR **#1470**). ...
+# In ``current-state.md`` it is a multi-line blockquote paragraph, so the clauses (band, doc link,
+# reset target) live on *different physical lines* than the leading ``PR #N`` — we must normalise the
+# whole paragraph into one logical line before matching, or the conflation check silently skips.
+_MARKER_START_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #\d+", re.IGNORECASE)
+# The leading ``PR #N`` captured from the normalised block.
+_MARKER_N_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #(\d+)", re.IGNORECASE)
+# The "reset to the latest merged PR #R" clause (R is the true reset target).
+_RESET_TARGET_RE = re.compile(
+    r"reset to the latest (?:merged )?PR\s*\*{0,2}#(\d+)",
+    re.IGNORECASE,
+)
+# The band label "band-#M".
+_BAND_LABEL_RE = re.compile(r"band-#(\d+)", re.IGNORECASE)
+# A linked reconciliation-pass record path, e.g. (planning/reconciliation-pass-2026-06-26-band1470.md).
+# The captured path forbids inner parens/whitespace so it can only match the markdown link target,
+# never the outer ``(2026-06-26, …)`` paren that also wraps the marker sentence.
+_PASS_DOC_RE = re.compile(
+    r"\(([^()\s]*reconciliation-pass-[^()\s]*\.md)\)",
+    re.IGNORECASE,
+)
+
+
+def find_marker_line(text: str) -> str | None:
+    """The full ``Last reconciliation pass`` marker paragraph as one normalised logical line.
+
+    The marker is a blockquote paragraph that wraps across several physical lines; this collapses
+    it (from the marker start to the next blank line) into a single ``> ``-stripped, single-spaced
+    string so the band / doc-link / reset-target clauses are all in scope at once. ``None`` if the
+    marker is absent.
+    """
+    m = _MARKER_START_RE.search(text)
+    if not m:
+        return None
+    start = text.rfind("\n", 0, m.start()) + 1
+    end = text.find("\n\n", m.start())  # paragraph break ends the marker block
+    block = text[start:] if end == -1 else text[start:end]
+    stripped = [re.sub(r"^\s*>\s?", "", ln) for ln in block.splitlines()]
+    return re.sub(r"\s+", " ", " ".join(stripped)).strip()
+
+
+def check_marker(
+    text: str | None = None,
+    *,
+    docs_root: Path | None = None,
+) -> list[str]:
+    """Return a list of human-readable inconsistency messages (empty = consistent).
+
+    ``text`` defaults to ``current-state.md``; ``docs_root`` (for the pass-doc existence check)
+    defaults to ``docs/`` next to it. Each assertion is skipped when its clause is absent, so an
+    older marker format degrades to "fewer checks", never a false positive.
+    """
+    if text is None:
+        try:
+            text = CURRENT_STATE.read_text(encoding="utf-8")
+        except OSError:
+            return []
+    if docs_root is None:
+        docs_root = CURRENT_STATE.parent
+
+    line = find_marker_line(text)
+    if line is None:
+        return []
+
+    marker_match = _MARKER_N_RE.search(line)
+    if marker_match is None:  # defensive: find_marker_line only returns a matched block
+        return []
+    marker_n = int(marker_match.group(1))
+
+    problems: list[str] = []
+
+    # 1. Conflation guard — leading #N must equal the stated reset target #R.
+    reset = _RESET_TARGET_RE.search(line)
+    if reset is not None:
+        reset_r = int(reset.group(1))
+        if reset_r != marker_n:
+            problems.append(
+                f"leading marker PR #{marker_n} != the stated 'reset to the latest merged PR "
+                f"#{reset_r}' — the marker's leading number must be the reset target (the latest "
+                f"merged PR), not the pass's own PR. Set the leading number to #{reset_r}.",
+            )
+
+    # 2. Band-boundary — band-#M must be the cadence boundary at/under the marker.
+    band = _BAND_LABEL_RE.search(line)
+    if band is not None:
+        band_m = int(band.group(1))
+        expected = (marker_n // STEP) * STEP
+        if band_m != expected:
+            problems.append(
+                f"band label band-#{band_m} != the cadence boundary band-#{expected} for marker "
+                f"#{marker_n} (M must be (N // {STEP}) * {STEP}).",
+            )
+
+    # 3. Pass-record link — the referenced reconciliation-pass-*.md must exist on disk.
+    doc = _PASS_DOC_RE.search(line)
+    if doc is not None:
+        rel = doc.group(1).strip()
+        # Marker links are relative to docs/ (e.g. "planning/reconciliation-pass-...md").
+        target = (docs_root / rel).resolve()
+        if not target.is_file():
+            problems.append(
+                f"linked pass record '{rel}' does not resolve to a file under {docs_root}.",
+            )
+
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="reconcile-marker band-consistency guard (idea "
+        "reconcile-trigger-band-consistency-guard-2026-06-26).",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if the marker is inconsistent",
+    )
+    args = parser.parse_args(argv)
+
+    if not CURRENT_STATE.is_file():
+        print(
+            "check_reconcile_marker: docs/current-state.md not found — nothing to check.",
+        )
+        return 0
+
+    problems = check_marker()
+    if not problems:
+        print(
+            "check_reconcile_marker: reconciliation marker is internally consistent ✓",
+        )
+        return 0
+
+    print(
+        f"check_reconcile_marker: {len(problems)} inconsistency(ies) in the "
+        "`Last reconciliation pass` marker:",
+    )
+    for p in problems:
+        print(f"  - {p}")
+    print(
+        "\nThis is the reconcile-marker conflation class (idea "
+        "reconcile-trigger-band-consistency-guard-2026-06-26): the leading marker PR # must be the "
+        "reset target (the latest merged PR), the band-#M label its cadence boundary, and the "
+        "linked pass record must exist. Fix the marker line in docs/current-state.md.",
+    )
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_ledger_hygiene.py
+++ b/tests/unit/scripts/test_check_ledger_hygiene.py
@@ -1,10 +1,14 @@
 """Tests for ``scripts/check_ledger_hygiene.py`` — the B2 ledger-hygiene linter.
 
-Covers section scoping, the three duplicate detectors (active-claim branches,
-idea index entries, any-link cross-refs), the entry-vs-advisory split, and
-``main`` exit codes in both report-only and ``--strict`` modes — including the
-real-repo invariant that the linter exits 0 against the live ledgers so its PR
-can land (it never modifies the ledgers it can only read).
+Covers the duplicate detectors (per-file claim-branch collisions, idea index
+entries, any-link cross-refs), the entry-vs-advisory split, and ``main`` exit
+codes in both report-only and ``--strict`` modes — including the real-repo
+invariant that the linter exits 0 against the live ledgers so its PR can land
+(it never modifies the ledgers it can only read).
+
+De-staled 2026-06-27 for the Q-0195 per-claim-file restructure: the claim half
+now scans ``docs/owner/claims/*.md`` for a branch claimed by more than one file
+(the single shared ``active-work.md`` claim ledger was retired to a pointer stub).
 """
 
 from __future__ import annotations
@@ -21,73 +25,80 @@ clh = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(clh)
 
 
-# --- section_body -----------------------------------------------------------
+def _claims(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Build a per-file claim directory and return it. ``files`` is {filename: body}."""
+    claims = tmp_path / "claims"
+    claims.mkdir()
+    for name, body in files.items():
+        (claims / name).write_text(body, encoding="utf-8")
+    return claims
 
 
-def test_section_body_extracts_named_section() -> None:
-    text = (
-        "# Title\n\n"
-        "## Active claims\n"
-        "- `claude/a` · scope\n"
-        "- `claude/b` · scope\n\n"
-        "## Recently cleared\n"
-        "- `claude/a` · 2026 · PR #1\n"
+# --- duplicate_claim_branches (per-file, Q-0195) ----------------------------
+
+
+def test_duplicate_claim_branches_flags_branch_in_two_files(tmp_path: Path) -> None:
+    claims = _claims(
+        tmp_path,
+        {
+            "a.md": "- `claude/dup` · scope one · 2026-06-27\n",
+            "b.md": "- `claude/dup` · scope two (accidental re-claim) · 2026-06-27\n",
+            "c.md": "- `claude/solo` · scope · 2026-06-27\n",
+        },
     )
-    body = clh.section_body(text, "Active claims")
-    assert "`claude/a`" in body and "`claude/b`" in body
-    # The Recently-cleared line must NOT bleed into the Active-claims body.
-    assert "PR #1" not in body
+    assert clh.duplicate_claim_branches(claims) == [("claude/dup", 2)]
 
 
-def test_section_body_missing_returns_empty() -> None:
-    assert clh.section_body("## Other\n- x\n", "Active claims") == ""
-
-
-def test_section_body_exact_heading_match_not_prefix() -> None:
-    text = "## Active claims extended\n- `claude/x`\n"
-    # The heading "Active claims" must not match "Active claims extended".
-    assert clh.section_body(text, "Active claims") == ""
-
-
-# --- duplicate_active_claims ------------------------------------------------
-
-
-def test_duplicate_active_claims_flags_repeat_in_section() -> None:
-    text = (
-        "## Active claims\n"
-        "- `claude/dup` · scope one\n"
-        "- `claude/solo` · scope\n"
-        "- `claude/dup` · scope two (accidental re-add)\n"
+def test_duplicate_claim_branches_same_branch_repeated_in_one_file_is_not_a_dupe(
+    tmp_path: Path,
+) -> None:
+    """A single claim file naming its own branch twice counts once (per-file)."""
+    claims = _claims(
+        tmp_path,
+        {"a.md": "- `claude/x` · scope\n- see `claude/x` again in this same file\n"},
     )
-    assert clh.duplicate_active_claims(text) == [("claude/dup", 2)]
+    assert clh.duplicate_claim_branches(claims) == []
 
 
-def test_duplicate_active_claims_ignores_recently_cleared() -> None:
-    """A branch in BOTH Active claims and Recently cleared is NOT a duplicate."""
-    text = (
-        "## Active claims\n"
-        "- `claude/live` · current work\n"
-        "## Recently cleared\n"
-        "- `claude/live` · 2026 · PR #9 (different older run, same generated slug)\n"
+def test_duplicate_claim_branches_skips_readme(tmp_path: Path) -> None:
+    claims = _claims(
+        tmp_path,
+        {
+            "README.md": "convention doc mentioning `claude/foo` as an example\n",
+            "foo.md": "- `claude/foo` · real claim\n",
+        },
     )
-    assert clh.duplicate_active_claims(text) == []
+    # README's example mention must not collide with the real claim.
+    assert clh.duplicate_claim_branches(claims) == []
 
 
-def test_duplicate_active_claims_clean_section() -> None:
-    text = "## Active claims\n- `claude/a`\n- `claude/b`\n"
-    assert clh.duplicate_active_claims(text) == []
-
-
-def test_duplicate_active_claims_sorted_and_counts() -> None:
-    text = (
-        "## Active claims\n"
-        "- `claude/zeta`\n- `claude/zeta`\n- `claude/zeta`\n"
-        "- `claude/alpha`\n- `claude/alpha`\n"
+def test_duplicate_claim_branches_clean(tmp_path: Path) -> None:
+    claims = _claims(
+        tmp_path,
+        {"a.md": "- `claude/a`\n", "b.md": "- `claude/b`\n"},
     )
-    assert clh.duplicate_active_claims(text) == [
+    assert clh.duplicate_claim_branches(claims) == []
+
+
+def test_duplicate_claim_branches_sorted_and_counts(tmp_path: Path) -> None:
+    claims = _claims(
+        tmp_path,
+        {
+            "1.md": "- `claude/zeta`\n",
+            "2.md": "- `claude/zeta`\n",
+            "3.md": "- `claude/zeta`\n",
+            "4.md": "- `claude/alpha`\n",
+            "5.md": "- `claude/alpha`\n",
+        },
+    )
+    assert clh.duplicate_claim_branches(claims) == [
         ("claude/alpha", 2),
         ("claude/zeta", 3),
     ]
+
+
+def test_duplicate_claim_branches_missing_dir_is_empty(tmp_path: Path) -> None:
+    assert clh.duplicate_claim_branches(tmp_path / "nope") == []
 
 
 # --- duplicate_idea_entries -------------------------------------------------
@@ -133,44 +144,38 @@ def test_duplicate_idea_links_includes_crossrefs() -> None:
 
 
 def test_main_clean_exits_zero(tmp_path, capsys) -> None:
-    aw = tmp_path / "active-work.md"
-    aw.write_text("## Active claims\n- `claude/a`\n", encoding="utf-8")
+    claims = _claims(tmp_path, {"a.md": "- `claude/a`\n"})
     rm = tmp_path / "README.md"
     rm.write_text("- [`a.md`](./a.md) — one\n", encoding="utf-8")
-    rc = clh.main(["--active-work", str(aw), "--ideas-readme", str(rm)])
+    rc = clh.main(["--claims-dir", str(claims), "--ideas-readme", str(rm)])
     assert rc == 0
     assert "clean" in capsys.readouterr().out
 
 
 def test_main_hard_dupe_report_only_exits_zero(tmp_path, capsys) -> None:
-    aw = tmp_path / "active-work.md"
-    aw.write_text(
-        "## Active claims\n- `claude/dup`\n- `claude/dup`\n", encoding="utf-8"
+    claims = _claims(
+        tmp_path,
+        {"a.md": "- `claude/dup`\n", "b.md": "- `claude/dup`\n"},
     )
     rm = tmp_path / "README.md"
     rm.write_text("- [`a.md`](./a.md)\n", encoding="utf-8")
     # Report-only default: surfaces the dupe but exits 0 (non-blocking advisory).
-    rc = clh.main(["--active-work", str(aw), "--ideas-readme", str(rm)])
+    rc = clh.main(["--claims-dir", str(claims), "--ideas-readme", str(rm)])
     out = capsys.readouterr().out
     assert rc == 0
     assert "claude/dup" in out and "report-only" in out
 
 
 def test_main_advisory_crossref_never_fails_strict(tmp_path, capsys) -> None:
-    """A cross-reference-only duplicate is advisory: exits 0 even under --strict.
-
-    This is the live-repo case (`live-decade-queue-pointer-invariant` linked
-    twice) — the linter must NOT redden a PR for an intentional cross-ref.
-    """
-    aw = tmp_path / "active-work.md"
-    aw.write_text("## Active claims\n- `claude/a`\n", encoding="utf-8")
+    """A cross-reference-only duplicate is advisory: exits 0 even under --strict."""
+    claims = _claims(tmp_path, {"a.md": "- `claude/a`\n"})
     rm = tmp_path / "README.md"
     rm.write_text(
         "- [`foo.md`](./foo.md) — entry\n"
         "- [`bar.md`](./bar.md) — see [`foo.md`](./foo.md)\n",
         encoding="utf-8",
     )
-    rc = clh.main(["--strict", "--active-work", str(aw), "--ideas-readme", str(rm)])
+    rc = clh.main(["--strict", "--claims-dir", str(claims), "--ideas-readme", str(rm)])
     out = capsys.readouterr().out
     assert rc == 0
     assert "Advisory" in out
@@ -180,38 +185,37 @@ def test_main_advisory_crossref_never_fails_strict(tmp_path, capsys) -> None:
 
 
 def test_main_strict_fails_on_duplicate_claim(tmp_path, capsys) -> None:
-    aw = tmp_path / "active-work.md"
-    aw.write_text(
-        "## Active claims\n- `claude/dup`\n- `claude/dup`\n", encoding="utf-8"
+    claims = _claims(
+        tmp_path,
+        {"a.md": "- `claude/dup`\n", "b.md": "- `claude/dup`\n"},
     )
     rm = tmp_path / "README.md"
     rm.write_text("- [`a.md`](./a.md)\n", encoding="utf-8")
-    rc = clh.main(["--strict", "--active-work", str(aw), "--ideas-readme", str(rm)])
+    rc = clh.main(["--strict", "--claims-dir", str(claims), "--ideas-readme", str(rm)])
     out = capsys.readouterr().out
     assert rc == 1
     assert "FAIL" in out and "claude/dup" in out
 
 
 def test_main_strict_fails_on_duplicate_idea_entry(tmp_path, capsys) -> None:
-    aw = tmp_path / "active-work.md"
-    aw.write_text("## Active claims\n- `claude/a`\n", encoding="utf-8")
+    claims = _claims(tmp_path, {"a.md": "- `claude/a`\n"})
     rm = tmp_path / "README.md"
     rm.write_text(
         "- [`foo.md`](./foo.md) — entry one\n- [`foo.md`](./foo.md) — entry two\n",
         encoding="utf-8",
     )
-    rc = clh.main(["--strict", "--active-work", str(aw), "--ideas-readme", str(rm)])
+    rc = clh.main(["--strict", "--claims-dir", str(claims), "--ideas-readme", str(rm)])
     out = capsys.readouterr().out
     assert rc == 1
     assert "FAIL" in out and "./foo.md" in out
 
 
 def test_main_missing_files_exit_zero(tmp_path, capsys) -> None:
-    """Absent ledger files read as empty → clean, never crash."""
+    """Absent claim dir / idea file read as empty → clean, never crash."""
     rc = clh.main(
         [
-            "--active-work",
-            str(tmp_path / "nope.md"),
+            "--claims-dir",
+            str(tmp_path / "nope"),
             "--ideas-readme",
             str(tmp_path / "nope2.md"),
         ]
@@ -224,11 +228,7 @@ def test_main_missing_files_exit_zero(tmp_path, capsys) -> None:
 
 
 def test_live_ledgers_exit_zero_report_only() -> None:
-    """Against the real ledgers, the default report-only run must exit 0.
-
-    Guards the brief's landing requirement: even if the live README has a real
-    cross-ref duplicate, the linter exits cleanly so its own PR can merge.
-    """
+    """Against the real ledgers, the default report-only run must exit 0."""
     assert clh.main([]) == 0
 
 

--- a/tests/unit/scripts/test_check_reconcile_marker.py
+++ b/tests/unit/scripts/test_check_reconcile_marker.py
@@ -1,0 +1,202 @@
+"""Tests for ``scripts/check_reconcile_marker.py`` — the reconcile-marker consistency guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_MOD = REPO_ROOT / "scripts" / "check_reconcile_marker.py"
+
+_spec = importlib.util.spec_from_file_location("check_reconcile_marker", _MOD)
+assert _spec and _spec.loader
+crm = importlib.util.module_from_spec(_spec)
+sys.modules["check_reconcile_marker"] = crm
+_spec.loader.exec_module(crm)
+
+
+def _marker(n: int, *, band: int, reset: int, doc: str) -> str:
+    return (
+        f"> **Last reconciliation pass:** PR #{n} (2026-06-26, twenty-sixth Q-0107 cadence pass, "
+        f"band-#{band} — [the pass record]({doc}); marker reset to the latest merged PR **#{reset}**). "
+        "The next pass is due once merged PRs cross #1500.\n"
+    )
+
+
+def _write_doc(tmp_path: Path, rel: str) -> Path:
+    """Create the linked pass-record file under a docs/ root and return that root."""
+    docs_root = tmp_path / "docs"
+    target = docs_root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("pass record\n", encoding="utf-8")
+    return docs_root
+
+
+# ---------------------------------------------------------------- happy path
+
+
+def test_consistent_marker_has_no_problems(tmp_path: Path) -> None:
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = _marker(1470, band=1470, reset=1470, doc=rel)
+    assert crm.check_marker(text, docs_root=docs_root) == []
+
+
+def test_marker_not_on_cadence_boundary_still_consistent(tmp_path: Path) -> None:
+    # A marker whose number is not itself a multiple of STEP: band = floor(N/STEP)*STEP.
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = _marker(1493, band=1470, reset=1493, doc=rel)  # 1493 // 30 * 30 == 1470
+    assert crm.check_marker(text, docs_root=docs_root) == []
+
+
+# ---------------------------------------------------------------- 1. conflation guard
+
+
+def test_conflation_leading_pr_differs_from_reset_target(tmp_path: Path) -> None:
+    # The real band-#1470 drift: leading #1472 (the pass's own PR) vs reset target #1470.
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = _marker(1472, band=1470, reset=1470, doc=rel)
+    problems = crm.check_marker(text, docs_root=docs_root)
+    assert len(problems) == 1
+    assert "1472" in problems[0] and "1470" in problems[0]
+
+
+def test_conflation_skipped_when_no_reset_clause(tmp_path: Path) -> None:
+    # An older/abbreviated marker without the "reset to ..." clause must not false-red,
+    # even when the leading PR is the pass's own number (#1472) — there's nothing to compare against.
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = f"> **Last reconciliation pass:** PR #1472 (band-#1470 — [rec]({rel})). next at #1500.\n"
+    assert crm.check_marker(text, docs_root=docs_root) == []
+
+
+# ---------------------------------------------------------------- 2. band-boundary
+
+
+def test_band_label_mismatch_flagged(tmp_path: Path) -> None:
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = _marker(
+        1470, band=1440, reset=1470, doc=rel
+    )  # 1470 // 30 * 30 == 1470, not 1440
+    problems = crm.check_marker(text, docs_root=docs_root)
+    assert len(problems) == 1
+    assert "band-#1440" in problems[0] and "band-#1470" in problems[0]
+
+
+def test_band_skipped_when_no_band_label(tmp_path: Path) -> None:
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = (
+        f"> **Last reconciliation pass:** PR #1470 ([rec]({rel}) — marker reset to the latest "
+        "merged PR **#1470**).\n"
+    )
+    assert crm.check_marker(text, docs_root=docs_root) == []
+
+
+# ---------------------------------------------------------------- 3. pass-record link
+
+
+def test_missing_pass_record_doc_flagged(tmp_path: Path) -> None:
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = tmp_path / "docs"  # do NOT create the file
+    docs_root.mkdir(parents=True, exist_ok=True)
+    text = _marker(1470, band=1470, reset=1470, doc=rel)
+    problems = crm.check_marker(text, docs_root=docs_root)
+    assert len(problems) == 1
+    assert rel in problems[0]
+
+
+def test_doc_link_skipped_when_absent(tmp_path: Path) -> None:
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir(parents=True, exist_ok=True)
+    text = (
+        "> **Last reconciliation pass:** PR #1470 (band-#1470; marker reset to the latest "
+        "merged PR **#1470**).\n"
+    )
+    assert crm.check_marker(text, docs_root=docs_root) == []
+
+
+# ---------------------------------------------------------------- multiple + no-marker
+
+
+def test_multiple_problems_reported_together(tmp_path: Path) -> None:
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = tmp_path / "docs"  # missing doc
+    docs_root.mkdir(parents=True, exist_ok=True)
+    text = _marker(
+        1472, band=1440, reset=1470, doc=rel
+    )  # conflation + band + missing doc
+    problems = crm.check_marker(text, docs_root=docs_root)
+    assert len(problems) == 3
+
+
+def test_no_marker_is_silent(tmp_path: Path) -> None:
+    assert crm.check_marker("no marker here at all\n", docs_root=tmp_path) == []
+
+
+# ---------------------------------------------------------------- multi-line block (real format)
+
+
+def test_multiline_blockquote_conflation_is_caught(tmp_path: Path) -> None:
+    """The real marker wraps across blockquote lines — the clauses on later lines must be in scope.
+
+    Regression for the bug where a single-physical-line extractor silently skipped the conflation
+    check because the "reset to ..." clause sat on a different line than the leading ``PR #N``.
+    """
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = (
+        "> some preamble\n"
+        ">\n"
+        "> **Last reconciliation pass:** PR #1472 (2026-06-26, twenty-sixth Q-0107 cadence pass, band-#1470 —\n"
+        f"> [the pass record + next-band queue]({rel}); marker reset\n"
+        "> to the latest merged PR **#1470**). The next pass is due once merged PRs cross #1500.\n"
+        "\n"
+        "- some later ledger entry\n"
+    )
+    problems = crm.check_marker(text, docs_root=docs_root)
+    assert (
+        len(problems) == 1
+    )  # only the conflation; band + doc are consistent across the lines
+    assert "1472" in problems[0] and "1470" in problems[0]
+
+
+def test_multiline_blockquote_consistent_is_clean(tmp_path: Path) -> None:
+    rel = "planning/reconciliation-pass-2026-06-26-band1470.md"
+    docs_root = _write_doc(tmp_path, rel)
+    text = (
+        "> **Last reconciliation pass:** PR #1470 (2026-06-26, twenty-sixth Q-0107 cadence pass, band-#1470 —\n"
+        f"> [the pass record + next-band queue]({rel}); marker reset\n"
+        "> to the latest merged PR **#1470**). The next pass is due once merged PRs cross #1500.\n"
+        "\n"
+        "- some later ledger entry that mentions #9999 and band-#1500 should not leak in\n"
+    )
+    assert crm.check_marker(text, docs_root=docs_root) == []
+
+
+# ---------------------------------------------------------------- live current-state.md
+
+
+def test_live_current_state_marker_is_consistent() -> None:
+    """The committed marker in docs/current-state.md must be consistent (drift fixed this PR)."""
+    assert crm.check_marker() == []
+
+
+# ---------------------------------------------------------------- STEP stays in sync
+
+
+def test_step_matches_reconciliation_due() -> None:
+    """STEP mirrors check_reconciliation_due.STEP — they must not drift apart."""
+    rd_path = REPO_ROOT / "scripts" / "check_reconciliation_due.py"
+    rd_spec = importlib.util.spec_from_file_location(
+        "check_reconciliation_due", rd_path
+    )
+    assert rd_spec and rd_spec.loader
+    rd = importlib.util.module_from_spec(rd_spec)
+    sys.modules["check_reconciliation_due"] = rd
+    rd_spec.loader.exec_module(rd)
+    assert crm.STEP == rd.STEP


### PR DESCRIPTION
## What & why

Self-initiated (Q-0172 — no dispatch work order this fire): promote the freshly-captured idea
[`reconcile-trigger-band-consistency-guard-2026-06-26`](https://github.com/menno420/superbot/blob/main/docs/ideas/reconcile-trigger-band-consistency-guard-2026-06-26.md)
into a shipped guard, and fix the live marker drift it catches.

The `Last reconciliation pass:** PR #N` marker in `current-state.md` is hand-written each pass and
conflates two numbers that look interchangeable: the **reset target** (the latest *merged* PR at pass
time — what the cadence/ledger checkers key off) and the **pass's own PR number**. The 26th pass wrote
`PR #1472` (its own PR) as the marker while its parenthetical said "reset to the latest merged PR
**#1470**" — an internal contradiction. (Same class as the #1441-vs-#1443 confusion the band-#1470 pass
spent real time disentangling.)

## Shape

- **`scripts/check_reconcile_marker.py`** — warn-first, stdlib, disposable (Q-0105) guard. Three
  independent assertions on the marker line, each skipped if its clause is absent (robust to format
  variation):
  1. **Conflation guard (core):** the leading `#N` must equal the "reset to the latest merged PR #R"
     value.
  2. **Band-boundary:** the `band-#M` label must satisfy `M == (N // 30) * 30` (the cadence boundary).
  3. **Pass-record link exists:** the linked `planning/reconciliation-pass-*.md` resolves on disk.
  Advisory (exit 0) by default; `--strict` gates.
- **`docs/current-state.md`** — fix the drift: marker `#1472` → `#1470` (the convention "reset to the
  latest PR", and the marker's own parenthetical, both say #1470). Cadence math is unchanged
  (`1472 // 30 == 1470 // 30 == 49`; next pass still at #1500).
- **`tests/unit/scripts/test_check_reconcile_marker.py`** — coverage for all three assertions (pass +
  fail + skip-when-absent).
- Idea marked shipped; a discoverability pointer added to the reconciliation routine prompt.

Born-red session card flips to `complete` as the final step.


---
_Generated by [Claude Code](https://claude.ai/code/session_012w2HAuekgpUeiBpgG2DAhc)_