### PR TITLE
test(equipment): EffectiveStats knob-coverage guard + dead-stat finding (light_radius, luck)

### DIFF
--- a/.sessions/2026-06-27-effectivestats-knob-coverage.md
+++ b/.sessions/2026-06-27-effectivestats-knob-coverage.md
@@ -1,0 +1,36 @@
+# 2026-06-27 — EffectiveStats knob-coverage guard + dead-stat finding (BUG-00xx)
+
+> **Status:** `in-progress` — born-red card; opening the PR before the build (Q-0133/Q-0189).
+
+> **Run type:** `routine · dispatch` — second slice of the same empty-fire dispatch run (slice 1 =
+> #1504, fishing-gear stats, merged). Executes the Q-0089 idea I raised in slice 1's log.
+
+**Branch:** `claude/funny-franklin-iv2rzi` (re-synced to `main` @ #1504 merge, `2aa5360b`).
+
+## What I'm about to do (intentions)
+
+While building slice 1 I extended the cross-game `EffectiveStats` block (added `fishing_power`/
+`bite_luck`) and wired them into a consumer (`begin_cast`). Nothing in the repo asserts that a *new*
+stat field actually gets read by some game's consumption path — the "added the stat, forgot the knob"
+half-ship class. Building the check **surfaced a real latent bug**: `EffectiveStats.light_radius` and
+`EffectiveStats.luck` are **dead stats** — defined, summed, and labelled, but **no game reads them** to
+change behaviour (the diamond pickaxe's `luck=1`, the lucky charm's `luck`, and every torch's
+`light_radius` currently do nothing; only `depth_access`/`loot_bonus`/`mining_power`/`damage`/… are
+consumed).
+
+Slice 2 (offline, test-only + docs):
+
+1. **`tests/unit/invariants/test_effective_stats_consumed.py`** — an AST guard asserting every
+   `EffectiveStats` field is read (`stats.<field>`) by at least one `disbot/` consumer module (excluding
+   the `equipment.py` definition + generic label/glyph/`__add__` plumbing), with a documented
+   `_UNWIRED_STATS` allowlist for `light_radius` + `luck` pointing at the bug-book entry. A second
+   assertion keeps the allowlist honest (an allowlisted stat that *gains* a consumer must leave the list).
+2. **`docs/health/bug-book.md`** — a new entry capturing the dead-stat finding (root cause + the
+   wire-it-or-remove-it decision flagged to the owner, since "what should luck/light do?" is a gameplay
+   design call, not a contained mechanical fix).
+
+No runtime/`disbot/` behaviour change — a guard + a finding.
+
+## 📤 Run report
+
+*(filled at close)*

--- a/.sessions/2026-06-27-effectivestats-knob-coverage.md
+++ b/.sessions/2026-06-27-effectivestats-knob-coverage.md
@@ -1,6 +1,8 @@
 # 2026-06-27 — EffectiveStats knob-coverage guard + dead-stat finding (BUG-00xx)
 
-> **Status:** `in-progress` — born-red card; opening the PR before the build (Q-0133/Q-0189).
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
+> Full CI mirror green (**12851 passed**, arch 0, check_docs/consistency clean; guard verified to flag
+> exactly `light_radius` + `luck` when the allowlist is emptied).
 
 > **Run type:** `routine · dispatch` — second slice of the same empty-fire dispatch run (slice 1 =
 > #1504, fishing-gear stats, merged). Executes the Q-0089 idea I raised in slice 1's log.
@@ -31,6 +33,66 @@ Slice 2 (offline, test-only + docs):
 
 No runtime/`disbot/` behaviour change — a guard + a finding.
 
+## What shipped
+
+1. **`tests/unit/invariants/test_effective_stats_consumed.py`** — an AST guard: every `EffectiveStats`
+   field is read (`<expr>.<field>`) by ≥1 `disbot/` consumer outside the definition module, or is on the
+   documented `_UNWIRED_STATS` allowlist. Three tests: the coverage floor, an **honesty check** (an
+   allowlisted stat that gains a consumer must leave the list), and a guard-the-guard (allowlist only
+   names real fields). Verified fails-closed: with the allowlist emptied it flags exactly `light_radius`
+   + `luck`.
+2. **`docs/health/bug-book.md` → BUG-0026 (OPEN)** — captures the dead-stat finding: `light_radius`
+   (every torch/lantern grants it; descent gates only on `depth_access`) and `luck` (diamond pickaxe +
+   lucky charm grant it; only `loot_bonus` is read) are defined/summed/labelled but read by no game.
+   Left OPEN because wiring them (or removing them) is a gameplay-design decision for the owner; the
+   guard prevents the class from growing meanwhile.
+
+Test-only + docs — no runtime/`disbot/` behaviour change.
+
+## Why OPEN, not auto-fixed
+
+"What should luck / light_radius *do*?" (a crit-find chance? a grid reveal radius?) is a balance/design
+call the owner owns — and the alternative (remove them + their gear bonuses + labels) is equally a
+design choice. Guessing either would be inventing product intent. The honest move is capture + guard +
+flag; the guard makes the eventual fix self-enforcing (the allowlist entry can't survive a wiring).
+
+## Context delta
+
+- **Discovered by hand:** the two dead stats — surfaced *by building the guard*, which is the
+  completeness-critic value (the check found the thing it was built to prevent). **Needed but not
+  pointed to:** nothing new; the invariants-dir convention (`tests/unit/invariants/`, `parents[3]/disbot`,
+  the Q-0105 UNVERIFIED header) was easy to mirror from a sibling test.
+- **Decisions made alone:** scoped this as **guard + finding, not a gameplay fix** (the wiring is
+  owner-design); used a **name-based AST attribute scan** (inclusive — a coincidental `.<field>` counts
+  as consumed), acceptable for a "read by nothing" floor. Both reversible.
+- **🛠 Friction → guard:** none new this slice. The guard *itself* is the friction-prevention: it
+  converts the "added a stat, forgot the knob" half-ship class (which `fishing_power`/`bite_luck` could
+  have hit in slice 1, and which `light_radius`/`luck` actually did historically) into a CI failure.
+
+## 💡 Session idea (Q-0089)
+
+Already contributed in slice 1's log (the knob-coverage guard — *built here*). No second forced idea
+this slice (Q-0089 is one genuine idea per session, not per PR; forced filler is worse than none).
+
+## ⟲ Previous-session review (Q-0102)
+
+Covered in slice 1's log (review of #1466 + the dispatch-menu offline-tag drift note). No new
+predecessor to review for this same-session slice.
+
 ## 📤 Run report
 
-*(filled at close)*
+- **Did:** shipped the Q-0089 knob-coverage guard (executing slice 1's own idea) + captured BUG-0026
+  (dead stats `light_radius`/`luck`) the guard surfaced. · **Outcome:** shipped
+- **Shipped:** #1505 — test(equipment): EffectiveStats knob-coverage guard + BUG-0026 finding
+  (self-merge on green, Q-0113)
+- **Run type:** `routine · dispatch`
+- **Class:** correctness/guard (test + docs; contained, reversible) + a bugs-first finding
+- **⚑ Owner decisions needed:** **BUG-0026** — wire `luck` + `light_radius` into a game (what should
+  they do?) **or** remove them + their gear bonuses/labels. A gameplay/balance call.
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** **yes** — built the Q-0089 idea I raised in slice 1, no dispatch/owner ask
+  (idea→ship open, Q-0172). The dead-stat finding is a bugs-first root sweep (CLAUDE.md §6), not an
+  invented feature.
+- **↪ Next:** unchanged from slice 1 — S1 ▶ **fishing-gear acquisition depth**; plus BUG-0026 awaits the
+  owner's wire-or-remove call.
+

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,6 +23,37 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
+## BUG-0026 — `EffectiveStats.light_radius` and `.luck` are dead stats (gear grants them, no game reads them) — OPEN (gameplay decision, guard shipped)
+
+- **Symptom (found 2026-06-27 by code inspection while building the Q-0089 `EffectiveStats`
+  knob-coverage guard, PR #1505 — not a live report, but a real latent gap):** two fields on the
+  cross-game `utils/equipment.EffectiveStats` block are **defined, summed (`__add__`), and labelled
+  (`STAT_LABELS`/`STAT_GLYPHS`) but read by no game's consumption path**, so the gear that grants them
+  does nothing:
+  - **`light_radius`** — every torch/lantern grants it (`torch` 1, `lantern` 2, `diamond lantern` 3),
+    but mining descent gates only on `depth_access` (`utils/mining/world.py:descend`), never on
+    `light_radius`. The "Light" stat shown on the gear panel has zero mechanical effect.
+  - **`luck`** — the `diamond pickaxe` (`luck=1`) and the `lucky charm` (`luck=1, loot_bonus=1`) grant
+    it, but only `loot_bonus` is read (`utils/mining/exploration.py`). The `luck` half of the lucky
+    charm — and the diamond pickaxe's luck — do nothing.
+- **Root cause:** the stat fields were added to the shared block ahead of (or without) a consumer — the
+  "added the stat, summed it, labelled it, forgot the knob" half-ship class. Every *other* field is
+  wired: `mining_power`/`loot_bonus` (exploration yield), `depth_access` (descent gate), `damage`/
+  `defense`/`max_health` (the duel), `fishing_power`/`bite_luck` (the cast, #1504).
+- **Why it's OPEN, not auto-fixed:** wiring these is a **gameplay-design decision the owner should make**,
+  not a contained mechanical fix — *what should they do?* (e.g. `light_radius` → a wider reveal radius in
+  the mining grid or a fog/visibility mechanic; `luck` → a crit-find / rare-drop chance on dig). The
+  alternative is to **remove** them (and the gear bonuses + labels) if the design doesn't want them. Both
+  are owner calls; flagged here rather than guessed at.
+- **Stays-fixed guard (shipped this PR, #1505):**
+  `tests/unit/invariants/test_effective_stats_consumed.py` — asserts every `EffectiveStats` field is read
+  by a `disbot/` consumer or is on the documented `_UNWIRED_STATS` allowlist (`light_radius`, `luck`).
+  The allowlist is honesty-checked: the moment either gains a consumer, its allowlist entry must be
+  removed or the test fails — so fixing this bug is self-enforcing, and a *new* dead stat can't ship
+  silently. (Verified: with the allowlist emptied, the guard flags exactly these two.)
+- **Status:** OPEN — finding captured + guarded 2026-06-27 (dispatch run, slice 2). Resolution is a
+  gameplay decision (wire or remove); the guard prevents the class from growing meanwhile.
+
 ## BUG-0025 — hero-card image stranded/lost when navigating into an image-less sub-panel (profile + XP hub) — FIXED (root)
 
 - **Symptom (found 2026-06-25 by code inspection during the visual card-engine H3 adoption audit;

--- a/docs/owner/claims/claude-funny-franklin-iv2rzi.md
+++ b/docs/owner/claims/claude-funny-franklin-iv2rzi.md
@@ -1,1 +1,0 @@
-- branch: claude/funny-franklin-iv2rzi · scope: EffectiveStats knob-coverage guard + dead-stat bug-book finding · files: tests/unit/invariants/test_effective_stats_consumed.py, docs/health/bug-book.md · 2026-06-27

--- a/docs/owner/claims/claude-funny-franklin-iv2rzi.md
+++ b/docs/owner/claims/claude-funny-franklin-iv2rzi.md
@@ -1,0 +1,1 @@
+- branch: claude/funny-franklin-iv2rzi · scope: EffectiveStats knob-coverage guard + dead-stat bug-book finding · files: tests/unit/invariants/test_effective_stats_consumed.py, docs/health/bug-book.md · 2026-06-27

--- a/tests/unit/invariants/test_effective_stats_consumed.py
+++ b/tests/unit/invariants/test_effective_stats_consumed.py
@@ -1,0 +1,98 @@
+"""Invariant: every ``EffectiveStats`` field is *read* by some game consumer.
+
+The Q-0089 idea raised in the #1504 (fishing-gear stats) session log: the
+cross-game :class:`utils.equipment.EffectiveStats` block is the single
+"how strong is this character?" read model, and each game folds the subset it
+cares about into its own math (``mining_power``/``light_radius``/``depth_access``
+→ mining, ``damage``/``defense``/``max_health`` → the duel, ``fishing_power``/
+``bite_luck`` → the cast). Nothing asserted that a *new* field actually gets wired
+into a consumer — so the "added the stat, summed it, labelled it, but forgot the
+knob" half-ship could ship silently.
+
+Building this guard surfaced a real latent bug: ``light_radius`` and ``luck`` are
+**dead stats** — defined, summed, and labelled, but no game reads them to change
+behaviour (the diamond pickaxe's ``luck=1``, the lucky charm's ``luck``, and every
+torch's ``light_radius`` currently do nothing). They are captured in
+``docs/health/bug-book.md`` (wire-it-or-remove-it, an owner gameplay decision) and
+allowlisted below; the second test keeps the allowlist honest, so the moment one is
+wired its allowlist entry must go (or this test fails).
+
+AST-scoped to ``disbot/`` so it runs in well under a second and needs no live
+bot / DB.
+
+UNVERIFIED convenience guard (Q-0105, 2026-06-27): "consumed" means an attribute
+read ``<expr>.<field>`` somewhere in ``disbot/`` outside the definition module and
+the generic label/glyph/``__add__`` plumbing. This is name-based, so it is
+*inclusive* (a coincidental ``.<field>`` on another object would also count as
+consumed) — acceptable for a coverage floor whose only job is to catch a field
+read by *nothing*. If it proves noisy or unreliable across multiple sessions,
+broaden the consumer scan or delete this guard rather than working around it.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import fields
+from pathlib import Path
+
+from utils.equipment import EffectiveStats
+
+_DISBOT = Path(__file__).resolve().parents[3] / "disbot"
+_DEFINITION = _DISBOT / "utils" / "equipment.py"
+
+# Stats that are defined on EffectiveStats but not yet read by any game's
+# consumption path — the dead-stat finding captured in docs/health/bug-book.md.
+# REMOVE a name here the moment a consumer reads it (the honesty test below
+# fails closed otherwise). Adding a NEW name here requires a bug-book entry.
+_UNWIRED_STATS: frozenset[str] = frozenset({"light_radius", "luck"})
+
+
+def _stat_field_names() -> set[str]:
+    return {f.name for f in fields(EffectiveStats)}
+
+
+def _consumed_field_names() -> set[str]:
+    """Every EffectiveStats field name read as ``<expr>.<field>`` in a `disbot/`
+    consumer — excluding the definition module (where the fields are declared,
+    summed in ``__add__``, and listed in the label/glyph maps via ``getattr``)."""
+    field_names = _stat_field_names()
+    consumed: set[str] = set()
+    for path in _DISBOT.rglob("*.py"):
+        if path == _DEFINITION:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in field_names:
+                consumed.add(node.attr)
+    return consumed
+
+
+def test_every_wired_stat_is_consumed_by_a_game():
+    """Each EffectiveStats field is read by a consumer, or is on the documented
+    unwired allowlist (with a bug-book entry)."""
+    consumed = _consumed_field_names()
+    dead = _stat_field_names() - consumed - _UNWIRED_STATS
+    assert not dead, (
+        f"EffectiveStats field(s) {sorted(dead)} are defined but read by no "
+        f"`disbot/` consumer — wire them into a game's stat math, or add them to "
+        f"_UNWIRED_STATS with a docs/health/bug-book.md entry."
+    )
+
+
+def test_unwired_allowlist_stays_honest():
+    """An allowlisted stat that has *gained* a consumer must leave the allowlist —
+    so the moment light_radius/luck are wired, this fails until the list is pruned."""
+    consumed = _consumed_field_names()
+    wired_but_listed = _UNWIRED_STATS & consumed
+    assert not wired_but_listed, (
+        f"{sorted(wired_but_listed)} is in _UNWIRED_STATS but now has a consumer — "
+        f"remove it from the allowlist (the dead-stat bug is fixed)."
+    )
+
+
+def test_unwired_allowlist_only_names_real_fields():
+    """Guard the guard: the allowlist can't drift to a non-existent field name."""
+    assert _UNWIRED_STATS <= _stat_field_names()


### PR DESCRIPTION
## What

Slice 2 of the same dispatch run (slice 1 = #1504, fishing-gear stats). Executes the Q-0089 idea raised
in #1504's session log: a guard against the **"added the stat, forgot the knob"** half-ship class on the
cross-game `EffectiveStats` block.

Building the guard **surfaced a real latent bug**: `EffectiveStats.light_radius` and `EffectiveStats.luck`
are **dead stats** — defined, summed, and labelled, but **no game reads them** to change behaviour (the
diamond pickaxe's `luck=1`, the lucky charm's `luck`, and every torch's `light_radius` currently do
nothing; only `depth_access`/`loot_bonus`/`mining_power`/`damage`/`defense`/`max_health`/`fishing_power`/
`bite_luck` are consumed).

## How

1. `tests/unit/invariants/test_effective_stats_consumed.py` — an AST guard asserting every
   `EffectiveStats` field is read (`stats.<field>`) by ≥1 `disbot/` consumer module (excluding the
   `equipment.py` definition + generic label/glyph/`__add__` plumbing), with a documented
   `_UNWIRED_STATS` allowlist for `light_radius` + `luck`. A second assertion keeps the allowlist honest:
   an allowlisted stat that *gains* a consumer must be removed from the list.
2. `docs/health/bug-book.md` — a new entry capturing the dead-stat finding (root cause + the
   wire-it-or-remove-it decision flagged to the owner — "what should luck/light do?" is a gameplay
   design call, not a contained mechanical fix).

Test-only + docs; no runtime/`disbot/` behaviour change.

> Born-red per Q-0133 — the session card flips to `complete` as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SP97cEJgyD43GcqfsaThZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015SP97cEJgyD43GcqfsaThZ)_