### PR TITLE
BTD6 absence-guard Layer B — grounded-contradiction gate

### DIFF
--- a/.sessions/2026-06-27-btd6-absence-guard-layer-b.md
+++ b/.sessions/2026-06-27-btd6-absence-guard-layer-b.md
@@ -1,6 +1,6 @@
 # 2026-06-27 — BTD6 absence-guard Layer B (grounded-contradiction slice)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** owner-directed (in-session greenlight: *"Build it now (offline + unit tests)"* —
 AskUserQuestion answer to the absence-guard Layer B question, after the codex-audit review)

--- a/.sessions/2026-06-27-btd6-absence-guard-layer-b.md
+++ b/.sessions/2026-06-27-btd6-absence-guard-layer-b.md
@@ -1,0 +1,69 @@
+# 2026-06-27 — BTD6 absence-guard Layer B (grounded-contradiction slice)
+
+> **Status:** `in-progress`
+
+**Run type:** owner-directed (in-session greenlight: *"Build it now (offline + unit tests)"* —
+AskUserQuestion answer to the absence-guard Layer B question, after the codex-audit review)
+
+## What this run did
+
+The faithfulness verifier catches ungrounded **positives** (a name/number not in the grounding) but
+**not** a false **negative** — a reply can fluently assert *"the Monkey Buccaneer does not have a
+paragon"* when the grounded facts in front of the model affirm it does (Navarch of the Seas). That
+fluent false "no" is worse than a refusal. The design doc
+([`btd6-absence-claim-guard-design.md`](../btd6/btd6-absence-claim-guard-design.md)) called for
+review-before-build; the owner greenlit it this session.
+
+**Shipped — the safe, high-precision §4.2-step-3 slice (grounded-contradiction):** reject an absence
+claim **only when the grounded payload affirms the very thing the reply denies**, so it can never block a
+*true* negative (a true "X has no paragon" has no contradicting positive → nothing fires). Deliberately
+**not** the §4.3 unresolved-subject half (the part with false-floor risk that needs a live FPR check).
+
+- `utils/btd6/absence_guard.py` (new, pure/stdlib) — `contradicted_absence_claims(answer, haystack)`. An
+  `_ExistenceAttribute` table (the extension point) seeded with **paragon** (the canonical Update-2
+  repro): reads the subjects the haystack affirms have a paragon, flags any reply *sentence* that names an
+  affirmed subject **and** denies its paragon (tight negation patterns + a "no *second* paragon" exclusion).
+- `services/btd6_grounding_service.validate_btd6_reply` runs it on `facts ∪ tool_results`, returns
+  `grounded=False` + note `absence_claim_contradicted`, so the **existing regenerate-once → deterministic
+  refusal** flow downgrades it for free; the retry constraint tells the model the data *does* list the
+  thing and to state it.
+- Design doc Update 7 records the shipped slice; the §4.3 half stays design-only.
+
+**Verified against the REAL pipeline:** `build("does the monkey buccaneer have a paragon")` grounds
+Navarch; a reply saying "...does not have a paragon" is now blocked (`absence_claim_contradicted`) while
+"...has a paragon, Navarch" passes. CI: `check_quality --full` green; arch 0 errors; new tests
+(15 util + 4 service) + the 89-test answer-path suite pass.
+
+## ⚑ Self-initiated
+
+None unprompted — **owner greenlit** "build it now (offline + unit tests)" in-session. Scope chosen to
+the safe grounded-contradiction slice (no false-floor risk), leaving the live-FPR-gated §4.3 half for a
+verified follow-up — flagged so the boundary is reviewable.
+
+## 💡 Session idea (Q-0089)
+
+*Generalize the grounded-contradiction principle into a domain-agnostic `absence_guard` so the next
+knowledge domain gets false-"no" protection for free.* Project Moon (Limbus) already has the same
+faithfulness-guard shape (`projmoon_grounding_service`, the BTD6 analogue). The contradicted-absence check
+is pure string logic over a grounded haystack + an attribute table — lift it to a shared helper keyed by
+each domain's existence-attributes, and Limbus (and LoR/LobCorp next) inherit the guard. Mirrors the
+cross-domain reuse theme of #1470. Routed as an idea, not built here.
+
+## ⟲ Previous-session review (Q-0102)
+
+The immediately-prior PR this session (#1510, the BTD6 corpus expansion) pinned the buccaneer-paragon
+absence repro at the **grounding** layer (proving the data is *retrieved*) but explicitly noted the
+**guard** layer — whether the bot *rejects the false claim* — was still gated. This session closed that
+exact loop: the corpus proves the fact is grounded, Layer B proves a reply contradicting it is now caught.
+**System improvement (applied):** the two are a **paired pattern** — when you pin a grounding fact for a
+false-"no" bug, also check whether a guard rejects the false *claim*; data-present and claim-rejected are
+different failure surfaces and both deserve a regression. Worth making the pairing explicit in the evals
+README so future false-"no" fixes ship both halves.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_quality --full` green (incl. `check_docs`/`check_consistency`); arch 0 errors. New facts homed: the
+guard code + design doc Update 7 + the status-block update (Layer B's slice marked shipped). Owner
+decisions this session (wire `light_radius`/`luck`; build Layer B; hold PR 3b) recorded in the question
+router (Q-block) for provenance; the BUG-0026 "wire" decision is actioned in its own follow-up PR. Ledger:
+merged-only convention — the next reconciliation adds this PR.

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -1252,13 +1252,24 @@ def _build_grounding_constraint(verdict: btd6_grounding_service.GroundingResult)
         bits.append("names not in the data: " + ", ".join(verdict.offending_names))
     if verdict.offending_numbers:
         bits.append("numbers not in the data: " + ", ".join(verdict.offending_numbers))
+    if verdict.offending_absence_claims:
+        bits.append(
+            "false 'does not have' claims the data refutes: "
+            + " | ".join(verdict.offending_absence_claims),
+        )
     detail = "; ".join(bits) if bits else "unsupported BTD6 claims"
-    return (
+    correction = (
         "GROUNDING CORRECTION: your previous reply contained "
         f"{detail}. Do NOT state these. Use only BTD6 names and numbers present "
         "in the provided data and tool results. If the data does not support an "
         "answer, say you don't have that information."
     )
+    if verdict.offending_absence_claims:
+        correction += (
+            " The provided data DOES list the thing you said is missing — state "
+            "what the data shows instead of claiming it does not exist."
+        )
+    return correction
 
 
 async def _send_btd6_refusal(message: discord.Message) -> None:

--- a/disbot/services/btd6_grounding_service.py
+++ b/disbot/services/btd6_grounding_service.py
@@ -22,7 +22,7 @@ from typing import Any
 from core.runtime.ai.contracts import AITask, PolicyDenialReason
 from core.runtime.ai.safety import claims_are_grounded
 from services import btd6_knowledge_api
-from utils.btd6 import name_guard
+from utils.btd6 import absence_guard, name_guard
 from utils.btd6.keywords import has_btd6_context
 from utils.btd6.paragon_math import PARAGONS
 
@@ -40,6 +40,10 @@ class GroundingResult:
     # constraint and the structured block-reply log.
     offending_names: tuple[str, ...] = ()
     offending_numbers: tuple[str, ...] = ()
+    # Set when a reply makes a *false absence* claim the grounding contradicts
+    # ("<tower> has no paragon" when the grounded facts affirm it has one) —
+    # the absence-claim guard, Layer B's grounded-contradiction slice.
+    offending_absence_claims: tuple[str, ...] = ()
 
 
 async def validate_answer(
@@ -311,7 +315,16 @@ def validate_btd6_reply(
         if task is AITask.BTD6_ANSWER:
             offending_numbers = name_guard.offending_numbers(answer_text, haystack)
 
-        if not offending_names and not offending_numbers:
+        # Layer B (grounded-contradiction slice): a reply may not assert an
+        # absence the grounded payload refutes ("<tower> has no paragon" when the
+        # facts affirm one). Only fires on a contradicted "no", so a true negative
+        # is never blocked. See docs/btd6/btd6-absence-claim-guard-design.md §4.2.
+        offending_absence = absence_guard.contradicted_absence_claims(
+            answer_text,
+            haystack,
+        )
+
+        if not offending_names and not offending_numbers and not offending_absence:
             return GroundingResult(
                 grounded=True,
                 reason_code=PolicyDenialReason.NONE.value,
@@ -323,6 +336,8 @@ def validate_btd6_reply(
             notes.append("entity_name_unsupported")
         if offending_numbers:
             notes.append("numeric_claim_unsupported")
+        if offending_absence:
+            notes.append("absence_claim_contradicted")
         return GroundingResult(
             grounded=False,
             reason_code=PolicyDenialReason.GROUNDING_FAILED.value,
@@ -330,6 +345,7 @@ def validate_btd6_reply(
             notes=tuple(notes),
             offending_names=offending_names,
             offending_numbers=offending_numbers,
+            offending_absence_claims=offending_absence,
         )
     except Exception:
         logger.warning(

--- a/disbot/utils/btd6/absence_guard.py
+++ b/disbot/utils/btd6/absence_guard.py
@@ -1,0 +1,127 @@
+"""Absence-claim contradiction guard — BTD6 faithfulness Layer B (first slice).
+
+The faithfulness verifier (``services.btd6_grounding_service.validate_btd6_reply``)
+catches ungrounded **positives**: a name or number the reply states that the
+grounded payload does not contain. It does **not** catch a false **negative** — a
+reply can fluently, confidently assert *"<tower> has no paragon"* when the
+committed data (and the grounded facts in front of the model that very turn) say
+it does. A fluent false "no" is worse than a refusal: it looks authoritative and
+the user believes it. The canonical repro is the design doc's Update 2 — *"Monkey
+Buccaneer does not have a paragon"* (it has Navarch of the Seas, and the grounding
+emitted that fact). See ``docs/btd6/btd6-absence-claim-guard-design.md`` §1.
+
+This is the **grounded-contradiction** slice of Layer B (design §4.2 step 3): it
+rejects an absence claim **only when the grounded haystack affirms the very thing
+the reply denies**. By construction it can never block a *true* negative — a true
+"X has no paragon" has no contradicting positive in the grounding, so nothing
+fires. The harder §4.3 half (downgrading a "no" about a subject that never
+*resolved*, where Layer A shrinks the trigger) needs the live false-positive-rate
+check and stays a follow-up.
+
+Seeded with the **paragon-existence** attribute (the documented repro). The
+:data:`_ATTRIBUTES` table is the extension point: add a clean existence-attribute
+with (a) a regex that reads the subject the grounding *affirms* has it and (b) the
+sentence patterns that *deny* it — then live-verify before trusting it.
+
+UNVERIFIED convenience guard (Q-0105, 2026-06-27): the deny patterns are
+deliberately tight (negation adjacent to the attribute word) to keep false floors
+near-zero, and a contradicted claim only costs one regeneration before the
+deterministic refusal. If it proves noisy across sessions, narrow the patterns or
+delete this guard rather than working around it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Sentence splitter — good enough for model prose (split after . ? ! + space).
+_SENTENCE_SPLIT = re.compile(r"(?<=[.?!])\s+")
+
+
+@dataclass(frozen=True)
+class _ExistenceAttribute:
+    """One binary "does <subject> have <attribute>?" fact the gate can check."""
+
+    name: str
+    # Reads, from the grounded haystack, the subject(s) the data AFFIRMS have this
+    # attribute. Group 1 = the subject's proper name (e.g. "Monkey Buccaneer").
+    affirm_re: re.Pattern[str]
+    # A sentence matching any of these (case-insensitively) DENIES the attribute.
+    deny_res: tuple[re.Pattern[str], ...]
+    # Words that turn a "no <attr>" into a non-absence ("no SECOND paragon"); a
+    # sentence containing one is skipped even if a deny pattern matched.
+    exclude_qualifiers: frozenset[str]
+
+
+# Apostrophe class covers the straight ' and the curly ' a model may emit.
+_APOS = r"['’]"
+
+_PARAGON = _ExistenceAttribute(
+    name="paragon",
+    # Both grounded paragon lines affirm the owning tower: the headline form
+    # (Monkey Buccaneer ... Paragon is Navarch) and the descriptive form
+    # (Navarch ... the Monkey Buccaneer Paragon, fusing ...).
+    affirm_re=re.compile(
+        r"([A-Z][A-Za-z]+(?: [A-Z][A-Za-z]+)*)" + _APOS + r"s Paragon\b",
+    ),
+    deny_res=(
+        # "no paragon", "no monkey buccaneer paragon" (<=2 words between)
+        re.compile(r"\bno\s+(?:\w+\s+){0,2}paragon\b"),
+        # "does not have a paragon", "doesn't have a paragon"
+        re.compile(
+            r"\b(?:does\s+not|doesn" + _APOS + r"?t|do\s+not|don" + _APOS + r"?t)"
+            r"\s+have\s+(?:a\s+|an\s+|any\s+)?(?:\w+\s+){0,2}paragon\b",
+        ),
+        # "lacks a paragon", "lack a paragon"
+        re.compile(r"\blacks?\s+(?:a\s+|an\s+|any\s+)?(?:\w+\s+){0,2}paragon\b"),
+        # "without a paragon"
+        re.compile(r"\bwithout\s+(?:a\s+|an\s+|any\s+)?(?:\w+\s+){0,2}paragon\b"),
+        # "paragon does not exist / doesn't exist / is not available"
+        re.compile(
+            r"\bparagon\b(?:\s+\w+){0,3}\s+(?:does\s+not|doesn" + _APOS + r"?t)"
+            r"\s+exist\b",
+        ),
+        re.compile(
+            r"\bparagon\b(?:\s+\w+){0,3}\s+(?:is\s+not|isn" + _APOS + r"?t)"
+            r"\s+available\b",
+        ),
+    ),
+    exclude_qualifiers=frozenset({"second", "another", "additional", "other", "more"}),
+)
+
+_ATTRIBUTES: tuple[_ExistenceAttribute, ...] = (_PARAGON,)
+
+
+def contradicted_absence_claims(answer_text: str, haystack: str) -> tuple[str, ...]:
+    """Return the reply sentences that deny an attribute the grounding affirms.
+
+    ``answer_text`` is the model's draft reply; ``haystack`` is the joined
+    grounded payload (auto-grounding facts ∪ approved tool results) — the same
+    haystack the positive faithfulness check uses. The result is empty unless the
+    reply makes a grounding-**contradicted** absence claim (so a true "no", or any
+    absence about a subject the grounding never affirmed, returns nothing).
+    """
+    if not answer_text or not haystack:
+        return ()
+
+    offending: list[str] = []
+    sentences = _SENTENCE_SPLIT.split(answer_text)
+    for attr in _ATTRIBUTES:
+        affirmed = {m.group(1).lower() for m in attr.affirm_re.finditer(haystack)}
+        if not affirmed:
+            continue
+        for sentence in sentences:
+            low = sentence.lower()
+            if not any(pat.search(low) for pat in attr.deny_res):
+                continue
+            if any(q in low for q in attr.exclude_qualifiers):
+                continue
+            if any(subject in low for subject in affirmed):
+                offending.append(sentence.strip())
+
+    # Preserve order, drop duplicates.
+    return tuple(dict.fromkeys(offending))
+
+
+__all__ = ["contradicted_absence_claims"]

--- a/docs/btd6/btd6-absence-claim-guard-design.md
+++ b/docs/btd6/btd6-absence-claim-guard-design.md
@@ -1,11 +1,13 @@
 # BTD6 absence-claim guard — design proposal
 
-> **Status:** `reference` — DESIGN PROPOSAL. **Layer A (retrieval) is now SHIPPED**
-> (path/line-aware resolution, PR #855, 2026-06-14 — see Update 6); **Layer B (the
-> negative-existential gate) remains design-only, *not* implemented**, pending review
-> per the v55 hand-off ("Task 1: DESIGN FIRST, do NOT implement blind"). Written for
-> independent review (ChatGPT / Analysis side) before any *guard* code is merged.
-> The companion status ledger is `btd6-gamedata-decode-status.md`.
+> **Status:** `reference` — DESIGN PROPOSAL. **Layer A (retrieval) is SHIPPED**
+> (path/line-aware resolution, PR #855, 2026-06-14 — see Update 6). **Layer B's
+> *grounded-contradiction* slice is now SHIPPED** (the §4.2-step-3 in-context record
+> check — reject a "no" the grounded payload refutes, 2026-06-27, owner-greenlit — see
+> Update 7); **the §4.3 *unresolved-subject* half remains design-only**, needing the
+> live false-positive-rate check. Written for independent review (ChatGPT / Analysis
+> side) before that half is merged. The companion status ledger is
+> `btd6-gamedata-decode-status.md`.
 >
 > **One-line ask of the reviewer:** does the layered design below (a cheap
 > retrieval fix + an absence-claim *gate* that never lets an *unresolved* empty
@@ -233,6 +235,42 @@ MOAB grounding, and the `build()` integration).
 map that its record-check consumes. Those need the review this doc asks for, plus the
 prod-creds live half. Layer A shrinks sub-mode A (never-resolved) so the eventual gate
 fires rarely, exactly as §4.1 intended.
+
+## Update 7 (2026-06-27) — Layer B grounded-contradiction slice SHIPPED (owner-greenlit)
+
+The owner greenlit building Layer B offline. Rather than the full §4.3 gate (whose
+risk is *false floors* on true negatives — see §5 — and which needs a live
+false-positive-rate check), this ships the **safe, high-precision core**: the §4.2
+**step-3 record check against the in-context grounding**. The gate rejects an absence
+claim **only when the grounded payload affirms the very thing the reply denies**, so by
+construction it can never block a *true* negative (a true "X has no paragon" has no
+contradicting positive in the haystack — nothing fires).
+
+**What shipped (a real guard, fail-precise):**
+
+- `utils/btd6/absence_guard.contradicted_absence_claims(answer, haystack)` — pure,
+  stdlib-only. An `_ExistenceAttribute` table (the extension point) seeded with
+  **paragon** (the canonical Update-2 repro): it reads the subjects the haystack
+  *affirms* have a paragon (`<Tower>'s Paragon`), then flags any reply *sentence* that
+  both names an affirmed subject **and** denies its paragon (tight negation patterns +
+  a "no *second* paragon" qualifier exclusion).
+- `btd6_grounding_service.validate_btd6_reply` runs it on the `facts ∪ tool_results`
+  haystack and returns `grounded=False` + note `absence_claim_contradicted` +
+  `offending_absence_claims`, so the **existing regenerate-once → deterministic
+  refusal** machinery handles the downgrade for free; the retry constraint
+  (`_build_grounding_constraint`) tells the model the data *does* list the thing and to
+  state it.
+
+Verified against the **real** pipeline: `build("does the monkey buccaneer have a
+paragon")` grounds Navarch, and a reply saying "Monkey Buccaneer does not have a
+paragon" is now blocked (`absence_claim_contradicted`) while the correct "has a
+paragon, Navarch" passes. Pinned by `tests/unit/utils/btd6/test_absence_guard.py`
+(15 cases) + the Layer B cases in `tests/unit/services/test_btd6_grounding_service.py`.
+
+**Still design-only:** the §4.3 **unresolved-subject** half (downgrading a "no" about a
+subject that never resolved — the part with false-floor risk that needs the live FPR
+check) and the §4.4 attribute-synonym map. Adding another existence-attribute to the
+table (ability, camo, etc.) wants the same live verification before it is trusted.
 
 ---
 

--- a/docs/owner/claims/claude-btd6-absence-guard-layer-b.md
+++ b/docs/owner/claims/claude-btd6-absence-guard-layer-b.md
@@ -1,0 +1,1 @@
+- branch `claude/btd6-absence-guard-layer-b` · scope: BTD6 absence-guard Layer B (grounded-contradiction slice — reject a false "no" the grounding refutes) · area: utils/btd6/absence_guard.py + services/btd6_grounding_service.py + core/runtime/ai/natural_language_stage.py · 2026-06-27

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7556,3 +7556,30 @@ into `dispatch_menu --unattended` is the natural next slice.
 `repo-sector-map.md` (durable home of the convention). Related: **Q-0143** (startability tag), **#1285 /
 Q-0172** (unattended-fit tag — the sector-level sibling), **Q-0102** (the self-audit loop that surfaced
 it), **Q-0105** (disposable-tool posture).
+
+---
+
+### Q-0208 — DECIDED: three audit-unblock decisions (wire dead stats · build absence-guard Layer B · hold Setup PR 3b) (2026-06-27)
+
+> **ANSWERED (owner, in-session via AskUserQuestion, 2026-06-27).** After an agent reviewed the codex
+> unfinished-work audit (PR #1509) and surfaced the genuinely owner-gated items, the owner made three
+> decisions in one round. Recorded here so the answers are preserved (Q-0104 "route durable conclusions").
+
+**The three decisions:**
+
+1. **BUG-0026 (`EffectiveStats.light_radius` / `luck` dead stats) → WIRE them into gameplay** (not remove,
+   not defer). The gear that grants them should *do* something: `light_radius` → a reveal/visibility effect
+   in the mining grid; `luck` → a rare-find/crit chance on dig. *Actioned in its own follow-on PR; the
+   BUG-0026 entry is updated there.* The agent brings the specific mechanic + sim-pinned numbers (reversible).
+
+2. **Absence-guard Layer B → BUILD now (offline + unit tests).** Greenlit the design doc's review gate. The
+   agent shipped the **grounded-contradiction slice** (§4.2 step 3 — the safe, no-false-floor core) this
+   session; the §4.3 unresolved-subject half stays design-only pending a live false-positive-rate check.
+   *Home: `btd6-absence-claim-guard-design.md` Update 7 + `.sessions/2026-06-27-btd6-absence-guard-layer-b.md`.*
+
+3. **Advanced Setup PR 3b → HOLD for a live-bot session.** The editor rework ("most of it does nothing")
+   genuinely needs a running bot to verify; not done offline. Stays the S1 `▶ Next` `[needs-live-bot]` item.
+
+**Home:** this Q-block (canonical) + the per-decision homes above. Related: **Q-0120** (cross-agent output
+is input-to-verify, not an order — the posture used to review the audit), **BUG-0026** (the dead-stats
+bug), **Q-0105** (disposable-tool posture).

--- a/tests/unit/services/test_btd6_grounding_service.py
+++ b/tests/unit/services/test_btd6_grounding_service.py
@@ -254,3 +254,56 @@ def test_enumeration_roster_is_subset_of_accepted_names():
             paragon.name, matchers
         )
         assert present, f"paragon {paragon.name!r} is not in the accepted index"
+
+
+# ---------------------------------------------------------------------------
+# Layer B — the absence-claim contradiction guard (grounded-contradiction slice)
+# ---------------------------------------------------------------------------
+
+_BUCC_PARAGON_FACT = (
+    "Monkey Buccaneer's Paragon (tier 6) is Navarch of the Seas, costing 550000"
+)
+
+
+def test_btd6_reply_blocks_contradicted_absence_claim():
+    # The canonical repro: the grounding AFFIRMS the paragon, the reply denies it.
+    v = btd6_grounding_service.validate_btd6_reply(
+        "The Monkey Buccaneer does not have a paragon.",
+        facts=(_BUCC_PARAGON_FACT,),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is False
+    assert "absence_claim_contradicted" in v.notes
+    assert v.offending_absence_claims  # the offending sentence captured
+
+
+def test_btd6_reply_allows_true_absence_when_grounding_silent():
+    # Grounding never affirms a paragon → "no paragon" is a true negative, allowed
+    # (the gate only fires on a grounding-contradicted "no" — no false floor).
+    v = btd6_grounding_service.validate_btd6_reply(
+        "The Spike Factory does not have a paragon.",
+        facts=("Spike Factory base cost: 1000",),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True
+
+
+def test_btd6_reply_absence_claim_matches_the_affirmed_subject():
+    # Grounding affirms the Buccaneer's paragon; a true "no paragon" about a
+    # DIFFERENT tower must not be blocked by it (subject-matched, not blanket).
+    v = btd6_grounding_service.validate_btd6_reply(
+        "The Spike Factory does not have a paragon.",
+        facts=(_BUCC_PARAGON_FACT, "Spike Factory base cost: 1000"),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True
+
+
+def test_btd6_reply_allows_grounded_paragon_answer():
+    # The correct positive answer passes cleanly.
+    v = btd6_grounding_service.validate_btd6_reply(
+        "The Monkey Buccaneer's paragon is Navarch of the Seas.",
+        facts=(_BUCC_PARAGON_FACT,),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True

--- a/tests/unit/utils/btd6/test_absence_guard.py
+++ b/tests/unit/utils/btd6/test_absence_guard.py
@@ -1,0 +1,110 @@
+"""Tests for the BTD6 absence-claim contradiction guard (Layer B first slice).
+
+The guard fires ONLY when the grounded haystack affirms the very attribute the
+reply denies — so it catches the canonical "Monkey Buccaneer does not have a
+paragon" repro (the data grounds Navarch) yet never blocks a true negative.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.btd6 import absence_guard
+
+# A realistic grounded line: the data AFFIRMS the Buccaneer's paragon.
+_BUCC_PARAGON = (
+    "[btd6_paragon] Monkey Buccaneer's Paragon (tier 6) is Navarch of the Seas, "
+    "costing 550000 on Medium (source: bloonswiki)"
+)
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "The Monkey Buccaneer does not have a paragon.",
+        "The Monkey Buccaneer doesn't have a paragon.",
+        "Monkey Buccaneer has no paragon.",
+        "There is no paragon for the Monkey Buccaneer.",
+        "The Monkey Buccaneer lacks a paragon.",
+        "The Monkey Buccaneer is without a paragon.",
+        "The Monkey Buccaneer's paragon does not exist.",
+    ],
+)
+def test_flags_contradicted_paragon_absence(reply):
+    """Every common phrasing of the false 'no paragon' is caught when the data
+    affirms the paragon."""
+    offending = absence_guard.contradicted_absence_claims(reply, _BUCC_PARAGON)
+    assert offending, f"expected {reply!r} to be flagged as a contradicted absence"
+
+
+def test_silent_when_grounding_does_not_affirm_the_attribute():
+    """A 'no paragon' statement is a true negative when the data never affirms a
+    paragon for the subject — the gate must stay silent (no false floor)."""
+    haystack = "[btd6_tower] Spike Factory base cost: 1000 (source: dataset)"
+    offending = absence_guard.contradicted_absence_claims(
+        "The Spike Factory does not have a paragon.", haystack
+    )
+    assert offending == ()
+
+
+def test_silent_for_a_different_tower_than_the_one_affirmed():
+    """The gate matches the subject: a true 'no paragon' about a tower other than
+    the one the data affirms must not be blocked."""
+    offending = absence_guard.contradicted_absence_claims(
+        "The Spike Factory does not have a paragon.", _BUCC_PARAGON
+    )
+    assert offending == ()
+
+
+def test_silent_on_a_no_second_paragon_qualifier():
+    """'no SECOND paragon' is a non-absence (towers have exactly one) — excluded."""
+    offending = absence_guard.contradicted_absence_claims(
+        "The Monkey Buccaneer has no second paragon.", _BUCC_PARAGON
+    )
+    assert offending == ()
+
+
+def test_silent_when_the_reply_affirms_the_paragon():
+    """A correct positive answer is never flagged."""
+    offending = absence_guard.contradicted_absence_claims(
+        "The Monkey Buccaneer's paragon is Navarch of the Seas.", _BUCC_PARAGON
+    )
+    assert offending == ()
+
+
+def test_handles_a_curly_apostrophe_in_the_grounding():
+    """A model/source may emit the curly apostrophe; the affirm match must still
+    find the subject."""
+    haystack = "[btd6_paragon] Monkey Buccaneer’s Paragon (tier 6) is Navarch"
+    offending = absence_guard.contradicted_absence_claims(
+        "The Monkey Buccaneer does not have a paragon.", haystack
+    )
+    assert offending
+
+
+def test_returns_the_offending_sentence_only():
+    """A multi-sentence reply returns just the contradicted sentence."""
+    reply = (
+        "The Monkey Buccaneer is a water tower. "
+        "It does not have a paragon, surprisingly. "
+        "Its top path ends in Trade Empire."
+    )
+    offending = absence_guard.contradicted_absence_claims(reply, _BUCC_PARAGON)
+    # "It does not have a paragon" names no tower → not flagged on its own; the
+    # subject must be in the same sentence. This documents the v1 same-sentence
+    # scope (pronoun-reference is the noted follow-up).
+    assert offending == ()
+
+
+def test_flags_when_subject_and_denial_share_the_sentence():
+    reply = (
+        "The Monkey Buccaneer is a water tower. "
+        "The Monkey Buccaneer does not have a paragon."
+    )
+    offending = absence_guard.contradicted_absence_claims(reply, _BUCC_PARAGON)
+    assert offending == ("The Monkey Buccaneer does not have a paragon.",)
+
+
+def test_empty_inputs_are_safe():
+    assert absence_guard.contradicted_absence_claims("", _BUCC_PARAGON) == ()
+    assert absence_guard.contradicted_absence_claims("no paragon", "") == ()


### PR DESCRIPTION
## Summary

The BTD6 faithfulness verifier catches ungrounded **positives** (a name/number not in the grounding) but not a false **negative** — a reply can fluently assert *"the Monkey Buccaneer does not have a paragon"* when the grounded facts in front of the model affirm it does (Navarch of the Seas). A fluent false "no" is worse than a refusal: it looks authoritative. This is the design doc's canonical Update-2 repro.

Owner greenlit building Layer B this session (router **Q-0208**). This ships the **safe, high-precision §4.2-step-3 slice** — the *grounded-contradiction* gate: reject an absence claim **only when the grounded payload affirms the very thing the reply denies**. By construction it can never block a *true* negative (a true "X has no paragon" has no contradicting positive → nothing fires), so there's **no false-floor risk**. The harder §4.3 *unresolved-subject* half (which has false-floor risk and needs a live false-positive-rate check) stays design-only.

**What shipped:**
- `utils/btd6/absence_guard.py` (new, pure/stdlib) — `contradicted_absence_claims(answer, haystack)`, an `_ExistenceAttribute` table (the extension point) seeded with **paragon** (the documented repro): reads the subjects the grounding *affirms* have a paragon, flags any reply *sentence* that names an affirmed subject **and** denies its paragon (tight negation patterns + a "no *second* paragon" exclusion).
- `services/btd6_grounding_service.validate_btd6_reply` runs it on the `facts ∪ tool_results` haystack and returns `grounded=False` + note `absence_claim_contradicted`, so the **existing regenerate-once → deterministic refusal** flow handles the downgrade for free; the retry constraint (`_build_grounding_constraint`) tells the model the data *does* list the thing and to state it.

**Verified against the real pipeline:** `build("does the monkey buccaneer have a paragon")` grounds Navarch; a reply saying "...does not have a paragon" is now blocked (`absence_claim_contradicted`), while "...has a paragon, Navarch" passes.

## Linked issue / plan

- Implements `docs/btd6/btd6-absence-claim-guard-design.md` §4.2 (Layer B), recorded as **Update 7**; pairs with the offline corpus probe for the same repro (PR #1510).
- Owner decision recorded as router **Q-0208** (build Layer B now).

## Type of change

- [x] New feature (AI correctness guard)
- [x] Documentation (design doc Update 7 + Q-0208)

## Checks

- [x] `python3.10 scripts/check_quality.py --full` — green (12,884 passed; formatters/mypy clean)
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors (49 pre-existing tracked warnings, none added)
- [x] New tests: 15 util (`test_absence_guard.py`) + 4 service (`test_btd6_grounding_service.py`); full answer-path suite green
- [x] No secrets, tokens, or credentials added

<sub>Born-red session card (Q-0133) — flips to `complete` as the deliberate final step.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoqstmiKgZowTLjYCYynqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoqstmiKgZowTLjYCYynqS)_