### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-28T03:14:38Z",
+    "generated_at": "2026-06-28T05:30:21Z",
     "build": {
-      "commit": "1b1170b6",
-      "subject": "feat(docs): assess Fishing, Counting, Word Chain against the completion rubric",
-      "committed_at": "2026-06-28T03:14:38Z"
+      "commit": "d901330a",
+      "subject": "Merge pull request #1519 from menno420/claude/funny-franklin-lye7pc",
+      "committed_at": "2026-06-28T05:30:21Z"
     },
     "counts": {
       "functions": 43,
@@ -2601,10 +2601,10 @@
     {
       "file": "2026-06-28-feature-completion-assessments.md",
       "date": "2026-06-28",
-      "title": "2026-06-28 — Feature-completion unit assessments (Q-0209 framework)",
-      "status": "in-progress",
+      "title": "2026-06-28 — Feature-completion unit assessments + counting leaderboard",
+      "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
+      "self_initiated": true
     },
     {
       "file": "2026-06-27-youtube-fetch-renderer-tests.md",


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.