### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-06-28T11:37:36Z",
+    "generated_at": "2026-06-28T14:35:03Z",
     "build": {
-      "commit": "37627c9a",
-      "subject": "Merge pull request #1525 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-06-28T11:37:36Z"
+      "commit": "c51c9cc9",
+      "subject": "Merge pull request #1527 from menno420/claude/funny-franklin-05mst6",
+      "committed_at": "2026-06-28T14:35:03Z"
     },
     "counts": {
       "functions": 43,
-      "ideas": 151,
-      "bugs": 27,
+      "ideas": 152,
+      "bugs": 28,
       "reviews": 0,
       "reviews_open": 0,
       "updates": 60,
@@ -1159,6 +1159,14 @@
     }
   ],
   "ideas": [
+    {
+      "file": "no-dead-end-terminal-view-guard-2026-06-28.md",
+      "title": "Idea — a \"no dead-end\" arch guard for game terminal views",
+      "status": "ideas",
+      "date": "2026-06-28",
+      "summary": "The 2026-06-23 owner directive is \"a finished game/duel is **never** a dead-end\" — a terminal view",
+      "subsystems": null
+    },
     {
       "file": "router-q-index-generator-2026-06-28.md",
       "title": "Idea: a generated router Q-index (resolve a Q-number without loading 490 KB)",
@@ -2442,6 +2450,12 @@
   ],
   "bugs": [
     {
+      "id": "BUG-0028",
+      "title": "panel-initiated PvP deathmatch crashes on resolve (ctx=None → self.ctx.guild.id AttributeError) — FIXED (root)",
+      "status": "unknown",
+      "summary": "Symptom (found 2026-06-28 by a dispatch run via code inspection during the Deathmatch completion-cert dead-end fix — not a live report, but a real latent crash): a PvP duel started from the panel (👤 Challenge Player → opponent select, not the !deathmatch @user command) would rai…"
+    },
+    {
       "id": "BUG-0027",
       "title": "born-red merge-gate silently fails open on a session-card slug collision (a partial PR auto-merged and clobbered a prior session log) — FIXED (root)",
       "status": "unknown",
@@ -2642,6 +2656,14 @@
       "file": "2026-06-28-feature-completion-assessments.md",
       "date": "2026-06-28",
       "title": "2026-06-28 — Feature-completion unit assessments + counting leaderboard",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-28-deathmatch-pvp-deadend.md",
+      "date": "2026-06-28",
+      "title": "2026-06-28 — Deathmatch + RPS PvP trapped-view dead-end fixes (completion-first)",
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
@@ -3074,14 +3096,6 @@
       "file": "2026-06-24-setup-spine-build.md",
       "date": "2026-06-24",
       "title": "Session — 2026-06-24 · build the essentials spine (PR 1)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-24-setup-reward-activity.md",
-      "date": "2026-06-24",
-      "title": "Session — 2026-06-24 · Essential Setup step \"Reward active members\"",
       "status": "complete",
       "run_type": "",
       "self_initiated": false


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.