### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-06-28T11:09:03Z",
+    "generated_at": "2026-06-28T11:37:36Z",
     "build": {
-      "commit": "a1bca4b9",
-      "subject": "Merge pull request #1523 from menno420/claude/funny-franklin-ca1e1q",
-      "committed_at": "2026-06-28T11:09:03Z"
+      "commit": "37627c9a",
+      "subject": "Merge pull request #1525 from menno420/bot/dashboard-refresh",
+      "committed_at": "2026-06-28T11:37:36Z"
     },
     "counts": {
       "functions": 43,
       "ideas": 151,
-      "bugs": 26,
+      "bugs": 27,
       "reviews": 0,
       "reviews_open": 0,
       "updates": 60,
@@ -2442,6 +2442,12 @@
   ],
   "bugs": [
     {
+      "id": "BUG-0027",
+      "title": "born-red merge-gate silently fails open on a session-card slug collision (a partial PR auto-merged and clobbered a prior session log) — FIXED (root)",
+      "status": "unknown",
+      "summary": "an empty-fire dispatch session opened its born-red PR (#1523) with an in-progress session card, per the Q-0133 flow — and GitHub auto-merged it immediately, while the card still said in-progress and before any real work landed. The born-red gate (check_session_gate.py, the whole…"
+    },
+    {
       "id": "BUG-0026",
       "title": "EffectiveStats.light_radius and .luck are dead stats (gear grants them, no game reads them) — FIXED (wired — owner decision Q-0208)",
       "status": "unknown",
@@ -2625,12 +2631,20 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-28-feature-completion-games-and-gate-fix.md",
+      "date": "2026-06-28",
+      "title": "2026-06-28 — Feature-completion assessments (RPS · Deathmatch · Chicken farm) + born-red gate collision fix",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-28-feature-completion-assessments.md",
       "date": "2026-06-28",
-      "title": "2026-06-28 — Feature-completion assessments (more S1 game units)",
-      "status": "in-progress",
+      "title": "2026-06-28 — Feature-completion unit assessments + counting leaderboard",
+      "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
+      "self_initiated": true
     },
     {
       "file": "2026-06-27-youtube-fetch-renderer-tests.md",
@@ -3068,14 +3082,6 @@
       "file": "2026-06-24-setup-reward-activity.md",
       "date": "2026-06-24",
       "title": "Session — 2026-06-24 · Essential Setup step \"Reward active members\"",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-24-setup-log-channel-step.md",
-      "date": "2026-06-24",
-      "title": "Session — 2026-06-24 · Essential Setup step \"Choose a log channel\"",
       "status": "complete",
       "run_type": "",
       "self_initiated": false


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.