### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-27T15:01:44Z",
+    "generated_at": "2026-06-27T17:28:44Z",
     "build": {
-      "commit": "39746a77",
-      "subject": "Merge pull request #1502 from menno420/claude/reconcile-1500",
-      "committed_at": "2026-06-27T15:01:44Z"
+      "commit": "2aa5360b",
+      "subject": "Merge pull request #1504 from menno420/claude/funny-franklin-iv2rzi",
+      "committed_at": "2026-06-27T17:28:44Z"
     },
     "counts": {
       "functions": 43,
@@ -1176,7 +1176,7 @@
     {
       "file": "fishing-gear-stats-2026-06-27.md",
       "title": "Idea — Fishing-specific gear stats (make loadout presets a real optimisation)",
-      "status": "ideas",
+      "status": "historical",
       "date": "2026-06-27",
       "summary": "The unified-loadout vision (`fishing-open-world-expansion-plan-2026-06-18.md`, Q-0175 / V-14) has two",
       "subsystems": null
@@ -2641,6 +2641,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-27-fishing-gear-stats.md",
+      "date": "2026-06-27",
+      "title": "2026-06-27 — Fishing-specific gear stats (loadout presets become a real optimisation)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-27-economy-flow-timeseries.md",
       "date": "2026-06-27",
       "title": "2026-06-27 — Games-economy observability: per-day faucet/sink trend view",
@@ -3044,14 +3052,6 @@
       "file": "2026-06-24-idea-grooming.md",
       "date": "2026-06-24",
       "title": "Session — 2026-06-24 · idea grooming (settle-once run, slice 3)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-24-help-nav-seam-hardening.md",
-      "date": "2026-06-24",
-      "title": "2026-06-24 — Harden the help-nav attachment seam (forward-path regression pins)",
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.