### PR TITLE
feat(fishing): fishing-specific gear stats — loadout presets become a real optimisation

### DIFF
--- a/.sessions/2026-06-27-fishing-gear-stats.md
+++ b/.sessions/2026-06-27-fishing-gear-stats.md
@@ -1,6 +1,8 @@
 # 2026-06-27 — Fishing-specific gear stats (loadout presets become a real optimisation)
 
-> **Status:** `in-progress` — born-red card; opening the PR before the build (Q-0133/Q-0189).
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
+> Full CI mirror green (pytest **12848 passed**, arch **0 errors**, formatters/lint/check_docs/
+> check_consistency clean).
 
 > **Run type:** `routine · dispatch` — empty-fire schedule fire, no work order. Took the next real
 > plan slice: the offline-tagged S1 ▶ Next item **Fishing-specific gear stats**
@@ -32,6 +34,108 @@ parallel fishing-stat store, no migration):
    new items automatically (slot-grouped).
 5. Sim-pin the numbers (mirror `docs/planning/gear-set-numbers-2026-06-11.md`) + tests.
 
+## What shipped
+
+The Q-0175 / V-14 **"matching gear → better fishing"** half — the offline successor to the gear
+loadout presets (#1499). A fishing loadout was previously cosmetic (it only changed *which* mining/
+combat gear was equipped); now it **biases the cast**, reusing the cross-game `EffectiveStats` seam
+(no parallel fishing-stat store, no migration).
+
+1. **`utils/equipment.py`** — `EffectiveStats` gained `fishing_power` + `bite_luck` (additive,
+   default-0 → every existing stat read byte-identical; wired `__add__`/`STAT_LABELS`/`STAT_GLYPHS`).
+   A **CHARM-slot fishing-charm ladder** (fishing / anglers / master-angler charm) added to `_GEAR` +
+   `MAX_DURABILITY`, deliberately *off* the combat `SET_SLOTS` so the duel-balance sim is untouched.
+2. **`utils/mining/market.py`** — gear-shop rows for the three charms (coins-only, no recipe →
+   satisfies `test_every_wearing_gear_is_reacquirable` without touching the curated-recipe lint).
+3. **`utils/fishing/gear.py`** (new, pure) — `fishing_pull_mult` / `fishing_bite_speed_mult`, the
+   bounded converters from `EffectiveStats` to the two cast knobs; `has_fishing_bonus` for the panel.
+4. **`services/fishing_workflow.begin_cast`** — reads `character.character_stats(equipped, skills)`
+   and folds the gear knobs into `effective_pull` / `effective_bite_speed` as the **4th** how-well
+   knob (rod × bait × weather × **gear**); `CastStart.fishing_gear_bonus` carries it to the panel.
+   No fishing gear ⇒ both multipliers `1.0` ⇒ byte-identical (additive safety property).
+5. **`views/fishing/cast_view.py`** — a `🎣 fishing gear` cast-panel footer note when a bonus is active.
+6. Numbers sim-pinned in `docs/planning/fishing-gear-numbers-2026-06-27.md`.
+
+**Tests (all green):** `tests/unit/utils/test_fishing_gear.py` (the converter — neutrality, the pinned
+ladder ×1.08/1.16/1.24 pull & ×0.97/0.94/0.91 bite, caps, monotonicity, negatives clamped) ·
+`test_equipment.py` (charms are CHARM-slot/off-sets, monotonic, wear+buyable, flow through
+`compute_stats`) · `test_fishing_workflow.py` (gear folds into the knobs; no-gear byte-identical) ·
+`test_fishing_workflow_bait.py` (autouse fixture defaults the new reads) · `test_fishing_cast_view.py`
+(footer note shown/omitted).
+
+## Context delta
+
+- **Needed but not pointed to:** that `begin_cast` is the single fold-point for the cast's how-well
+  knobs (rod × bait × weather) — found by reading the workflow, not routed. The S1 idea doc pointed at
+  the right files, which was enough. **Discovered by hand:** the recipe↔catalog alignment lint
+  (`test_recipes_catalog_alignment.py`) means new wearing gear must be **either** craftable **or** in
+  `GEAR_SHOP` — buyable-only is the contained path that leaves `recipes.json` (and its exact-set lint)
+  untouched.
+- **Pointed to but didn't need:** CodeGraph — a contained, idea-doc-scoped change; `context_map` +
+  targeted grep carried it (matches the CLAUDE.md "contained change" guidance).
+- **Decisions made alone:** (a) fishing gear lives **only in the CHARM slot** (a single fishing-charm
+  ladder), not a new slot or the combat set slots — keeps it migration-free and duel-balance-neutral,
+  at the cost that a "fishing loadout" fills one slot, not several; (b) the per-point knob constants
+  (0.04 pull / 0.03 bite) + caps, tuned so the full ladder ≈ one rod tier of pull. Both reversible
+  tuning; flagged for the owner's eventual balance pass.
+- **Flagged for maintainer / known limits:** numbers are **sim-pinned, not live-played** — the
+  cast-balance feel wants a Q-0086-style live walk (same posture as the rod/bait/weather knobs). The
+  charms are **coins-only** for now (no craft/loot earn) — captured as the next offline successor in
+  the S1 ▶ Next.
+- **🛠 Friction → guard:** my `python3` heredoc edit to add DB mocks across the begin_cast tests
+  **bypassed the PostToolUse auto-format hook** (only Edit/Write trigger it), so lint wasn't auto-fixed
+  on those lines — caught by the explicit `check_quality --check-only` pass before flipping the card.
+  No new guard shipped (the existing pre-PR mirror already catches it); **the durable lesson is the
+  rule itself: prefer the Edit tool over shell heredocs for test edits so the format hook runs.** Also:
+  adding two `db` reads to `begin_cast` reddened *two* test files' begin_cast suites — the second
+  (`_bait`) only surfaced in the full mirror, not the targeted run. Cheapest durable fix used: an
+  autouse fixture in the bait file rather than per-test patches.
+
+## 💡 Session idea (Q-0089)
+
+**A `check_effectivestats_knob_coverage` guard / test** — every `EffectiveStats` field should be
+*read* by at least one game's stat-consumption path, or it's a dead stat (a field added to the block
+but never folded into any cast/descent/duel). `fishing_power`/`bite_luck` are now read by `begin_cast`,
+`mining_power`/… by descent, `damage`/… by the duel — but nothing asserts a *new* field gets wired to
+a consumer. A small test mapping each field → its consumer (grep/AST) would catch a future "added the
+stat, forgot the knob" half-ship. Genuinely useful, small, offline. Captured here; if it earns a file
+it goes under `docs/ideas/` next pass.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous run (`2026-06-26-btd6-eval-anchor-coverage`, #1466) **did well:** it explicitly teed up its
+own next lane ("▶ remaining anchor-tooling tail: none cleanly offline → the live llm_judge battery"),
+which made *this* session's dispatch decision instant — I could see S2's offline lane was exhausted
+and move to S1's offline item without re-deriving it. That's the handoff-sharpening loop working.
+**Could improve / system note:** the S2 sector file's "none cleanly offline" verdict is only in prose;
+the `dispatch_menu.py --unattended` resolver still listed "S2 (Next): P1-1 BTD6 eval cases" as a 🟢
+self-mergeable lane, which contradicts the sector file. **Improvement:** the resolver's offline-fit
+tag should be driven by the same per-item `[offline]/[needs-live-bot]` tags the sector files carry, so
+a sector that has *narrated* its offline tail as exhausted isn't re-suggested as 🟢 — otherwise a
+dispatch run can be pointed at a lane that's actually creds-gated. (This is the same class as the
+band-#1482 "per-sector offline-fit startability tags" idea — worth folding the resolver onto those
+tags.) Not shipped this run (it touches the dispatch tooling + sector-file convention); noting it for
+the docs/S3 lane.
+
 ## 📤 Run report
 
-*(filled at close)*
+- **Did:** shipped the Q-0175 "matching gear → better fishing" half — fishing stats on `EffectiveStats`
+  + a CHARM-slot charm ladder + the 4th cast knob in `begin_cast`. · **Outcome:** shipped
+- **Shipped:** #1504 — feat(fishing): fishing-specific gear stats (self-merge on green, Q-0113)
+- **Run type:** `routine · dispatch`
+- **Class:** feature (dispatched empty-fire → next real plan slice; contained, reversible, test-covered)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (merge auto-deploys; the new charms appear in the gear shop on the
+  next boot — no seed/data step)
+- **⚑ Self-initiated:** **yes** — this was an empty-fire schedule run (no work order); I promoted the
+  already-captured S1 idea [`fishing-gear-stats-2026-06-27`](../docs/ideas/fishing-gear-stats-2026-06-27.md)
+  straight to a build (idea→ship is open, Q-0172). The idea pre-existed (captured alongside #1499); no
+  new feature was invented from nothing.
+- **↪ Next:** S1 ▶ — **fishing-gear acquisition depth** (a craft/loot earn for the charms, currently
+  coins-only); pure + offline + sim-pinnable. The cast-balance feel still wants a Q-0086 live walk.
+
+## ⟲ Bug-book
+
+No bug-book entries fixed or opened this run (the open BUG-0009/0011/0019 items are data-/VPS-/
+owner-decision-gated, none offline-actionable this run).
+

--- a/.sessions/2026-06-27-fishing-gear-stats.md
+++ b/.sessions/2026-06-27-fishing-gear-stats.md
@@ -1,0 +1,37 @@
+# 2026-06-27 — Fishing-specific gear stats (loadout presets become a real optimisation)
+
+> **Status:** `in-progress` — born-red card; opening the PR before the build (Q-0133/Q-0189).
+
+> **Run type:** `routine · dispatch` — empty-fire schedule fire, no work order. Took the next real
+> plan slice: the offline-tagged S1 ▶ Next item **Fishing-specific gear stats**
+> ([idea](../docs/ideas/fishing-gear-stats-2026-06-27.md)), the offline successor to the gear loadout
+> presets (#1499).
+
+**Branch:** `claude/funny-franklin-iv2rzi` (off `main` @ #1503 merge, `a7c11f53`).
+
+## What I'm about to do (intentions)
+
+Complete the Q-0175 / V-14 "matching gear → better fishing" half. The loadout-*swap* shipped (#1499),
+but a "fishing loadout" only changes *which* mining/combat gear is equipped — nothing biases fishing,
+because `utils/equipment.EffectiveStats` models only mining + combat stats. So a fishing loadout is
+currently cosmetic convenience, not an optimisation.
+
+Plan (pure, sim-pinned, offline-self-mergeable — reuses the cross-game `EffectiveStats` seam, no
+parallel fishing-stat store, no migration):
+
+1. `utils/equipment.py` — add `fishing_power` + `bite_luck` to `EffectiveStats` (additive, default 0,
+   so every existing stat read is byte-identical), wire `__add__`/`STAT_LABELS`/`STAT_GLYPHS`. Add a
+   small **fishing-charm ladder** in the existing CHARM slot (kept off the combat SET_SLOTS so the
+   duel-balance sim is untouched) to `_GEAR` + `MAX_DURABILITY` + `GEAR_SHOP` (buyable = reacquirable).
+2. `utils/fishing/gear.py` (new, pure) — convert `EffectiveStats` → the two cast knobs (a bounded
+   rarity-pull multiplier from `fishing_power`, a bounded faster-bite multiplier from `bite_luck`).
+3. `services/fishing_workflow.begin_cast` — read equipped gear + skills → `character_stats` → fold the
+   gear knobs into `effective_pull` / `effective_bite_speed` as the **4th** how-well knob
+   (rod × bait × weather × **gear**). Default-preserving: no fishing gear ⇒ ×1.0 ⇒ byte-identical.
+4. Surface a small cast-panel note when fishing gear is contributing; the gear panel + shop pick up the
+   new items automatically (slot-grouped).
+5. Sim-pin the numbers (mirror `docs/planning/gear-set-numbers-2026-06-11.md`) + tests.
+
+## 📤 Run report
+
+*(filled at close)*

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -27,10 +27,12 @@ from utils.fishing import MAX_LEVEL, Catch
 from utils.fishing import bait as bait_mod
 from utils.fishing import energy as fish_energy
 from utils.fishing import fish as fish_mod
+from utils.fishing import gear as fishing_gear
 from utils.fishing import rods as rods_mod
 from utils.fishing import roll_catch
 from utils.fishing import venue as venue_mod
 from utils.fishing import weather as weather_mod
+from utils.mining import character
 
 logger = logging.getLogger("bot.fishing_workflow")
 
@@ -218,6 +220,11 @@ class CastStart:
     #: The day's weather, already compounded into ``effective_bite_speed`` /
     #: the roll's rarity pull — carried for the cast-panel forecast note.
     weather: weather_mod.Weather = weather_mod.CONDITIONS[0]
+    #: Whether the player's equipped gear contributed a fishing bonus (its
+    #: ``fishing_power``/``bite_luck`` are already folded into the roll pull /
+    #: ``effective_bite_speed``) — for the 🎣 cast-panel note. ``False`` when no
+    #: fishing gear is equipped, in which case the cast is byte-identical.
+    fishing_gear_bonus: bool = False
 
 
 def _fmt_wait(seconds: int) -> str:
@@ -278,16 +285,32 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
     profile = venue_mod.profile_for(venue)
     weather = weather_mod.current_weather()
     bait, bait_charges = await get_active_bait(user_id, guild_id)
-    # Three "how-well" knobs compound: rod × bait × the day's weather. rarity_pull
+    # The 4th "how-well" knob: equipped fishing gear (Q-0175 / V-14). Read the
+    # character's gear+skill stats and fold fishing_power → rarity pull and
+    # bite_luck → bite speed. No fishing gear ⇒ both multipliers are 1.0 ⇒ the
+    # cast is byte-identical to the pre-gear behaviour (additive safety property).
+    gear_stats = character.character_stats(
+        await db.get_equipment(str(user_id), guild_id),
+        await db.get_skills(user_id, guild_id),
+    )
+    gear_pull = fishing_gear.fishing_pull_mult(gear_stats)
+    gear_bite_speed = fishing_gear.fishing_bite_speed_mult(gear_stats)
+    # Four "how-well" knobs compound: rod × bait × weather × gear. rarity_pull
     # (all ≥ 1) pulls the catch toward the big end of the SAME unlocked band (never
-    # a new band — that stays the fishing-level axis); bite_speed (rod/bait ≤ 1,
+    # a new band — that stays the fishing-level axis); bite_speed (rod/bait/gear ≤ 1,
     # weather either way) scales the bite wait. Weather is the transient, shared,
     # free knob (a storm makes a rarer catch likelier but the wait longer).
     effective_pull = (
-        rod.rarity_pull * (bait.rarity_pull if bait else 1.0) * weather.rarity_mult
+        rod.rarity_pull
+        * (bait.rarity_pull if bait else 1.0)
+        * weather.rarity_mult
+        * gear_pull
     )
     effective_bite_speed = (
-        rod.bite_speed * (bait.bite_speed if bait else 1.0) * weather.bite_speed_mult
+        rod.bite_speed
+        * (bait.bite_speed if bait else 1.0)
+        * weather.bite_speed_mult
+        * gear_bite_speed
     )
     cast = await roll_cast(
         user_id,
@@ -330,6 +353,7 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
         bait_charges_left=charges_left,
         venue_profile=profile,
         weather=weather,
+        fishing_gear_bonus=fishing_gear.has_fishing_bonus(gear_stats),
     )
 
 

--- a/disbot/utils/equipment.py
+++ b/disbot/utils/equipment.py
@@ -73,10 +73,15 @@ class EffectiveStats:
     depth_access: int = 0
     luck: int = 0
     loot_bonus: int = 0
-    # Reserved for combat gear (deathmatch / PvP); zero until it exists.
+    # Combat gear (deathmatch / PvP).
     damage: int = 0
     defense: int = 0
     max_health: int = 0
+    # Fishing gear (Q-0175 / V-14 "matching gear → better fishing").  ``utils.
+    # fishing.gear`` reads these into the cast's 4th how-well knob; zero until a
+    # fishing item is equipped, so every existing read stays byte-identical.
+    fishing_power: int = 0  # biases the catch toward the big end of the band
+    bite_luck: int = 0  # quickens the bite wait
 
     def __add__(self, other: EffectiveStats) -> EffectiveStats:
         return EffectiveStats(
@@ -88,6 +93,8 @@ class EffectiveStats:
             damage=self.damage + other.damage,
             defense=self.defense + other.defense,
             max_health=self.max_health + other.max_health,
+            fishing_power=self.fishing_power + other.fishing_power,
+            bite_luck=self.bite_luck + other.bite_luck,
         )
 
 
@@ -102,6 +109,8 @@ STAT_LABELS: dict[str, str] = {
     "damage": "Damage",
     "defense": "Defense",
     "max_health": "Max health",
+    "fishing_power": "Fishing power",
+    "bite_luck": "Bite luck",
 }
 
 # Compact glyphs for tight surfaces (shop rows, recipe pickers), damage/defence
@@ -115,6 +124,8 @@ STAT_GLYPHS: dict[str, str] = {
     "depth_access": "🔽",
     "luck": "🍀",
     "loot_bonus": "💰",
+    "fishing_power": "🎣",
+    "bite_luck": "🐟",
 }
 
 
@@ -138,6 +149,16 @@ _GEAR: dict[str, tuple[str, EffectiveStats]] = {
     "lantern": (LIGHT, EffectiveStats(light_radius=2, depth_access=2)),
     "diamond lantern": (LIGHT, EffectiveStats(light_radius=3, depth_access=3)),
     "lucky charm": (CHARM, EffectiveStats(luck=1, loot_bonus=1)),
+    # Fishing gear (Q-0175 / V-14) — a CHARM-slot ladder, deliberately off the
+    # combat SET_SLOTS so the duel-balance sim is untouched.  They contribute
+    # only fishing stats, which utils.fishing.gear reads as the cast's 4th
+    # how-well knob (rod × bait × weather × gear).  A "fishing loadout" equips
+    # one of these instead of the lucky charm — an optimisation, never a gate
+    # (the starter still fishes fine; numbers in
+    # docs/planning/fishing-gear-numbers-2026-06-27.md).
+    "fishing charm": (CHARM, EffectiveStats(fishing_power=2, bite_luck=1)),
+    "anglers charm": (CHARM, EffectiveStats(fishing_power=4, bite_luck=2)),
+    "master angler charm": (CHARM, EffectiveStats(fishing_power=6, bite_luck=3)),
     # Starter combat gear — pre-metal entry pieces, strictly below bronze.
     "sword": (WEAPON, EffectiveStats(damage=3)),
     "shield": (SHIELD, EffectiveStats(defense=2, max_health=10)),
@@ -210,6 +231,10 @@ MAX_DURABILITY: dict[str, int] = {
     "lantern": 100,
     "diamond lantern": 180,
     "lucky charm": 80,
+    # Fishing charms — wear like the lucky charm (a coin sink), generous.
+    "fishing charm": 80,
+    "anglers charm": 140,
+    "master angler charm": 220,
     # Starters.
     "sword": 60,
     "shield": 90,

--- a/disbot/utils/fishing/gear.py
+++ b/disbot/utils/fishing/gear.py
@@ -1,0 +1,74 @@
+"""Fishing gear → cast knobs (Q-0175 / V-14 "matching gear → better fishing").
+
+The pure converter that turns the equipped character's :class:`~utils.equipment.
+EffectiveStats` into the fishing cast's **4th** how-well knob, beside the rod, the
+bait, and the day's weather.  Two stats feed two multipliers:
+
+* ``fishing_power`` → a **rarity-pull** multiplier (≥ 1): like a rod's
+  ``rarity_pull``, it biases the catch toward the big end of the *same* unlocked
+  band — never a new band (that stays the fishing-level axis).
+* ``bite_luck`` → a **bite-speed** multiplier (≤ 1 = faster): like a rod's
+  ``bite_speed``, it quickens the bite wait.
+
+Both are **bounded** and **default-preserving**: with no fishing gear equipped
+(``fishing_power == bite_luck == 0``) every multiplier is exactly ``1.0``, so a
+cast is byte-identical to the pre-gear behaviour.  The full ladder of three
+charms tops out well below a rod tier on its own, so fishing gear is an
+*optimisation*, never a gate (the starter still fishes fine).
+
+Pure + stdlib-only (no Discord, no DB).  :mod:`services.fishing_workflow` reads
+these and compounds them into the cast; the numbers are sim-pinned in
+``docs/planning/fishing-gear-numbers-2026-06-27.md`` and
+``tests/unit/utils/test_fishing_gear.py``.
+"""
+
+from __future__ import annotations
+
+from utils.equipment import EffectiveStats
+
+#: Per-point rarity-pull added by ``fishing_power`` (the full ladder's
+#: ``fishing_power=6`` → ×1.24, a touch under a Silver rod's 1.25 pull).
+PULL_PER_FISHING_POWER = 0.04
+#: Per-point bite-wait reduction from ``bite_luck`` (``bite_luck=3`` → ×0.91).
+BITE_SPEED_PER_BITE_LUCK = 0.03
+
+#: Hard caps so gear can never dominate the rod×bait×weather stack even if a
+#: future item or stacking path pushes the stats far past the charm ladder.
+MAX_GEAR_PULL = 1.40  # ceiling on the rarity-pull multiplier
+MIN_GEAR_BITE_SPEED = 0.75  # floor on the bite-speed multiplier (faster)
+
+
+def fishing_pull_mult(stats: EffectiveStats) -> float:
+    """Rarity-pull multiplier (≥ 1.0) contributed by ``stats.fishing_power``.
+
+    ``1.0`` when no fishing gear is equipped (``fishing_power <= 0``); rises
+    ``PULL_PER_FISHING_POWER`` per point, capped at :data:`MAX_GEAR_PULL`.
+    """
+    power = max(0, stats.fishing_power)
+    return min(1.0 + PULL_PER_FISHING_POWER * power, MAX_GEAR_PULL)
+
+
+def fishing_bite_speed_mult(stats: EffectiveStats) -> float:
+    """Bite-speed multiplier (≤ 1.0 = faster) contributed by ``stats.bite_luck``.
+
+    ``1.0`` when no fishing gear is equipped (``bite_luck <= 0``); falls
+    ``BITE_SPEED_PER_BITE_LUCK`` per point, floored at :data:`MIN_GEAR_BITE_SPEED`.
+    """
+    luck = max(0, stats.bite_luck)
+    return max(1.0 - BITE_SPEED_PER_BITE_LUCK * luck, MIN_GEAR_BITE_SPEED)
+
+
+def has_fishing_bonus(stats: EffectiveStats) -> bool:
+    """Whether *stats* carry any fishing gear contribution (for cast-panel copy)."""
+    return stats.fishing_power > 0 or stats.bite_luck > 0
+
+
+__all__ = [
+    "PULL_PER_FISHING_POWER",
+    "BITE_SPEED_PER_BITE_LUCK",
+    "MAX_GEAR_PULL",
+    "MIN_GEAR_BITE_SPEED",
+    "fishing_pull_mult",
+    "fishing_bite_speed_mult",
+    "has_fishing_bonus",
+]

--- a/disbot/utils/mining/market.py
+++ b/disbot/utils/mining/market.py
@@ -38,6 +38,11 @@ GEAR_SHOP: dict[str, int] = {
     "lantern": 40,
     "iron pickaxe": 60,
     "lucky charm": 80,
+    # Fishing charms (Q-0175 / V-14) — the CHARM-slot fishing ladder; coins
+    # only (no recipe), priced above the lucky charm and monotonic up the ladder.
+    "fishing charm": 90,
+    "anglers charm": 220,
+    "master angler charm": 420,
     # Food / boosters — refill mining energy (utils/mining/energy.py). A coin
     # sink that lets an active player dig past the passive regen rate; priced
     # well above their flavour value so they stay a convenience, not arbitrage.

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -123,6 +123,10 @@ async def prepare_cast(
             f" · {start.bait_used.emoji} {start.bait_used.name} "
             f"({start.bait_charges_left} left)"
         )
+    if start.fishing_gear_bonus:
+        # Equipped fishing gear is biasing this cast (rarer catches + quicker
+        # bites) — its stats are already folded into the roll / bite speed.
+        footer += " · 🎣 fishing gear"
     embed.set_footer(text=footer)
     return embed, view
 

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -22,6 +22,14 @@
   gear-panel button + `!loadout`). `mining_loadout_presets` (migration 101, direct-lane like
   `mining_equipment`) + `mining_workflow.{save,apply,list,delete}_loadout`; apply equips every still-owned
   item, clears other slots, reports anything no longer owned; reversible + additive.
+- **Fishing-specific gear stats** (#1504, V-14/Q-0175 "matching gear → better fishing" half) — makes a
+  fishing loadout a **real optimisation**, not just convenience. `EffectiveStats` gained `fishing_power` +
+  `bite_luck` (additive, default-0 → existing reads byte-identical), a CHARM-slot **fishing-charm ladder**
+  (fishing/anglers/master-angler charm, off the combat SET_SLOTS so duel balance is untouched) in
+  `utils/equipment.py` + the gear shop, the pure converter `utils/fishing/gear.py`, and
+  `fishing_workflow.begin_cast` now folds them in as the **4th** cast knob (rod × bait × weather ×
+  **gear**). Coins-only (no recipe), sim-pinned
+  ([numbers](../planning/fishing-gear-numbers-2026-06-27.md)); self-merged on green.
 - **Starboard / Hall-of-Fame** — plan #1254 → PR 1 #1259 → PR 2 #1270.
 - **Fishing minigame** — cast/reel loop + rod ladder + energy (#1296–#1304, incl. the generous
   sell-value rebalance 1–7 → 1–21 in #1304); **Bait layer** — coin-bought consumable with **both**
@@ -53,14 +61,12 @@
 *(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
 creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
 § "the offline-fit startability tag". A tag reflects the arc's *next actionable* step.)*
-- `[offline]` **Fishing-specific gear stats** ([idea](../ideas/fishing-gear-stats-2026-06-27.md)) — the
-  offline successor to the gear loadout presets (#1499): the loadout-*swap* shipped, but matching gear
-  has nothing to bias because `utils/equipment.EffectiveStats` models only mining + combat stats. Add a
-  `fishing_power`/`bite_luck` stat + a few fishing gear items (existing slots/tier ladder) and read it as
-  a 4th cast knob (rod × bait × weather × gear) in `fishing_workflow.begin_cast` — completing the Q-0175
-  "matching gear → better fishing" half. Pure + sim-pinnable (mirror `planning/gear-set-numbers-2026-06-11.md`);
-  self-mergeable. *(Listed first so an empty-fire dispatch has a clearly-offline S1 lane — the rest below
-  need a live bot or an owner decision.)*
+- `[offline]` **Fishing-specific gear stats — SHIPPED 2026-06-27 (#1504)** (see Recently shipped above):
+  the Q-0175 "matching gear → better fishing" half is done — `fishing_power`/`bite_luck` on
+  `EffectiveStats`, a CHARM-slot fishing-charm ladder, and the cast's 4th knob in `begin_cast`. ▶ **Next
+  offline successor:** **fishing-gear acquisition depth** — the charms are coins-only for now; a craft
+  path (turn caught-fish/bait materials into charms via the bait-craft seam) or a fish-loot drop would
+  give them a non-coin earn, mirroring the rod/bait ladders. Pure + sim-pinnable, self-mergeable.
 - `[needs-live-bot]` **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
   (owner-directed, 2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow
   (**7 steps**: what kind of server is this · greet · moderators · block spam · choose a log channel ·

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -38,11 +38,11 @@ Current broad captures:
   named" — making the planning-vs-reality gap legible across bands. The manual precursor to E3 (the
   planned-slice hit-rate tracker). Subsystem: S4 docs-system.
 - [`fishing-gear-stats-2026-06-27.md`](./fishing-gear-stats-2026-06-27.md) —
-  **captured 2026-06-27 (dispatch run, alongside gear-loadout-presets #1499):** the loadout-swap half of
-  the unified-loadout vision (Q-0175) shipped, but matching gear has nothing to bias — `EffectiveStats`
-  models only mining + combat stats. Add a `fishing_power`/`bite_luck` stat + a few fishing gear items
-  and read it as a 4th cast knob (rod × bait × weather × gear), turning loadout presets from convenience
-  into a real optimisation. Reuses the cross-game `EffectiveStats` seam. Subsystem: games (mining/fishing).
+  **✅ BUILT 2026-06-27 (#1504, dispatch run):** the Q-0175 "matching gear → better fishing" half.
+  `EffectiveStats` gained `fishing_power`/`bite_luck`, a CHARM-slot fishing-charm ladder + gear-shop rows,
+  the pure converter `utils/fishing/gear.py`, and `begin_cast` now folds them in as the 4th cast knob
+  (rod × bait × weather × gear) — turning the loadout presets (#1499) from convenience into a real
+  optimisation, reusing the cross-game `EffectiveStats` seam. Subsystem: games (mining/fishing).
 - [`cog-routing-enforcement-gap-2026-06-27.md`](./cog-routing-enforcement-gap-2026-06-27.md) —
   **surfaced 2026-06-27 (PR #1496):** the per-feature, per-channel command toggle system (`cog_routing`)
   is configurable but **not wired to runtime enforcement** — `is_cog_enabled` is read only by the

--- a/docs/ideas/fishing-gear-stats-2026-06-27.md
+++ b/docs/ideas/fishing-gear-stats-2026-06-27.md
@@ -1,7 +1,15 @@
 # Idea — Fishing-specific gear stats (make loadout presets a real optimisation)
 
-> **Status:** `ideas` · captured 2026-06-27 (dispatch run, alongside the gear-loadout-presets ship #1499).
+> **Status:** `historical` — **built** 2026-06-27 (dispatch run, PR #1504) · captured 2026-06-27
+> (dispatch run, alongside the gear-loadout-presets ship #1499).
 > **Lane:** S1 bot product · games/mining-fishing. **Size:** small–medium, offline-buildable.
+>
+> **Shipped 2026-06-27 (#1504):** `EffectiveStats` gained `fishing_power` + `bite_luck` (additive,
+> default-0), a CHARM-slot fishing-charm ladder (fishing/anglers/master-angler charm) in
+> `utils/equipment.py` + the gear shop, the pure converter `utils/fishing/gear.py`
+> (`fishing_pull_mult` / `fishing_bite_speed_mult`, bounded), and `fishing_workflow.begin_cast` now
+> folds them into the cast as the 4th knob (rod × bait × weather × **gear**). Numbers sim-pinned in
+> [`../planning/fishing-gear-numbers-2026-06-27.md`](../planning/fishing-gear-numbers-2026-06-27.md).
 
 ## The gap
 

--- a/docs/owner/claims/claude-funny-franklin-iv2rzi.md
+++ b/docs/owner/claims/claude-funny-franklin-iv2rzi.md
@@ -1,1 +1,0 @@
-- branch: claude/funny-franklin-iv2rzi · scope: fishing-specific gear stats (EffectiveStats fishing_power/bite_luck + cast knob) · files: utils/equipment.py, utils/fishing/gear.py, services/fishing_workflow.py, views/fishing/cast_view.py, tests · 2026-06-27

--- a/docs/owner/claims/claude-funny-franklin-iv2rzi.md
+++ b/docs/owner/claims/claude-funny-franklin-iv2rzi.md
@@ -1,0 +1,1 @@
+- branch: claude/funny-franklin-iv2rzi · scope: fishing-specific gear stats (EffectiveStats fishing_power/bite_luck + cast knob) · files: utils/equipment.py, utils/fishing/gear.py, services/fishing_workflow.py, views/fishing/cast_view.py, tests · 2026-06-27

--- a/docs/planning/fishing-gear-numbers-2026-06-27.md
+++ b/docs/planning/fishing-gear-numbers-2026-06-27.md
@@ -1,0 +1,65 @@
+# Fishing gear numbers — the sim-pin record (2026-06-27)
+
+> **Status:** `historical` design-numbers record (mirrors
+> `gear-set-numbers-2026-06-11.md`). The authoritative copy of these numbers is the
+> code (`utils/equipment.py`, `utils/fishing/gear.py`, `utils/mining/market.py`) +
+> the guard test (`tests/unit/utils/test_fishing_gear.py`). This doc explains *why*
+> the numbers are what they are.
+
+## What shipped
+
+The Q-0175 / V-14 *"matching gear → better fishing"* half (the offline successor to
+the gear loadout presets, #1499). A fishing loadout now *biases the cast*, not just
+swaps which mining/combat gear is equipped — by reusing the cross-game
+`EffectiveStats` seam, no parallel fishing-stat store.
+
+## The two stats
+
+`EffectiveStats` gained two additive, default-0 fields:
+
+| stat | feeds | cast effect |
+|---|---|---|
+| `fishing_power` | `utils.fishing.gear.fishing_pull_mult` | rarity pull (≥ 1, big-end of the *same* band) |
+| `bite_luck` | `utils.fishing.gear.fishing_bite_speed_mult` | bite-speed (≤ 1, faster bites) |
+
+Both default to 0 ⇒ both multipliers are exactly `1.0` ⇒ a cast with no fishing
+gear is **byte-identical** to the pre-gear behaviour (the additive safety
+property, the same one the skill tree relied on).
+
+## The charm ladder (CHARM slot)
+
+Deliberately in the **CHARM slot**, *off* the combat `SET_SLOTS`, so the duel-balance
+sim (`tests/unit/utils/test_gear_set_numbers.py`) is untouched. A fishing loadout
+equips one of these *instead of* the lucky charm — an optimisation, never a gate (the
+starter still fishes fine).
+
+| item | `fishing_power` | `bite_luck` | shop price | durability |
+|---|---|---|---|---|
+| fishing charm | 2 | 1 | 90 | 80 |
+| anglers charm | 4 | 2 | 220 | 140 |
+| master angler charm | 6 | 3 | 420 | 220 |
+
+Coins-only (no recipe) — buyable satisfies `test_every_wearing_gear_is_reacquirable`;
+no `recipes.json` change, so the curated-recipe-set lint is untouched. Prices are
+monotonic and above the lucky charm.
+
+## The conversion knobs
+
+`utils/fishing/gear.py`:
+
+- `PULL_PER_FISHING_POWER = 0.04` → master angler (`fishing_power=6`) gives **×1.24**
+  rarity pull, a touch under a **Silver Rod** (1.25). So a fully-kitted fishing charm
+  is roughly *one rod tier* of pull on top of the rod you hold — meaningful, not
+  dominant.
+- `BITE_SPEED_PER_BITE_LUCK = 0.03` → master angler (`bite_luck=3`) gives **×0.91**
+  bite speed (~9% quicker bites). Gentle, like a low rod tier's `bite_speed`.
+- Caps (`MAX_GEAR_PULL = 1.40`, `MIN_GEAR_BITE_SPEED = 0.75`) ensure gear can never
+  dominate the rod × bait × weather stack even if a future item or stacking path
+  pushes the stats far past this ladder.
+
+## Where it folds in
+
+`services.fishing_workflow.begin_cast` reads `character.character_stats(equipped,
+skills)` and multiplies the gear knobs into `effective_pull` / `effective_bite_speed`
+as the **4th** how-well knob (rod × bait × weather × **gear**). The cast panel shows a
+`🎣 fishing gear` footer note when a bonus is active.

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -381,6 +381,8 @@ async def test_buy_rod_debits_coins_and_raises_the_tier():
     bronze = rods.rod_for_tier(1)
     with (
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
         patch.object(wf.db, "transaction", _ctx),
         patch.object(
             wf.economy_service,
@@ -411,6 +413,8 @@ async def test_buy_rod_with_insufficient_funds_writes_nothing():
 
     with (
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
         patch.object(wf.db, "transaction", _ctx),
         patch.object(
             wf.economy_service,
@@ -460,6 +464,8 @@ async def test_begin_cast_spends_energy_and_rolls_when_charged():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
@@ -498,6 +504,8 @@ async def test_begin_cast_does_not_charge_on_an_empty_catalog():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
@@ -576,6 +584,8 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="deepwater")),
         patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf, "roll_catch", recording_roll_catch(rec)),
@@ -609,6 +619,8 @@ async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
         patch.object(wf.weather_mod, "current_weather", lambda: storm),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf, "roll_catch", recording_roll_catch(rec)),
@@ -623,6 +635,81 @@ async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
         gold.bite_speed * storm.bite_speed_mult,
     )
     assert start.effective_bite_speed != pytest.approx(gold.bite_speed)  # weather moved it
+
+
+# ---------------------------------------------------------------------------
+# Fishing gear — the 4th cast knob (Q-0175 / V-14): rod × bait × weather × gear
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_folds_equipped_fishing_gear_into_the_knobs():
+    """An equipped fishing charm biases the roll pull + bite speed and flags
+    ``fishing_gear_bonus`` — the 4th how-well knob."""
+    from utils import equipment as eq_mod
+    from utils.fishing import gear as fishing_gear
+    from utils.fishing import rods
+
+    rec: dict = {}
+    starter = rods.rod_for_tier(0)
+    full = eq_mod.EffectiveStats(fishing_power=6, bite_luck=3)
+    # A master angler charm in the CHARM slot → fishing_power=6, bite_luck=3.
+    equipped = {"charm": "master angler charm"}
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value=equipped)),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert rec["rarity_pull"] == pytest.approx(
+        starter.rarity_pull * fishing_gear.fishing_pull_mult(full),
+    )
+    assert start.effective_bite_speed == pytest.approx(
+        starter.bite_speed * fishing_gear.fishing_bite_speed_mult(full),
+    )
+    assert rec["rarity_pull"] > starter.rarity_pull  # gear actually pulled
+    assert start.fishing_gear_bonus is True
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_with_no_fishing_gear_is_byte_identical():
+    """No fishing gear ⇒ knobs unchanged + ``fishing_gear_bonus`` False (the
+    additive safety property — mining gear must not move the fishing knobs)."""
+    from utils.fishing import rods
+
+    rec: dict = {}
+    starter = rods.rod_for_tier(0)
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(
+            wf.db,
+            "get_equipment",
+            AsyncMock(return_value={"tool": "diamond pickaxe"}),
+        ),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert rec["rarity_pull"] == pytest.approx(starter.rarity_pull)
+    assert start.effective_bite_speed == pytest.approx(starter.bite_speed)
+    assert start.fishing_gear_bonus is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_fishing_workflow_bait.py
+++ b/tests/unit/services/test_fishing_workflow_bait.py
@@ -28,6 +28,18 @@ _LURE = bait_mod.bait_by_key("lure")
 _SPINNER = bait_mod.bait_by_key("spinner")  # a pure speed bait (bite_speed < 1)
 
 
+@pytest.fixture(autouse=True)
+def _no_fishing_gear():
+    """Default the cast's gear reads (Q-0175 4th knob) to empty so the bait-layer
+    assertions stay rod×bait-only — fishing gear is exercised in
+    ``test_fishing_workflow.py``. Tests that need gear can re-patch these."""
+    with (
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # get_active_bait — key → Bait resolution
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_equipment.py
+++ b/tests/unit/utils/test_equipment.py
@@ -197,3 +197,44 @@ def test_describe_stats_empty():
 def test_stat_labels_match_dataclass_fields():
     field_names = {f.name for f in fields(eq.EffectiveStats)}
     assert set(eq.STAT_LABELS) == field_names
+
+
+# --- fishing gear (Q-0175 / V-14) -------------------------------------------
+
+_FISHING_CHARMS = ("fishing charm", "anglers charm", "master angler charm")
+
+
+def test_fishing_charms_are_charm_slot_off_the_combat_sets():
+    """Fishing charms equip into CHARM (not a combat SET_SLOT, so the duel-
+    balance sim is untouched) and carry only fishing stats."""
+    for name in _FISHING_CHARMS:
+        assert eq.slot_for(name) == eq.CHARM
+        assert eq.CHARM not in eq.SET_SLOTS
+        assert eq.gear_tier(name) is None  # not a tiered combat-set piece
+        stats = eq.item_stats(name)
+        assert stats.fishing_power > 0 and stats.bite_luck > 0
+        # No combat/mining contribution — purely a fishing item.
+        assert stats.damage == 0 and stats.defense == 0 and stats.mining_power == 0
+
+
+def test_fishing_charm_ladder_is_monotonic():
+    powers = [eq.item_stats(n).fishing_power for n in _FISHING_CHARMS]
+    lucks = [eq.item_stats(n).bite_luck for n in _FISHING_CHARMS]
+    assert powers == sorted(powers) and len(set(powers)) == len(powers)
+    assert lucks == sorted(lucks) and len(set(lucks)) == len(lucks)
+
+
+def test_fishing_charms_wear_and_are_buyable():
+    """Every fishing charm wears (a coin sink) and is reacquirable in the shop —
+    the durability-loop invariant (also enforced repo-wide by the alignment lint)."""
+    from utils.mining.market import GEAR_SHOP
+
+    for name in _FISHING_CHARMS:
+        assert eq.max_durability(name) is not None
+        assert name in GEAR_SHOP
+
+
+def test_compute_stats_sums_fishing_gear():
+    """The fishing stats flow through the generic compute_stats path."""
+    stats = eq.compute_stats({eq.CHARM: "master angler charm"})
+    assert stats.fishing_power == 6 and stats.bite_luck == 3

--- a/tests/unit/utils/test_fishing_gear.py
+++ b/tests/unit/utils/test_fishing_gear.py
@@ -1,0 +1,101 @@
+"""Fishing gear → cast-knob conversion (Q-0175 / V-14).
+
+Pins the sim numbers in ``docs/planning/fishing-gear-numbers-2026-06-27.md`` and
+the default-preserving (additive) safety property: no fishing gear ⇒ ×1.0 knobs.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from utils import equipment as eq
+from utils.fishing import gear
+
+
+def _stats(**kw: int) -> eq.EffectiveStats:
+    return eq.EffectiveStats(**kw)
+
+
+# --- default-preserving (byte-identical) safety property ---------------------
+
+
+def test_no_fishing_gear_is_neutral():
+    """Zero fishing stats ⇒ both multipliers are exactly 1.0 (the additive
+    safety property: a cast is byte-identical to the pre-gear behaviour)."""
+    s = _stats()
+    assert gear.fishing_pull_mult(s) == 1.0
+    assert gear.fishing_bite_speed_mult(s) == 1.0
+    assert gear.has_fishing_bonus(s) is False
+
+
+def test_mining_combat_stats_do_not_leak_into_fishing():
+    """Only fishing_power/bite_luck move the knobs — mining/combat stats are inert."""
+    s = _stats(mining_power=9, damage=20, defense=14, luck=5, loot_bonus=5)
+    assert gear.fishing_pull_mult(s) == 1.0
+    assert gear.fishing_bite_speed_mult(s) == 1.0
+    assert gear.has_fishing_bonus(s) is False
+
+
+# --- the sim-pinned ladder numbers ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("power", "expected"),
+    [(2, 1.08), (4, 1.16), (6, 1.24)],  # the three charm tiers
+)
+def test_pull_mult_matches_the_pinned_ladder(power: int, expected: float):
+    assert math.isclose(gear.fishing_pull_mult(_stats(fishing_power=power)), expected)
+
+
+@pytest.mark.parametrize(
+    ("luck", "expected"),
+    [(1, 0.97), (2, 0.94), (3, 0.91)],  # the three charm tiers
+)
+def test_bite_speed_mult_matches_the_pinned_ladder(luck: int, expected: float):
+    assert math.isclose(
+        gear.fishing_bite_speed_mult(_stats(bite_luck=luck)),
+        expected,
+    )
+
+
+def test_master_angler_stays_under_a_silver_rod_pull():
+    """The full ladder's pull (×1.24) is a touch under a Silver rod (1.25) — gear
+    is an optimisation on top of the rod, never a replacement for it."""
+    from utils.fishing import rods
+
+    silver = rods.rod_for_tier(2)
+    assert gear.fishing_pull_mult(_stats(fishing_power=6)) < silver.rarity_pull
+
+
+# --- bounds + monotonicity --------------------------------------------------
+
+
+def test_pull_is_capped():
+    assert gear.fishing_pull_mult(_stats(fishing_power=10_000)) == gear.MAX_GEAR_PULL
+
+
+def test_bite_speed_is_floored():
+    assert (
+        gear.fishing_bite_speed_mult(_stats(bite_luck=10_000))
+        == gear.MIN_GEAR_BITE_SPEED
+    )
+
+
+def test_negative_stats_are_clamped_to_neutral():
+    s = _stats(fishing_power=-3, bite_luck=-3)
+    assert gear.fishing_pull_mult(s) == 1.0
+    assert gear.fishing_bite_speed_mult(s) == 1.0
+
+
+def test_knobs_are_monotonic():
+    pulls = [gear.fishing_pull_mult(_stats(fishing_power=p)) for p in range(0, 8)]
+    bites = [gear.fishing_bite_speed_mult(_stats(bite_luck=b)) for b in range(0, 8)]
+    assert pulls == sorted(pulls)  # non-decreasing pull
+    assert bites == sorted(bites, reverse=True)  # non-increasing (faster) bite
+
+
+def test_has_fishing_bonus_detects_either_stat():
+    assert gear.has_fishing_bonus(_stats(fishing_power=1)) is True
+    assert gear.has_fishing_bonus(_stats(bite_luck=1)) is True

--- a/tests/unit/views/test_fishing_cast_view.py
+++ b/tests/unit/views/test_fishing_cast_view.py
@@ -509,6 +509,40 @@ async def test_prepare_cast_threads_effective_bite_speed_into_the_view():
     assert view._bite_speed == 0.36
 
 
+@pytest.mark.asyncio
+async def test_prepare_cast_shows_a_fishing_gear_footer_note_when_geared():
+    from views.fishing.cast_view import prepare_cast
+
+    start = fishing_workflow.CastStart(
+        ok=True,
+        cast=_ORDINARY,
+        rod=rods.STARTER,
+        energy_current=9,
+        fishing_gear_bonus=True,
+    )
+    with patch(
+        "views.fishing.cast_view.fishing_workflow.begin_cast",
+        AsyncMock(return_value=start),
+    ):
+        embed, _ = await prepare_cast(1, 99)
+    assert "fishing gear" in (embed.footer.text or "")
+
+
+@pytest.mark.asyncio
+async def test_prepare_cast_omits_the_gear_note_without_fishing_gear():
+    from views.fishing.cast_view import prepare_cast
+
+    start = fishing_workflow.CastStart(
+        ok=True, cast=_ORDINARY, rod=rods.STARTER, energy_current=9
+    )
+    with patch(
+        "views.fishing.cast_view.fishing_workflow.begin_cast",
+        AsyncMock(return_value=start),
+    ):
+        embed, _ = await prepare_cast(1, 99)
+    assert "fishing gear" not in (embed.footer.text or "")
+
+
 # ---------------------------------------------------------------------------
 # prepare_cast — the shared cast-launch helper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Completes the Q-0175 / V-14 **"matching gear → better fishing"** half. The loadout-*swap* shipped
(#1499), but a "fishing loadout" only changed *which* mining/combat gear is equipped — nothing biased
fishing, because `utils/equipment.EffectiveStats` modelled only mining + combat stats. This makes a
fishing loadout a **real optimisation** by reusing the cross-game `EffectiveStats` seam (no parallel
fishing-stat store, no migration).

## How

1. `utils/equipment.py` — `fishing_power` + `bite_luck` added to `EffectiveStats` (additive, default 0,
   so every existing stat read is byte-identical), plus a **fishing-charm ladder** in the existing
   CHARM slot (kept off the combat SET_SLOTS so duel balance is untouched), wired into
   `_GEAR`/`MAX_DURABILITY`/`GEAR_SHOP`.
2. `utils/fishing/gear.py` (new, pure) — converts `EffectiveStats` → the two bounded cast knobs.
3. `services/fishing_workflow.begin_cast` — folds the gear knobs into `effective_pull` /
   `effective_bite_speed` as the **4th** how-well knob (rod × bait × weather × **gear**);
   default-preserving (no fishing gear ⇒ ×1.0 ⇒ byte-identical).
4. Cast-panel note when fishing gear contributes; shop/gear panel pick up the new items automatically.
5. Sim-pinned numbers + tests.

> Born-red per Q-0133 — the session card flips to `complete` as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SP97cEJgyD43GcqfsaThZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015SP97cEJgyD43GcqfsaThZ)_