### PR TITLE
docs(S1): surface an offline-startable item in ▶ Next (handoff hygiene)

### DIFF
--- a/.sessions/2026-06-27-s1-offline-handoff.md
+++ b/.sessions/2026-06-27-s1-offline-handoff.md
@@ -1,6 +1,6 @@
 # 2026-06-27 — Sharpen S1 ▶ Next with an offline-startable item (handoff hygiene)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
@@ -15,4 +15,33 @@ dispatch sees an offline S1 lane immediately.
 
 Docs-only; sharpens the live handoff (the dispatch contract's hand-off mechanism).
 
-(close-out filled at the end.)
+## What shipped (PR #1500)
+
+Added the `[offline]` **fishing-gear-stats** slice as the **first** ▶ Next-startable item in
+`docs/current-state/S1-bot.md`, so an empty-fire dispatch with no live bot sees a clearly-offline S1
+lane immediately (the rest of S1's queue is `[needs-live-bot]`/`[owner]`). Links the idea doc shipped
+in #1499. Docs-only; `check_docs --strict` green.
+
+## 📤 Run report
+
+- **Did:** sharpened S1's ▶ Next-startable with the now-unblocked offline fishing-gear-stats lane ·
+  **Outcome:** shipped
+- **Shipped:** #1500 — one S1 sector-file ▶ Next-startable entry (docs-only handoff hygiene)
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** the handoff item points at the Q-0172 self-initiated fishing-gear-stats idea
+  from #1499; this PR itself is dispatch handoff hygiene (no new feature)
+- **↪ Next:** S1 ▶ now leads with `[offline]` fishing-gear-stats (idea
+  `docs/ideas/fishing-gear-stats-2026-06-27.md`) — the turn-key next slice for an empty-fire dispatch.
+
+## ⟲ Previous-session review (Q-0102)
+
+This is the second PR of the same dispatch run (reviewing the first, #1499): the gear-loadout-presets
+ship did well — reused the existing direct-lane `mining_equipment` seam (no needless audit ceremony),
+kept the additive-safety property, and folded in a genuine DRY cleanup (the `!gear` embed duplication)
+rather than suppressing the cog-size guard. What it could have done better — and what *this* PR fixes:
+it left S1's live queue with no offline-startable item, so the handoff was thinner than it should have
+been. System improvement: a dispatch run that ships a feature whose successor is offline should add
+that successor to the sector's ▶ Next *in the same run* — handoff hygiene is part of "complete," not a
+separate task. (No new idea here — Q-0089 idea was filed in the #1499 log this run; not duplicating.)

--- a/.sessions/2026-06-27-s1-offline-handoff.md
+++ b/.sessions/2026-06-27-s1-offline-handoff.md
@@ -1,0 +1,18 @@
+# 2026-06-27 — Sharpen S1 ▶ Next with an offline-startable item (handoff hygiene)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What I'm about to do
+
+Second slice of this dispatch run (PR #1499 — gear loadout presets — merged). This run surfaced a real
+friction: **S1's ▶ Next-startable items are all `[needs-live-bot]` / `[owner]`**, so an empty-fire
+dispatch (no live bot) has no clearly-offline S1 lane and must dig for one. The gear-loadout-presets
+ship merged its successor idea (`docs/ideas/fishing-gear-stats-2026-06-27.md`, now on main) — an
+`[offline]` self-mergeable slice. I'll add it to S1's ▶ Next-startable list so the next empty-fire
+dispatch sees an offline S1 lane immediately.
+
+Docs-only; sharpens the live handoff (the dispatch contract's hand-off mechanism).
+
+(close-out filled at the end.)

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -53,6 +53,14 @@
 *(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
 creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
 § "the offline-fit startability tag". A tag reflects the arc's *next actionable* step.)*
+- `[offline]` **Fishing-specific gear stats** ([idea](../ideas/fishing-gear-stats-2026-06-27.md)) — the
+  offline successor to the gear loadout presets (#1499): the loadout-*swap* shipped, but matching gear
+  has nothing to bias because `utils/equipment.EffectiveStats` models only mining + combat stats. Add a
+  `fishing_power`/`bite_luck` stat + a few fishing gear items (existing slots/tier ladder) and read it as
+  a 4th cast knob (rod × bait × weather × gear) in `fishing_workflow.begin_cast` — completing the Q-0175
+  "matching gear → better fishing" half. Pure + sim-pinnable (mirror `planning/gear-set-numbers-2026-06-11.md`);
+  self-mergeable. *(Listed first so an empty-fire dispatch has a clearly-offline S1 lane — the rest below
+  need a live bot or an owner decision.)*
 - `[needs-live-bot]` **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
   (owner-directed, 2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow
   (**7 steps**: what kind of server is this · greet · moderators · block spam · choose a log channel ·

--- a/docs/owner/claims/claude-franklin-s1-offline-handoff.md
+++ b/docs/owner/claims/claude-franklin-s1-offline-handoff.md
@@ -1,0 +1,1 @@
+- branch `claude/franklin-s1-offline-handoff` · scope: add offline-startable item to S1 ▶ Next (handoff hygiene) · area: docs/current-state/S1-bot.md · 2026-06-27


### PR DESCRIPTION
## What

Adds the now-unblocked `[offline]` **fishing-gear-stats** slice to the S1 sector's **▶ Next startable**
list (`docs/current-state/S1-bot.md`).

## Why

This dispatch run surfaced real friction: S1's ▶ Next-startable items were **all** `[needs-live-bot]` /
`[owner]`-gated, so an empty-fire dispatch (no live bot) had no clearly-offline S1 lane and had to dig
for one. PR #1499 (gear loadout presets) shipped its successor idea
(`docs/ideas/fishing-gear-stats-2026-06-27.md`) — a self-mergeable offline slice that completes the
Q-0175 unified-loadout vision ("matching gear → better fishing"). Surfacing it in the live queue means
the next empty-fire dispatch sees an offline S1 lane immediately.

Docs-only; sharpens the dispatch handoff mechanism. Born-red card flips `complete` last; auto-merges on green.


---
_Generated by [Claude Code](https://claude.ai/code/session_012SXkCx7pWXttqJtSk2342U)_