### PR TITLE
docs(router): document owner answers (Q-0182…Q-0207) + decide the router-vs-durable-home convention

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,6 +87,14 @@ The short version that governs how you work:
   readout, not a block). The maintainer thinks associatively on purpose; classify, route, **then
   build freely**. Pipeline + idea states: `docs/owner/ai-project-workflow.md`; working style:
   `docs/owner/maintainer-working-profile.md`.
+- **Friction → guard (owner directive Q-0194, 2026-06-22; promoted to binding Q-0194-rider,
+  2026-06-28).** Anytime something interrupts a session's workflow — a wrong-branch slip, a stale
+  file, a checker that lied, a footgun — **convert it into the cheapest *enforcing* prevention before
+  the session ends**, in order: **checker / CI / test → hook → journal Rule** ("enforce, don't
+  exhort", Q-0132) — don't merely note it. The point is that the system catches its own mistakes next
+  time instead of relying on the maintainer to spot them. Ownership split: docs / journal / test /
+  checker guards are **free to ship now**; a hook / `.claude/settings.json` / binding-`CLAUDE.md` rule
+  is **owner-gated** (build if owner-directed in-session, else propose a router DISCUSS Q).
 
 ## Read first — agent orientation
 
@@ -424,6 +432,7 @@ Any new import from `views/` in a `services/` file is an immediate ERROR.
 - Before adding a utility function anywhere, read `docs/helper-policy.md`.
 - **Never** define a utility function in `views/` or `cogs/` that other layers need. Move it to `utils/` or `services/`.
 - If a function is needed by both `services/` and `views/`, it belongs in `utils/` — not in either layer.
+- **Exact-name guard (Q-0200):** before defining a new `services/`-or-`utils/` function, `grep "def <exact_name>"` in the target module + its siblings (plus the 1–2 nearest concept synonyms) — a later same-name `def` silently shadows the earlier one (the `round_composition` collision, caught only at CI). Checklist line, not a CI gate; full rationale in `docs/helper-policy.md` §2.
 
 ### Pre-commit verification
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -80,6 +80,16 @@ jobs:
       - name: Run doc hygiene (check_docs)
         run: python3 scripts/check_docs.py --strict
 
+      # Stale-claim surfacing (owner decision Q-0206, option 2). WARN-ONLY:
+      # surfaces any orphan claim file in docs/owner/claims/ (a session that
+      # forgot to delete its own claim at close) so it doesn't linger across
+      # reconciliation passes. continue-on-error => never blocks a merge; the
+      # reconciliation pass (Q-0195) is still the actuator that --prunes.
+      # UNVERIFIED (Q-0105) — delete this step if it proves noisy.
+      - name: Surface stale claim files (advisory)
+        continue-on-error: true
+        run: python3 scripts/check_stale_claims.py --strict
+
       # Born-red session merge-gate (owner directive Q-0133). On a PR, if this
       # session ADDED a `.sessions/` card, the merge is HELD until that card's
       # `> **Status:**` badge is a ready token (`complete`). The card is created

--- a/.sessions/2026-06-28-question-router-answer-documentation.md
+++ b/.sessions/2026-06-28-question-router-answer-documentation.md
@@ -1,6 +1,6 @@
 # 2026-06-28 — Document owner answers + decide the router-vs-durable-home convention
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** owner-directed (in-chat)
 
@@ -32,4 +32,50 @@ answered+routed blocks to `maintainer-question-router-archive.md`, exactly mirro
 `current-state.md`/`current-state-archive.md` split — driven by the reconciliation pass.** NOT a
 wholesale re-route.
 
-_(Enders — idea / prev-session review / doc audit — appended before the card flips to `complete`.)_
+## What shipped (PR #1522)
+
+- **10 router Q-blocks documented** (append-only, PROPOSED → ANSWERED, answers preserved, `Home:`
+  set): Q-0182, Q-0184, Q-0185, Q-0186, Q-0187, Q-0194-rider, Q-0198, Q-0200, Q-0206, Q-0207.
+- **Conclusions routed to homes:** creature plan (Q-0187), Pokétwo plan + wild-encounters idea
+  (Q-0186), explore-hub plan (Q-0182), mining-grid-encounters idea + mining-hub-redesign plan
+  (Q-0198), honcho-memory idea (Q-0184), website-split plan (Q-0185), `helper-policy.md` §2 +
+  CLAUDE.md helper rules (Q-0200), CLAUDE.md Working agreement [binding] (Q-0194), `code-quality.yml`
+  warn-only stale-claim step (Q-0206), `repo-sector-map.md` [blessed] (Q-0207).
+- **New Q-0210** — the router-vs-durable-home decision: router stays the canonical append-only
+  Q-block ledger (Q-numbers never move); conclusions route to homes; size managed by **archiving**
+  old blocks (reconciliation pass owns it), mirroring `current-state-archive.md`. Recorded in
+  `ai-project-workflow.md` §9 + the reconciliation routine; **scaffolded `maintainer-question-router-archive.md`**.
+- Verified: `check_docs --strict` ✓ · `check_consistency --strict` ✓ · `check_architecture` 0 errors
+  · `check_current_state_ledger --strict` exit 0 (benign newest-merge lag only) · YAML valid.
+
+## 💡 Session idea (Q-0089)
+
+[`router-q-index-generator-2026-06-28.md`](../ideas/router-q-index-generator-2026-06-28.md) — a stdlib
+`build_q_index.py` emitting one line per Q (number · title · status · Home · file) over the router +
+its archive, so a `Q-0NNN` lookup (~9k refs repo-wide) greps ~215 lines instead of loading the 490 KB
+router. The **findability** half of Q-0210's **size** fix. Genuine — it's the friction I hit firsthand
+this session (had to slice-read the router to find the open questions).
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed [`2026-06-28-feature-completion-assessments.md`](./2026-06-28-feature-completion-assessments.md).
+**Did well:** ran the assess→close loop the framework exists for — assessed 3 game units *and* closed a
+real surfaced gap (counting's dead leaderboard) in one PR, not just paperwork. **Could improve:** it
+surfaced two genuinely **owner-gated** punch-list items (Word Chain mis-classification; counting
+XP/coin reward decision) but left them only in the per-unit cert files — where a future session won't
+see them unless it opens that exact cert. Per the routing discipline, an owner-gated completion blocker
+should **also** become a router DISCUSS Q (or at least the sector `▶ Next [owner]` queue) so it's
+discoverable. **System improvement this surfaces:** the same gap that made *this* session necessary —
+**ten** DISCUSS Q-blocks had accumulated unanswered because nothing routinely surfaces "open questions
+awaiting the owner." A cheap fix: SessionStart (or the empty-fire dispatch) prints the **count of
+`PROPOSED` router blocks**, and the feature-completion certs' owner-gated blockers feed the same digest.
+Captured the adjacent half (cheap Q-lookup) as today's Q-0089 idea; the digest itself is a natural next
+idea/guard.
+
+## ⚑ Self-initiated
+
+None beyond the owner's explicit request. The owner directed this session (document all answers + decide
+the durable-home approach); every edit routes a now-answered owner decision or implements the convention
+he chose. Q-0210, the CLAUDE.md/helper-policy/CI edits are applied under the Q-0106 live-owner exception
+(he answered each via the panel).
+

--- a/.sessions/2026-06-28-question-router-answer-documentation.md
+++ b/.sessions/2026-06-28-question-router-answer-documentation.md
@@ -1,0 +1,35 @@
+# 2026-06-28 — Document owner answers + decide the router-vs-durable-home convention
+
+> **Status:** `in-progress`
+
+**Run type:** owner-directed (in-chat)
+
+## What this run is doing
+
+The owner ran an open-question sweep via the panel and answered ten open router DISCUSS/DECIDE
+Q-blocks (Q-0182, Q-0184, Q-0185, Q-0186, Q-0187, Q-0194-rider, Q-0198, Q-0200, Q-0206, Q-0207).
+This session:
+
+1. **Documents every answer** in its Q-block (preserve the answer, flip status PROPOSED → ANSWERED,
+   set the `Home:` routing) — append-only, no renumber (router §9 / Q-0060).
+2. **Routes each durable conclusion to its real home** (the creature/Pokétwo/explore-hub plans,
+   the mining-grid-encounters idea + mining-hub-redesign plan, the honcho-memory idea, the
+   website-split plan, `helper-policy.md`, `.claude/CLAUDE.md`).
+3. **Answers the owner's meta-question** — should answers get a more durable home, or stay in the
+   router given Q-number cross-references? — as a new decision (Q-0210) + `ai-project-workflow.md` §9.
+
+## Evidence behind the convention decision (Q-0210)
+
+- Router is **491 KB / 7,619 lines / 215 Q-blocks** and exceeds the file-read limit (real friction).
+- **9,084 `Q-0XXX` references across 1,307 files** — the Q-number is the repo's stable cross-ref key.
+- **Only ONE anchor-style link (`#q-0017`) exists repo-wide** — every other reference is plain text,
+  so moving a Q-block to an archive file keeps it grep-resolvable; physically re-homing answers to
+  scattered new docs would orphan the Q-number anchor.
+
+→ Best option: **router stays the canonical, append-only Q-block ledger (Q-numbers never move);
+conclusions keep routing to homes (already the convention); size is managed by archiving OLD
+answered+routed blocks to `maintainer-question-router-archive.md`, exactly mirroring the
+`current-state.md`/`current-state-archive.md` split — driven by the reconciliation pass.** NOT a
+wholesale re-route.
+
+_(Enders — idea / prev-session review / doc audit — appended before the card flips to `complete`.)_

--- a/docs/helper-policy.md
+++ b/docs/helper-policy.md
@@ -62,6 +62,14 @@ logic or reuse what exists.
   The duplication rate in `utils/helpers.py`, `utils/embeds.py`, and
   the back-button factories is high enough that "I will check later"
   reliably becomes "I will not check".
+  **Exact-name guard (Q-0200):** before defining a new function in
+  `services/` or `utils/`, `grep "def <exact_name>"` in the target
+  module **and** its sibling modules, plus the 1–2 nearest concept
+  synonyms. A later same-name `def` silently *shadows* the earlier one
+  (Python keeps the last) — the `round_composition` collision in
+  `btd6_data_service` broke its AI-tool + ABR tests and was caught only
+  at the full CI mirror, not pre-write. A five-second grep, not a CI
+  gate.
 - **Bypasses a registry, pipeline, or owner.** If a helper writes
   directly to a governed table, the helper is illegal regardless of
   how convenient it is. Re-read `docs/ownership.md` § "Direct DB

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`router-q-index-generator-2026-06-28.md`](./router-q-index-generator-2026-06-28.md) —
+  **session idea (2026-06-28, Q-0089, from documenting the open-question sweep + deciding Q-0210):** a
+  stdlib `build_q_index.py` → a one-line-per-Q index (number · title · status · Home · file) over the
+  router + its archive, so an agent resolves a `Q-0NNN` reference (~9k repo-wide) by grepping ~215 lines
+  instead of loading the 490 KB router. The *findability* half of Q-0210's *size* fix; regenerate in the
+  reconciliation pass. Disposable (Q-0105). Subsystem: none (S4/S3 tooling).
 - [`completion-ledger-registry-parity-guard-2026-06-27.md`](./completion-ledger-registry-parity-guard-2026-06-27.md) —
   **session idea (2026-06-27, Q-0089, from building the feature-completion framework #1513):** a stdlib
   `check_completion_ledger_parity.py` asserting every user-facing game/server-function registry key has a

--- a/docs/ideas/honcho-memory-evaluation-2026-06-16.md
+++ b/docs/ideas/honcho-memory-evaluation-2026-06-16.md
@@ -1,5 +1,11 @@
 # Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations
 
+> **✅ OWNER DECISION (Q-0184, 2026-06-28, question panel):** memory scope = **user-chosen
+> global-vs-per-guild** — each user picks whether memory follows them across servers or stays
+> this-server-only (not per-guild-only-default, not global-default). Still light / opt-in / bounded
+> under the Q-0082 spend ceiling; shares the per-user config surface with the gear auto-equip toggle
+> (Q-0182). Canonical: router Q-0184.
+
 > **Status:** `ideas` — **bot / AI-lane idea** (owner-flagged "would be cool to have for our bot",
 > 2026-06-16; wants to look into it **soon**). It first surfaced while evaluating Honcho for the
 > *Hermes* control plane — not a fit there (footnote below) — but it **is** the right shape for the

--- a/docs/ideas/mining-grid-encounters-2026-06-22.md
+++ b/docs/ideas/mining-grid-encounters-2026-06-22.md
@@ -1,5 +1,10 @@
 # Mining grid encounters — depth-gated sparse events (2026-06-22)
 
+> **✅ OWNER DECISION (Q-0198, 2026-06-28, question panel):** **build the encounters, loot/flavour-only
+> first** — combat is a fast-follow that reuses the creature/deathmatch engine (never a third bespoke
+> combat model). Depth/chance/cooldown, a live roll (not per-cell-deterministic), and navigator-button
+> resolution ride this doc's recommended defaults, sim-tunable at build time. Canonical: router Q-0198.
+
 > **Status:** `ideas`. **Not a plan, not approval.** Capture doc. Source + binding contracts +
 > `docs/current-state.md` win. **Subsystem:** games, mining.
 >

--- a/docs/ideas/router-q-index-generator-2026-06-28.md
+++ b/docs/ideas/router-q-index-generator-2026-06-28.md
@@ -1,0 +1,42 @@
+# Idea: a generated router Q-index (resolve a Q-number without loading 490 KB)
+
+> **Status:** `ideas`. **Not a plan, not approval.** Capture doc. Source + binding contracts +
+> `docs/current-state.md` win. **Subsystem:** none (S4/S3 docs tooling).
+>
+> **Session idea (2026-06-28, Q-0089, from documenting the open-question sweep + deciding Q-0210).**
+
+## The friction
+
+`docs/owner/maintainer-question-router.md` is **~490 KB / 215 Q-blocks** and now **exceeds the
+file-read size limit** — this session had to read it in offset/limit slices just to find the open
+questions, and every agent that needs to resolve a single `Q-0NNN` reference (there are ~9,000 across
+1,307 files) pays that cost. Q-0210 decided the structural fix (archive old blocks on the
+reconciliation cadence), but archiving is coarse and periodic; it doesn't help an agent that needs to
+look up *one* answered Q **today** without loading the whole file.
+
+## The idea
+
+A tiny stdlib generator — `scripts/build_q_index.py` → `docs/owner/maintainer-question-router-index.md`
+— that parses every `### Q-0NNN — …` header (live router **and** the Q-0210 archive) and emits **one
+line per Q**: `Q-0NNN · <title> · <status: PROPOSED/ANSWERED/DEFERRED/SUPERSEDED> · <Home: pointer> ·
+<file it lives in>`. An agent resolves a Q-number by grepping the ~215-line index instead of the
+490 KB body, and only opens the full block when it needs the reasoning.
+
+- **Status** is derivable from the block's callouts (the `> **ANSWERED …**` / `> **PROPOSED …**` /
+  `> **DEFERRED …**` lines this session's convention already uses).
+- **Home** is the existing `**Home:**` line each block carries (§7 routing).
+- Regenerate it in the reconciliation pass (next to the archive step) so it never drifts; a warn-only
+  checker can assert every `Q-0NNN` header appears in the index.
+
+## Why it's worth having
+
+It's the cheap, *queryable* complement to Q-0210's archive: archiving controls **size**, the index
+controls **findability**. Together they make the router scale without agents paying the full-file read
+cost — and the index doubles as a human "what was decided, and where did it land?" overview. Pure
+stdlib, read-only, disposable (Q-0105 — delete if it drifts or goes unused).
+
+## Related
+
+- **Q-0210** (router stays canonical/append-only; archive old blocks) — this is its findability half.
+- **Q-0107** (reconciliation pass owns ledger/index maintenance).
+- `current-state-archive.md` + `completion_scoreboard.py` (generated-overview precedent).

--- a/docs/ideas/wild-encounters-activity-spawning-2026-06-20.md
+++ b/docs/ideas/wild-encounters-activity-spawning-2026-06-20.md
@@ -1,5 +1,11 @@
 # Wild Encounters — activity-based spawning (2026-06-20)
 
+> **✅ OWNER DECISION (Q-0186, 2026-06-28, question panel):** this is the Pokétwo **Lane A** the owner
+> chose to **build first** (highest engagement leverage; feeds the Collection / Quest / Shiny lanes).
+> Spawn defaults + anti-spam guardrails (per-channel opt-in, rate-limit, no auto-catch, earned-only per
+> Q-0039, stranger-grade per Q-0080) ride this doc's defaults; a runtime session builds it in small PRs.
+> Canonical: router Q-0186.
+
 > **Status:** `ideas`. **Not a plan, not approval.** Capture doc. Source + binding contracts +
 > `docs/current-state.md` win. **Subsystem:** games.
 >

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -151,6 +151,15 @@ STEP 2 — RECONCILE (the Q-0107 pass):
       **recomputes the "Older merges (#HIGH … #LOW)" floor pointer** from the true archive span, so
       the prose pointer can't drift. Re-run `check_current_state_ledger.py --strict` afterward as
       the real guard (the actuator never deletes a bullet).
+  - ARCHIVE OLD ROUTER Q-BLOCKS (Q-0210): when `docs/owner/maintainer-question-router.md` grows
+    unwieldy (it exceeds the file-read limit at ~490 KB), move the **oldest fully answered + routed**
+    Q-blocks into `docs/owner/maintainer-question-router-archive.md` (newest kept in the live router,
+    oldest archived), leaving a pointer in the live file — exactly like the `current-state.md` →
+    `current-state-archive.md` trim above. References are plain `Q-0XXX` text, so an archived block
+    stays grep-resolvable; only the lone `#q-0017` *anchor* link needs a fix if Q-0017 is archived.
+    **Never renumber, never re-home a decision's canonical record out to a scattered doc** — only
+    physically relocate the block to the archive file. Skip in a pass where the router is comfortably
+    sized.
   - Docs: run `python3.10 scripts/check_docs.py --strict`; fix every reachability/badge/
     staleness issue + stale links, wrong PR numbers, broken references.
   - Prune/relabel clearly stale docs; restate current priorities in current-state ▶ Next action.

--- a/docs/owner/ai-project-workflow.md
+++ b/docs/owner/ai-project-workflow.md
@@ -175,6 +175,18 @@ conflict:
 | `.sessions/` | **Per-file.** One `YYYY-MM-DD-<slug>.md` per session — no shared anchor, so no structural conflict. |
 | `.session-journal.md` (guidebook) · `docs/current-state.md` | Edit the **smallest** relevant block; on conflict resolve by **UNION** (keep both additions — it's docs, no CI risk). |
 
+**Where answers live (Q-0210, 2026-06-28).** The router is the **single canonical, append-only Q-block
+ledger** — a decision keeps its `Q-0NNN` block here forever; numbers are never moved. That is what keeps
+the **~9,000 plain-text `Q-0XXX` references across the repo** resolvable, so we do **not** physically
+re-home answers to scattered docs (that would orphan the anchor). Instead: (1) the **`Home:` line** (§7)
+routes each durable *conclusion* to its real home — the plan / folio / `CLAUDE.md` is where agents *read*
+the decision, the Q-block is the *provenance*; and (2) **size** is managed by **archiving** old, fully
+answered + routed Q-blocks to **`docs/owner/maintainer-question-router-archive.md`** (newest kept here,
+oldest archived, with a pointer) — mirroring the proven `current-state.md` → `current-state-archive.md`
+split. Because references are plain text, an archived `Q-0XXX` stays grep-resolvable (the lone
+`#q-0017` anchor link is the only thing to fix if Q-0017 is ever archived). **Archiving is a
+reconciliation-pass (Q-0107) job**, not ad hoc — the same pass that already trims `current-state`.
+
 Practical rules when several chats are live:
 
 - **Expect `main` to move.** Re-fetch before you push; prefer additive, section-scoped edits

--- a/docs/owner/claims/claude-question-router-docs-prhcr9.md
+++ b/docs/owner/claims/claude-question-router-docs-prhcr9.md
@@ -1,0 +1,1 @@
+- branch `claude/question-router-docs-prhcr9` · scope: document owner answers (Q-0182/0184/0185/0186/0187/0194/0198/0200/0206/0207) into the question router + route conclusions to homes; decide & document the router-vs-durable-home convention (archive vs re-route) · area: docs/owner/, docs/planning/, docs/ideas/, docs/helper-policy.md, .claude/CLAUDE.md · 2026-06-28

--- a/docs/owner/claims/claude-question-router-docs-prhcr9.md
+++ b/docs/owner/claims/claude-question-router-docs-prhcr9.md
@@ -1,1 +1,0 @@
-- branch `claude/question-router-docs-prhcr9` · scope: document owner answers (Q-0182/0184/0185/0186/0187/0194/0198/0200/0206/0207) into the question router + route conclusions to homes; decide & document the router-vs-durable-home convention (archive vs re-route) · area: docs/owner/, docs/planning/, docs/ideas/, docs/helper-policy.md, .claude/CLAUDE.md · 2026-06-28

--- a/docs/owner/maintainer-question-router-archive.md
+++ b/docs/owner/maintainer-question-router-archive.md
@@ -1,0 +1,26 @@
+# Maintainer Question Router — archive
+
+> **Status:** `archive` — overflow from
+> [`maintainer-question-router.md`](./maintainer-question-router.md) § Q-blocks.
+> Old, fully **answered + routed** `Q-0NNN` blocks are moved here (oldest first) by the
+> reconciliation pass (Q-0107) to keep the live router lean, **without ever renumbering or
+> re-homing a decision's canonical record** (convention Q-0210).
+>
+> **Source code, merged PRs, and binding docs win over anything here.** Start at the live router.
+
+## How this file works (Q-0210)
+
+- The live router stays the **single canonical, append-only Q-block ledger**. A decision keeps
+  its `Q-0NNN` block forever; numbers are **never moved or reused**.
+- References across the repo are plain `Q-0XXX` **text** (only one `#q-0017` *anchor* link exists
+  repo-wide), so a block archived here stays fully **grep-resolvable** — moving it changes nothing
+  for the ~9,000 references that cite it by number.
+- **Archiving is a reconciliation-pass job** (the same pass that trims `current-state.md` →
+  `current-state-archive.md`), not an ad-hoc edit. Move the **oldest answered + routed** blocks,
+  newest stay live, and leave the live router's pointer intact.
+
+## Archived Q-blocks
+
+> _Empty._ No blocks have been archived yet — the live router is still within a comfortable size.
+> The first move happens in a future reconciliation pass when the live file grows unwieldy; archived
+> blocks land below this line, newest-first within each move.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -10,6 +10,11 @@
 > **Not a roadmap:** unanswered questions are not approval. Answered questions that
 > affect code, architecture, priorities, or product behavior still need the normal
 > decision/planning/promotion path before implementation.
+>
+> **Archive:** old, fully answered + routed `Q-0NNN` blocks move to
+> [`maintainer-question-router-archive.md`](./maintainer-question-router-archive.md) on the
+> reconciliation cadence (convention **Q-0210**) — numbers are never moved/renumbered, so every
+> `Q-0XXX` reference stays grep-resolvable wherever the block lives.
 
 ## 1. What this file is for
 
@@ -6713,6 +6718,12 @@ Q-block. Related: Q-0104 (session-close doc audit), Q-0120 (verify bot output vs
 > Routed for live owner review per the owner's #1140-fire directive ("surface the open questions
 > … into the question router (DISCUSS lane)"). The spine those answers do NOT gate is already
 > planned ([explore-hub plan](../planning/explore-hub-federated-world-plan-2026-06-19.md), Q-0172).
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → explore-hub plan.** Q1 (what the hub *is*):
+> **flat Discord `HubView` router first; the map/biome/location layer stays a deferred layer** (the plan's
+> existing sequencing — build the flat router, treat the map as later). Q2–Q4 (survival-overlay attach ·
+> subsystem docking · cross-game-identity richness) were **not** put to the panel — they gate only the
+> deferred layers and ride on the plan's defaults until that layer is greenlit.
 
 **Context:** the owner wants one world where each subsystem (mining/fishing/pets/survival) is both
 part of a shared world *and* its own complete game. The progression model (three XP tracks: message
@@ -6777,6 +6788,12 @@ gate), Q-0121 (Hermes triage write scope), Q-0082 (spend), the website-split red
 > **PROPOSED — surfaced by the band-#1140 reconciliation pass** from
 > [`ideas/honcho-memory-evaluation-2026-06-16.md`](../ideas/honcho-memory-evaluation-2026-06-16.md).
 > Routed for live owner review per the #1140-fire directive.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → honcho-memory idea doc.** The owner chose
+> **user-chosen global-vs-per-guild scope** (each user picks whether memory follows them across servers
+> or stays this-server-only) — *not* per-guild-only-by-default, *not* global-by-default. Memory still
+> stays light / opt-in / bounded under the Q-0082 spend ceiling; this also fixes the per-user config
+> surface the hybrid-gear auto-equip toggle (Q-0182) shares.
 
 **Context:** the memory idea currently proposes **user-chosen scope** — each user picks **global**
 (memory follows them across servers) or **per-guild** (this server only), as the *user's* choice,
@@ -6798,6 +6815,11 @@ per-user config surface**. **Home:** the honcho-memory idea doc + this Q-block. 
 > ("…and the public bot-site's one-line pitch"). The website split is built/in-flight
 > ([website-two-site-split plan](../planning/website-two-site-split-plan-2026-06-19.md), Q-0178/Q-0179);
 > the marketing pages need a headline.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → website-split plan "Layout & UX guidance".**
+> The public bot-site one-line pitch is **"Everything your server needs — free, forever."** (leads with
+> the free-for-everyone North Star, Q-0190, + all-in-one breadth). Picked over the "actually free" wedge
+> and the feature-list variants.
 
 **The question:** what is the **one-line pitch** for the public bot site — the single sentence a
 visitor reads first that says what SuperBot *is*? The repo description is *"The best bot ever made"*;
@@ -6817,6 +6839,13 @@ audience should drive the wording — agents should **not** invent the public-fa
 > decisions for when a future session executes. The mapping already settled the gated/rejected
 > items (marketplace = its own roadmap gate; premium currency = rejected Q-0039; music = Q-0041
 > arch-review pack).
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → the feature-mapping plan.** Build order (Q1):
+> **Lane A (Wild Encounters) first** (the agent rec — highest engagement leverage, ungated, feeds B/C/D).
+> Q2 (spawn defaults) + Q3 (guardrails) were not separately polled — they ride the plan's documented
+> defaults (config-driven threshold/debounce, off by default; earned-only / no-buyable-power per Q-0039;
+> per-channel opt-in + rate-limit + no auto-catch; stranger-grade claims per Q-0080), refined when Lane A's
+> runtime session builds.
 
 **Context:** most Pokétwo mechanics already have lanes here (catching = fishing/mining/pets;
 trading = the economy-marketplace roadmap; "one world" = the federated Explore hub). The mapping
@@ -6850,6 +6879,14 @@ bounded menus), Q-0080 (stranger-grade), Q-0071 (atomic workflow).
 > (*"PvP battles with the Pokémon would be great"*). A v1 ruleset + a playability simulator are
 > built ([creature-game-design-and-sim](../planning/creature-game-design-and-sim-2026-06-20.md),
 > `tools/game_sim/creature_battle_sim.py`). These are the design calls before a build session.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → the design+sim plan.** (a) Creature IP =
+> **original creatures** (no Pokémon names/dex — publish-safe, the agent's strong rec). (b) PvP =
+> **normalize to a flat level** (types/team-building/ordering decide; raw levels stay PvE/collection
+> prestige — avoids the Q-0039 P2W trap the sim found). (d) Roster = **tiered: sim-core 12 → v1 launch
+> ~30–40 → growth in waves**, data-driven JSON catalog, text/emoji-first art. (c) Art bar was not
+> separately polled — it rides the agent default (emoji/text v1 → an original sprite pack later, the gear
+> paper-doll path).
 
 **(a) Creature IP — original vs Pokémon names.** **Agent answer + strong recommendation: make our
 own.** Game *mechanics* (catch/types/turn-based battle/stats) are **not** copyrightable — we can
@@ -7121,6 +7158,13 @@ pipe / confirm `git branch --show-current` after a checkout) to `.session-journa
 CLAUDE.md content is propose-first (Q-0035) and the reflex is already operative via the session enders;
 the owner can promote it if he wants it binding rather than guidebook-level.
 
+> **ANSWERED 2026-06-28 (owner, question panel) — PROMOTE.** The owner chose to elevate the
+> **friction → guard** reflex to a binding one-line principle in the `.claude/CLAUDE.md` Working
+> agreement (over keeping it journal/README-level). Applied this session under the Q-0106 live-owner
+> exception (the owner directed it via the panel; behaviour is unchanged — the reflex was already
+> operative — this raises its authority/visibility). **Home:** `.claude/CLAUDE.md` Working agreement +
+> this Q-block.
+
 **Home:** this Q-block (canonical) + `scripts/check_branch_freshness.py` header (the hook) +
 `.sessions/README.md` Q7 + `.session-journal.md` END step 4b & Rules (the operative reflex).
 
@@ -7220,6 +7264,13 @@ is now unreferenced and harmless). PR for this change: branch `claude/jolly-saga
 > later session."* The [idea](../ideas/mining-grid-encounters-2026-06-22.md) itself says **"route to a
 > router Q before building, don't decide unprompted"** — so this poses the decisions, with defaults,
 > rather than building. Q-0172 "build freely" yields here to the owner's explicit design reservation.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → mining-hub-redesign plan + the grid-encounters
+> idea.** **Build the encounters, loot/flavour-only first** (Q2 = loot/flavour v1; combat is a fast-follow
+> that reuses the creature/deathmatch engine, never a third bespoke combat model). Q1 (depth/chance/
+> cooldown), Q3 (live roll — not per-cell-deterministic) and Q4 (extra buttons on the navigator) were not
+> separately polled — they ride the agent recommendations in this block, sim-tunable when the runtime
+> session builds it.
 
 **Context:** layer **sparse, depth-gated random encounters** onto the shipped grid navigator — a
 low-probability event on a `move` / `Mine here` action once deep enough, resolved through the audited
@@ -7293,6 +7344,11 @@ write lift — the parent rule), Q-0123 (auto-merge on green).
 > **PROPOSED — surfaced by a real collision this session** (`.sessions/2026-06-24-btd6-per-round-economy-commands.md`).
 > This proposes a rule addition, so it routes here rather than self-editing CLAUDE.md / `helper-policy.md`
 > (the binding-rule channel). The owner is the live reviewer when present; otherwise it waits.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — Routed → `docs/helper-policy.md` (+ CLAUDE.md helper
+> rules mirror).** **Adopt** the one-line dedup guard: before defining a new `services/`-or-`utils/`
+> function, grep `def <exact_name>` in the target module + its sibling modules (plus the 1–2 nearest
+> concept synonyms). A checklist line, not a CI gate (Q-0105 disposable).
 
 **Context:** building the per-round economy commands (PR #1404), I added a new `round_composition` to
 `btd6_data_service` **without noticing one already existed** (the range/AI variant). Python took my later
@@ -7487,6 +7543,12 @@ Related: **Q-0202**/**Q-0203**/**Q-0204** (the per-step spine decisions), **Q-A*
 
 > **PROPOSED — surfaced by a dispatch run (2026-06-25).** Captured here, not applied: this is a
 > *workflow* change, which CLAUDE.md says an agent **proposes** (router DISCUSS), never self-applies.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — option 2.** Make the claim-GC sweep non-skippable via a
+> **warn-only `code-quality` step** (`check_stale_claims.py`, advisory — never blocks merges, recursion-free).
+> Cheapest safe surfacing; an agent/human still prunes on sight (Q-0166). Chosen over the auto-prune
+> workflow (heaviest, #778 recursion class) and the Stop-hook (owner-config, Q-0106). Implemented this
+> session.
 
 **The observation.** This dispatch run found a **stale claim file** left on `main`:
 `docs/owner/claims/claude-jolly-johnson-rqf8wt.md`, for a branch that merged via **#1407** (band-#1380,
@@ -7529,6 +7591,12 @@ default, optionally paired with **option 3**. Option 1 only if the owner wants i
 > have free rein on (Q-0105) and shipped this run; **this Q-block is only the rule-level question** —
 > should the convention be codified/blessed, or left as a disposable guard? It routes here rather than
 > self-editing CLAUDE.md (the binding-rule channel). Owner is the live reviewer when present; else it waits.
+>
+> **ANSWERED 2026-06-28 (owner, question panel) — options (a)+(c).** **Bless** the per-item offline-fit
+> startability tag as a standing convention **and fold it into `dispatch_menu.py`** — the fold already
+> shipped in #1482 (`dispatch_menu --unattended` surfaces the per-sector `[offline]` pick). So this is now
+> a blessed standing convention (homed in `repo-sector-map.md`); the checker may later graduate to a
+> warn-only CI step / Stop-hook advisory (Q-0105 graduate-when-proven). Not left disposable, not dropped.
 
 **Context:** two consecutive empty-fire dispatch runs' Q-0102 reviews (the 2026-06-25 and 2026-06-26
 session logs) flagged the same friction: only **S2**'s per-sector live-state file tagged its `▶ Next`
@@ -7617,3 +7685,57 @@ Wired the soft completion-first gate into [`docs/ideas/README.md`](../ideas/READ
 default proves itself, a one-line binding rule in `.claude/CLAUDE.md` (proposed via a DISCUSS Q, the
 graduate-when-proven pattern — Q-0105) would harden it; not done day-one. Related: **Q-0015** (backlog
 grooming / secondary task), **Q-0089** (idea generation), **production-readiness** maps (the risk axis).
+
+### Q-0210 — DECIDED: where answers live — router stays the canonical append-only ledger; conclusions route to homes; old blocks archive (never re-home) (2026-06-28)
+
+> **ANSWERED (owner, in-chat, 2026-06-28).** Closing the open-question sweep, the owner asked whether
+> some answers should get "a more durable home in the repo," noting the worry that *"a lot of things are
+> referred to by question number, so [moving them] might confuse future agents,"* and asked the agent to
+> find the best option — leave everything in the router, or slowly start re-routing some answers
+> elsewhere. The agent investigated and the decision below records the answer + its evidence.
+
+**Area:** Workflow / docs system · **Type:** Workflow convention · **Status:** Answered — Routed →
+`docs/owner/ai-project-workflow.md` §9 + this Q-block.
+
+**The evidence (measured this session).**
+- The router is **~491 KB / 7,600+ lines / 215 Q-blocks** and now exceeds the file-read size limit — a
+  real, recurring friction (this very session had to read it in slices).
+- **9,084 `Q-0XXX` references span 1,307 files.** The Q-number is the repo's stable cross-reference key;
+  CLAUDE.md, plans, ideas, session logs, and reconciliation passes all cite decisions *by number*.
+- **Exactly ONE anchor-style link exists repo-wide** (`maintainer-question-router.md#q-0017`). Every
+  other reference is **plain `Q-0XXX` text** — so a Q-block resolves by `grep`, independent of which file
+  it physically lives in.
+
+**The decision (the "best option").** A three-part convention, not the binary the question posed:
+
+1. **The router stays the single canonical, append-only Q-block ledger.** Every decision keeps its
+   `Q-0NNN` block here; numbers are **never moved or renumbered** (router §9 / Q-0060). This is what keeps
+   the 9,084 references resolvable — the owner's worry is correct, and it is exactly why we do **not**
+   physically re-home answers to scattered new docs.
+2. **Durable conclusions keep routing to their real homes** via the existing **`Home:` line** (router §7).
+   This already happens — the plan / folio / `CLAUDE.md` is where an agent *reads* the decision; the
+   Q-block is the *provenance*. So "give answers a more durable home" is already satisfied **by linking,
+   not by moving**.
+3. **Size is managed by archiving, not re-homing.** When the router grows unwieldy, **old, fully
+   answered + routed Q-blocks** move to a new **`docs/owner/maintainer-question-router-archive.md`**
+   (newest-kept-here, oldest-archived), with the main file keeping a pointer — exactly mirroring the
+   proven **`current-state.md` → `current-state-archive.md`** split. Because references are plain text,
+   the archived `Q-0XXX` stays grep-resolvable; the lone `#q-0017` anchor link is the only thing to fix
+   if/when Q-0017 is archived. **Archiving is a reconciliation-pass (Q-0107) responsibility**, the same
+   pass that already trims `current-state` — so the bulk move happens under an established, careful
+   cadence rather than ad hoc.
+
+**Why not the two options as posed.** *"Leave it all in the router"* ignores the real size friction.
+*"Slowly re-route answers elsewhere"* (move the canonical record out) would orphan the Q-number anchor
+1,307 files depend on — the owner's exact concern. The synthesis keeps provenance stable **and** gives
+conclusions durable homes **and** controls size.
+
+**Applied this session (docs-only):** recorded the convention in `ai-project-workflow.md` §9 (the
+router-convention home) + added the archive step to the reconciliation routine. The actual first bulk
+archive is left to the next reconciliation pass (it is not due — band marker #1500, next at #1530), so
+this session changes the *rule*, not 200 blocks of content.
+
+**Home:** this Q-block (canonical) + `docs/owner/ai-project-workflow.md` §9 (the convention) +
+`docs/operations/autonomous-routines.md` (the reconciliation archive step). Related: **Q-0060**
+(append-only / accept-and-reconcile), **Q-0107** (reconciliation pass owns ledger trimming), **Q-0104**
+(route durable conclusions), **Q-0166** (fix drift on sight), the `current-state-archive.md` precedent.

--- a/docs/planning/creature-game-design-and-sim-2026-06-20.md
+++ b/docs/planning/creature-game-design-and-sim-2026-06-20.md
@@ -1,5 +1,11 @@
 # Creature game — v1 design + playability sim (2026-06-20)
 
+> **✅ OWNER DECISIONS (Q-0187, 2026-06-28, question panel):** creatures = **original** (no Pokémon
+> names/dex — publish-safe) · PvP = **normalize to a flat level** (raw levels stay PvE/collection
+> prestige; avoids the P2W the sim found) · roster = **tiered — sim-core 12 → ~30–40 at launch →
+> growth in waves** (data-driven JSON catalog) · art = emoji/text v1 → original sprite pack later.
+> Canonical: router Q-0187.
+
 > **Status:** `plan` — design + a runnable balance simulator. **Not implementation approval.**
 > Source, binding contracts, and owner decisions win. **Subsystem:** games.
 >

--- a/docs/planning/explore-hub-federated-world-plan-2026-06-19.md
+++ b/docs/planning/explore-hub-federated-world-plan-2026-06-19.md
@@ -1,5 +1,11 @@
 # Federated Explore hub — the open-world spine plan (2026-06-19)
 
+> **✅ OWNER DECISION (Q-0182, 2026-06-28, question panel):** the hub starts as a **flat `HubView`
+> router** into each game; the **map/biome/location layer stays deferred** (this plan's existing
+> sequencing). The other Q-0182 deferred-layer questions (survival-overlay attach · subsystem docking ·
+> cross-game-identity richness) were not separately polled — they ride this plan's defaults until that
+> layer is greenlit. Canonical: router Q-0182.
+
 > **Status:** `plan` — promoted from [`ideas/explore-hub-federated-world-2026-06-19.md`](../ideas/explore-hub-federated-world-2026-06-19.md)
 > by the band-#1140 reconciliation pass under the **idea→plan gate (Q-0172)** and the owner's
 > #1140-fire directive ("promote the federated Explore-hub spine first — it homes

--- a/docs/planning/mining-hub-redesign-2026-06-15.md
+++ b/docs/planning/mining-hub-redesign-2026-06-15.md
@@ -100,6 +100,8 @@ this **replaces** the old linear Descend/Ascend.
    on top of the grid (the owner's shape — "after a certain depth you can get random
    encounters, but not too many"). Captured in
    [`../ideas/mining-grid-encounters-2026-06-22.md`](../ideas/mining-grid-encounters-2026-06-22.md).
+   **✅ Design decided (owner, Q-0198, 2026-06-28):** build **loot/flavour-only first**; combat is a
+   fast-follow reusing the creature/deathmatch engine. The runtime session is now startable.
 5. **Later — open-world Explore**: fishing / quests / roam — own design pass (the main-hub
    🗺️ Explore now forwards to the federated world hub).
 

--- a/docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md
+++ b/docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md
@@ -1,5 +1,9 @@
 # Pokétwo + MusicBot research report → feature-mapping plan (2026-06-20)
 
+> **✅ OWNER DECISION (Q-0186, 2026-06-28, question panel):** build order = **Lane A (Wild Encounters)
+> first** (then B Collection / C Quests / D Shiny). Spawn defaults + guardrails ride this doc's
+> documented defaults until Lane A's runtime session refines them. Canonical: router Q-0186.
+
 > **Status:** `plan` — routing/mapping plan. **Not implementation approval.** Source code,
 > the binding contracts, owner decisions (router `Q-####`), and `docs/current-state.md` win
 > over this doc. **Subsystem:** games, ai, media.

--- a/docs/planning/website-two-site-split-plan-2026-06-19.md
+++ b/docs/planning/website-two-site-split-plan-2026-06-19.md
@@ -117,6 +117,11 @@ not *whether a change is user-relevant* — every `.sessions/` log is dev/repo c
 that **every function any Discord bot offers is present here, and better.** The hero one-liner is the
 owner's: **"Add SuperBot and you can remove every other bot from your server."**
 
+> **✅ OWNER DECISION (Q-0185, 2026-06-28, question panel) — the one-line pitch:** **"Everything your
+> server needs — free, forever."** Leads with the free-for-everyone North Star (Q-0190) + the all-in-one
+> breadth. Pairs with the hero one-liner above (replace-the-stack); exact placement/wording stays the
+> owner's to refine. Canonical: router Q-0185.
+
 **Feel.** Fun **but** professional. Simple, self-explanatory, **easily browsable** — a visitor finds what
 they need in seconds, never hunts. Clear explanations over cleverness.
 

--- a/docs/repo-sector-map.md
+++ b/docs/repo-sector-map.md
@@ -180,6 +180,12 @@ tag stops a run from missing the auto-buildable per-sector work. Provenance: #12
 #1274's surfaced fix).*
 
 ### Which *item* is offline — the offline-fit startability tag
+
+> **✅ BLESSED standing convention (owner, Q-0207, 2026-06-28, question panel).** Keep the per-item
+> tags + the checker as a standing convention, and `dispatch_menu.py --unattended` reads them directly
+> (shipped #1482). The checker may later graduate to a warn-only CI step / Stop-hook advisory
+> (Q-0105 graduate-when-proven). Not left disposable, not dropped.
+
 The unattended-fit tag above lives on the roadmap and tags one lane **per sector**. But a dispatch run
 that picks a sector then opens that sector's **live-state file**
 ([`current-state/S<n>.md`](current-state/README.md)), which lists *several* `▶ Next` startable items —


### PR DESCRIPTION
## What this PR does

Documents the owner's answers from an open-question sweep (panel session, 2026-06-28) and decides the meta-question the owner raised: should answers get a more durable home, or stay in the router given the Q-number cross-references?

### 1. Owner answers documented (append-only, no renumber)
Ten router DISCUSS/DECIDE Q-blocks flipped PROPOSED → ANSWERED, answers preserved, conclusions routed to homes:
- **Q-0186** Pokétwo lane first → **Wild Encounters**
- **Q-0187** creature game → **original creatures** · **flat-level PvP** · **tiered ~30–40 roster**
- **Q-0198** mining-grid encounters → **build, loot/flavour-only first**
- **Q-0182** explore hub → **flat router first, map deferred**
- **Q-0184** AI memory → **user-chosen global vs per-guild**
- **Q-0185** bot-site pitch → **"Everything your server needs — free, forever."**
- **Q-0206** claim-GC → **warn-only CI step**
- **Q-0207** offline-fit startability tag → **bless + fold into `dispatch_menu`** (fold already shipped #1482)
- **Q-0200** dedup → **adopt `grep def <exact_name>` in `helper-policy.md`**
- **Q-0194 rider** → **promote "friction → guard" reflex to a binding `.claude/CLAUDE.md` principle**

### 2. Router-vs-durable-home convention (new Q-0210)
Evidence: router is 491 KB / 215 Q-blocks (exceeds read limit); **9,084 `Q-0XXX` refs across 1,307 files**; **only 1 anchor-style link repo-wide**. Decision: router stays the canonical, append-only Q-block ledger (Q-numbers never move); conclusions keep routing to homes; size is managed by **archiving old answered+routed blocks** to a router archive (mirroring `current-state-archive.md`), driven by the reconciliation pass — **not** a wholesale re-route (that would orphan the Q-number anchor).

Docs/tooling only. Owner-directed → auto-merge on green (Q-0191). Born-red until the close-out docs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBEYumY4ukceeYp8jMZufE)_