### PR TITLE
Fishing + Counting completion punch-list: un-trap shops, menu nav/rules, player entry point

### DIFF
--- a/.sessions/2026-06-28-fishing-counting-completion-punchlist.md
+++ b/.sessions/2026-06-28-fishing-counting-completion-punchlist.md
@@ -1,19 +1,87 @@
 # 2026-06-28 — Fishing + Counting feature-completion punch-list clears
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch (no work order — advancing the S1 completion-first arc, Q-0209)
 
-## What this run is about (born-red card)
+## What this run did
 
-The S1 completion-first arc (Q-0209) assessed Fishing and Counting to `◐` and surfaced contained,
-**offline** UX punch-list gaps. This run clears the offline-fit ones at the root:
+The S1 completion-first arc (Q-0209) had assessed Fishing and Counting to `◐` and surfaced contained,
+**offline** UX punch-list gaps. This run cleared all three offline-fit ones at the root (PR #1521).
 
-- **Fishing #1 (headline):** Rod/Bait shops are *trapped views* — `FishingMenuView` `self.stop()`s
-  when it opens them and the shops have no way back, so a player who opens Rod/Bait is stranded.
-  → add return navigation (↩ Fishing menu) + make the menu carry standard Help/↩ Games nav.
-- **Fishing #2 (minor):** no dedicated "how to play" affordance — add a 📖 How to fish button.
-- **Counting #3:** the only registered `entry_point` is the admin-only `countingmenu`, so counting
-  has no player-facing discovery surface → register the player commands as entry points.
+**Fishing #1 (headline) — trapped shop views.** `FishingMenuView` `self.stop()`s when it opens the
+Rod/Bait shops, and the shops were `BaseView` panels with no way back — a player who opened Rod/Bait
+was stranded with no path to the menu, Games hub, or Help. Fixed:
+- `RodShopView`/`BaitShopView` each gained a **↩ Fishing menu** `back_btn` that rebuilds the menu in
+  place via the new module helper `menu.open_fishing_menu` (lazy-imported in the shops to respect the
+  menu→shop import direction — no new cycle).
+- `FishingMenuView` now declares `SUBSYSTEM = "fishing"` so `attach_standard_nav` adds **📚 Help** +
+  **↩ Games** (the 2026-06-23 never-stranded directive; mirrors `_FishingDoneView`). The menu itself
+  previously lacked these — a real consistency gap, fixed on sight. Back-from-shop now lands on a
+  fully-navigable menu.
 
-Mark the cleared punch-list items in the two completion certificates.
+**Fishing #2 (minor) — rules affordance.** A **📖 How to fish** button on the menu sends an ephemeral
+how-to-play card (`rules_btn` → `_rules_embed`), mirroring the blackjack panel's rules button.
+Allowlisted in `consistency_exceptions.yml` (`edit_in_place`) — a read-only help aside is a genuine
+new ephemeral, not a panel re-render.
+
+**Counting #3 — admin-only discovery.** The only registered `entry_point` was the staff-only
+`countingmenu`; counting had no player-facing discovery surface. `entry_points` now leads with the
+existing player commands `count_info`/`counttop` (then `countingmenu`).
+
+Both completion certificates (`feature-completion/units/{fishing,counting}.md`) updated to mark the
+cleared items; each unit's remaining gaps are now owner-paced only (live walkthrough + sign-off; the
+fishing coins Q-0175 and counting-reward decisions).
+
+**Verified:** `check_quality --full` green (12953 tests; black/isort/ruff/mypy/check_consistency all
+pass — fixed a black wrap + a COM812 trailing comma + allowlisted the rules-button ephemeral that the
+first full run flagged); `check_architecture --mode strict` 0 errors. New tests: shop `back_btn` →
+menu rebuild (rod + bait), menu `SUBSYSTEM`/Help+Games nav, `rules_btn` ephemeral, `open_fishing_menu`.
+
+## 📤 Run report
+
+- **Did:** cleared the offline Fishing (#1/#2) + Counting (#3) completion punch-list gaps · **Outcome:** shipped
+- **Shipped:** #1521 — un-trap Rod/Bait shops (↩ Fishing menu + menu Help/Games nav), 📖 How-to-fish button, counting player entry point
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none (the two units' remaining `◐ → ✔` items are owner-paced: live walkthrough + sign-off; the fishing coins question Q-0175 and the counting XP/coin-reward decision are pre-existing, unchanged by this run)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none — advancing the dispatched S1 completion-first arc (Q-0209) off the assessed punch-lists; no new idea promoted to a plan/build
+- **↪ Next:** S1 completion-first — assess the remaining unassessed units (Mining [big read], Casino, Deathmatch, RPS, Creatures, Chicken Farm) one cert each; then the per-unit live walkthroughs + owner `◐ → ✔` sign-offs (needs a live bot)
+
+## 💡 Session idea (Q-0089)
+
+*A `check_consistency` rule (or a `subsystem_registry` test) that flags any user-tier subsystem whose
+`entry_points` are **all** staff-gated commands.* Counting #3 was exactly this class — a player-facing
+game (`visibility_tier: user`) whose only registered entry point was `@staff_or_owner`-decorated, so it
+had no discovery surface yet looked "wired." The check would catch the next one at lint time instead of
+waiting for a completion assessment to notice. Routed as an idea, not built here (it needs the cog
+decorator→staff-gate mapping, which is more than a one-liner).
+
+## ⟲ Previous-session review (Q-0102)
+
+The prior run (#1518, the fishing pearl rare-material drop) deepened the fishing *economy* well but, like
+the runs before it, kept adding **content** to a unit whose **navigation** was quietly broken — the
+trapped Rod/Bait shops have existed since the shops shipped, unnoticed until the Q-0209 completion
+assessment walked the UX. That's the completion-first arc working as designed: assessing for "right
+buttons in the right places" caught a real stranding bug that feature-velocity sessions skated past.
+**System improvement (applied this run):** the assessment's punch-list is genuinely actionable — I built
+straight off it with no re-investigation. Worth reinforcing in the feature-completion README that an
+`◐`-assessed unit's offline punch-list items are *pre-scoped dispatch work*, so a later run picks them up
+without re-deriving the gap.
+
+## 🧾 Doc audit (Q-0104)
+
+`check_quality --full` green (incl. `check_docs`/`check_consistency`); arch 0 errors. New facts homed in
+their durable place: the two completion certificates updated in lockstep with the code; no new owner
+decision (the run executed within Q-0209/Q-0175's existing envelope). Ledger: merged-only convention —
+the next reconciliation pass adds #1521. No chat-only facts left unhomed.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs opened | 1 (#1521) |
+| Punch-list gaps cleared | 3 (Fishing #1, #2; Counting #3) |
+| Files touched | 9 (3 runtime views, 1 registry, 1 arch-allowlist, 2 certs, 3 tests — net new tests +4 cases) |
+| New test cases | 4 (rod/bait back-nav, menu nav, rules ephemeral, open_fishing_menu) |
+| CI | `check_quality --full` green · `check_architecture --mode strict` 0 errors |

--- a/.sessions/2026-06-28-fishing-counting-completion-punchlist.md
+++ b/.sessions/2026-06-28-fishing-counting-completion-punchlist.md
@@ -1,0 +1,19 @@
+# 2026-06-28 — Fishing + Counting feature-completion punch-list clears
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch (no work order — advancing the S1 completion-first arc, Q-0209)
+
+## What this run is about (born-red card)
+
+The S1 completion-first arc (Q-0209) assessed Fishing and Counting to `◐` and surfaced contained,
+**offline** UX punch-list gaps. This run clears the offline-fit ones at the root:
+
+- **Fishing #1 (headline):** Rod/Bait shops are *trapped views* — `FishingMenuView` `self.stop()`s
+  when it opens them and the shops have no way back, so a player who opens Rod/Bait is stranded.
+  → add return navigation (↩ Fishing menu) + make the menu carry standard Help/↩ Games nav.
+- **Fishing #2 (minor):** no dedicated "how to play" affordance — add a 📖 How to fish button.
+- **Counting #3:** the only registered `entry_point` is the admin-only `countingmenu`, so counting
+  has no player-facing discovery surface → register the player commands as entry points.
+
+Mark the cleared punch-list items in the two completion certificates.

--- a/architecture_rules/consistency_exceptions.yml
+++ b/architecture_rules/consistency_exceptions.yml
@@ -106,6 +106,8 @@ edit_in_place:
       reason: "Terminal apply-outcome report after installing the template (the config view's job is done)."
     - pattern: views/setup/template_picker.py::TemplateConfigView._cancel
       reason: "Terminal 'cancelled — not installed' confirmation toast."
+    - pattern: views/fishing/menu.py::FishingMenuView.rules_btn
+      reason: "Read-only ephemeral 'how to fish' help card (mirrors the blackjack rules button); the menu panel is unchanged by viewing it — a genuine new message, not a panel re-render."
     - pattern: views/tickets/hub.py::TicketHubView.list_btn
       reason: "Read-only ephemeral list of the caller's own open tickets; the hub panel is unchanged by viewing it (a genuine new message, not a panel re-render)."
     - pattern: views/tickets/hub.py::TicketHubView.post_panel_btn

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -883,7 +883,10 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "games",
         "tags": ["games", "counting", "community"],
-        "entry_points": ["countingmenu"],
+        # Player-facing entry points lead (count_info shows live state + top
+        # counters; counttop the leaderboard) so counting has a public discovery
+        # surface — countingmenu stays for the staff config hub.
+        "entry_points": ["count_info", "counttop", "countingmenu"],
         "default_channels": ["counting", "games"],
         "related_subsystems": [],
         "dependencies": [],

--- a/disbot/views/fishing/bait_shop.py
+++ b/disbot/views/fishing/bait_shop.py
@@ -236,3 +236,21 @@ class BaitShopView(BaseView):
         pearls = inventory.get(PEARL_ITEM, 0)
         embed = build_bait_embed(active, charges, balance, pearls=pearls, note=note)
         await safe_edit(interaction, embed=embed, view=self)
+
+    @discord.ui.button(
+        label="↩ Fishing menu",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+    )
+    async def back_btn(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        # The menu self.stop()s when it opens this shop, so a player would be
+        # stranded here — rebuild the fully-navigable menu in place. Lazy import
+        # to respect the menu→shop import direction.
+        from views.fishing.menu import open_fishing_menu
+
+        self.stop()
+        await open_fishing_menu(interaction, self._author, self.guild_id)

--- a/disbot/views/fishing/menu.py
+++ b/disbot/views/fishing/menu.py
@@ -177,8 +177,39 @@ async def _fishdex_embed(
     return build_fishlog_embed(display_name, log, level, records)
 
 
+def _rules_embed() -> discord.Embed:
+    """The "how to fish" quick-reference — the menu's 📖 rules affordance."""
+    return discord.Embed(
+        title="📖 How to fish",
+        description=(
+            "**The loop**\n"
+            "1. **🎣 Cast** — drop a line, then *wait* for the bite.\n"
+            "2. **Bite!** — when the float dips, hit **Reel** before the fish "
+            "spits the hook (reel too early and it spooks).\n"
+            "3. **Fight** the big ones — keep reeling to land a trophy.\n\n"
+            "**Get better catches**\n"
+            "• **🎒 Rod** — upgrade your rod for a wider reel window, faster "
+            "bites, and less escape.\n"
+            "• **🪱 Bait** — load a lure for rarer fish (a consumable knob on "
+            "top of your rod).\n"
+            "• **⛵ Set sail** — head to deepwater for the rare boat-only fish.\n"
+            "• **📖 Fishdex** — track your collection and personal-best weights."
+        ),
+        color=GAME_COLOR,
+    )
+
+
 class FishingMenuView(HubView):
-    """The author-restricted fishing hub panel (Cast · Rod · Fishdex)."""
+    """The author-restricted fishing hub panel (Cast · Rod · Fishdex).
+
+    Declares ``SUBSYSTEM = "fishing"`` so
+    :func:`views.navigation.attach_standard_nav` auto-attaches **📚 Help** +
+    **↩ Games** — a panel reached by ``!fishing`` / the Help hook stays one click
+    from Help and its mother hub (the 2026-06-23 never-stranded directive;
+    mirrors ``_FishingDoneView``).
+    """
+
+    SUBSYSTEM = "fishing"
 
     def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
         super().__init__(author)
@@ -265,3 +296,40 @@ class FishingMenuView(HubView):
         )
         # Keep the menu so the player can Cast / open the Rod shop after browsing.
         await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(
+        label="How to fish",
+        emoji="📖",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def rules_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # An ephemeral how-to-play card (mirrors the blackjack panel's rules
+        # affordance) — the menu embed describes the loop, this spells it out.
+        await interaction.response.send_message(embed=_rules_embed(), ephemeral=True)
+
+
+async def open_fishing_menu(
+    interaction: discord.Interaction,
+    author: discord.Member | discord.User,
+    guild_id: int,
+) -> None:
+    """Rebuild the fishing menu in place — the Rod/Bait shops' ↩ back target.
+
+    The menu ``self.stop()``s when it opens a shop, so the shops can't simply
+    re-show the old menu instance; they call this to mint a fresh, fully-
+    navigable :class:`FishingMenuView` (Cast · Sail · Rod · Bait · Fishdex +
+    Help/↩ Games) and edit it back onto the panel message. Lazy-imported by the
+    shops to respect the menu→shop import direction.
+    """
+    energy = await fishing_workflow.get_energy(author.id, guild_id)
+    profile = await fishing_workflow.get_venue(author.id, guild_id)
+    view = FishingMenuView(author, guild_id)
+    await interaction.response.edit_message(
+        embed=build_menu_embed(energy, profile),
+        view=view,
+    )
+    view.message = interaction.message

--- a/disbot/views/fishing/rod_shop.py
+++ b/disbot/views/fishing/rod_shop.py
@@ -136,3 +136,21 @@ class RodShopView(BaseView):
             return
         result = await fishing_workflow.craft_rod(self._author.id, self.guild_id)
         await self._rerender(interaction, result.tier, result.message)
+
+    @discord.ui.button(
+        label="↩ Fishing menu",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+    )
+    async def back_btn(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        # The menu self.stop()s when it opens this shop, so a player would be
+        # stranded here — rebuild the fully-navigable menu in place. Lazy import
+        # to respect the menu→shop import direction.
+        from views.fishing.menu import open_fishing_menu
+
+        self.stop()
+        await open_fishing_menu(interaction, self._author, self.guild_id)

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -73,10 +73,11 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   startable, offline:** (1) **assess more units** — the unassessed games (Mining [big read], Casino,
   Deathmatch, RPS, Creatures, Chicken Farm) then server-fns, one cert each under
   [`../planning/feature-completion/units/`](../planning/feature-completion/README.md) from the rubric;
-  (2) **close the contained punch-list gaps this run surfaced** — **Fishing #1** (the Rod/Bait shops are
-  *trapped views*: give them back-nav / `attach_standard_nav`; mind the menu↔shop import cycle) and
-  **Counting #3** (no player-facing registry entry point). *(Counting #2 — the dead-state leaderboard —
-  was already closed in #1519: `!counttop` + a `count_info` field.)* **▶ Owner decisions waiting:**
+  (2) the contained offline punch-list gaps are now **cleared (#1521):** **Fishing #1** (Rod/Bait shops
+  un-trapped — ↩ Fishing-menu back button + the menu carries Help/↩ Games nav) + **#2** (📖 How-to-fish
+  button), and **Counting #3** (player-facing `count_info`/`counttop` lead the registry `entry_points`).
+  *(Counting #2 — the dead-state leaderboard — was closed in #1519: `!counttop` + a `count_info` field.)*
+  Each unit's remaining items are now owner-paced (live walkthrough + `◐ → ✔` sign-off). **▶ Owner decisions waiting:**
   Word Chain re-classify (game vs. moderation tool), Counting XP/coin reward, plus every unit's final
   `◐ → ✔` sign-off (needs a live walkthrough — `[needs-live-bot]`/`[owner]`).
 - `[offline]` **Fishing-specific gear stats — SHIPPED 2026-06-27 (#1504)** (see Recently shipped above):

--- a/docs/owner/claims/claude-funny-franklin-upk5bc.md
+++ b/docs/owner/claims/claude-funny-franklin-upk5bc.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-upk5bc` · S1 feature-completion punch-list clears (Fishing #1/#2 trapped-shop nav + rules button; Counting #3 player entry point) · `disbot/views/fishing/*` · `disbot/utils/subsystem_registry.py` · `docs/planning/feature-completion/units/*` · 2026-06-28

--- a/docs/owner/claims/claude-funny-franklin-upk5bc.md
+++ b/docs/owner/claims/claude-funny-franklin-upk5bc.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-upk5bc` · S1 feature-completion punch-list clears (Fishing #1/#2 trapped-shop nav + rules button; Counting #3 player entry point) · `disbot/views/fishing/*` · `disbot/utils/subsystem_registry.py` · `docs/planning/feature-completion/units/*` · 2026-06-28

--- a/docs/planning/feature-completion/rubric-game.md
+++ b/docs/planning/feature-completion/rubric-game.md
@@ -34,6 +34,10 @@ item; the unit cannot be `✔ certified` until the punch-list is empty and the o
       selection on the panel; nothing buried or misplaced.
 - [ ] **A "Rules / how to play" affordance** is reachable.
 - [ ] **Return navigation everywhere** — back to the game panel and to Help; no trapped views.
+      *Watch the common trap:* a hub/menu that `self.stop()`s when it opens a sub-panel, where the
+      sub-panel is a plain `BaseView` with no back affordance → the player is stranded (the Fishing
+      Rod/Bait shops, fixed in #1521). Check every sub-panel a menu hands off to: does it carry a
+      `↩ <menu>` button (or `SUBSYSTEM` so `attach_standard_nav` adds Help + ↩ hub)?
 - [ ] **Terminal state is visually correct** — finished hands/rounds disable or swap their controls;
       no stale clickable buttons after the game ends.
 - [ ] **Embeds/copy are consistent** — titles, emojis, result text follow the house style; no

--- a/docs/planning/feature-completion/units/counting.md
+++ b/docs/planning/feature-completion/units/counting.md
@@ -66,10 +66,10 @@
 ### E. Money-safety integration — N/A (no economy surface; no wagering).
 
 ### F. Wiring & discoverability
-- [⚠] **Registry entry_points are admin-only** — `entry_points: ["countingmenu"]`
-      (`subsystem_registry.py`), which is `@staff_or_owner`. There is **no player-facing entry point**;
-      a player discovers counting only by being in a counting channel. `count_info`/`count_rules` are
-      public commands but aren't registered entry points. → punch-list #3.
+- [x] **Registry has a player entry point** — ✅ fixed (punch-list #3, PR #1521):
+      `entry_points: ["count_info", "counttop", "countingmenu"]` (`subsystem_registry.py`) — the
+      player-facing `count_info`/`counttop` lead so counting has a public discovery surface; the
+      staff-only `countingmenu` config hub stays registered too.
 - [x] **Help + Games hub** — registered `parent_hub: games`, `hub_group: activities`; Help hook returns
       the (admin) hub.
 - [x] **Configurable** — turns, reset-on-wrong, skip-step are per-channel admin toggles.
@@ -91,8 +91,9 @@
    owner waives it (counting is a collaborative streak, reward-free by design). Needs an owner call.
 2. ✅ **DONE this run — leaderboard surfaced.** `!counttop` + a `count_info` top-3 field
    (`cogs/counting/leaderboard.py`, tested). The previously-dead tally is now player-visible.
-3. **Player-facing discovery** — add a player entry point (e.g. surface `count_info`/`count_rules`/the
-   new `counttop` as the unit's player entry) so counting isn't admin-only in the registry.
+3. ~~**Player-facing discovery**~~ ✅ **FIXED 2026-06-28 (PR #1521).** `entry_points` now leads with the
+   player-facing `count_info`/`counttop` (then `countingmenu`), so counting is no longer admin-only in
+   the registry.
 4. **Live walkthrough** — `/verify-bot` boot + a scripted play-through of a couple of modes (normal +
    one exotic, e.g. prime/random) showing validate/reset/turns, with screenshots, attached here.
 5. **Owner sign-off** — maintainer plays it and confirms "nothing left to add or move," resolving #1.
@@ -110,7 +111,8 @@
 Counting is **deep and well-engineered** — 11 modes, math-expression parsing, DB-persisted
 restart-safe state, scope-locked concurrency, and a real security hardening (BUG-0012). The
 **invisible-leaderboard** gap (#2) was **closed this run** — the standings are now player-visible via
-`!counttop` + `count_info`. It is **not yet `✔ certified`**: what remains is **admin-only discovery**
-(#3) and the **reward decision** (#1), then the walkthrough (#4) + owner sign-off (#5). The assess →
+`!counttop` + `count_info`, and the **admin-only discovery** gap (#3) was **closed (PR #1521)** —
+`entry_points` now leads with player commands. It is **not yet `✔ certified`**: what remains is the
+**reward decision** (#1, owner call), then the walkthrough (#4) + owner sign-off (#5). The assess →
 close loop the framework exists for is demonstrated here: assess surfaced the dead-state leaderboard,
 the same PR shipped the fix.

--- a/docs/planning/feature-completion/units/fishing.md
+++ b/docs/planning/feature-completion/units/fishing.md
@@ -38,13 +38,15 @@
       Fishdex), reached from `!fishing` and the Help hook (`menu.py:180-268`).
 - [x] **Every action has a control in the right place** — cast/sail/rod/bait/dex on the menu;
       reel on the cast view.
-- [~] **Rules affordance** — the menu embed *describes* the loop inline (`menu.py:56-65`); there is no
-      dedicated "📖 Rules / how to play" button as the blackjack panel has. → punch-list #2 (minor).
-- [ ] **Return navigation everywhere** — the **cast** flow has full nav (Cast again + Help + Games via
-      `_FishingDoneView`). But the **Rod shop** and **Bait shop** are `BaseView` panels with **no back
-      button** (`rod_shop.py:88`, `bait_shop.py:209`), and `FishingMenuView` **`self.stop()`s** when it
-      opens them (`menu.py:236,253`) — so a player who opens Rod/Bait is **trapped** with no way back
-      to the menu, Games hub, or Help. → **punch-list #1 (headline gap).**
+- [x] **Rules affordance** — ✅ fixed (punch-list #2): a dedicated **📖 How to fish** button on the
+      menu sends an ephemeral how-to-play card (`menu.py` `rules_btn`/`_rules_embed`), mirroring the
+      blackjack panel; the menu embed still describes the loop inline as well.
+- [x] **Return navigation everywhere** — ✅ fixed (punch-list #1, headline). The **cast** flow already
+      had full nav (`_FishingDoneView`); now the **Rod shop** and **Bait shop** each carry a
+      **↩ Fishing menu** button that rebuilds the menu in place (`rod_shop.py`/`bait_shop.py`
+      `back_btn` → `menu.open_fishing_menu`, lazy-imported for the menu→shop cycle), and
+      `FishingMenuView` declares `SUBSYSTEM = "fishing"` so `attach_standard_nav` adds **📚 Help** +
+      **↩ Games** — so back-from-shop lands on a fully-navigable menu (the 2026-06-23 directive).
 - [x] **Terminal state correct** — disable-on-terminal + handoff to the Done view; the cast button
       label/style track the phase (`cast_view.py:445-447,182-192`).
 - [x] **Consistent copy/embeds** — house-style embeds, shared colours (`GAME_COLOR`/`SUCCESS`/`ERROR`).
@@ -98,13 +100,13 @@
 
 ## Punch-list (clear these to certify)
 
-1. **Trapped shop views (headline).** Give `RodShopView` and `BaitShopView` return navigation — a
-   "↩ Fishing menu" button (or convert them to `HubView` with `SUBSYSTEM = "fishing"` so
-   `attach_standard_nav` adds 📚 Help + ↩ Games, the pattern `_FishingDoneView` already uses). Today
-   opening Rod/Bait from the menu strands the player (the menu `self.stop()`s and the shops have no way
-   back). Offline/contained; mind the menu↔shop import cycle (lazy-import or the HubView route).
-2. **Rules affordance + minor UX** — a dedicated "📖 How to fish" button on the menu (the loop is only
-   described in the embed body today); optionally a quick-rebet equivalent.
+1. ~~**Trapped shop views (headline).**~~ ✅ **FIXED 2026-06-28 (PR #1521).** `RodShopView` and
+   `BaitShopView` each got a **↩ Fishing menu** `back_btn` that rebuilds the menu in place via
+   `menu.open_fishing_menu` (lazy-imported for the menu→shop cycle), and `FishingMenuView` now declares
+   `SUBSYSTEM = "fishing"` so `attach_standard_nav` adds 📚 Help + ↩ Games — back-from-shop lands on a
+   fully-navigable menu.
+2. ~~**Rules affordance + minor UX**~~ ✅ **FIXED 2026-06-28 (PR #1521).** A dedicated **📖 How to fish**
+   button on the menu (`rules_btn` → ephemeral `_rules_embed`) mirrors the blackjack panel.
 3. *(none — test coverage is strong; A/D/E/G loop+edge+money items are all green.)*
 4. **Live walkthrough** — `/verify-bot` boot + scripted click-through (cast → trophy fight → got-away →
    menu → rod → bait → dex → sail), with screenshots, attached here.
@@ -123,7 +125,7 @@
 
 Fishing is **substantially complete and feature-rich** — a genuine skill-moment cast loop with trophy
 fights, two venues, daily weather, four craft paths, leaderboards, and a dex, all on an audited write
-seam with strong tests. It is **not yet `✔ certified`**: the one real UX-completeness gap is the
-**trapped Rod/Bait shop views** (#1) — fix that and the menu is a fully-navigable place. Add a Rules
-button (#2), record the walkthrough (#4), and get the owner's coins/sign-off call (#5). #1 and #2 are
-a focused offline session; #4/#5 are owner-paced.
+seam with strong tests. The two offline UX gaps are **cleared (PR #1521):** the Rod/Bait shops are
+no longer trapped (#1) and the menu has a 📖 How-to-fish button (#2). It is **not yet `✔ certified`**:
+what remains is owner-paced — record the walkthrough (#4) and get the owner's coins/sign-off call (#5,
+resolving the deferred fish-value/coins question Q-0175).

--- a/tests/unit/views/test_fishing_bait_shop.py
+++ b/tests/unit/views/test_fishing_bait_shop.py
@@ -8,7 +8,10 @@ assertions.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import discord
+import pytest
 
 from utils.fishing import bait as bait_mod
 from views.fishing.bait_shop import (
@@ -61,3 +64,33 @@ def test_panel_wires_buy_fish_craft_and_pearl_craft_selects():
 
 def test_embed_is_a_discord_embed():
     assert isinstance(build_bait_embed(None, 0, 0, pearls=1), discord.Embed)
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_the_fishing_menu():
+    # The menu self.stop()s when it opens the shop, so the back button must mint
+    # a fresh, fully-navigable FishingMenuView (punch-list #1, the trapped-view fix).
+    from views.fishing.menu import FishingMenuView
+
+    author = MagicMock()
+    author.id = 7
+    view = BaitShopView(author, guild_id=99)
+    interaction = MagicMock()
+    interaction.message = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    with (
+        patch(
+            "views.fishing.menu.fishing_workflow.get_energy",
+            AsyncMock(return_value=5),
+        ),
+        patch(
+            "views.fishing.menu.fishing_workflow.get_venue",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await type(view).back_btn(view, interaction, MagicMock())
+
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.await_args
+    assert isinstance(kwargs["view"], FishingMenuView)
+    assert view.is_finished()

--- a/tests/unit/views/test_fishing_menu.py
+++ b/tests/unit/views/test_fishing_menu.py
@@ -194,3 +194,46 @@ async def test_fishdex_button_renders_the_collection_and_keeps_the_menu():
     interaction.response.edit_message.assert_awaited_once()
     _, kwargs = interaction.response.edit_message.await_args
     assert kwargs["view"] is view  # the menu stays so you can act again
+
+
+def test_menu_declares_the_fishing_subsystem_for_standard_nav():
+    # SUBSYSTEM = "fishing" makes attach_standard_nav add 📚 Help + ↩ Games so the
+    # menu is never a dead-end (the 2026-06-23 never-stranded directive).
+    assert FishingMenuView.SUBSYSTEM == "fishing"
+    view = _menu()
+    labels = [getattr(c, "label", "") or "" for c in view.children]
+    assert any("Help" in lbl for lbl in labels)
+    assert any("Games" in lbl for lbl in labels)
+
+
+@pytest.mark.asyncio
+async def test_rules_button_sends_an_ephemeral_how_to_card():
+    view = _menu()
+    interaction = _interaction()
+    await _click(view, "rules_btn", interaction)
+    interaction.response.send_message.assert_awaited_once()
+    _, kwargs = interaction.response.send_message.await_args
+    assert kwargs.get("ephemeral") is True
+    assert "How to fish" in kwargs["embed"].title
+
+
+@pytest.mark.asyncio
+async def test_open_fishing_menu_rebuilds_a_navigable_menu():
+    from views.fishing.menu import open_fishing_menu
+
+    interaction = _interaction()
+    with (
+        patch(
+            "views.fishing.menu.fishing_workflow.get_energy",
+            AsyncMock(return_value=9),
+        ),
+        patch(
+            "views.fishing.menu.fishing_workflow.get_venue",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await open_fishing_menu(interaction, _author(), guild_id=99)
+
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.await_args
+    assert isinstance(kwargs["view"], FishingMenuView)

--- a/tests/unit/views/test_fishing_rod_shop.py
+++ b/tests/unit/views/test_fishing_rod_shop.py
@@ -69,3 +69,29 @@ async def test_craft_button_calls_craft_rod_and_rerenders():
     # crafting into tier 1 (not the top) leaves both buttons live
     assert view.craft_btn.disabled is False
     assert view.upgrade_btn.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_the_fishing_menu():
+    # The menu self.stop()s when it opens the shop, so the back button must mint
+    # a fresh, fully-navigable FishingMenuView (punch-list #1, the trapped-view fix).
+    from views.fishing.menu import FishingMenuView
+
+    view = RodShopView(_author(7), 99, at_max=False)
+    interaction = _interaction(7)
+    with (
+        patch(
+            "views.fishing.menu.fishing_workflow.get_energy",
+            AsyncMock(return_value=5),
+        ),
+        patch(
+            "views.fishing.menu.fishing_workflow.get_venue",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await type(view).back_btn(view, interaction, MagicMock())
+
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.await_args
+    assert isinstance(kwargs["view"], FishingMenuView)
+    assert view.is_finished()  # the shop view stopped so it can't fight for the message


### PR DESCRIPTION
## Why

S1 completion-first arc (Q-0209). The Fishing and Counting completion assessments (`◐`) surfaced
contained, **offline** UX punch-list gaps. This PR clears the offline-fit ones at the root.

## What

**Fishing #1 (headline) — trapped shop views.** `FishingMenuView` `self.stop()`s when it opens the
Rod/Bait shops, and the shops were `BaseView` panels with no way back — a player who opened Rod/Bait
was stranded. Fix:
- `RodShopView`/`BaitShopView` get a **↩ Fishing menu** back button that rebuilds the menu in place
  (lazy-import `open_fishing_menu` to respect the menu↔shop import direction).
- `FishingMenuView` now declares `SUBSYSTEM = "fishing"` so `attach_standard_nav` adds **📚 Help** +
  **↩ Games** (the 2026-06-23 never-stranded directive; mirrors `_FishingDoneView`) — so back-from-shop
  lands on a fully-navigable menu.

**Fishing #2 (minor) — rules affordance.** A **📖 How to fish** button on the menu sends an ephemeral
how-to-play embed (mirrors the blackjack panel's rules button).

**Counting #3 — admin-only discovery.** The only registered `entry_point` was the staff-only
`countingmenu`; counting had no player-facing discovery surface. Registered the existing player
commands (`count_info`, `counttop`) as entry points.

Both completion certificates updated to mark the cleared items.

## Tests

`python3.10 scripts/check_quality.py --full` + `check_architecture --mode strict` green; new view
back-nav/rules tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFM5iEKkebEReis48vLBcm)_