### PR TITLE
Wire light_radius + luck into mining gameplay (BUG-0026)

### DIFF
--- a/.sessions/2026-06-27-mining-wire-light-luck.md
+++ b/.sessions/2026-06-27-mining-wire-light-luck.md
@@ -1,0 +1,63 @@
+# 2026-06-27 — Wire the two dead EffectiveStats (light_radius + luck) into mining (BUG-0026)
+
+> **Status:** `in-progress`
+
+**Run type:** owner-directed (in-session greenlight: *"Wire them into gameplay"* — AskUserQuestion answer
+on BUG-0026, recorded as router Q-0208)
+
+## What this run did
+
+BUG-0026 found two `utils/equipment.EffectiveStats` fields — `light_radius` and `luck` — that gear grants
+and the panel labels, but **no game read**, so the "Light"/"Luck" stats did nothing. The owner chose to
+**wire** them (not remove). Both wirings are **additive-safe** (byte-identical when the stat is 0):
+
+- **`light_radius` → the fog-of-war window.** New `utils/mining/grid.reveal_radius(light_radius)`
+  (`min(2 + max(0, light_radius-1), 4)`); `views/mining/grid_mine_view.build_grid_embed` now computes it
+  from the player's `character_stats(...).light_radius` and feeds it to **both** the discovered-cell query
+  and the render so they stay in lock-step. **Non-regressive:** no-light/torch keep the prior radius 2; a
+  lantern → 3, a diamond lantern → 4 (capped). A brighter light literally shows more of the map.
+- **`luck` → rare-find weighting.** `utils/mining/exploration.resolve` now biases the weighted outcome
+  pick toward rarer finds by `luck` (`_luck_weighted`: Common flat, Uncommon ×1.15, Rare ×1.4, Legendary
+  ×1.6 per point). One luck source lifts the rare diamond-vein rate 7.7% → 10% **and** trims the hazard
+  rate (Common stays flat, so hazards fall relatively). Numbers pinned in
+  [`planning/mining-luck-light-numbers-2026-06-27.md`](../planning/mining-luck-light-numbers-2026-06-27.md).
+
+The `_UNWIRED_STATS` allowlist (`test_effective_stats_consumed.py`) is now **empty**, so the
+every-stat-is-consumed invariant *requires* both to stay wired. BUG-0026 → FIXED.
+
+CI: `check_quality --full` green; arch 0 errors; new/updated tests (`reveal_radius`, `luck`, the view
+light-widening case, the now-empty allowlist invariant) pass.
+
+## ⚑ Self-initiated
+
+Owner greenlit "wire them into gameplay" (Q-0208); **I chose the specific mechanics** — `light_radius` →
+reveal-window width, `luck` → rarity-weighted find chance — within that goal, picking the thematic +
+contained + reversible options over inventing a heavier mechanic (e.g. a new fog/visibility system or a
+crit-damage stat). Sim-pinned + byte-identical-when-0, so fully tunable/reversible if the owner wants a
+different feel.
+
+## 💡 Session idea (Q-0089)
+
+*Advertise the now-live `light_radius`/`luck` effects in the gear panel / character sheet.* The stats do
+something now, but the panel still just shows a "Light: 3 / Luck: 2" number with no hint of the payoff —
+a one-line effect blurb ("wider map view", "luckier rare finds") on the gear/character card would make the
+upgrade path *legible*, turning a silent buff into a reason to chase better gear. Small view-layer
+follow-on; routed as an idea, not built here.
+
+## ⟲ Previous-session review (Q-0102)
+
+The immediately-prior PR (#1511, absence-guard Layer B) scoped well to the safe grounded-contradiction
+slice (no false-floor risk) and recorded the owner decision in the router. **What it could have done
+better:** it shipped an *offline* guard for a *live-reported* false-"no" but didn't queue a
+**live-battery probe** for the repro (for when creds are available) — the §4.3 half is noted as gated, but
+the verification of the slice that *did* ship still rests on owner spot-checks. **System improvement:** when
+shipping an offline guard for a live-reported bug, add the live-eval probe in the same PR even if it can't
+run yet, so "verify live later" is a committed test, not a memory. (This session applied the same
+principle — the BUG-0026 fix ships its full regression set, not a deferred "test later".)
+
+## 🧾 Doc audit (Q-0104)
+
+`check_quality --full` green (incl. `check_docs`/`check_consistency`); arch 0 errors. New facts homed: the
+sim-pinned numbers doc (linked from the BUG-0026 entry), BUG-0026 flipped to FIXED with the fix detail.
+The owner decision was recorded as router **Q-0208** in the prior (Layer B) PR — no new router entry
+needed. Ledger: merged-only convention — the next reconciliation adds this PR.

--- a/.sessions/2026-06-27-mining-wire-light-luck.md
+++ b/.sessions/2026-06-27-mining-wire-light-luck.md
@@ -1,6 +1,6 @@
 # 2026-06-27 — Wire the two dead EffectiveStats (light_radius + luck) into mining (BUG-0026)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** owner-directed (in-session greenlight: *"Wire them into gameplay"* — AskUserQuestion answer
 on BUG-0026, recorded as router Q-0208)

--- a/disbot/utils/mining/exploration.py
+++ b/disbot/utils/mining/exploration.py
@@ -274,6 +274,37 @@ def _scale_amount(outcome: ExploreOutcome, stats: equipment.EffectiveStats) -> i
     return amount
 
 
+# Per point of ``luck``, an outcome's selection weight is multiplied by
+# ``(1 + luck * boost)`` where the boost rises with rarity — luck favours
+# fortune, never junk (Common stays at base, so hazards/empty rolls fall in
+# *relative* likelihood as the rarer finds rise). Tuned small: one Lucky Charm
+# (luck 1) lifts a Rare by 40%, a Legendary by 60%; see
+# ``docs/planning/mining-luck-light-numbers-2026-06-27.md``.
+_LUCK_RARITY_BOOST: dict[Rarity, float] = {
+    Rarity.COMMON: 0.0,
+    Rarity.UNCOMMON: 0.15,
+    Rarity.RARE: 0.4,
+    Rarity.LEGENDARY: 0.6,
+}
+
+
+def _luck_weighted(
+    candidates: list[ExploreOutcome],
+    luck: int,
+) -> list[float]:
+    """Selection weights biased toward rarer finds by ``luck``.
+
+    **Byte-identical to the base weights when ``luck <= 0``** (the additive
+    safety property — a player with no luck gear rolls exactly as before).
+    """
+    if luck <= 0:
+        return [o.weight for o in candidates]
+    return [
+        o.weight * (1.0 + luck * _LUCK_RARITY_BOOST.get(o.rarity, 0.0))
+        for o in candidates
+    ]
+
+
 def resolve(
     biome: Biome,
     loadout: Loadout,
@@ -300,9 +331,8 @@ def resolve(
         )
         return ExploreResult(empty, biome, 0, empty.narration)
 
-    outcome = chooser.choices(candidates, weights=[o.weight for o in candidates], k=1)[
-        0
-    ]
+    weights = _luck_weighted(candidates, effective.luck)
+    outcome = chooser.choices(candidates, weights=weights, k=1)[0]
     final_amount = _scale_amount(outcome, effective)
     narration = outcome.narration.format(
         amount=abs(final_amount),

--- a/disbot/utils/mining/grid.py
+++ b/disbot/utils/mining/grid.py
@@ -200,6 +200,26 @@ _FEATURE_LABEL: dict[CellFeature, str] = {
 }
 
 
+# Fog-of-war window sizing. The base half-width is what every player saw before
+# gear ``light_radius`` was wired in; a brighter light widens it so you literally
+# see more of the map at once (capped so the rendered grid stays embed-sized).
+_BASE_REVEAL_RADIUS = 2
+_MAX_REVEAL_RADIUS = 4
+
+
+def reveal_radius(light_radius: int) -> int:
+    """Half-width of the fog-of-war window for a player whose gear sums to
+    ``light_radius``.
+
+    **Non-regressive:** ``light_radius`` 0 or 1 → the base 2, so a player with no
+    light or a single torch sees exactly what they did before this stat was wired.
+    A lantern (2) → 3, a diamond lantern (3) → 4. Capped at
+    :data:`_MAX_REVEAL_RADIUS` so a future brighter light can't blow up the embed.
+    """
+    radius = _BASE_REVEAL_RADIUS + max(0, light_radius - 1)
+    return min(radius, _MAX_REVEAL_RADIUS)
+
+
 def render_local_map(
     seed: int,
     cx: int,

--- a/disbot/views/mining/grid_mine_view.py
+++ b/disbot/views/mining/grid_mine_view.py
@@ -22,13 +22,11 @@ from core.runtime.interaction_helpers import safe_defer, safe_edit
 from services import mining_workflow
 from utils import db
 from utils.mining import energy, grid, world
+from utils.mining.character import character_stats
 from utils.ui_constants import ERROR_COLOR, MINING_COLOR, SUCCESS_COLOR
 from views.base import BaseView
 
 logger = logging.getLogger("bot.views.mining.grid_mine_view")
-
-# Half-width of the rendered fog-of-war window (a (2·R+1)² grid around the player).
-_MAP_RADIUS = 2
 
 
 async def build_grid_embed(
@@ -43,17 +41,23 @@ async def build_grid_embed(
     depth = await db.get_depth(suid, guild_id)
     x, y = await db.get_position(suid, guild_id)
     seed = await db.get_world_seed(guild_id)
+    # A brighter equipped light widens the fog-of-war window (BUG-0026 wiring):
+    # the same radius feeds the discovered-cell query and the render so they
+    # stay in lock-step. light_radius 0-1 keeps the prior default of 2.
+    equipped = await db.get_equipment(suid, guild_id)
+    alloc = await db.get_skills(suid, guild_id)
+    radius = grid.reveal_radius(character_stats(equipped, alloc).light_radius)
     discovered = await db.get_discovered_window(
         suid,
         guild_id,
         depth,
-        x - _MAP_RADIUS,
-        x + _MAP_RADIUS,
-        y - _MAP_RADIUS,
-        y + _MAP_RADIUS,
+        x - radius,
+        x + radius,
+        y - radius,
+        y + radius,
     )
     cell = grid.cell_at(seed, x, y, depth)
-    body = grid.render_local_map(seed, x, y, depth, discovered, radius=_MAP_RADIUS)
+    body = grid.render_local_map(seed, x, y, depth, discovered, radius=radius)
 
     description = grid.describe_cell(cell)
     if note:

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,7 +23,7 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
-## BUG-0026 — `EffectiveStats.light_radius` and `.luck` are dead stats (gear grants them, no game reads them) — OPEN (gameplay decision, guard shipped)
+## BUG-0026 — `EffectiveStats.light_radius` and `.luck` are dead stats (gear grants them, no game reads them) — FIXED (wired — owner decision Q-0208)
 
 - **Symptom (found 2026-06-27 by code inspection while building the Q-0089 `EffectiveStats`
   knob-coverage guard, PR #1505 — not a live report, but a real latent gap):** two fields on the
@@ -40,19 +40,27 @@
   "added the stat, summed it, labelled it, forgot the knob" half-ship class. Every *other* field is
   wired: `mining_power`/`loot_bonus` (exploration yield), `depth_access` (descent gate), `damage`/
   `defense`/`max_health` (the duel), `fishing_power`/`bite_luck` (the cast, #1504).
-- **Why it's OPEN, not auto-fixed:** wiring these is a **gameplay-design decision the owner should make**,
-  not a contained mechanical fix — *what should they do?* (e.g. `light_radius` → a wider reveal radius in
-  the mining grid or a fog/visibility mechanic; `luck` → a crit-find / rare-drop chance on dig). The
-  alternative is to **remove** them (and the gear bonuses + labels) if the design doesn't want them. Both
-  are owner calls; flagged here rather than guessed at.
-- **Stays-fixed guard (shipped this PR, #1505):**
-  `tests/unit/invariants/test_effective_stats_consumed.py` — asserts every `EffectiveStats` field is read
-  by a `disbot/` consumer or is on the documented `_UNWIRED_STATS` allowlist (`light_radius`, `luck`).
-  The allowlist is honesty-checked: the moment either gains a consumer, its allowlist entry must be
-  removed or the test fails — so fixing this bug is self-enforcing, and a *new* dead stat can't ship
-  silently. (Verified: with the allowlist emptied, the guard flags exactly these two.)
-- **Status:** OPEN — finding captured + guarded 2026-06-27 (dispatch run, slice 2). Resolution is a
-  gameplay decision (wire or remove); the guard prevents the class from growing meanwhile.
+- **Owner decision (Q-0208, 2026-06-27): WIRE them** (not remove). The owner chose to give the gear that
+  grants these stats a real effect, with the mechanics the agent proposed (reversible + sim-pinned).
+- **Fix — both wired, byte-identical when the stat is 0:**
+  - **`light_radius` → the fog-of-war window.** `utils/mining/grid.reveal_radius(light_radius)` maps the
+    summed light to the navigator's reveal half-width; `views/mining/grid_mine_view.build_grid_embed` now
+    computes it from the player's `character_stats(...).light_radius` and feeds it to **both** the
+    discovered-cell query and the render. **Non-regressive:** light 0–1 → the prior default 2; a lantern
+    (2) → 3, a diamond lantern (3) → 4 (capped at 4). A brighter light literally lets you see more of the
+    map at once.
+  - **`luck` → rare-find weighting.** `utils/mining/exploration.resolve` now biases the weighted outcome
+    pick toward rarer finds by `luck` (`_luck_weighted`: Common stays flat, Uncommon ×1.15, Rare ×1.4,
+    Legendary ×1.6 per luck point), so the diamond pickaxe's and lucky charm's `luck` makes fortunate
+    finds more frequent. **Byte-identical when `luck <= 0`.** Numbers pinned in
+    [`docs/planning/mining-luck-light-numbers-2026-06-27.md`](../planning/mining-luck-light-numbers-2026-06-27.md).
+- **Stays-fixed guard:** `tests/unit/invariants/test_effective_stats_consumed.py` — its `_UNWIRED_STATS`
+  allowlist is now **empty**, so the invariant (every `EffectiveStats` field is read by a `disbot/`
+  consumer) *requires* `light_radius` + `luck` to stay wired; the moment a reader is removed the test
+  fails. Plus the wiring tests: `test_mining_grid.py::test_reveal_radius_*`,
+  `test_mining_exploration.py::test_luck_*`, and
+  `test_mining_grid_view.py::test_build_grid_embed_widens_window_with_a_brighter_light`.
+- **Status:** FIXED 2026-06-27 (owner-greenlit Q-0208). Live on the next auto-deploy; no data step needed.
 
 ## BUG-0025 — hero-card image stranded/lost when navigating into an image-less sub-panel (profile + XP hub) — FIXED (root)
 

--- a/docs/owner/claims/claude-mining-wire-light-luck.md
+++ b/docs/owner/claims/claude-mining-wire-light-luck.md
@@ -1,0 +1,1 @@
+- branch `claude/mining-wire-light-luck` · scope: wire the two dead EffectiveStats (light_radius → grid reveal window, luck → rare-find weighting) — BUG-0026, owner decision Q-0208 · area: utils/mining/{grid,exploration}.py + views/mining/grid_mine_view.py · 2026-06-27

--- a/docs/planning/mining-luck-light-numbers-2026-06-27.md
+++ b/docs/planning/mining-luck-light-numbers-2026-06-27.md
@@ -1,0 +1,63 @@
+# Mining `luck` + `light_radius` wiring — pinned numbers (BUG-0026)
+
+> **Status:** `reference` — the sim-pinned tuning for the two formerly-dead
+> `EffectiveStats` wired in BUG-0026 (owner decision **Q-0208**, 2026-06-27).
+> Source code wins; figures here are re-derivable from the cited code.
+
+The owner chose to **wire** `light_radius` and `luck` (not remove them). Both are
+**additive-safe** — byte-identical to prior behaviour when the stat is 0 — so they
+change nothing for a player without the relevant gear and only ever *improve* play
+for one who equips it.
+
+## `light_radius` → fog-of-war reveal window
+
+`utils/mining/grid.reveal_radius(light_radius)`:
+`radius = min(2 + max(0, light_radius - 1), 4)`.
+
+| light source (summed `light_radius`) | reveal radius | window |
+|---|---|---|
+| none / single torch (0–1) | **2** (unchanged) | 5×5 |
+| lantern (2) | 3 | 7×7 |
+| diamond lantern (3) | 4 | 9×9 |
+| any future brighter light (4+) | 4 (capped) | 9×9 |
+
+Non-regressive by design: a torch player sees exactly the pre-wiring window; only a
+*better* light widens it. The same radius feeds the discovered-cell DB query and the
+render in `views/mining/grid_mine_view.build_grid_embed`, so they never drift.
+
+## `luck` → rare-find weighting
+
+`utils/mining/exploration._luck_weighted` multiplies each outcome's selection weight
+by `(1 + luck × boost)`, boost by rarity. Common stays flat, so luck never makes
+junk/hazards *more* likely — and because the rarer finds rise, hazards fall in
+*relative* terms.
+
+| rarity | boost per luck point | weight ×, luck 1 / 2 / 3 |
+|---|---|---|
+| Common | 0.00 | 1.00 / 1.00 / 1.00 |
+| Uncommon | 0.15 | 1.15 / 1.30 / 1.45 |
+| Rare | 0.40 | 1.40 / 1.80 / 2.20 |
+| Legendary | 0.60 | 1.60 / 2.20 / 2.80 |
+
+**End-to-end effect** (re-derived from `eligible_outcomes(CAVERN, torch+pickaxe)` —
+6 outcomes, base weight 13):
+
+| luck (gear) | P(rare diamond vein) | P(hazard ambush) |
+|---|---|---|
+| 0 (none) | 7.69% | 15.38% |
+| 1 (lucky charm *or* diamond pickaxe) | 10.00% | 14.29% |
+| 2 (both) | 12.00% | 13.33% |
+| 3 | 13.75% | 12.50% |
+
+Small and steady: one luck source lifts the rare find by ~⅓ and trims the hazard
+rate. Tunable via `_LUCK_RARITY_BOOST` — re-run the figures above
+(`PYTHONPATH=disbot python3.10 -c "..."`) if the table changes.
+
+## Guards
+
+- `tests/unit/invariants/test_effective_stats_consumed.py` — `_UNWIRED_STATS` is now
+  **empty**; the invariant fails if either stat loses its consumer.
+- `tests/unit/utils/test_mining_grid.py::test_reveal_radius_*` — the curve + cap.
+- `tests/unit/cogs/test_mining_exploration.py::test_luck_*` — identity at 0, rarity
+  ordering, end-to-end rare-rate increase.
+- `tests/unit/views/test_mining_grid_view.py::test_build_grid_embed_widens_window_with_a_brighter_light`.

--- a/tests/unit/cogs/test_mining_exploration.py
+++ b/tests/unit/cogs/test_mining_exploration.py
@@ -186,3 +186,52 @@ def test_explore_from_state_default_biome_is_surface():
         equipped, {}, biome=exp.Biome.SURFACE, rng=random.Random(3)
     )
     assert default == explicit
+
+
+# --- luck → rare-find weighting (BUG-0026 wiring) --------------------------
+
+
+def test_luck_weighting_is_identity_at_zero():
+    # No luck gear → selection weights are byte-identical to the base weights
+    # (the additive safety property — a luckless player rolls exactly as before).
+    from utils.mining.exploration import _luck_weighted
+
+    cands = list(exp.CATALOG)
+    assert _luck_weighted(cands, 0) == [o.weight for o in cands]
+    assert _luck_weighted(cands, -2) == [o.weight for o in cands]
+
+
+def test_luck_boosts_by_rarity_common_flat_legendary_most():
+    # Per point of luck the weight multiplier rises with rarity; Common stays flat.
+    from utils.mining.exploration import _luck_weighted
+
+    by_rarity = {o.rarity: o for o in exp.CATALOG}
+    cands = [
+        by_rarity[exp.Rarity.COMMON],
+        by_rarity[exp.Rarity.UNCOMMON],
+        by_rarity[exp.Rarity.RARE],
+        by_rarity[exp.Rarity.LEGENDARY],
+    ]
+    base = [o.weight for o in cands]
+    ratios = [b / w for b, w in zip(_luck_weighted(cands, 1), base)]
+    assert ratios[0] == 1.0  # Common unchanged
+    assert 1.0 < ratios[1] < ratios[2] < ratios[3]  # rarer → bigger boost
+
+
+def test_luck_increases_rare_find_frequency_end_to_end():
+    # Through resolve(): luck makes the Cavern's rare diamond vein more frequent.
+    from utils.equipment import EffectiveStats
+
+    loadout = exp.Loadout(tools=frozenset({exp.TORCH, exp.PICKAXE}))
+
+    def diamond_hits(luck: int) -> int:
+        rng = random.Random(7)
+        return sum(
+            exp.resolve_to_legacy_tuple(
+                exp.Biome.CAVERN, loadout, stats=EffectiveStats(luck=luck), rng=rng
+            )[1]
+            == "diamond"
+            for _ in range(3000)
+        )
+
+    assert diamond_hits(3) > diamond_hits(0)

--- a/tests/unit/invariants/test_effective_stats_consumed.py
+++ b/tests/unit/invariants/test_effective_stats_consumed.py
@@ -9,13 +9,13 @@ cares about into its own math (``mining_power``/``light_radius``/``depth_access`
 into a consumer — so the "added the stat, summed it, labelled it, but forgot the
 knob" half-ship could ship silently.
 
-Building this guard surfaced a real latent bug: ``light_radius`` and ``luck`` are
-**dead stats** — defined, summed, and labelled, but no game reads them to change
-behaviour (the diamond pickaxe's ``luck=1``, the lucky charm's ``luck``, and every
-torch's ``light_radius`` currently do nothing). They are captured in
-``docs/health/bug-book.md`` (wire-it-or-remove-it, an owner gameplay decision) and
-allowlisted below; the second test keeps the allowlist honest, so the moment one is
-wired its allowlist entry must go (or this test fails).
+Building this guard surfaced a real latent bug: ``light_radius`` and ``luck`` *were*
+**dead stats** — defined, summed, and labelled, but read by no game. The owner chose
+to wire them (BUG-0026), so they are now consumed (``light_radius`` → the fog-of-war
+window in ``grid.reveal_radius``; ``luck`` → rare-find weighting in
+``exploration.resolve``) and the allowlist below is **empty**. The second test keeps
+the allowlist honest, so the moment a *new* dead stat ships its allowlist entry must
+go (or this test fails).
 
 AST-scoped to ``disbot/`` so it runs in well under a second and needs no live
 bot / DB.
@@ -41,10 +41,12 @@ _DISBOT = Path(__file__).resolve().parents[3] / "disbot"
 _DEFINITION = _DISBOT / "utils" / "equipment.py"
 
 # Stats that are defined on EffectiveStats but not yet read by any game's
-# consumption path — the dead-stat finding captured in docs/health/bug-book.md.
-# REMOVE a name here the moment a consumer reads it (the honesty test below
-# fails closed otherwise). Adding a NEW name here requires a bug-book entry.
-_UNWIRED_STATS: frozenset[str] = frozenset({"light_radius", "luck"})
+# consumption path. EMPTY now that light_radius + luck are wired (BUG-0026 FIXED,
+# 2026-06-27): light_radius → grid.reveal_radius (the fog-of-war window widens with
+# a brighter light), luck → exploration rare-find weighting. REMOVE a name here the
+# moment a consumer reads it (the honesty test below fails closed otherwise);
+# adding a NEW name requires a docs/health/bug-book.md entry.
+_UNWIRED_STATS: frozenset[str] = frozenset()
 
 
 def _stat_field_names() -> set[str]:

--- a/tests/unit/utils/test_mining_grid.py
+++ b/tests/unit/utils/test_mining_grid.py
@@ -161,3 +161,24 @@ def test_describe_cell_mentions_ore_only_for_notable_cells():
     assert "gold" in grid.describe_cell(_cell(CellFeature.RICH, "gold"))
     # NORMAL cells don't name an ore (nothing notable underfoot).
     assert "(" not in grid.describe_cell(_cell(CellFeature.NORMAL))
+
+
+# ---------------------------------------------------------------------------
+# reveal_radius — light_radius → fog-of-war window (BUG-0026 wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_reveal_radius_is_non_regressive_for_no_or_single_light():
+    # No light or a single torch keeps the historical default window of 2.
+    assert grid.reveal_radius(0) == 2
+    assert grid.reveal_radius(1) == 2
+
+
+def test_reveal_radius_widens_with_a_brighter_light():
+    assert grid.reveal_radius(2) == 3  # lantern
+    assert grid.reveal_radius(3) == 4  # diamond lantern
+
+
+def test_reveal_radius_is_capped_so_a_future_light_cannot_blow_up_the_embed():
+    assert grid.reveal_radius(10) == 4
+    assert grid.reveal_radius(99) == grid.reveal_radius(3)

--- a/tests/unit/views/test_mining_grid_view.py
+++ b/tests/unit/views/test_mining_grid_view.py
@@ -80,6 +80,8 @@ async def test_build_grid_embed_shows_position_depth_seed_and_map():
         get_world_seed=AsyncMock(return_value=4242),
         get_discovered_window=AsyncMock(return_value=set()),
         get_energy=AsyncMock(return_value=(60, 0)),
+        get_equipment=AsyncMock(return_value={}),
+        get_skills=AsyncMock(return_value={}),
     ):
         embed = await build_grid_embed(1, 2)
     field_names = [f.name for f in embed.fields]
@@ -90,6 +92,31 @@ async def test_build_grid_embed_shows_position_depth_seed_and_map():
     assert "4242" in seed_field.value
     map_field = next(f for f in embed.fields if "Map" in f.name)
     assert grid.PLAYER_GLYPH in map_field.value
+
+
+@pytest.mark.asyncio
+async def test_build_grid_embed_widens_window_with_a_brighter_light():
+    # A diamond-lantern-grade light (light_radius 3 → reveal radius 4, BUG-0026)
+    # widens the discovered-cell query beyond the base 2 — proving the stat is wired.
+    from utils.equipment import EffectiveStats
+
+    window = AsyncMock(return_value=set())
+    with patch.multiple(
+        "views.mining.grid_mine_view.db",
+        get_depth=AsyncMock(return_value=0),
+        get_position=AsyncMock(return_value=(0, 0)),
+        get_world_seed=AsyncMock(return_value=4242),
+        get_discovered_window=window,
+        get_energy=AsyncMock(return_value=(60, 0)),
+        get_equipment=AsyncMock(return_value={"light": "diamond lantern"}),
+        get_skills=AsyncMock(return_value={}),
+    ), patch(
+        "views.mining.grid_mine_view.character_stats",
+        return_value=EffectiveStats(light_radius=3),
+    ):
+        await build_grid_embed(1, 2)
+    # get_discovered_window(suid, guild, depth, x-R, x+R, y-R, y+R) — R must be 4.
+    assert window.await_args.args[3:7] == (-4, 4, -4, 4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

BUG-0026 found two `utils/equipment.EffectiveStats` fields — `light_radius` and `luck` — that gear granted and the panel labelled, but **no game read**, so the "Light"/"Luck" stats did nothing. The owner chose to **wire** them (router **Q-0208** — wire, not remove). Both wirings are **additive-safe** (byte-identical when the stat is 0, so nothing changes for a player without the gear):

- **`light_radius` → the fog-of-war window.** New `utils/mining/grid.reveal_radius(light_radius)` = `min(2 + max(0, light_radius-1), 4)`; `views/mining/grid_mine_view.build_grid_embed` computes it from the player's `character_stats(...).light_radius` and feeds it to **both** the discovered-cell DB query and the render (lock-step). **Non-regressive:** no-light/torch keep the prior radius 2; a lantern → 3, a diamond lantern → 4 (capped). A brighter light literally shows more of the map.
- **`luck` → rare-find weighting.** `utils/mining/exploration.resolve` biases the weighted outcome pick toward rarer finds by `luck` (`_luck_weighted`: Common flat, Uncommon ×1.15, Rare ×1.4, Legendary ×1.6 per point). One luck source lifts the Cavern's rare diamond-vein rate **7.7% → 10%** (→ 13.75% at luck 3) **and** trims the hazard rate (Common stays flat, so hazards fall relatively). Numbers pinned in `docs/planning/mining-luck-light-numbers-2026-06-27.md`.

The `_UNWIRED_STATS` allowlist (`test_effective_stats_consumed.py`) is now **empty**, so the every-stat-is-consumed invariant *requires* both to stay wired. **BUG-0026 → FIXED.**

## Linked issue / plan

- Fixes **BUG-0026** (`docs/health/bug-book.md`); implements owner decision **Q-0208**.
- Tuning record: `docs/planning/mining-luck-light-numbers-2026-06-27.md`.

## Type of change

- [x] Bug fix (dead-stat wiring)
- [x] New feature (gear stats now affect play)

## Checks

- [x] `python3.10 scripts/check_quality.py --full` — running as the final gate; targeted suites + `--check-only` (lint/format/docs/consistency) green
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors (49 pre-existing warnings, none added)
- [x] Tests: `reveal_radius` curve+cap, `luck` identity/ordering/end-to-end, the view light-widening case, the now-empty allowlist invariant
- [x] No secrets, tokens, or credentials added

<sub>Born-red session card (Q-0133) — flips to `complete` as the deliberate final step after the full suite confirms green.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoqstmiKgZowTLjYCYynqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoqstmiKgZowTLjYCYynqS)_