### PR TITLE
BTD6: revert auto-derived DDT counter list (it grounded wrong towers)

### DIFF
--- a/.sessions/2026-06-27-btd6-revert-counter-list.md
+++ b/.sessions/2026-06-27-btd6-revert-counter-list.md
@@ -1,0 +1,60 @@
+# 2026-06-27 — BTD6: revert the auto-derived DDT counter list (it grounded wrong towers)
+
+> **Status:** `complete`
+
+**Run type:** owner-directed (owner live-tested #1492 and reported 3 wrong recommendations)
+
+## What this run did
+
+The owner live-tested the #1492 DDT counter-tower list in production and found it **wrong**:
+
+1. **Ice Monkey 2-0-0** — base ice can't damage MOAB-class, and a DDT *is* MOAB-class (needs Embrittlement
+   4-x-x). The list recommended a tower that literally can't hit a DDT.
+2. **Monkey Ace 0-2-5** — its explosions can't pop Black (DDT has Black).
+3. **Sniper 0-4-0** — a weak config; the real answers are 2-4-0 / 2-5-0 / 4-2-0 / 5-2-0.
+
+**Root cause:** "can damage a DDT" needs (a) MOAB-class targeting and (b) config quality, and the
+committed stats encode **neither** — I confirmed Ice 2-0-0 and 4-0-0 have byte-identical projectiles; the
+only "can hit MOAB-class" signal is Embrittlement's *description text*. So the primary-attack damage-type
+derivation is **unsound** for this. Grounding it ground misinformation, which is worse than refusing.
+
+**Revert + correct curation:**
+- Removed `towers_that_can_damage` / `CounterHit` / `_primary_attack` from `btd6_capability_service` and
+  the `_counter_fact` wiring from `btd6_interaction_service` (+ their tests).
+- Replaced it with **correct curated prose** in the DDT pop-guide note (`damage_types.json`): a DDT is
+  MOAB-class, so a counter needs camo + a non-resisted damage type **AND** the ability to hit MOAB-class —
+  base Ice (until Embrittlement) and Glue (until MOAB Glue 0-0-3) cannot. This captures the owner's Ice
+  correction as real knowledge.
+- Updated the corpus doc with the lesson + the open question.
+
+The damage-type **rules** grounding (camo + non-resisted type) stays — it is correct. The bot no longer
+auto-lists specific counter towers (the part that was wrong).
+
+CI: `check_quality --check-only` green, arch 0 errors, mypy clean, 1719 btd6 tests pass.
+
+## ⚑ Self-initiated
+
+None — owner-reported bug; this is the fix.
+
+## 💡 Session idea (Q-0089)
+
+*A "derivation confidence" convention: a data-derived BTD6 claim may only be grounded when every premise
+is in the structured data — if any premise lives only in description text (like MOAB-class targeting),
+the claim is curated prose, not auto-derived.* This run's bug was exactly an auto-derivation built on a
+premise (MOAB-class capability) the data doesn't encode. Routed as an idea.
+
+## ⟲ Previous-session review (Q-0102)
+
+The #1492 run verified the *damage-type* premise carefully (owner + wiki confirmed Sniper) but shipped a
+derivation resting on an *unverified* premise — that "primary attack pops lead+black+camo" ⇒ "can damage a
+DDT" — without checking the MOAB-class requirement at all. Lesson applied: verify EVERY premise a derived
+claim depends on, not just the one you happened to doubt. The owner's live test was the safety net that
+caught it; the durable fix is the confidence convention above. Good that the damage-type rules were
+separable and correct, so the revert kept the real value.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_docs`/`check_consistency` green. The reverted feature + the lesson + the open owner question are
+recorded in the corpus doc; the capability/interaction code carries revert-note comments. **Open owner
+decision** (how to do tower recommendations) is surfaced to the owner in-chat for a call. Ledger: next
+reconciliation pass.

--- a/disbot/data/btd6/damage_types.json
+++ b/disbot/data/btd6/damage_types.json
@@ -198,7 +198,7 @@
       "id": "ddt",
       "needs": "camo detection PLUS a damage type that bypasses Lead+Black: Fire, Plasma, Normal, Acid, or Glacier (NOT Sharp, Shatter, Cold, Energy, or Explosion)",
       "blocked": "Sharp, Shatter, Cold, Energy, and Explosion are all blocked (Lead + Black); and without camo detection nothing targets it",
-      "note": "DDTs are fast with 400 HP. You need ONE tower (or a tower + support) that has camo detection AND deals a non-blocked damage type: Fire, Plasma, Normal, Acid, or Glacier. Glue/slow works only via MOAB Glue (0-0-3) + camo detection. No base tower handles a DDT alone — Sharp (most primaries), Cold (ice) and Explosion (bomb) are all blocked."
+      "note": "A DDT is fast (400 HP) and MOAB-class with Lead + Black + Camo, so a tower needs THREE things at once: (1) camo detection, (2) a damage type a DDT does not resist — Fire, Plasma, Normal, Acid, or Glacier (NOT Sharp, Shatter, Cold, Energy, or Explosion), AND (3) the ability to damage MOAB-class bloons. Most damage towers satisfy (3), but two important exceptions do NOT until upgraded: base Ice Monkey (its Cold/Glacier attack cannot damage MOAB-class until Embrittlement 4-x-x — so Cold Snap alone, which pops lead+camo, still cannot hit a DDT) and base Glue (needs MOAB Glue 0-0-3). So 'pops lead and sees camo' is necessary but NOT sufficient — the tower must also be able to hit MOAB-class. (The committed stats don't encode MOAB-class targeting, so the bot does not auto-list specific counter towers — recommend by these rules.)"
     }
   ]
 }

--- a/disbot/services/btd6_capability_service.py
+++ b/disbot/services/btd6_capability_service.py
@@ -182,91 +182,13 @@ def towers_with_capability(
     return hits
 
 
-@dataclass(frozen=True)
-class CounterHit:
-    """One tower whose attack can damage a given bloon, and the earliest config."""
-
-    tower_id: str
-    canonical: str
-    crosspath: str  # "0-0-5"
-    damage_type: str
-
-
-def _primary_attack(tower_id: str, code: str) -> tuple[str | None, bool, float] | None:
-    """The (damage_type, sees_camo, damage) of a tier's PRIMARY projectile.
-
-    Reads ``attacks[0].projectiles[0]`` directly from the committed stats — the
-    main shot, NOT a sub-attack. (``normal_stats`` can select a secondary attack
-    for some towers — e.g. it reports the Ninja's caltrops as Normal while the
-    main shuriken is Sharp — so a "can it damage X" derivation must read the
-    primary projectile explicitly. Verified against the wiki on the subtle Sniper
-    case: Supply Drop/Elite Sniper 0-4-0+ main bullet IS Normal and pops Lead.)
-    """
-    from services import btd6_data_service
-
-    raw = btd6_data_service.read_blob(f"stats/{tower_id}.json")
-    tier = raw.get("tiers", {}).get(code) if raw else None
-    if not tier:
-        return None
-    attacks = tier.get("attacks") or []
-    if not attacks:
-        return None
-    projectiles = attacks[0].get("projectiles") or []
-    if not projectiles:
-        return None
-    proj = projectiles[0]
-    return (
-        proj.get("damage_type"),
-        not proj.get("filterInvisible", True),  # filterInvisible False → sees camo
-        float(proj.get("damage", 0) or 0),
-    )
-
-
-def towers_that_can_damage(bloon_id: str) -> list[CounterHit]:
-    """Towers whose PRIMARY attack can damage the bloon ``bloon_id``.
-
-    A tower qualifies when some single config's main shot (a) deals a damage type
-    the bloon does NOT resist (``bloon.immune_to``) and (b) detects camo if the
-    bloon is camo. Reports the earliest such config per tower. Purely derived
-    from the committed bloon ``immune_to`` (game-sourced) + the per-tier stats, so
-    it always matches the data — there is no curated list to drift. It answers
-    "which towers can damage a DDT?" (the hardest case: Lead + Black + Camo) so
-    the grounding can name verified towers instead of letting the model freelance.
-    """
-    from services import btd6_data_service
-
-    bloon = btd6_data_service.get_bloon(bloon_id)
-    if bloon is None:
-        return []
-    immune = set(bloon.immune_to or ())
-    needs_camo = "camo" in (bloon.properties or ())
-
-    hits: list[CounterHit] = []
-    for tower in btd6_data_service.get_dataset().towers:
-        stats = btd6_stats_service.get_tower_stats(tower.id)
-        if stats is None or not stats.has_combat_stats:
-            continue
-        for code in stats.tier_codes():
-            info = _primary_attack(tower.id, code)
-            if info is None:
-                continue
-            damage_type, sees_camo, damage = info
-            if (
-                damage > 0
-                and damage_type
-                and damage_type not in immune
-                and (sees_camo or not needs_camo)
-            ):
-                hits.append(
-                    CounterHit(
-                        tower_id=tower.id,
-                        canonical=tower.canonical,
-                        crosspath="-".join(code),
-                        damage_type=damage_type,
-                    ),
-                )
-                break
-    return hits
+# NOTE: an auto-derived "towers_that_can_damage(ddt)" lived here (PR #1492) but was
+# reverted — a DDT is MOAB-class and the committed stats do NOT encode MOAB-class
+# targeting (Ice 2-0-0 and 4-0-0 have byte-identical projectiles; only
+# Embrittlement's *description* says "Can hit MOAB-class"), nor config quality, so
+# the derivation recommended towers that can't actually hit a DDT (base Ice) and
+# weak configs. The correct MOAB-class subtlety is now curated prose in
+# damage_types.json instead. See docs/btd6/qa-accuracy-corpus-2026-06-27.md.
 
 
 __all__ = [
@@ -277,9 +199,7 @@ __all__ = [
     "PURPLE_POPPING",
     "WHITE_POPPING",
     "CapabilityHit",
-    "CounterHit",
     "ParagonCapabilityHit",
     "paragons_with_capability",
-    "towers_that_can_damage",
     "towers_with_capability",
 ]

--- a/disbot/services/btd6_interaction_service.py
+++ b/disbot/services/btd6_interaction_service.py
@@ -137,35 +137,11 @@ def _pop_guide_fact(entry: dict[str, Any]) -> str:
     )
 
 
-# pop_guide ids whose answer is really "which tower?" — for these we ground a
-# VERIFIED tower list (derived from the dump) so the model names real towers
-# instead of freelancing (which the faithfulness guard then refuses). Keyed to a
-# bloon id the capability derivation understands.
-_COUNTER_BLOON_FOR: dict[str, str] = {"ddt": "ddt"}
-
-
-def _counter_fact(pop_guide_id: str, label: str) -> str | None:
-    """A grounded "towers that can damage <bloon>" fact, or ``None``.
-
-    Derived at runtime from ``btd6_capability_service.towers_that_can_damage`` so
-    it always matches the committed data. Each named tower's primary attack
-    detects camo AND deals a damage type the bloon does not resist.
-    """
-    bloon_id = _COUNTER_BLOON_FOR.get(pop_guide_id)
-    if bloon_id is None:
-        return None
-    from services import btd6_capability_service
-
-    hits = btd6_capability_service.towers_that_can_damage(bloon_id)
-    if not hits:
-        return None
-    listed = ", ".join(f"{h.canonical} ({h.crosspath}, {h.damage_type})" for h in hits)
-    return (
-        f"[btd6_interaction] Towers whose attack can damage a {label} — verified "
-        f"from game data, each detects camo AND deals a damage type a {label} does "
-        f"not resist (the crosspath shown is the earliest config that works; it is "
-        f"a capability list, not a power ranking): {listed}. (source: {_SOURCE})"
-    )
+# NOTE: an auto-derived "towers that can damage a DDT" fact was grounded here
+# (PR #1492) and reverted — the derivation could not tell that base Ice / Glue
+# can't hit MOAB-class (a DDT is MOAB-class, and that capability is NOT in the
+# stats), nor that a config is weak, so it grounded wrong recommendations. The
+# correct MOAB-class subtlety is curated prose in damage_types.json instead.
 
 
 def interaction_facts(message_text: str) -> list[str]:
@@ -203,9 +179,6 @@ def interaction_facts(message_text: str) -> list[str]:
         facts.append(_status_fact(status))
     for prop in matched_props:
         facts.append(_pop_guide_fact(prop))
-        counter = _counter_fact(str(prop.get("id", "")), prop.get("property", ""))
-        if counter is not None:
-            facts.append(counter)
     for damage in matched_damage:
         facts.append(_damage_type_fact(damage))
 

--- a/docs/btd6/qa-accuracy-corpus-2026-06-27.md
+++ b/docs/btd6/qa-accuracy-corpus-2026-06-27.md
@@ -197,16 +197,29 @@ keyed off the bot's REAL `btd6_context_service.build()` grounding:
 | **#1488** | Corpus wired into the evals: the offline grounding test (`test_btd6_qa_corpus.py`, free, every PR) + the live action suite picker. |
 | **#1490** | The faithful **"exactly live"** runner (`btd6_live_path.py`) — replays the real production answer path (router → grounding → instruction stack → gateway → faithfulness guard). |
 | **#1491** | Fixed the eval grader: live answers are graded **semantically** by `llm_judge` (the model paraphrases — substring-matching the fact wording gave false negatives). |
-| **#1492** | Verified **DDT counter-tower grounding** (`towers_that_can_damage`) so "how do I deal with a DDT" recommends real towers instead of refusing. |
+| **#1492** | Attempted an auto-derived **DDT counter-tower list** — **REVERTED** (see below): the derivation couldn't tell that base Ice/Glue can't hit MOAB-class, so it recommended towers that can't actually damage a DDT. Replaced with curated MOAB-class prose. |
+
+### ⚠ Lesson — the auto-derived counter list was wrong (reverted)
+
+The owner live-tested the #1492 list and found three errors: it recommended **Ice Monkey 2-0-0** (base
+ice can't damage MOAB-class — a DDT is MOAB-class — until Embrittlement 4-x-x), **Monkey Ace 0-2-5**
+(its explosions can't pop Black), and **Sniper 0-4-0** (a weak config — 2-4-0/2-5-0/4-2-0/5-2-0 are the
+real answers). Root cause: "can damage a DDT" needs (a) MOAB-class targeting and (b) config quality,
+and **the committed stats encode neither** (Ice 2-0-0 and 4-0-0 have byte-identical projectiles; the only
+"can hit MOAB-class" signal is Embrittlement's *description text*). So the derivation is unsound and was
+reverted. The damage-type **requirement** (camo + non-resisted type + must hit MOAB-class) is now curated
+prose in `damage_types.json` — correct, but it deliberately does **not** name specific counter towers.
+**Open question for the owner:** how to do tower recommendations (a hand-curated, wiki-verified list vs.
+leaving the rules-based guidance).
 
 ## Live verification checklist — what still needs a real-key / prod test
 
 Everything above is offline-verified (1500+ tests, no creds). These need a real provider key or a live
 bot to confirm, and are **not** done:
 
-- [ ] **Re-run *AI Evals → suite: btd6*** after deploy. Expect: the interaction questions PASS on the
-      semantic grader, and **`how do I deal with a DDT` now answers with towers instead of refusing**
-      (the #1492 fix — not yet re-run live).
+- [ ] **Re-run *AI Evals → suite: btd6*** after deploy. Expect the interaction questions PASS on the
+      semantic grader. Note: `how do I deal with a DDT` now answers by the *rules* (camo + non-resisted
+      damage + must hit MOAB-class), NOT a specific tower list (#1492 was reverted — see the lesson above).
 - [ ] **Live Discord spot-check** of the original screenshot questions (glue/avenger/DDT, "can ice slow
       DDTs") on the real bot — confirm the answers are now correct in production, not just in the eval.
 - [ ] **The golden-set over-refusals are NOT fixed** — `knowledge.btd6_round_cash_*`,
@@ -219,9 +232,10 @@ bot to confirm, and are **not** done:
 
 ## Open follow-ups (next sessions)
 
-- **Generalize the counter grounding** beyond DDT — `towers_that_can_damage` is already general; extend
-  the `_COUNTER_BLOON_FOR` map in `btd6_interaction_service` to camo-lead / the Camo bloon to close the
-  same over-refusal there.
+- **Tower recommendations for "how do I deal with X" (owner decision pending)** — the auto-derivation was
+  reverted (above). To recommend specific towers correctly we need MOAB-class targeting + config quality,
+  which aren't in the dump. Options: a hand-curated wiki-verified list (small, per-bloon), an owner-supplied
+  list, or leaving the rules-based guidance. The over-refusal on these questions returns until decided.
 - **Broaden the live corpus** with strategy/opinion questions graded by `llm_judge` rubrics.
 - **Newer-tower coverage** (Desperado, Mermonkey): the dump has them; spot-check their damage-type
   interaction questions ground correctly.

--- a/docs/btd6/qa-accuracy-corpus-2026-06-27.md
+++ b/docs/btd6/qa-accuracy-corpus-2026-06-27.md
@@ -232,10 +232,12 @@ bot to confirm, and are **not** done:
 
 ## Open follow-ups (next sessions)
 
-- **Tower recommendations for "how do I deal with X" (owner decision pending)** — the auto-derivation was
-  reverted (above). To recommend specific towers correctly we need MOAB-class targeting + config quality,
-  which aren't in the dump. Options: a hand-curated wiki-verified list (small, per-bloon), an owner-supplied
-  list, or leaving the rules-based guidance. The over-refusal on these questions returns until decided.
+- **Tower recommendations for "how do I deal with X" — DEFERRED (owner decision 2026-06-27).** The
+  auto-derivation was reverted (above); the owner chose to leave the **rules-based** guidance (camo +
+  non-resisted damage + must hit MOAB-class) for now and revisit specific tower recommendations later as
+  its own focused task. To do it correctly later we need MOAB-class targeting + config quality, which
+  aren't in the dump — so it will be a hand-curated, wiki-verified (or owner-supplied) list, not an
+  auto-derivation. (The over-refusal on a bare "which tower?" ask may return until then; that's accepted.)
 - **Broaden the live corpus** with strategy/opinion questions graded by `llm_judge` rubrics.
 - **Newer-tower coverage** (Desperado, Mermonkey): the dump has them; spot-check their damage-type
   interaction questions ground correctly.

--- a/tests/unit/services/test_btd6_capability_service.py
+++ b/tests/unit/services/test_btd6_capability_service.py
@@ -117,29 +117,3 @@ def test_paragon_camo_curation_keys_match_real_paragons():
 def test_paragons_with_capability_only_supports_camo():
     assert cap.paragons_with_capability(cap.LEAD_POPPING) == []
     assert cap.paragons_with_capability("nonsense") == []
-
-
-def test_towers_that_can_damage_ddt_is_verified_and_sane():
-    """Every DDT counter must, by the game-sourced data, deal a damage type a DDT
-    does NOT resist AND detect camo — the invariant the grounding relies on."""
-    from services import btd6_data_service
-
-    ddt = btd6_data_service.get_bloon("ddt")
-    immune = set(ddt.immune_to or ())  # Sharp, Shatter, Cold, Energy, Explosion
-
-    hits = cap.towers_that_can_damage("ddt")
-    assert hits, "expected a non-empty DDT counter list"
-    names = {h.canonical for h in hits}
-    # Canonical DDT damage-dealers must appear.
-    for expected in ("Super Monkey", "Spike Factory", "Dart Monkey", "Wizard Monkey"):
-        assert expected in names, f"{expected} should be able to damage a DDT"
-    # The invariant: no counter deals a type the DDT resists.
-    for h in hits:
-        assert h.damage_type not in immune, (
-            f"{h.canonical} ({h.crosspath}) deals {h.damage_type}, which a DDT "
-            f"resists — derivation is wrong"
-        )
-
-
-def test_towers_that_can_damage_unknown_bloon_is_empty():
-    assert cap.towers_that_can_damage("not_a_bloon") == []

--- a/tests/unit/services/test_btd6_interaction_service.py
+++ b/tests/unit/services/test_btd6_interaction_service.py
@@ -100,20 +100,16 @@ def test_ice_is_cold_blocked_by_lead():
     assert "cold snap" in blob
 
 
-def test_ddt_grounds_verified_counter_towers():
-    """'how do I deal with a DDT' must ground a VERIFIED tower list so the model
-    names real towers (and the faithfulness guard does not refuse the answer).
-    This is the over-refusal fix: the towers are derived from the dump, not
-    freelanced."""
+def test_ddt_note_states_moab_class_requirement():
+    """The DDT note must convey the MOAB-class subtlety (a DDT is MOAB-class, so
+    base Ice/Glue can't hit it without Embrittlement / MOAB Glue) — the curated
+    correction that replaced the reverted auto-counter list."""
     facts = btd6_interaction_service.interaction_facts("how do I deal with a DDT")
-    counter = [f for f in facts if "towers whose attack can damage a ddt" in f.lower()]
-    assert counter, "expected a grounded DDT counter-tower fact"
-    blob = counter[0].lower()
-    # Real, verified damage-dealers must be named.
-    assert "super monkey" in blob
-    assert "spike factory" in blob
-    # It must be framed as a capability list, not freelanced advice.
-    assert "verified from game data" in blob
+    blob = " ".join(facts).lower()
+    assert "moab-class" in blob
+    assert "embrittlement" in blob
+    # The reverted auto-list must NOT come back.
+    assert "towers whose attack can damage" not in blob
 
 
 def test_ddt_pop_guide_lists_correct_damage():


### PR DESCRIPTION
## Why

You live-tested the #1492 DDT counter-tower list and found it **wrong** in 3 places:

- **Ice Monkey 2-0-0** — base ice can't damage MOAB-class, and a DDT *is* MOAB-class (needs Embrittlement
  4-x-x). It recommended a tower that literally can't hit a DDT.
- **Monkey Ace 0-2-5** — its explosions can't pop Black (DDT has Black).
- **Sniper 0-4-0** — a weak config; the real answers are 2-4-0 / 2-5-0 / 4-2-0 / 5-2-0.

**Root cause:** "can damage a DDT" needs (a) MOAB-class targeting and (b) config quality, and the
committed stats encode **neither** — Ice 2-0-0 and 4-0-0 have byte-identical projectiles; the only
"can hit MOAB-class" signal is Embrittlement's *description text*. So the primary-attack derivation is
unsound, and grounding it = grounding misinformation, which is worse than refusing.

## What this does

- **Reverts** the auto-derived list: removes `towers_that_can_damage` / `CounterHit` / `_primary_attack`
  from `btd6_capability_service` and the `_counter_fact` wiring from `btd6_interaction_service` (+ tests).
- **Replaces it with correct curated prose** in the DDT pop-guide note (`damage_types.json`): a DDT is
  MOAB-class, so a counter needs camo + a non-resisted damage type **AND** the ability to hit MOAB-class —
  base Ice (until Embrittlement) and Glue (until MOAB Glue 0-0-3) cannot. (Captures your Ice correction as
  real knowledge.)
- Corpus doc records the lesson + the **open question**: how to do tower recommendations (hand-curated
  wiki-verified list, an owner-supplied list, or leave the rules-based guidance).

The damage-type **rules** grounding stays — it's correct. The bot just no longer auto-lists specific
counter towers (the part that was wrong). arch 0 errors, mypy clean, 1719 BTD6 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PznCdhdV59y79932VKCj4g)_