### PR TITLE
Expand BTD6 regression corpus with 4 fixed-live-miss probes (codex audit #1509 review)

### DIFF
--- a/.sessions/2026-06-27-audit-review-btd6-corpus.md
+++ b/.sessions/2026-06-27-audit-review-btd6-corpus.md
@@ -1,0 +1,84 @@
+# 2026-06-27 — Reviewed the codex unfinished-work audit (PR #1509); shipped a BTD6 regression-corpus expansion
+
+> **Status:** `in-progress`
+
+**Run type:** owner-directed (*"I asked codex to review the current state of the bot and find some
+unfinished work, please review the open PR and see what you can execute"*)
+
+## What this run did
+
+**1. Reviewed PR #1509 (the codex audit) against live source** — per the working agreement, cross-agent
+output is *input to verify against shipped source, never an order*. The audit (`docs/analysis/
+unfinished-work-audit.md`) is solid and repo-grounded, but was produced in a **degraded environment** (no
+`gh`, broken `python3.10` shim) so it could not check live PRs or run the quality suite. Doing the live +
+deep-source verification it couldn't tightened its "startable offline" classification:
+
+- **Fishing-gear acquisition depth** (its clean S1 offline item) is **already in flight as PR #1508** —
+  ruled out (no duplication).
+- **Unwired `light_radius`/`luck` stats** = **BUG-0026**, an explicit **owner gameplay decision**
+  (wire-or-remove) — not mine to decide.
+- **procedures→skills Batch 2** edits **`.claude/CLAUDE.md`** → off-limits to self-initiate autonomously
+  (Q-0106); its Batch 3–4 skills already exist.
+- **Advanced Setup PR 3b** is `[needs-live-bot]` (editor rework); the **self-test walker** needs runtime;
+  **absence-guard Layer B** is **design-review-gated** by the project's own rule (*"design-first, do NOT
+  implement blind"*). All gated for an autonomous offline session.
+- `check_quality.py --full` runs **green** here (the verification the audit's env couldn't complete).
+
+Net finding: every *substantive* item the audit flagged "startable" is, on live inspection, claimed /
+owner-gated / CLAUDE.md-restricted / design-gated / needs-live-bot. The one genuinely safe, offline,
+additive, non-gated lane serving the audit's **#1 critical area (BTD6 correctness)** is the offline
+regression corpus.
+
+**2. Shipped — expanded the offline BTD6 regression corpus** (`tests/evals/btd6_corpus.py`), the
+project's creds-free *"test all BTD6 questions at once"* layer the README says to *grow from real
+failures*. The 14 existing probes were all damage-type/immunity (the #1487 arc); added **4 probes on new
+axes**, each pinning the answer-bearing grounding fact for a documented owner-reported live miss so a
+data/retrieval regression is caught offline on every PR:
+
+| Question | Pins |
+|---|---|
+| "what is the damage of a d67 dart paragon" | **BUG-0015** — `d67` is the paragon DEGREE, not a `0-6-7` path |
+| "does the monkey buccaneer have a paragon" | absence-claim repro (guard design doc Update 2 — the false "no paragon") |
+| "how much is a despo on impoppable" | **BUG-0003** — `despo` shorthand → Desperado, not PMFC |
+| "what is the health of an elite lych" | **BUG-0002** — Elite HP from the Elite table, not Standard |
+
+Each verified groundable via `btd6_context_service.build()` before wiring (real retrieval, no model). Two
+(`elite_lych_hp`, `despo`) double as live *over-refusal* items in the corpus doc's checklist — the probe
+now localizes any live miss to the guard/model layer, not a data-retrieval gap. Doc synced
+(`docs/btd6/qa-accuracy-corpus-2026-06-27.md` § "Regression probes from prior fixed live misses").
+
+CI: `check_quality.py --full` green (with changes); `tests/evals/` 144 passed; corpus 14 → 18 probes.
+
+## ⚑ Self-initiated
+
+Owner-directed to *execute startable work from the audit*; **I selected the specific lane** (BTD6
+regression-corpus expansion) after verifying the audit's other startable items were claimed/gated (see
+above). Additive test-data + docs only — no runtime/`disbot/` change, fully reversible.
+
+## 💡 Session idea (Q-0089)
+
+*A `check_corpus_doc_sync` guard (Q-0105 disposable): assert every `GROUNDING_PROBES` question appears in
+the human-readable `qa-accuracy-corpus-2026-06-27.md` and vice-versa.* The corpus module calls itself
+*"the machine-readable half of"* that doc, but **nothing enforces the link** — I had to remember to update
+the doc by hand this session. A tiny stdlib lint over the two would close that drift class (same shape as
+the existing thin-pointer-integrity ideas). Genuinely useful, not built here. *(Dedup-checked: no test
+currently references the corpus doc.)*
+
+## ⟲ Previous-session review (Q-0102)
+
+The immediately-prior corpus session (`2026-06-27-btd6-eval-corpus-action.md`, PR #1488) did the hard
+part well — a clean shared `GroundingProbe` table feeding both the offline and live layers, so extending
+it took minutes. **What it missed:** it seeded the corpus with *only* the #1487 interaction-arc questions,
+leaving the bug book's own fixed BTD6 misses (BUG-0002/0003/0015, the absence-claim repro) un-probed —
+yet the README explicitly says to *"grow from real failures,"* and the **bug book is the canonical
+real-failures source.** **System improvement (applied this session):** when seeding a regression corpus,
+draw from the bug book's fixed-entry list, not just the current arc — a "test all the questions" corpus
+that omits the project's own logged bugs is incomplete by construction.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_quality --check-only` (incl. `check_docs` + `check_consistency`) green; ledger checker green. New
+facts homed: the 4 probes (module) + the regression-probe section (corpus doc), kept in sync. No new owner
+decision to route. Ledger: merged-only convention — the next reconciliation pass adds this PR. Backlog
+grooming (Q-0015): the 💡 idea above is the forward contribution; no idea-file move this run (contained
+single-lane session).

--- a/.sessions/2026-06-27-audit-review-btd6-corpus.md
+++ b/.sessions/2026-06-27-audit-review-btd6-corpus.md
@@ -1,6 +1,6 @@
 # 2026-06-27 — Reviewed the codex unfinished-work audit (PR #1509); shipped a BTD6 regression-corpus expansion
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** owner-directed (*"I asked codex to review the current state of the bot and find some
 unfinished work, please review the open PR and see what you can execute"*)

--- a/docs/btd6/qa-accuracy-corpus-2026-06-27.md
+++ b/docs/btd6/qa-accuracy-corpus-2026-06-27.md
@@ -212,6 +212,27 @@ prose in `damage_types.json` — correct, but it deliberately does **not** name 
 **Open question for the owner:** how to do tower recommendations (a hand-curated, wiki-verified list vs.
 leaving the rules-based guidance).
 
+## Regression probes from prior fixed live misses (machine-checked)
+
+Beyond the damage-type interaction arc above, the machine-readable corpus
+(`tests/evals/btd6_corpus.py`) also pins the **answer-bearing grounding fact** for
+four earlier owner-reported misses, so a data/retrieval regression of any of those
+fixes is caught offline on every PR (`test_btd6_qa_corpus.py`, no creds). These
+probe a different axis than the interaction questions — paragon degree, paragon
+existence, entity-shorthand resolution, and boss HP:
+
+| Q | Verified answer (grounded) | Pins |
+|---|---|---|
+| "what is the damage of a d67 dart paragon" | `d67` = the paragon **Degree** (1-100); Apex Plasma Master at Degree 67 ≈ 48 dmg — NOT a `0-6-7` upgrade path. `[dump ✓]` | **BUG-0015** (degree misread as a path code) |
+| "does the monkey buccaneer have a paragon" | **Yes** — Navarch of the Seas (tier 6, $550,000 on Medium). `[dump ✓]` | absence-claim repro (guard design doc Update 2 — the false "no paragon") |
+| "how much is a despo on impoppable" | The **Desperado** (Primary tower, Impoppable base $360) — the `despo`/`despos` shorthand, not the Plasma Monkey Fan Club. `[dump ✓]` | **BUG-0003** (shorthand hallucinated as PMFC) |
+| "what is the health of an elite lych" | The **Elite** Lych table (T1 30,000 HP → T5 24,000,000 HP), not the Standard table (T1 14,000). `[dump ✓]` | **BUG-0002** (elite HP served from the Standard table) |
+
+These pin only that the bot **grounds** the right fact (the offline-provable half).
+Two of them (`btd6_elite_lych_hp`, `btd6_despo_bulk_cost`) also appear as live
+*over-refusal* items in the checklist below — so if a live answer is still wrong,
+the probe localizes it to the guard/model layer, not a data-retrieval gap.
+
 ## Live verification checklist — what still needs a real-key / prod test
 
 Everything above is offline-verified (1500+ tests, no creds). These need a real provider key or a live

--- a/docs/owner/claims/claude-review-open-pr-5dvsd7.md
+++ b/docs/owner/claims/claude-review-open-pr-5dvsd7.md
@@ -1,0 +1,1 @@
+- branch `claude/review-open-pr-5dvsd7` · scope: review codex audit PR #1509 + ship the best safe offline item (BTD6 regression-corpus expansion) · area: tests/evals/btd6_corpus.py + docs/btd6/qa-accuracy-corpus-2026-06-27.md · 2026-06-27

--- a/tests/evals/btd6_corpus.py
+++ b/tests/evals/btd6_corpus.py
@@ -165,6 +165,58 @@ GROUNDING_PROBES: tuple[GroundingProbe, ...] = (
             "is a FAIL."
         ),
     ),
+    # --- regression probes for prior fixed live misses -----------------------
+    # Each pins the answer-bearing fact for a documented owner-reported bug so a
+    # data/retrieval regression of the fix is caught offline on every PR. Themes
+    # beyond damage-type interactions (paragon degree, paragon existence, entity
+    # shorthand, boss HP) — see docs/btd6/qa-accuracy-corpus-2026-06-27.md.
+    GroundingProbe(
+        question="what is the damage of a d67 dart paragon",
+        expect=("apex plasma master at degree 67", "not an upgrade-path code"),
+        rubric=(
+            "Must treat 'd67' as the paragon's DEGREE (1-100) and give the Apex "
+            "Plasma Master's Degree-67 stats (~48 dmg). FAIL if it reads 'd67' as "
+            "an upgrade path '0-6-7' or claims it can't exist because tiers cap at 5."
+        ),
+        forbid=("0-6-7",),
+        note="BUG-0015 — 'd67' is the paragon DEGREE, not a 0-6-7 upgrade-path code",
+    ),
+    GroundingProbe(
+        question="does the monkey buccaneer have a paragon",
+        expect=("navarch of the seas",),
+        rubric=(
+            "Must answer YES and name Navarch of the Seas as the Monkey "
+            "Buccaneer's paragon. FAIL if it claims the Monkey Buccaneer has no "
+            "paragon."
+        ),
+        forbid=("no paragon", "does not have a paragon", "doesn't have a paragon"),
+        note=(
+            "absence-claim repro (absence-guard design doc Update 2) — the false "
+            "'Monkey Buccaneer has no paragon' that the committed data grounds against"
+        ),
+    ),
+    GroundingProbe(
+        question="how much is a despo on impoppable",
+        expect=("desperado", "impoppable $360"),
+        rubric=(
+            "Must identify and price the Desperado (a Primary-category tower; "
+            "Impoppable base $360), resolving the 'despo' shorthand correctly. "
+            "FAIL if it answers about the Plasma Monkey Fan Club (PMFC) or any "
+            "other tower."
+        ),
+        forbid=("plasma monkey fan club", "pmfc"),
+        note="BUG-0003 — 'despo'/'despos' shorthand resolves to Desperado, not PMFC",
+    ),
+    GroundingProbe(
+        question="what is the health of an elite lych",
+        expect=("elite lych per-tier health", "30,000 hp"),
+        rubric=(
+            "Must give the ELITE Lych health from the Elite table (T1 30,000 HP "
+            "up to T5 24,000,000 HP), NOT the Standard table (T1 14,000 HP). FAIL "
+            "if it serves Standard HP as Elite."
+        ),
+        note="BUG-0002 — Elite boss HP comes from the Elite table, not the Standard one",
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

Reviewed the **codex unfinished-work audit (PR #1509)** against live source — per the working agreement, cross-agent output is *input to verify against shipped source, never an order*. The audit was produced in a degraded env (no `gh`, broken `python3.10` shim), so it couldn't check live PRs or run the quality suite; doing that verification tightened its "startable offline" list:

- **Fishing acquisition depth** (its clean S1 offline item) is **already in flight as PR #1508** — ruled out.
- **Unwired `light_radius`/`luck` stats** = **BUG-0026**, an explicit **owner gameplay decision**.
- **procedures→skills Batch 2** edits `.claude/CLAUDE.md` → off-limits to self-initiate (Q-0106).
- **Advanced Setup PR 3b** is `[needs-live-bot]`; **absence-guard Layer B** is design-review-gated (*"design-first, do NOT implement blind"*); the **self-test walker** needs runtime.
- `check_quality.py --full` runs **green** here (the verification the audit's env couldn't complete).

The one safe, offline, additive, non-gated lane serving the audit's **#1 critical area (BTD6 correctness)** is the creds-free regression corpus, which the README says to *grow from real failures*. The existing 14 probes are all damage-type/immunity (the #1487 arc); this adds **4 on new axes**, each pinning the answer-bearing grounding fact for a documented owner-reported live miss (verified groundable via `btd6_context_service.build()` before wiring):

| Question | Pins |
|---|---|
| `what is the damage of a d67 dart paragon` | **BUG-0015** — `d67` is the paragon DEGREE, not a `0-6-7` path |
| `does the monkey buccaneer have a paragon` | absence-claim repro (guard design doc Update 2 — the false "no paragon") |
| `how much is a despo on impoppable` | **BUG-0003** — `despo` shorthand → Desperado, not PMFC |
| `what is the health of an elite lych` | **BUG-0002** — Elite HP from the Elite table, not Standard |

Two (`elite_lych_hp`, `despo`) double as live *over-refusal* items in the corpus doc's checklist — the probe now localizes any live miss to the guard/model layer, not a data-retrieval gap.

## Linked issue / plan

- Reviews **PR #1509** (codex unfinished-work audit).
- Implements the corpus's "grow from real failures" mandate (`tests/evals/README.md`); pins BUG-0002 / BUG-0003 / BUG-0015 + the absence-claim repro from the bug book & guard design doc.

## Type of change

- [x] Documentation
- [x] Tooling / CI (offline regression coverage)

## Checks

- [x] `python3.10 scripts/check_quality.py --full` passes (black + isort + ruff + mypy + pytest) — green with changes
- [x] No `disbot/` change → architecture check trivially clean; `tests/evals/` 144 passed; corpus 14 → 18 probes
- [x] Docs / corpus doc updated and kept in sync
- [x] No secrets, tokens, or credentials added

<sub>Born-red session card (Q-0133) — flips to `complete` as the deliberate final step so auto-merge fires on a complete PR.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoqstmiKgZowTLjYCYynqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoqstmiKgZowTLjYCYynqS)_