### PR TITLE
fix(deathmatch): PvP terminal views are no longer dead-ends (+ panel-PvP ctx crash root fix)

### DIFF
--- a/.sessions/2026-06-28-deathmatch-pvp-deadend.md
+++ b/.sessions/2026-06-28-deathmatch-pvp-deadend.md
@@ -1,0 +1,31 @@
+# 2026-06-28 — Deathmatch PvP trapped-view dead-end fix (completion-first)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What I'm about to do
+
+Empty-fire dispatch (no work order). The active S1 thread is **completion-first** certification
+(Q-0209); several assessed game units carry real, offline-fixable UX gaps. Picked the **headline
+gap** in the Deathmatch completion cert (`◐ assessed`): the **PvP** terminal views (`_DuelView`,
+`_ChallengeView`) are **dead-ends** — on finish / timeout / decline / expire the player is stranded
+on a dead embed with no return navigation (the bot-duel path already swaps to a nav-bearing result
+view; the 2026-06-23 "never a dead-end" directive was missed for PvP). Punch-list #1 (headline) + #3
+(PvP loop tests).
+
+Scope (turn-key, mirrors the shipped bot-duel result view):
+- New `_PvpDuelResultView(HubView, SUBSYSTEM="deathmatch")` in `deathmatch_panel.py` → auto-nav
+  (📚 Help + ↩ Games) + a 🔁 Rematch button (re-challenge via the normal Accept/Decline flow);
+  both fighters may use it.
+- `_DuelView._resolve`/`on_timeout` and `_ChallengeView.btn_decline`/`on_timeout` swap to it on
+  terminal instead of leaving a dead embed.
+- **Bugs-first root fix:** panel-initiated PvP passes `ctx=None`; `_DuelView` reads
+  `self.ctx.guild.id` on resolve → `AttributeError` crash. Thread an explicit `guild_id` through
+  `_ChallengeView.btn_accept` → `_DuelView` so the panel-PvP path no longer crashes and records
+  under the correct guild. Captured as a bug-book entry.
+- PvP loop tests (finish/timeout swap-to-result, decline/expire nav, rematch re-challenge,
+  panel-path guild_id) + cert update.
+
+If capacity remains: the RPS PvP-play trapped-view gap (rps_tournament cert punch-list #2) is the
+same class — a second slice.

--- a/.sessions/2026-06-28-deathmatch-pvp-deadend.md
+++ b/.sessions/2026-06-28-deathmatch-pvp-deadend.md
@@ -1,6 +1,6 @@
-# 2026-06-28 — Deathmatch PvP trapped-view dead-end fix (completion-first)
+# 2026-06-28 — Deathmatch + RPS PvP trapped-view dead-end fixes (completion-first)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
@@ -8,24 +8,99 @@
 
 Empty-fire dispatch (no work order). The active S1 thread is **completion-first** certification
 (Q-0209); several assessed game units carry real, offline-fixable UX gaps. Picked the **headline
-gap** in the Deathmatch completion cert (`◐ assessed`): the **PvP** terminal views (`_DuelView`,
-`_ChallengeView`) are **dead-ends** — on finish / timeout / decline / expire the player is stranded
-on a dead embed with no return navigation (the bot-duel path already swaps to a nav-bearing result
-view; the 2026-06-23 "never a dead-end" directive was missed for PvP). Punch-list #1 (headline) + #3
-(PvP loop tests).
+gap** in the Deathmatch completion cert (and the same trapped-view class in RPS): PvP terminal views
+were **dead-ends** (no return navigation after a duel/match resolves).
 
-Scope (turn-key, mirrors the shipped bot-duel result view):
-- New `_PvpDuelResultView(HubView, SUBSYSTEM="deathmatch")` in `deathmatch_panel.py` → auto-nav
-  (📚 Help + ↩ Games) + a 🔁 Rematch button (re-challenge via the normal Accept/Decline flow);
-  both fighters may use it.
-- `_DuelView._resolve`/`on_timeout` and `_ChallengeView.btn_decline`/`on_timeout` swap to it on
-  terminal instead of leaving a dead embed.
-- **Bugs-first root fix:** panel-initiated PvP passes `ctx=None`; `_DuelView` reads
-  `self.ctx.guild.id` on resolve → `AttributeError` crash. Thread an explicit `guild_id` through
-  `_ChallengeView.btn_accept` → `_DuelView` so the panel-PvP path no longer crashes and records
-  under the correct guild. Captured as a bug-book entry.
-- PvP loop tests (finish/timeout swap-to-result, decline/expire nav, rematch re-challenge,
-  panel-path guild_id) + cert update.
+## What shipped (PR #1527)
 
-If capacity remains: the RPS PvP-play trapped-view gap (rps_tournament cert punch-list #2) is the
-same class — a second slice.
+Two completion-first slices closing the same recurring **trapped-view** bug class across the two
+competitive PvP games, plus a latent crash root-fix found mid-task.
+
+### Slice 1 — Deathmatch PvP is never a dead-end (cert punch-list #1 headline + #3)
+- New `_PvpDuelResultView(HubView, SUBSYSTEM="deathmatch")` in `deathmatch_panel.py` →
+  `attach_standard_nav` auto-adds **📚 Help + ↩ Games**; plus a **🔁 Rematch** button that
+  re-challenges the other fighter through the normal Accept/Decline flow (consent preserved). Either
+  fighter may use it.
+- `_DuelView._resolve` (winner) / `_DuelView.on_timeout` / `_ChallengeView.btn_decline` /
+  `_ChallengeView.on_timeout` now swap to it on every PvP terminal instead of leaving a dead embed —
+  closing the 2026-06-23 "never a dead-end" gap for PvP (it was applied only to the bot path's
+  `_BotDuelResultView`).
+- **Bugs-first root fix (BUG-0028):** panel-initiated PvP built the duel with `ctx=None`, so
+  `_DuelView._resolve`/`on_timeout` reading `self.ctx.guild.id` **crashed (`AttributeError`) on every
+  panel-PvP resolution** (and would have recorded under the wrong guild). Fixed at root by threading an
+  explicit `guild_id` from `_ChallengeView.btn_accept` (`interaction.guild_id`) into `_DuelView`
+  (`self.guild_id`, ctx fallback preserved for the command path + existing tests).
+- DRY: extracted `build_deathmatch_challenge_embed` so the challenge prompt has one builder.
+- Tests: `tests/unit/cogs/test_deathmatch_pvp_deadend.py` (7) — finish/timeout swap-to-result,
+  decline/expire nav, rematch re-challenge, the `guild_id` thread + ctx-None no-crash, result-view
+  authority (both duelists / bystander blocked).
+
+### Slice 2 — RPS PvP result is never a dead-end (cert punch-list #2/#3 + part of #4)
+- New `_RpsPvpResultView` in `views/rps/pvp_play.py` carrying the shared **◀ Back to RPS** button;
+  `_resolve` now posts the result with it instead of a bare channel embed. Either participant may use it.
+- `build_rps_rules_embed` gained a "Timeouts & forfeits" field (#3).
+- Tests: `tests/unit/cogs/test_rps_pvp_deadend.py` (4) — `_resolve` posts the nav-bearing view,
+  result-view authority, and a `!rpshelp` output **drift-guard** (the underscored/leaderboard drift
+  fixed in the prior PR can't silently return).
+
+Both certs updated: Deathmatch is now a **✔-ready candidate** (only owner walkthrough / coin-staking
+remain); RPS is close to ✔-ready (owner rematch call + bot-batch test + walkthrough remain).
+
+CI mirror green end-to-end (`check_quality.py --full`) · `check_architecture --mode strict` 0 errors ·
+`check_consistency` clean. Born-red gate held the merge until this card flipped `complete`.
+
+## 💡 Session idea (Q-0089)
+
+**A "no-dead-end" arch invariant for game terminal paths.** This run (and several before it) keeps
+re-finding the *same* bug class: a game view that `stop()`s / disables its buttons on a terminal
+branch without swapping to a `SUBSYSTEM`-bearing result view, leaving the player stranded. The
+2026-06-23 directive is enforced only by per-unit completion assessments catching it one game at a
+time. Idea: a lightweight checker (`scripts/check_architecture.py` rule or a dedicated AST lint) that
+flags any `discord.ui.View` subclass under `views/`/`cogs/` whose terminal handler (`on_timeout` /
+a handler that calls `self.stop()`) ends with `view=self` / disabled-only children and **no** swap to
+a view that carries standard nav — turning a recurring manual catch into an enforced guard
+("enforce, don't exhort", Q-0132). Genuinely believe in this: the dead-end has now recurred in
+deathmatch, rps, fishing shops, and the chain/farm assessments flagged it as a risk too — exactly the
+"friction → guard" pattern (Q-0194). Will file to `docs/ideas/` (route-in: the completion rubric's
+"no dead-end controls" line).
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewing `2026-06-27-mining-loadout-presets`: **did well** — it shipped a clean Phase-1 slice *and*
+folded in a real bugs-first cleanup (the `!gear` command had reimplemented the gear embed + paper-doll
+that already lived in the view layer; it extracted `build_gear_command_embed` to the view layer,
+dropping the cog 842→787 LOC). That "the feature exposed a duplication, so I removed the duplication at
+its root" instinct is exactly the discipline the workflow wants. **Could improve / system note:** its
+Q-0089 idea (fishing-specific gear stats) turned out to **already be shipped** (#1504) — the run
+proposed it as "the natural next slice" without grepping that `fishing_power`/`bite_luck` were already
+in `equipment.py`. Minor (it was a forward idea, not built), but it shows the Q-0089 dedup-grep step
+can slip. **System improvement surfaced:** the Q-0089 ender already *says* "dedup-grep `docs/ideas/` +
+the roadmap first" — but a forward idea can also already be *built in source* (not just captured as an
+idea). A cheap guard: the idea-capture step should grep the **source tree** for the proposed
+symbol/feature, not only the ideas index — which is exactly what this run did at orient time (grepping
+`fishing_power` before picking work), and it immediately revealed the idea was done.
+
+## 📤 Run report
+
+- **Did:** closed the trapped-view dead-end gap in both competitive PvP games (Deathmatch + RPS) +
+  root-fixed a latent panel-PvP crash · **Outcome:** shipped
+- **Shipped:** #1527 — Deathmatch `_PvpDuelResultView` (Help/Games nav + Rematch) on every PvP
+  terminal + BUG-0028 panel-PvP `ctx=None` crash root fix; RPS `_RpsPvpResultView` (◀ Back to RPS) +
+  rules "Timeouts & forfeits" field; 11 new tests; both completion certs advanced toward ✔
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (no migration; live on the next auto-deploy)
+- **⚑ Self-initiated:** the two PvP dead-end fixes + the BUG-0028 root fix were picked off the
+  completion-first thread with no dispatch/owner ask (Q-0172, completion-first deepening per Q-0209)
+- **↪ Next:** continue completion-first — the next high-value offline gaps are Blackjack punch-list #1
+  (split/insurance/surrender — bigger engine work, owner-paced) and the unassessed `▢` units (Mining,
+  Creatures, Casino, and the server-fn families). A cheap win: build the "no-dead-end" arch checker
+  (Q-0089 idea above) so this bug class is caught automatically instead of per-assessment.
+
+## Doc audit (Q-0104)
+
+`check_quality.py --full` green · `check_architecture --mode strict` 0 errors · `check_consistency`
+clean. Updated both completion certs (deathmatch.md, rps_tournament.md), added BUG-0028 to the bug
+book, and refreshed the S1 sector recently-shipped list. No owner decision this run → router
+untouched. Completion scoreboard counts unchanged (both units stay `◐ assessed` — certification needs
+the owner walkthrough), so no `completion_scoreboard.py` regen needed.

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -100,6 +100,7 @@ class _DuelView(discord.ui.View):
         ctx: commands.Context,
         *,
         timeout: float = 60.0,
+        guild_id: int | None = None,
     ):
         # PR 8 — ``timeout`` is now a keyword arg; defaults to the
         # historical 60s value when called without the setting-aware
@@ -110,6 +111,15 @@ class _DuelView(discord.ui.View):
         self.duel = duel
         self.duel_key = duel_key
         self.ctx = ctx
+        # The originating guild for the leaderboard / gear-wear writes. The
+        # panel-initiated PvP path constructs this view with ``ctx=None`` (it
+        # only has an interaction), so reading ``ctx.guild.id`` on resolve used
+        # to raise ``AttributeError`` mid-duel — callers now pass ``guild_id``
+        # explicitly. The ctx fallback preserves the command path + existing
+        # tests that build a ``_DuelView`` with a real ``ctx`` and no guild_id.
+        if guild_id is None:
+            guild_id = ctx.guild.id if ctx and getattr(ctx, "guild", None) else 0
+        self.guild_id = guild_id
         self.message: discord.Message | None = None
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -148,15 +158,13 @@ class _DuelView(discord.ui.View):
         await self.cog.update_leaderboard(
             winner_id=opponent.id,
             loser_id=duel.turn.id,
-            guild_id=self.ctx.guild.id if self.ctx.guild else 0,
+            guild_id=self.guild_id,
         )
         wear_notes = await _tick_duel_gear_wear(
-            self.ctx.guild.id if self.ctx.guild else 0,
+            self.guild_id,
             duel.player1,
             duel.player2,
         )
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
         description = (
             f"{duel.turn.mention} took too long to respond.\n"
             f"🏆 {opponent.mention} wins by default!"
@@ -170,7 +178,15 @@ class _DuelView(discord.ui.View):
         )
         if self.message:
             try:
-                await self.message.edit(embed=embed, view=self)
+                # Swap to the terminal result view (Help + Games nav + Rematch)
+                # so a timed-out PvP duel is never a dead-end (owner directive
+                # 2026-06-23, previously applied only to the bot path).
+                from views.games.deathmatch_panel import _PvpDuelResultView
+
+                await self.message.edit(
+                    embed=embed,
+                    view=_PvpDuelResultView(self.cog, duel.player1, duel.player2),
+                )
             except Exception:
                 pass
 
@@ -217,15 +233,13 @@ class _DuelView(discord.ui.View):
             await self.cog.update_leaderboard(
                 winner_id=winner.id,
                 loser_id=loser.id,
-                guild_id=self.ctx.guild.id if self.ctx.guild else 0,
+                guild_id=self.guild_id,
             )
             wear_notes = await _tick_duel_gear_wear(
-                self.ctx.guild.id if self.ctx.guild else 0,
+                self.guild_id,
                 duel.player1,
                 duel.player2,
             )
-            for item in self.children:
-                item.disabled = True  # type: ignore[attr-defined]
             description = (
                 f"{action_text}\n\n"
                 f"**{duel.player1.display_name}** — "
@@ -241,7 +255,15 @@ class _DuelView(discord.ui.View):
                 description=description,
                 color=discord.Color.gold(),
             )
-            await interaction.response.edit_message(embed=embed, view=self)
+            # Swap to the terminal result view (Help + Games nav + Rematch) so a
+            # finished PvP duel is never a dead-end (owner directive 2026-06-23,
+            # previously applied only to the bot path via _BotDuelResultView).
+            from views.games.deathmatch_panel import _PvpDuelResultView
+
+            await interaction.response.edit_message(
+                embed=embed,
+                view=_PvpDuelResultView(self.cog, duel.player1, duel.player2),
+            )
         else:
             await interaction.response.edit_message(
                 embed=self.build_embed(action_text),
@@ -286,8 +308,6 @@ class _ChallengeView(discord.ui.View):
         # message, so the expired-challenge notice must not clobber it.
         if self._resolved:
             return
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
         embed = discord.Embed(
             title="⚔️ Challenge Expired",
             description=f"{self.opponent.mention} did not respond in time.",
@@ -295,7 +315,14 @@ class _ChallengeView(discord.ui.View):
         )
         if self.message:
             try:
-                await self.message.edit(embed=embed, view=self)
+                # Not a dead-end — offer Help + Games nav and a 🔁 Rematch
+                # (re-challenge) instead of a dead embed.
+                from views.games.deathmatch_panel import _PvpDuelResultView
+
+                await self.message.edit(
+                    embed=embed,
+                    view=_PvpDuelResultView(self.cog, self.challenger, self.opponent),
+                )
             except Exception:
                 pass
 
@@ -338,6 +365,11 @@ class _ChallengeView(discord.ui.View):
             self.duel_key,
             self.ctx,
             timeout=turn_timeout,
+            # Thread the originating guild explicitly: the panel-initiated PvP
+            # path builds this challenge with ctx=None, so the duel must take
+            # its guild from the accept interaction rather than ``ctx.guild``
+            # (which would AttributeError on resolve).
+            guild_id=gid,
         )
         await interaction.response.edit_message(
             embed=duel_view.build_embed(),
@@ -353,14 +385,19 @@ class _ChallengeView(discord.ui.View):
     @discord.ui.button(label="❌ Decline", style=discord.ButtonStyle.danger)
     async def btn_decline(self, interaction: discord.Interaction, _: discord.ui.Button):
         self._resolved = True
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
         embed = discord.Embed(
             title="⚔️ Challenge Declined",
             description=f"{self.opponent.mention} declined the duel.",
             color=discord.Color.greyple(),
         )
-        await interaction.response.edit_message(embed=embed, view=self)
+        # Not a dead-end — swap to the result view (Help + Games nav + a
+        # 🔁 Rematch the challenger can use to re-issue the challenge).
+        from views.games.deathmatch_panel import _PvpDuelResultView
+
+        await interaction.response.edit_message(
+            embed=embed,
+            view=_PvpDuelResultView(self.cog, self.challenger, self.opponent),
+        )
         # Challenge resolved — stop the view so its timeout can't later fire and
         # replace this "Declined" notice with an "Expired" one.
         self.stop()

--- a/disbot/views/games/deathmatch_panel.py
+++ b/disbot/views/games/deathmatch_panel.py
@@ -164,6 +164,26 @@ def build_deathmatch_challenge_picker_embed() -> discord.Embed:
     )
 
 
+def build_deathmatch_challenge_embed(
+    challenger: discord.Member | discord.User,
+    opponent: discord.Member | discord.User,
+) -> discord.Embed:
+    """The Accept/Decline challenge prompt — one builder for every entry
+    point (panel opponent-select + the PvP-result rematch), so the copy
+    can't drift between them.
+    """
+    embed = discord.Embed(
+        title="⚔️ Deathmatch Challenge",
+        description=(
+            f"{challenger.mention} has challenged {opponent.mention} to a "
+            "duel!\n\nPress **Accept** or **Decline** below."
+        ),
+        color=discord.Color.red(),
+    )
+    embed.set_footer(text="You have 30 seconds to respond.")
+    return embed
+
+
 # ---------------------------------------------------------------------------
 # Bot-duel view
 # ---------------------------------------------------------------------------
@@ -368,6 +388,103 @@ class _BotDuelResultView(HubView):
         view.message = interaction.message
 
 
+class _PvpDuelResultView(HubView):
+    """Terminal screen after a human-vs-human duel / resolved challenge —
+    never a dead-end.
+
+    A ``HubView`` with ``SUBSYSTEM = "deathmatch"`` so
+    :func:`views.navigation.attach_standard_nav` auto-attaches **📚 Help** and
+    **↩ Games** (row 4) — neither fighter is ever stranded on a dead embed
+    (owner directive 2026-06-23, previously applied only to the bot path via
+    :class:`_BotDuelResultView`). The **🔁 Rematch** button re-challenges: the
+    clicker challenges the *other* fighter, who re-confirms via the normal
+    Accept/Decline prompt (consent preserved). Used by the PvP duel-finish /
+    timeout / decline / expire paths in ``cogs.deathmatch_cog``.
+
+    Both duelists may interact (``interaction_check`` allows either id) — a
+    duel has two owners, unlike the single-player bot result view.
+    """
+
+    SUBSYSTEM = "deathmatch"
+
+    def __init__(
+        self,
+        cog: Deathmatch,
+        player1: discord.Member | discord.User,
+        player2: discord.Member | discord.User,
+    ) -> None:
+        # ``player1`` is the nominal author (BaseView needs one); the override
+        # below widens access to both fighters.
+        super().__init__(player1)
+        self.cog = cog
+        self.player1 = player1
+        self.player2 = player2
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id in (self.player1.id, self.player2.id):
+            return True
+        await interaction.response.send_message(
+            "Only the two duelists can use this.",
+            ephemeral=True,
+        )
+        return False
+
+    @discord.ui.button(
+        label="🔁 Rematch",
+        style=discord.ButtonStyle.success,
+        custom_id="deathmatch_pvp_result:rematch",
+        row=0,
+    )
+    async def btn_rematch(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        # Lazy imports — the rematch reuses the cog's ``_ChallengeView`` and the
+        # ``actions`` duel-key/guard helpers; keeping them function-body keeps
+        # the panel free of a module-level ``views → cogs`` edge.
+        from cogs.deathmatch.actions import has_existing_duel, make_duel_key
+        from cogs.deathmatch_cog import _ChallengeView
+
+        # The clicker becomes the new challenger; the other fighter is the
+        # opponent (re-confirms via Accept/Decline).
+        if interaction.user.id == self.player1.id:
+            challenger, opponent = self.player1, self.player2
+        else:
+            challenger, opponent = self.player2, self.player1
+        if not isinstance(challenger, discord.Member) or not isinstance(
+            opponent,
+            discord.Member,
+        ):
+            await interaction.response.send_message(
+                "A rematch needs both players to be server members.",
+                ephemeral=True,
+            )
+            return
+        cog = self.cog
+        conflict = has_existing_duel(cog, challenger.id, opponent.id)
+        if conflict:
+            await interaction.response.send_message(conflict, ephemeral=True)
+            return
+        duel_key = make_duel_key(challenger.id, opponent.id)
+        # ``_ChallengeView`` only reads ``ctx`` to forward into ``_DuelView``,
+        # which now takes its ``guild_id`` from the accept interaction — so the
+        # panel/rematch path safely passes ctx=None (no longer crashes on
+        # resolve; see the deathmatch_cog guild_id thread).
+        challenge_view = _ChallengeView(
+            cog,
+            challenger,
+            opponent,
+            duel_key,
+            None,  # type: ignore[arg-type]
+        )
+        await interaction.response.edit_message(
+            embed=build_deathmatch_challenge_embed(challenger, opponent),
+            view=challenge_view,
+        )
+        challenge_view.message = interaction.message
+
+
 # ---------------------------------------------------------------------------
 # Challenge-picker sub-view
 # ---------------------------------------------------------------------------
@@ -443,16 +560,10 @@ class _DeathmatchOpponentSelect(discord.ui.UserSelect):
             duel_key,
             None,  # type: ignore[arg-type]
         )
-        embed = discord.Embed(
-            title="⚔️ Deathmatch Challenge",
-            description=(
-                f"{challenger.mention} has challenged {opponent.mention} "
-                "to a duel!\n\nPress **Accept** or **Decline** below."
-            ),
-            color=discord.Color.red(),
+        await interaction.response.edit_message(
+            embed=build_deathmatch_challenge_embed(challenger, opponent),
+            view=challenge_view,
         )
-        embed.set_footer(text="You have 30 seconds to respond.")
-        await interaction.response.edit_message(embed=embed, view=challenge_view)
         challenge_view.message = interaction.message
 
 
@@ -565,6 +676,7 @@ class DeathmatchPanelView(HubView):
 
 __all__ = [
     "DeathmatchPanelView",
+    "build_deathmatch_challenge_embed",
     "build_deathmatch_overview_embed",
     "build_deathmatch_rules_embed",
 ]

--- a/disbot/views/games/rps_panel.py
+++ b/disbot/views/games/rps_panel.py
@@ -179,6 +179,16 @@ def build_rps_rules_embed() -> discord.Embed:
         ),
         inline=False,
     )
+    embed.add_field(
+        name="Timeouts & forfeits",
+        value=(
+            "You have a short window to lock in your move. Run out of "
+            "time and you **forfeit** the round — in a stakes match the "
+            "pot goes to your opponent. If **neither** player picks, it's "
+            "a draw and stakes are refunded."
+        ),
+        inline=False,
+    )
     return embed
 
 

--- a/disbot/views/rps/pvp_play.py
+++ b/disbot/views/rps/pvp_play.py
@@ -27,6 +27,48 @@ from views.rps._helpers import (
 logger = logging.getLogger("bot.rps.pvp_play")
 
 
+class _RpsPvpResultView(discord.ui.View):
+    """Terminal screen after a PvP match resolves — never a dead-end.
+
+    The PvP result used to be posted as a bare channel embed with no
+    controls (completion cert punch-list #2), stranding both players. This
+    view carries the shared **◀ Back to RPS** affordance every other RPS
+    sub-view already uses (`_make_rps_back_button`), so either player is one
+    click from the RPS hub. Either match participant may use it; the back
+    panel opens for whoever clicks (its author is read off the interaction).
+    """
+
+    def __init__(self, p1: discord.Member, p2: discord.Member) -> None:
+        super().__init__(timeout=180)
+        self.p1 = p1
+        self.p2 = p2
+        self.message: discord.Message | None = None
+        # Late import: rps_panel imports this module's siblings, so a
+        # module-level import would create a cycle (mirrors solo_play).
+        from views.games.rps_panel import _make_rps_back_button
+
+        self.add_item(_make_rps_back_button())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id not in (self.p1.id, self.p2.id):
+            await interaction.response.send_message(
+                "You're not part of this match.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        if self.message is None:
+            return
+        for item in self.children:
+            item.disabled = True  # type: ignore[attr-defined]
+        try:
+            await self.message.edit(view=self)
+        except Exception as exc:
+            logger.debug("rps_pvp result on_timeout: message.edit failed: %s", exc)
+
+
 class _RpsPvpPlayView(SettleOnceMixin, discord.ui.View):
     """Visible to the channel; each player clicks for their ephemeral picker."""
 
@@ -194,7 +236,11 @@ class _RpsPvpPlayView(SettleOnceMixin, discord.ui.View):
             ),
             color=SUCCESS_COLOR if winner_id else GAME_COLOR,
         )
-        await self.channel.send(embed=embed)
+        # Not a dead-end (cert punch-list #2): post the result with a
+        # ◀ Back to RPS affordance so neither player is stranded on a bare
+        # channel embed.
+        result_view = _RpsPvpResultView(self.p1, self.p2)
+        result_view.message = await self.channel.send(embed=embed, view=result_view)
 
         # PR G1 — match resolved naturally; drop the persisted state.
         try:

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,13 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Completion-first PvP dead-end fixes** (#1527, Q-0209) — closed the recurring **trapped-view** bug
+  class in both competitive PvP games. **Deathmatch:** PvP `_DuelView`/`_ChallengeView` now swap to
+  `_PvpDuelResultView` (Help/Games nav + 🔁 Rematch) on every terminal, and the latent panel-PvP
+  `ctx=None` resolve crash was root-fixed (BUG-0028, explicit `guild_id` thread). **RPS:** the PvP
+  match result now carries ◀ Back to RPS (`_RpsPvpResultView`) + a rules "Timeouts & forfeits" field.
+  Both completion certs advanced toward ✔ (Deathmatch is now a ✔-ready candidate pending owner
+  walkthrough). 11 new tests.
 - **Reaction-roles arc — Carl-bot-mature** (#1234/#1237/#1242/#1243/#1245/#1246/#1248/#1250):
   multi-emote-per-message, channel/message pickers, role + gradient presets, free temp-roles
   member view, dead-binding self-heal. **PR 6 (PIL banner cards) shipped (#1279);** only the gated web
@@ -74,14 +81,14 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   startable, offline:** (1) **assess more units** — the remaining unassessed games (Mining [big read],
   Casino, Creatures) then server-fns, one cert each under
   [`../planning/feature-completion/units/`](../planning/feature-completion/README.md) from the rubric;
-  (2) **a turn-key contained fix surfaced by the assessments:** **Deathmatch PvP trapped views** — the
-  PvP `_DuelView`/`_ChallengeView` (`disbot/cogs/deathmatch_cog.py:94,252`) are plain `discord.ui.View`s
-  that dead-end after a duel (no back nav), while the bot-duel path already swaps to a
-  `HubView` result view; mirror that pattern (a `HubView` result view with `SUBSYSTEM="deathmatch"` +
-  a 🔁 Rematch button) to close the dead-end **and** the missing PvP rematch in one slice
-  ([cert headline](../planning/feature-completion/units/deathmatch.md)). RPS help-text drift was fixed
-  in #1524. **▶ Owner decisions waiting:** Word Chain re-classify, Counting XP/coin reward, Deathmatch
-  optional coin-staking, plus every assessed unit's `◐ → ✔` live-walkthrough sign-off
+  (2) **build the "no-dead-end" arch guard** ([idea](../ideas/no-dead-end-terminal-view-guard-2026-06-28.md))
+  so the trapped-view bug class is caught automatically instead of per-assessment. **✅ DONE
+  2026-06-28 (#1527):** the Deathmatch PvP trapped views (+ the panel-PvP `ctx=None` crash, BUG-0028)
+  **and** the RPS PvP-result dead-end were both fixed — `_PvpDuelResultView` / `_RpsPvpResultView` with
+  standard nav + rematch/back; both certs advanced toward ✔. The next turn-key gap is **Blackjack
+  punch-list #1** (split/insurance/surrender — bigger engine work, owner-paced). **▶ Owner decisions
+  waiting:** Word Chain re-classify, Counting XP/coin reward, Deathmatch optional coin-staking, plus
+  every assessed unit's `◐ → ✔` live-walkthrough sign-off
   (`[needs-live-bot]`/`[owner]`).
 - `[offline]` **Fishing-specific gear stats — SHIPPED 2026-06-27 (#1504)** (see Recently shipped above):
   the Q-0175 "matching gear → better fishing" half is done — `fishing_power`/`bite_luck` on

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,6 +23,35 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
+## BUG-0028 — panel-initiated PvP deathmatch crashes on resolve (`ctx=None` → `self.ctx.guild.id` AttributeError) — FIXED (root)
+
+- **Symptom (found 2026-06-28 by a dispatch run via code inspection during the Deathmatch
+  completion-cert dead-end fix — not a live report, but a real latent crash):** a PvP duel started
+  from the **panel** (`👤 Challenge Player` → opponent select, not the `!deathmatch @user` command)
+  would raise `AttributeError: 'NoneType' object has no attribute 'guild'` the moment the duel
+  **resolved** (a finishing blow or a turn timeout) — i.e. the whole panel-PvP path was broken at the
+  finish line.
+- **Root cause:** `views/games/deathmatch_panel.py::_DeathmatchOpponentSelect.callback` builds
+  `_ChallengeView(cog, challenger, opponent, duel_key, None)` — `ctx=None`, since the panel only has
+  an `interaction`. On accept that `None` ctx is forwarded into `_DuelView`, whose `_resolve` /
+  `on_timeout` computed the originating guild as `self.ctx.guild.id if self.ctx.guild else 0` —
+  `None.guild` raises. (The `!deathmatch` command path was unaffected: it passes a real ctx.) It also
+  meant the panel path would have recorded results under the wrong guild even if it hadn't crashed.
+- **Fix (root, PR #1527):** thread an **explicit `guild_id`** through the duel instead of reaching
+  into `ctx`. `_ChallengeView.btn_accept` already had `gid = interaction.guild_id or 0` (for gear); it
+  now passes `guild_id=gid` into `_DuelView`, which stores `self.guild_id` (falling back to
+  `ctx.guild.id` only when no `guild_id` is given, preserving the command path + existing tests) and
+  uses `self.guild_id` for the leaderboard + gear-wear writes. The panel/rematch path can now pass
+  `ctx=None` safely.
+- **Stays-fixed guard:** `tests/unit/cogs/test_deathmatch_pvp_deadend.py::`
+  `test_pvp_duel_timeout_swaps_to_result_view_and_uses_guild_id` builds a `_DuelView` with `ctx=None`
+  and `guild_id=777`, runs `on_timeout`, and asserts the write is recorded under `777` with **no
+  crash** (fails against the pre-fix `self.ctx.guild.id`); `test_duelview_guild_id_falls_back_to_ctx`
+  pins the backward-compatible ctx fallback (and that `ctx=None`+no-guild_id degrades to `0`, never
+  raises).
+- **Status:** FIXED (root) 2026-06-28. Fixed alongside the PvP trapped-view dead-end gap (Deathmatch
+  completion cert punch-list #1); live on the next auto-deploy.
+
 ## BUG-0027 — born-red merge-gate silently fails open on a session-card slug collision (a partial PR auto-merged and clobbered a prior session log) — FIXED (root)
 
 - **Symptom (found 2026-06-28 by a dispatch run, from its own behavior — not a live user report):**

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`no-dead-end-terminal-view-guard-2026-06-28.md`](./no-dead-end-terminal-view-guard-2026-06-28.md) —
+  **session idea (2026-06-28, Q-0089, from fixing the Deathmatch + RPS PvP dead-ends #1527):** an arch
+  lint flagging any game terminal view that disables/`stop()`s without swapping to a nav-bearing result
+  view (or posts a terminal message with no `view=`). Turns a recurring manual catch (fishing, deathmatch,
+  rps, chain/farm) into an enforced guard — the "friction → guard" pattern (Q-0194). Warn-tier first,
+  disposable (Q-0105). Subsystem: S1 games / S3 tooling.
 - [`router-q-index-generator-2026-06-28.md`](./router-q-index-generator-2026-06-28.md) —
   **session idea (2026-06-28, Q-0089, from documenting the open-question sweep + deciding Q-0210):** a
   stdlib `build_q_index.py` → a one-line-per-Q index (number · title · status · Home · file) over the

--- a/docs/ideas/no-dead-end-terminal-view-guard-2026-06-28.md
+++ b/docs/ideas/no-dead-end-terminal-view-guard-2026-06-28.md
@@ -1,0 +1,42 @@
+# Idea — a "no dead-end" arch guard for game terminal views
+
+> **Status:** `ideas` · captured 2026-06-28 (dispatch run, Q-0089 session idea).
+> Route-in: the completion rubric's "No dead-end controls" line
+> ([`../planning/feature-completion/rubric-game.md`](../planning/feature-completion/rubric-game.md))
+> + the architecture checker (`scripts/check_architecture.py`).
+
+## The recurring bug
+
+The 2026-06-23 owner directive is "a finished game/duel is **never** a dead-end" — a terminal view
+must swap to (or carry) a result view with standard nav (`SUBSYSTEM` → 📚 Help + ↩ Games / a
+◀ Back button), never just disable its buttons and `stop()`. This keeps re-appearing one game at a
+time, caught only by manual completion assessments:
+
+- Fishing — the Rod/Bait shops were trapped (fixed #1521).
+- Deathmatch — the **PvP** `_DuelView`/`_ChallengeView` were dead-ends (fixed #1527).
+- RPS — the **PvP** match result was a bare channel embed (fixed #1527).
+- Chain / Farm assessments flagged the same risk on their terminal paths.
+
+It is the textbook **friction → guard** case (Q-0194): a known, repeating defect class enforced only
+by exhortation, not by a checker.
+
+## The guard
+
+A lightweight AST lint (a `scripts/check_architecture.py` rule, or a dedicated checker) that flags any
+`discord.ui.View` subclass under `views/` / `cogs/` whose **terminal handler** either:
+
+- ends an `on_timeout` / a handler that calls `self.stop()` with `view=self` (or only disabling
+  `self.children`) and **no** swap to a view that carries standard nav, **or**
+- posts a fresh terminal message (`channel.send(embed=…)` / `edit_message`) with **no `view=`** on a
+  resolve path.
+
+Heuristic, so it would need an allowlist (genuinely ephemeral one-offs, confirmations) — same shape as
+the existing `baseview_inheritance` warn rule. Start as a **warning tier** (like the cog-size warn),
+graduate to error once the existing fleet is clean.
+
+## Why it's worth having
+
+Turns a recurring manual catch into an enforced one ("enforce, don't exhort", Q-0132). Every
+completion assessment currently spends effort re-checking this by hand; a guard frees that effort and
+stops new games from shipping the same dead-end. Disposable per the adopt-freely-with-a-kill-switch
+rule — if the heuristic proves too noisy across a few sessions, delete it.

--- a/docs/owner/claims/claude-funny-franklin-05mst6.md
+++ b/docs/owner/claims/claude-funny-franklin-05mst6.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-05mst6` · scope: completion-first — fix trapped PvP terminal views (dead-end gap) in Deathmatch (+RPS if time), add rematch + PvP loop tests; root-fix the panel-PvP ctx=None crash · area: disbot/cogs/deathmatch_cog.py, disbot/views/games/deathmatch_panel.py, tests, docs/planning/feature-completion/units/ · 2026-06-28

--- a/docs/owner/claims/claude-funny-franklin-05mst6.md
+++ b/docs/owner/claims/claude-funny-franklin-05mst6.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-05mst6` · scope: completion-first — fix trapped PvP terminal views (dead-end gap) in Deathmatch (+RPS if time), add rematch + PvP loop tests; root-fix the panel-PvP ctx=None crash · area: disbot/cogs/deathmatch_cog.py, disbot/views/games/deathmatch_panel.py, tests, docs/planning/feature-completion/units/ · 2026-06-28

--- a/docs/planning/feature-completion/units/deathmatch.md
+++ b/docs/planning/feature-completion/units/deathmatch.md
@@ -25,8 +25,9 @@
       (`deathmatch/actions.py:40`), crit, armor floor.
 - [x] **Loop runs start→finish** — challenge→accept→turn loop→resolve→leaderboard (PvP,
       `deathmatch_cog.py:214`); gear-load→duel→result view (bot, `deathmatch_panel.py:216`).
-- [ ] **No dead-end controls** — ❌ **the PvP `_DuelView` and `_ChallengeView` are trapped** (see B,
-      punch-list #1). The bot-duel path is clean (swaps to `_BotDuelResultView`).
+- [x] **No dead-end controls** — ✅ **fixed (punch-list #1, this PR).** The PvP `_DuelView` /
+      `_ChallengeView` now swap to `_PvpDuelResultView` (Help + Games nav + 🔁 Rematch) on
+      finish/timeout/decline/expire, mirroring the bot path's `_BotDuelResultView`.
 - [x] **Rewards wired** — leaderboard W/L via `db.update_deathmatch`; gear wear ticked once per PvP duel
       via `mining_workflow.wear_tick` (`deathmatch_cog.py:68`). Free game (no coins/XP by design).
 
@@ -36,22 +37,20 @@
 - [x] **Every action has a control** — Fight Bot / Challenge / Rules on the panel; Attack/Defend in the
       duel; opponent picker on Challenge.
 - [x] **Rules affordance** — 📖 Rules on the panel (`deathmatch_panel.py:67`).
-- [ ] **Return navigation everywhere** — ❌ **headline gap.** `_BotDuelResultView` declares
-      `SUBSYSTEM = "deathmatch"` so `attach_standard_nav` gives it 📚 Help + ↩ Games (correct). But the
-      **PvP** `_DuelView` (in-game) and `_ChallengeView` (accept prompt) are plain `discord.ui.View`
-      subclasses (`deathmatch_cog.py:94,252`): on finish / timeout / decline they disable their buttons
-      and **stop with no back affordance** → the player is stranded on a dead embed. The 2026-06-23
-      "finished duel is never a dead-end" directive was applied to the bot path and **missed for PvP**.
-      → punch-list #1.
+- [x] **Return navigation everywhere** — ✅ **fixed (punch-list #1, headline, this PR).** Both the
+      PvP `_DuelView` (finish/timeout) and `_ChallengeView` (decline/expire) now swap to
+      `_PvpDuelResultView` — a `HubView` with `SUBSYSTEM = "deathmatch"` so `attach_standard_nav`
+      gives it 📚 Help + ↩ Games — instead of leaving a dead embed, closing the 2026-06-23
+      "never a dead-end" gap for the PvP path (it was applied only to the bot `_BotDuelResultView`).
 - [x] **Terminal state correct** — controls disable on terminal in every branch (bot path additionally
       swaps to the result view); `SettleOnceMixin` on the bot duel.
 - [x] **Consistent copy/embeds** — house-style; no debug/placeholder strings found.
 
 ### C. Convenience — "the most convenient way"
 - [x] **No needless clicks** — Challenge opens the opponent picker directly; Fight Bot launches at once.
-- [ ] **Replay without retyping** — ✅ 🔁 Play again on the **bot** result view (`deathmatch_panel.py:354`);
-      ❌ **no PvP rematch** — after a PvP duel the player must re-issue `!deathmatch @opponent`. → folded
-      into punch-list #1 (the PvP result view should carry a rematch).
+- [x] **Replay without retyping** — ✅ 🔁 Play again on the **bot** result view (`deathmatch_panel.py:354`);
+      ✅ **PvP rematch fixed (this PR)** — `_PvpDuelResultView` carries a 🔁 Rematch that re-issues the
+      challenge to the other fighter (re-confirmed via the normal Accept/Decline prompt).
 - [x] **Sensible defaults** — turn timeout is per-guild configurable (`schemas.py`).
 - [x] **Reachable the natural way** — `!deathmatch`/`!dm` + Games hub + Help.
 
@@ -81,40 +80,46 @@
 - [x] **Loop tests (bot path)** — bot AI, combat stats, gear wear, guild scope, settle-once
       (`test_deathmatch_bot_duel.py`, `test_deathmatch_combat_stats.py`, `test_deathmatch_gear_wear.py`,
       `test_deathmatch_guild_scope.py`).
-- [ ] **Edge tests (PvP path)** — the PvP `_DuelView` finish/timeout/settle is untested (only the bot
-      path is). → punch-list #3.
+- [x] **Edge tests (PvP path)** — ✅ **added (punch-list #3, this PR):**
+      `tests/unit/cogs/test_deathmatch_pvp_deadend.py` pins finish/timeout swap-to-result-view,
+      decline/expire nav, rematch re-challenge, the explicit `guild_id` thread, and the
+      both-duelists/bystander authority on the result view.
 - [x] **Money tests** — n/a (free game).
 - [ ] **Live walkthrough recorded** — pending. → punch-list #4.
 - [ ] **Owner ✔** — pending. → punch-list #5/#6.
 
 ## Punch-list (clear these to certify)
 
-1. **PvP terminal views are dead-ends (headline).** `_DuelView` and `_ChallengeView`
-   (`deathmatch_cog.py:94,252`) are plain `discord.ui.View`s; on finish/timeout/decline the player has
-   no back affordance. **Fix (turn-key, mirrors the bot path):** swap each to a small
-   `HubView`-derived result view (`SUBSYSTEM = "deathmatch"`, so `attach_standard_nav` adds 📚 Help +
-   ↩ Games) on terminal, carrying a **🔁 Rematch** button — closing both the dead-end (rubric B) **and**
-   the missing-PvP-rematch convenience (rubric C) in one change. Owner directive precedent: the
-   2026-06-23 "never a dead-end" rule (already applied to `_BotDuelResultView`).
+1. ~~**PvP terminal views are dead-ends (headline).**~~ ✅ **FIXED (this PR).** `_DuelView` and
+   `_ChallengeView` now swap to `_PvpDuelResultView` — a `HubView` (`SUBSYSTEM = "deathmatch"` →
+   `attach_standard_nav` adds 📚 Help + ↩ Games) carrying a **🔁 Rematch** button — on every PvP
+   terminal (finish/timeout/decline/expire), closing both the dead-end (rubric B) **and** the
+   missing-PvP-rematch convenience (rubric C). Bugs-first: the panel-PvP path's `ctx=None` →
+   `self.ctx.guild.id` crash on resolve was root-fixed by threading an explicit `guild_id` through
+   `_ChallengeView.btn_accept` → `_DuelView` (see BUG-0028).
 2. **Uniformity (optional):** move the PvP `_resolved`/`is_over` guard onto `SettleOnceMixin` so PvP and
    bot paths share one settle-once primitive.
-3. **PvP loop tests** — add finish/timeout/settle-once pins for the PvP duel (mirror the bot-duel tests),
-   including correct `guild_id` on a timeout-recorded result.
-4. **Live walkthrough** — `/verify-bot` boot + scripted click-through (challenge → accept → duel →
-   finish → rematch; Fight Bot → result → play again), with screenshots.
+3. ~~**PvP loop tests**~~ ✅ **FIXED (this PR)** — `tests/unit/cogs/test_deathmatch_pvp_deadend.py`
+   pins finish/timeout swap-to-result, decline/expire nav, rematch re-challenge, the `guild_id` thread,
+   and result-view authority (7 tests).
+4. **Live walkthrough** *(owner / live-bot)* — `/verify-bot` boot + scripted click-through (challenge →
+   accept → duel → finish → rematch; Fight Bot → result → play again), with screenshots.
 5. **Coin-staking** *(owner)* — decide whether PvP gains optional wagering via `game_wager_workflow`
    (Blackjack/RPS have it) or stays a free game.
 6. **Owner sign-off** — maintainer plays it and confirms "nothing left to add or move."
 
 ## Evidence
 - **Tests:** `tests/unit/.../test_deathmatch_bot_duel.py` · `test_deathmatch_challenge_timeout.py` ·
-  `test_deathmatch_combat_stats.py` · `test_deathmatch_gear_wear.py` · `test_deathmatch_guild_scope.py`
+  `test_deathmatch_combat_stats.py` · `test_deathmatch_gear_wear.py` · `test_deathmatch_guild_scope.py` ·
+  **`test_deathmatch_pvp_deadend.py` (PvP dead-end / rematch / guild_id — this PR)**
 - **Walkthrough:** pending (punch-list #4)
 - **Owner sign-off:** pending (punch-list #6)
 
 ## Verdict
-Deathmatch is **feature-rich and money-safe** (no stakes), with gear integration, two modes, and a
-well-tested, dead-end-free **bot** path. It is **not yet `✔ certified`**: the **PvP** path has a real
-trapped-view dead-end (#1, the headline) that also carries the missing PvP rematch, plus PvP loop tests
-(#3) and the owner walkthrough/sign-off (#4/#6). #1 is a contained, turn-key fix that mirrors the
-already-shipped bot-duel result view — a strong next slice for a focused follow-up.
+Deathmatch is **feature-rich and money-safe** (no stakes), with gear integration, two modes, and now
+a dead-end-free **bot *and* PvP** path. The headline trapped-view gap (#1) and PvP loop tests (#3)
+are **cleared this PR**, and the latent panel-PvP `ctx=None` crash was root-fixed (BUG-0028). It is
+**not yet `✔ certified`**: what remains is owner-paced / live-bot only — the live walkthrough (#4),
+the optional coin-staking decision (#5), and the owner sign-off (#6); the optional settle-once
+uniformity (#2) is a nice-to-have. The code-side completion bar is essentially met — this unit is now
+a strong **✔-ready candidate** pending the owner walkthrough.

--- a/docs/planning/feature-completion/units/rps_tournament.md
+++ b/docs/planning/feature-completion/units/rps_tournament.md
@@ -27,7 +27,8 @@
 - [x] **Loop runs start→finish** — solo `_play`→resolve→result view; PvP escrow-at-accept→both-pick→
       atomic resolve; tournament seed→match channels→resolve+advance→idempotent payout.
 - [x] **No dead-end/placeholder controls** — solo + bet + challenge-select + tournament sub-views all
-      swap to terminal/result states; one PvP-play result is a channel embed (see B / punch-list #2).
+      swap to terminal/result states; the PvP-play result now carries ◀ Back to RPS too (fixed this PR,
+      punch-list #2).
 - [x] **Rewards wired** — solo win via `economy_service`; PvP/tournament via `game_wager_workflow`
       (`pvp_challenge.py:77`, `pvp_play.py:177`, `rps_tournament_cog.py:673`); stats via `rps_players`.
 
@@ -37,11 +38,11 @@
 - [x] **Every action has a control** — quick play / bet / challenge / tournament on the panel; presets
       on the bet sub-view; move picker ephemeral. PvP is reachable from the panel (not command-only).
 - [x] **Rules affordance** — 📖 Rules on the panel (`build_rps_rules_embed`, `rps_panel.py:157`).
-      *Minor:* the rules embed omits timeout/forfeit semantics (punch-list #3).
-- [ ] **Return navigation everywhere** — ✅ for panel-spawned sub-views (solo result, bet preset,
-      challenge select, tournament sub-view all carry **◀ Back to RPS**). ❌ the **PvP play** result is
-      posted as a bare channel embed with no view (`pvp_play.py:197`), so a panel-spawned PvP challenge
-      has no return affordance after it resolves. → punch-list #2.
+      ✅ **fixed (punch-list #3, this PR):** the rules embed now carries a "Timeouts & forfeits" field.
+- [x] **Return navigation everywhere** — ✅ for panel-spawned sub-views (solo result, bet preset,
+      challenge select, tournament sub-view all carry **◀ Back to RPS**). ✅ **fixed (punch-list #2,
+      this PR):** the **PvP play** result is now posted with `_RpsPvpResultView` carrying ◀ Back to RPS
+      (`pvp_play.py`), so a resolved PvP match is no longer a bare dead-end embed.
 - [x] **Terminal state correct** — solo/challenge/tournament views disable controls on terminal;
       `SettleOnceMixin` guards PvP resolution.
 - [x] **Consistent copy/embeds** — house-style; no debug/placeholder strings.
@@ -83,8 +84,10 @@
 - [x] **Loop tests** — persistence/recovery, solo replay, panel actionability, naming/Help routing
       (`test_rps_tournament_persistence.py`, `test_rps_solo_replay.py`, `test_rps_naming.py`,
       `test_help_actionability_contract.py`).
-- [ ] **Edge tests** — PvP `_RpsPvpPlayView` finish/timeout and bot-batch matches lack dedicated unit
-      pins (covered only indirectly). → punch-list #4.
+- [~] **Edge tests** — ✅ **partly closed (punch-list #4, this PR):**
+      `tests/unit/cogs/test_rps_pvp_deadend.py` pins the PvP `_resolve` posting the nav-bearing result
+      view, the result-view authority, and a `!rpshelp` output drift-guard. Still open: a dedicated
+      bot-batch match test.
 - [x] **Money tests** — escrow/settle/refund via the persistence suites.
 - [ ] **Live walkthrough recorded** — pending. → punch-list #6.
 - [ ] **Owner ✔** — pending. → punch-list #7.
@@ -96,14 +99,14 @@
    `!rps_bot`, `!rps_settings`, `!rps_help`) plus a **`!rps_leaderboard` command that was never
    implemented**. Rewritten to the real no-underscore names (`!rpsregister`/`!rpsstart`/`!rpsbot`/
    `!rpssettings`/`!rpshelp`) led by `!rps` (the panel), with the bogus leaderboard line removed.
-2. **PvP play result has no back affordance** (`pvp_play.py:197`) — a panel-spawned PvP challenge
-   resolves to a bare channel embed; add a small result view with **◀ Back to RPS** (the pattern the
-   solo/bet/challenge views already use), or document PvP as a deliberate one-off. *(Acceptable as-is
-   for tournament matches, which live in ephemeral channels.)*
-3. **Rules embed completeness** — add timeout/forfeit semantics (forfeit on no-pick; 55 s picker) to
-   `build_rps_rules_embed`.
-4. **Edge tests** — add PvP-play finish/timeout/settle-once pins + a bot-batch match test, and a
-   `!rpshelp` output test to catch future command-help drift.
+2. ~~**PvP play result has no back affordance.**~~ ✅ **FIXED (this PR).** `_resolve` now posts the
+   result with `_RpsPvpResultView` carrying **◀ Back to RPS** (the shared `_make_rps_back_button`
+   pattern the solo/bet/challenge views use); either participant may use it.
+3. ~~**Rules embed completeness.**~~ ✅ **FIXED (this PR)** — `build_rps_rules_embed` gained a
+   "Timeouts & forfeits" field (forfeit on no-pick → opponent takes the pot; both no-pick → refund).
+4. **Edge tests** — ✅ **partly closed (this PR):** PvP `_resolve` result-view + authority pins and a
+   `!rpshelp` output drift-guard (`test_rps_pvp_deadend.py`). Still open: a dedicated bot-batch match
+   test.
 5. **PvP rematch affordance** *(owner)* — a 🔁 Rematch button on the PvP result (mirrors the solo
    result), if one-off PvP isn't the intended design.
 6. **Live walkthrough** — `/verify-bot` boot + scripted click-through (quick play → bet → challenge →
@@ -113,13 +116,15 @@
 ## Evidence
 - **Tests:** `tests/unit/.../test_rps_tournament_persistence.py` · `test_rps_pvp_pending_persistence.py` ·
   `test_rps_solo_replay.py` · `test_rps_naming.py` · `test_rps_guild_scope.py` ·
-  `test_help_actionability_contract.py`
+  `test_help_actionability_contract.py` · **`test_rps_pvp_deadend.py` (PvP result back-affordance +
+  rpshelp drift-guard — this PR)**
 - **Walkthrough:** pending (punch-list #6)
 - **Owner sign-off:** pending (punch-list #7)
 
 ## Verdict
 RPS is **substantially complete and money-safe** — the most mode-rich game in the bot (four rule sets,
-four flows), with atomic escrow, full persistence/recovery, and good panel UX. The one offline drift
-(misnamed `!rpshelp` commands) is **fixed in this PR**. It is **not yet `✔ certified`**: the remaining
-items are a PvP-play back affordance (#2), rules-copy + edge tests (#3/#4), an owner PvP-rematch call
-(#5), and the recorded walkthrough + sign-off (#6/#7).
+four flows), with atomic escrow, full persistence/recovery, and good panel UX. The offline gaps are now
+cleared: the `!rpshelp` drift (#1), the PvP-play back affordance (#2), the rules copy (#3), and most of
+the edge tests (#4) are **fixed across this PR + the prior one**. It is **not yet `✔ certified`**: what
+remains is owner-paced / live-bot — an owner PvP-rematch call (#5), a bot-batch match test (tail of #4),
+and the recorded walkthrough + sign-off (#6/#7). Code-side, this unit is now close to ✔-ready.

--- a/tests/unit/cogs/test_deathmatch_pvp_deadend.py
+++ b/tests/unit/cogs/test_deathmatch_pvp_deadend.py
@@ -1,0 +1,211 @@
+"""Completion-first (Q-0209) — Deathmatch PvP terminal views are never dead-ends.
+
+Pins the headline gap from the Deathmatch completion cert (punch-list #1 + #3):
+the **PvP** ``_DuelView`` / ``_ChallengeView`` used to disable their buttons and
+stop on finish / timeout / decline / expire, stranding the player on a dead embed
+(the bot path already swaps to a nav-bearing ``_BotDuelResultView``). They now
+swap to ``_PvpDuelResultView`` (a ``HubView`` with SUBSYSTEM="deathmatch" → 📚 Help
++ ↩ Games nav + a 🔁 Rematch button).
+
+Also pins the bugs-first root fix: the panel-initiated PvP path builds the duel
+with ``ctx=None``; the leaderboard / gear-wear writes now take an explicit
+``guild_id`` instead of ``ctx.guild.id`` (which crashed on resolve).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+def _player(id_: int, name: str = "P") -> SimpleNamespace:
+    return SimpleNamespace(id=id_, display_name=name, mention=f"<@{id_}>", bot=False)
+
+
+def _member(id_: int, name: str = "P") -> MagicMock:
+    """A discord.Member-spec'd mock — needed where the code isinstance-checks."""
+    m = MagicMock(spec=discord.Member)
+    m.id = id_
+    m.display_name = name
+    m.mention = f"<@{id_}>"
+    m.bot = False
+    return m
+
+
+def _stub_interaction(user) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = user
+    interaction.guild_id = 0
+    interaction.message = AsyncMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _result_view_cls():
+    from views.games.deathmatch_panel import _PvpDuelResultView
+
+    return _PvpDuelResultView
+
+
+@pytest.mark.asyncio
+async def test_pvp_duel_finish_swaps_to_result_view():
+    """A finishing blow swaps the in-game view for the nav-bearing result view."""
+    from cogs.deathmatch_cog import _Duel, _DuelView
+
+    cog = MagicMock()
+    cog.active_duels = {}
+    cog.update_leaderboard = AsyncMock()
+    p1, p2 = _player(1, "One"), _player(2, "Two")
+    duel = _Duel(p1, p2)  # type: ignore[arg-type]
+    duel.player2_hp = 1  # next attack from p1 finishes p2
+    key = (1, 2)
+    cog.active_duels[key] = duel
+    view = _DuelView(cog, duel, key, MagicMock(), guild_id=42)
+    interaction = _stub_interaction(p1)
+
+    with patch(
+        "cogs.deathmatch_cog._tick_duel_gear_wear",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        attack = next(c for c in view.children if (c.label or "").startswith("⚔️"))
+        await attack.callback(interaction)  # type: ignore[union-attr]
+
+    cog.update_leaderboard.assert_awaited_once_with(
+        winner_id=p1.id,
+        loser_id=p2.id,
+        guild_id=42,
+    )
+    swapped = interaction.response.edit_message.call_args.kwargs["view"]
+    assert isinstance(swapped, _result_view_cls())
+    assert key not in cog.active_duels
+
+
+@pytest.mark.asyncio
+async def test_pvp_duel_timeout_swaps_to_result_view_and_uses_guild_id():
+    """A timeout records under the explicit guild_id (panel path: ctx=None) and
+    swaps to the result view — no ``ctx.guild`` AttributeError crash."""
+    from cogs.deathmatch_cog import _Duel, _DuelView
+
+    cog = MagicMock()
+    cog.active_duels = {}
+    cog.update_leaderboard = AsyncMock()
+    p1, p2 = _player(1, "One"), _player(2, "Two")
+    duel = _Duel(p1, p2)  # type: ignore[arg-type]
+    key = (1, 2)
+    cog.active_duels[key] = duel
+    # ctx=None is the panel-initiated PvP path — used to crash on resolve.
+    view = _DuelView(cog, duel, key, None, guild_id=777)  # type: ignore[arg-type]
+    view.message = AsyncMock()
+
+    with patch(
+        "cogs.deathmatch_cog._tick_duel_gear_wear",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        await view.on_timeout()  # turn == p1 → p1 loses to p2
+
+    cog.update_leaderboard.assert_awaited_once_with(
+        winner_id=p2.id,
+        loser_id=p1.id,
+        guild_id=777,
+    )
+    swapped = view.message.edit.call_args.kwargs["view"]
+    assert isinstance(swapped, _result_view_cls())
+
+
+@pytest.mark.asyncio
+async def test_duelview_guild_id_falls_back_to_ctx():
+    """Backward-compat: with no explicit guild_id the duel still reads ctx.guild
+    (the command path + existing tests)."""
+    from cogs.deathmatch_cog import _Duel, _DuelView
+
+    duel = _Duel(_player(1), _player(2))  # type: ignore[arg-type]
+    ctx = MagicMock()
+    ctx.guild.id = 999
+    assert _DuelView(MagicMock(), duel, (1, 2), ctx).guild_id == 999
+    # ctx=None with no guild_id degrades to the global bucket, never crashes.
+    assert _DuelView(MagicMock(), duel, (1, 2), None).guild_id == 0  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_challenge_decline_swaps_to_result_view():
+    from cogs.deathmatch_cog import _ChallengeView
+
+    cog = MagicMock()
+    cog.active_duels = {}
+    challenger, opponent = _player(1, "Chal"), _player(2, "Opp")
+    view = _ChallengeView(cog, challenger, opponent, (1, 2), MagicMock())
+    view.message = AsyncMock()
+    interaction = _stub_interaction(opponent)
+
+    decline = next(c for c in view.children if (c.label or "").startswith("❌"))
+    await decline.callback(interaction)  # type: ignore[union-attr]
+
+    swapped = interaction.response.edit_message.call_args.kwargs["view"]
+    assert isinstance(swapped, _result_view_cls())
+    assert view.is_finished()
+
+
+@pytest.mark.asyncio
+async def test_challenge_expire_swaps_to_result_view():
+    from cogs.deathmatch_cog import _ChallengeView
+
+    cog = MagicMock()
+    cog.active_duels = {}
+    challenger, opponent = _player(1, "Chal"), _player(2, "Opp")
+    view = _ChallengeView(cog, challenger, opponent, (1, 2), MagicMock())
+    view.message = AsyncMock()
+
+    await view.on_timeout()
+
+    swapped = view.message.edit.call_args.kwargs["view"]
+    assert isinstance(swapped, _result_view_cls())
+
+
+@pytest.mark.asyncio
+async def test_rematch_reissues_challenge():
+    """🔁 Rematch swaps the result view for a fresh Accept/Decline challenge."""
+    from cogs.deathmatch_cog import _ChallengeView
+
+    cog = MagicMock()
+    cog.active_duels = {}
+    p1, p2 = _member(1, "One"), _member(2, "Two")
+    view = _result_view_cls()(cog, p1, p2)
+    interaction = _stub_interaction(p1)
+
+    rematch = next(
+        c
+        for c in view.children
+        if getattr(c, "custom_id", "") == "deathmatch_pvp_result:rematch"
+    )
+    await rematch.callback(interaction)  # type: ignore[union-attr]
+
+    swapped = interaction.response.edit_message.call_args.kwargs["view"]
+    assert isinstance(swapped, _ChallengeView)
+    assert swapped.challenger is p1 and swapped.opponent is p2
+
+
+@pytest.mark.asyncio
+async def test_result_view_blocks_non_duelists():
+    cog = MagicMock()
+    p1, p2 = _player(1), _player(2)
+    view = _result_view_cls()(cog, p1, p2)
+    bystander = _stub_interaction(_player(99))
+
+    assert await view.interaction_check(bystander) is False
+    bystander.response.send_message.assert_awaited_once()
+
+    for fighter in (p1, p2):
+        assert await view.interaction_check(_stub_interaction(fighter)) is True

--- a/tests/unit/cogs/test_rps_pvp_deadend.py
+++ b/tests/unit/cogs/test_rps_pvp_deadend.py
@@ -1,0 +1,97 @@
+"""Completion-first (Q-0209) — RPS PvP result is never a dead-end + help-text guard.
+
+Pins the remaining offline gaps from the RPS completion cert:
+- punch-list #2 — the PvP match result used to post a bare channel embed with no
+  controls; it now carries a ◀ Back to RPS affordance (`_RpsPvpResultView`).
+- punch-list #4 — a `!rpshelp` output guard so the command-name drift fixed in the
+  prior PR (underscored `!rps_*` names + a nonexistent leaderboard) can't silently
+  return.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+def _player(id_: int) -> SimpleNamespace:
+    return SimpleNamespace(id=id_, mention=f"<@{id_}>")
+
+
+def _stub_interaction(user) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = user
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def test_pvp_result_view_carries_back_to_rps():
+    from views.rps.pvp_play import _RpsPvpResultView
+
+    view = _RpsPvpResultView(_player(1), _player(2))
+    labels = [getattr(c, "label", "") for c in view.children]
+    assert any("Back to RPS" in (lbl or "") for lbl in labels), labels
+
+
+@pytest.mark.asyncio
+async def test_pvp_result_view_blocks_non_participants():
+    from views.rps.pvp_play import _RpsPvpResultView
+
+    p1, p2 = _player(1), _player(2)
+    view = _RpsPvpResultView(p1, p2)
+    assert await view.interaction_check(_stub_interaction(_player(99))) is False
+    for fighter in (p1, p2):
+        assert await view.interaction_check(_stub_interaction(fighter)) is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_posts_result_with_back_affordance():
+    """A resolved (free) PvP match posts its result with the nav-bearing view —
+    not a bare embed."""
+    from views.rps.pvp_play import _RpsPvpPlayView, _RpsPvpResultView
+
+    p1, p2 = _player(1), _player(2)
+    channel = MagicMock()
+    channel.id = 5
+    channel.send = AsyncMock(return_value=AsyncMock())
+    view = _RpsPvpPlayView(p1, p2, guild_id=7, bet=0, channel=channel)
+    view.message = AsyncMock()
+    view.choices = {p1.id: "rock", p2.id: "scissors"}  # p1 wins
+
+    with patch(
+        "views.rps.pvp_play.game_state_service.clear",
+        new_callable=AsyncMock,
+    ):
+        await view._resolve()
+
+    channel.send.assert_awaited_once()
+    posted_view = channel.send.await_args.kwargs["view"]
+    assert isinstance(posted_view, _RpsPvpResultView)
+
+
+@pytest.mark.asyncio
+async def test_rpshelp_lists_only_real_command_names():
+    """Guard against the punch-list #1 drift recurring: the help text must use the
+    real no-underscore commands and never advertise a leaderboard that doesn't
+    exist."""
+    from cogs.rps_tournament_cog import RockPaperScissorsCog
+
+    ctx = SimpleNamespace(send=AsyncMock())
+    await RockPaperScissorsCog.rps_help.callback(MagicMock(), ctx)  # type: ignore[attr-defined]
+    text = ctx.send.await_args.args[0]
+
+    for real in ("!rps", "!rpsregister", "!rpsstart", "!rpsbot", "!rpssettings", "!rpshelp"):
+        assert real in text, f"{real} missing from rpshelp"
+    for bogus in ("!rps_register", "!rps_start", "!rps_bot", "!rps_settings", "!rps_help"):
+        assert bogus not in text, f"stale underscored command {bogus} in rpshelp"
+    assert "leaderboard" not in text.lower(), "rpshelp advertises a nonexistent leaderboard"


### PR DESCRIPTION
## Completion-first — Deathmatch cert punch-list #1 (headline) + #3

Empty-fire dispatch run. The active S1 thread is completion-first certification (Q-0209). This
closes the **headline gap** in the Deathmatch completion cert (`◐ assessed`): the **PvP** terminal
views were **dead-ends**.

### The gap
On a PvP duel **finish / timeout** (`_DuelView`) and challenge **decline / expire**
(`_ChallengeView`) the player was left on a dead embed with disabled buttons and **no return
navigation** — even though the bot-duel path already swaps to a nav-bearing result view
(`_BotDuelResultView`). The 2026-06-23 "a finished duel is never a dead-end" directive was applied to
the bot path and missed for PvP.

### The fix (mirrors the shipped bot-duel result view)
- New `_PvpDuelResultView(HubView, SUBSYSTEM="deathmatch")` → `attach_standard_nav` auto-adds
  **📚 Help + ↩ Games**; plus a **🔁 Rematch** button (re-challenge through the normal
  Accept/Decline flow, so consent is preserved). Either fighter may use it.
- `_DuelView._resolve` (winner) / `_DuelView.on_timeout` / `_ChallengeView.btn_decline` /
  `_ChallengeView.on_timeout` now swap to it on terminal instead of leaving a dead embed.

### Bugs-first root fix (found mid-task)
Panel-initiated PvP (`👤 Challenge Player` → opponent select) built `_ChallengeView(..., ctx=None)`,
and `_DuelView._resolve`/`on_timeout` read `self.ctx.guild.id` → **`AttributeError` crash** when
the duel resolved, and would have recorded under the wrong guild. Fixed at root: thread an explicit
`guild_id` from `_ChallengeView.btn_accept` (`interaction.guild_id`) into `_DuelView`, which now uses
`self.guild_id` (derived from `ctx` only as a backward-compatible fallback). Captured as a bug-book
entry.

### Tests
PvP loop pins (punch-list #3): finish/timeout swap-to-result-view, decline/expire nav, rematch
re-challenge, and the panel-path `guild_id` thread.

CI mirror green + arch strict clean before the card flips `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EC76KQ2FcaCgYM6tvLdsZ1)_