### PR TITLE
arch guard: flag no-swap terminal handlers in game views (friction→guard, Q-0194)

### DIFF
--- a/.sessions/2026-06-28-no-dead-end-view-guard.md
+++ b/.sessions/2026-06-28-no-dead-end-view-guard.md
@@ -1,0 +1,21 @@
+# 2026-06-28 — No-dead-end terminal-view arch guard (friction→guard)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What I'm about to do
+
+Empty-fire dispatch. S1's ▶ Next-startable (offline) names: *"build the 'no-dead-end' arch guard
+so the trapped-view bug class is caught automatically instead of per-assessment."* The completion-first
+posture (Q-0209) keeps re-finding the same dead-end bug one game at a time (Fishing #1521, Deathmatch
++ RPS PvP #1527). This is the textbook friction→guard case (Q-0194): enforce, don't exhort.
+
+**The slice:** a conservative warn-tier rule in `scripts/check_architecture.py` that flags a game
+view's **terminal handler** (a method calling `self.stop()`) that re-renders / posts a terminal message
+without swapping to a nav-carrying view (no other `*View(...)` constructed in the handler body). Scoped
+to game-view dirs, allowlist-driven (same shape as `baseview_inheritance`), starts as warning. Verified
+clean (or known-small) against the current fixed fleet, with unit tests pinning both the flagged
+anti-pattern and the allowed swap pattern.
+
+Offline / self-mergeable on green; checker guard ships free per CLAUDE.md.

--- a/.sessions/2026-06-28-no-dead-end-view-guard.md
+++ b/.sessions/2026-06-28-no-dead-end-view-guard.md
@@ -1,6 +1,6 @@
 # 2026-06-28 — No-dead-end terminal-view arch guard (friction→guard)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
@@ -19,3 +19,75 @@ clean (or known-small) against the current fixed fleet, with unit tests pinning 
 anti-pattern and the allowed swap pattern.
 
 Offline / self-mergeable on green; checker guard ships free per CLAUDE.md.
+
+## What shipped (PR #1529)
+
+The **`no_dead_end` arch guard** — a warn-tier rule in `scripts/check_architecture.py`
+(`check_no_dead_end_terminal_views`) that flags a **game-view terminal handler** (a method calling
+`self.stop()`) which renders a terminal message but neither **swaps** to a freshly-constructed
+`*View` nor **delegates** to another awaited coroutine. That heuristic — "stop + render + no swap +
+no delegate" — isolates the real trapped-view dead-end from the legitimate launcher/transition cases.
+
+- **Config + allowlist** in `architecture_rules/canonical_helpers.yaml` (`no_dead_end` block): scoped
+  to game-view dirs (`views/rps|blackjack|casino|fishing|games/`), `ClassName.method` exemptions for
+  the 4 genuine pre-game **invite** decline/timeout handlers (`_ChallengeView` / `_RpsPvpChallengeView`),
+  with a documented kill-switch (delete the block + checker if it proves noisy — Q-0105).
+- **Clean on the current (fixed) fleet:** the refined heuristic yielded exactly the 4 invite-closer
+  findings, all allowlisted → 0 unexplained warnings (`by check` shows no `no_dead_end`). Going forward,
+  a new game whose *resolve* path forgets to swap to a result view gets flagged automatically.
+- **+7 tests** (`tests/unit/scripts/test_check_architecture.py`): flags the trapped terminal handler
+  (fails against the pre-guard world), and does NOT flag a view swap, a coroutine delegation, an
+  allowlisted `Class.method`, a non-game dir, a handler that never `stop()`s, or an unconfigured rule.
+- **Wired into the completion rubric** ("No dead-end controls" line, `rubric-game.md`) as a partial
+  enforcement backstop; idea file re-badged `historical` (shipped); S1 sector ▶ Next + recently-shipped
+  de-staled.
+
+CI mirror green: `check_quality --full` (ruff/black/isort/mypy + 12,975 tests pass) + `check_docs
+--strict` + `check_consistency`; `check_architecture --mode strict` exit 0. Self-merged on green
+(small, contained, additive checker/docs — `CLASS: feature`/tooling, self-initiated Q-0172; guards
+ship free per CLAUDE.md).
+
+## 📤 Run report
+
+- **Did:** built the no-dead-end terminal-view arch guard, the named S1 ▶ Next offline-startable item
+  (a friction→guard enforcement for the recurring trapped-view bug class) · **Outcome:** shipped
+- **Shipped:** #1529 — `no_dead_end` rule + config/allowlist + 7 tests + rubric/idea/S1 docs.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (checker/docs only — no runtime/deploy/data step)
+- **⚑ Self-initiated:** yes — empty-fire dispatch; built the S1-named ▶ Next offline guard (grounded in
+  the live queue + the captured idea) → shipped without a dispatch/owner ask (Q-0172). Tooling guard,
+  free to ship per CLAUDE.md.
+- **↪ Next:** S1 ▶ Next offline-startable now = **feature-completion assessments** (assess the remaining
+  unassessed games — Mining [big read], Casino, Creatures — one cert each under
+  `planning/feature-completion/units/`), or the next fishing offline successor (a rare *material* feeding
+  a new craft target, or the rod-ladder recipe-browser UI). All pure + self-mergeable.
+
+## 💡 Session idea (Q-0089)
+
+**Graduate the `no_dead_end` guard from warn → error once the fleet stays clean for a few sessions,**
+and **broaden its scope beyond `views/games|rps|...` to all interactive views** — the trapped-view
+class isn't unique to games (a settings wizard or a paginator can dead-end too). The guard is built
+conservatively today (game dirs, warn-tier) precisely so it can graduate; capturing the graduation
+path now means a later session doesn't have to re-derive the heuristic's safety record. (Genuine new
+idea, not filler — it's the natural lifecycle of a warn-tier guard per the `baseview_inheritance`
+precedent, which is still warn-tier.) → route to `docs/ideas/` if a later session picks it up.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1518, the fishing "pearl" drop) was clean, well-scoped, and correctly self-merged —
+and notably its own Q-0102 note already articulated the right lesson ("a ▶ Next pointer should name the
+*not-yet-built* successor, not the just-shipped feature") and then *honoured it* by leaving a genuinely
+not-yet-built handoff. That handoff is exactly why this run could start instantly. **One improvement to
+the system it surfaces:** the S1 ▶ Next block now carries *two* parallel offline tracks (feature-completion
+assessments **and** the fishing craft-successor chain), and an empty-fire dispatch has to read the whole
+block to pick. A tiny win would be a single explicit "**pick this next**" pointer at the top of the S1 ▶
+Next list (the dispatch-menu already resolves *a* pick, but the sector file itself buries it) — so the
+human-readable handoff and the machine `dispatch_menu --unattended` pick never diverge. Captured as a
+candidate, not built (the dispatch_menu resolver already covers the machine half).
+
+## Doc audit (Q-0104)
+
+`check_current_state_ledger --strict` not newly affected (no merged-PR ledger change this run — #1529
+is this session's own PR, reconciled at merge by convention). New tooling reachable: the guard is
+documented in the rubric + the idea file + the S1 sector. No owner decisions to route. No drift spotted.

--- a/architecture_rules/canonical_helpers.yaml
+++ b/architecture_rules/canonical_helpers.yaml
@@ -57,3 +57,41 @@ audit_events:
   severity: warning
   # Not yet automatically checked — tracked here for documentation.
   auto_checked: false
+
+no_dead_end:
+  # Friction->guard (Q-0194) for the recurring "trapped-view" bug class — a finished
+  # game/duel that leaves disabled buttons and stop()s without swapping to a nav-carrying
+  # result view (Fishing #1521, Deathmatch + RPS PvP #1527 / BUG-0028). Heuristic AST lint,
+  # so it ships warning-tier with an allowlist (same shape as base_view above) and is
+  # disposable per the adopt-freely-with-a-kill-switch rule (Q-0105) — if the heuristic
+  # proves noisy across a few sessions, delete this block + check_no_dead_end_terminal_views.
+  description: >
+    A game-view terminal handler (a method that calls self.stop()) which renders a terminal
+    message should swap to a view that carries standard navigation (a result view / a Back
+    button) rather than re-render the now-disabled self or post a bare embed with no view.
+    The checker flags a handler that stop()s and renders a message but neither constructs a
+    *View nor delegates to another coroutine (which may render the swap elsewhere).
+  severity: warning
+  # Only game-view directories are scoped (these own gameplay terminal lifecycles).
+  game_dirs:
+    - views/rps/
+    - views/blackjack/
+    - views/casino/
+    - views/fishing/
+    - views/games/
+  # Accepted terminal handlers — keyed by ClassName.method. Pre-game challenge *invites*
+  # that were declined / timed out never became a game, so there is no result to navigate;
+  # closing with terminal copy + disabled buttons is correct, not a dead-end.
+  exemptions:
+    - view: _ChallengeView
+      method: decline
+      reason: pre-game blackjack PvP invite declined — no game result to navigate
+    - view: _ChallengeView
+      method: on_timeout
+      reason: pre-game blackjack PvP invite expired — no game result to navigate
+    - view: _RpsPvpChallengeView
+      method: decline
+      reason: pre-game RPS PvP invite declined — no game result to navigate
+    - view: _RpsPvpChallengeView
+      method: on_timeout
+      reason: pre-game RPS PvP invite expired — no game result to navigate

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,11 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **No-dead-end terminal-view arch guard** (#1529, Q-0194 friction→guard) — a warn-tier `no_dead_end`
+  rule in `scripts/check_architecture.py` flags any game-view terminal handler (calls `self.stop()`)
+  that renders a message without swapping to a nav-carrying view; allowlist for genuine pre-game
+  invite decline/timeout. Turns the recurring trapped-view catch (#1521/#1527) from a manual
+  per-assessment check into an enforced one. +7 tests; clean on the current fleet.
 - **Completion-first PvP dead-end fixes** (#1527, Q-0209) — closed the recurring **trapped-view** bug
   class in both competitive PvP games. **Deathmatch:** PvP `_DuelView`/`_ChallengeView` now swap to
   `_PvpDuelResultView` (Help/Games nav + 🔁 Rematch) on every terminal, and the latent panel-PvP
@@ -80,9 +85,13 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   born-red-gate-fix dispatch run (2026-06-28, PR #1524) added **RPS, Deathmatch, Chicken farm**. **▶ Next
   startable, offline:** (1) **assess more units** — the remaining unassessed games (Mining [big read],
   Casino, Creatures) then server-fns, one cert each under
-  [`../planning/feature-completion/units/`](../planning/feature-completion/README.md) from the rubric;
-  (2) **build the "no-dead-end" arch guard** ([idea](../ideas/no-dead-end-terminal-view-guard-2026-06-28.md))
-  so the trapped-view bug class is caught automatically instead of per-assessment. **✅ DONE
+  [`../planning/feature-completion/units/`](../planning/feature-completion/README.md) from the rubric.
+  **✅ (2) DONE 2026-06-28 (#1529):** the **"no-dead-end" arch guard** shipped — a warn-tier
+  `no_dead_end` rule in `scripts/check_architecture.py` (config + allowlist in
+  `architecture_rules/canonical_helpers.yaml`, +7 tests) flags a game-view terminal handler that
+  `self.stop()`s + renders a message without swapping to a nav-carrying view, so the trapped-view bug
+  class is caught automatically instead of per-assessment ([idea](../ideas/no-dead-end-terminal-view-guard-2026-06-28.md),
+  now `historical`). **✅ DONE
   2026-06-28 (#1527):** the Deathmatch PvP trapped views (+ the panel-PvP `ctx=None` crash, BUG-0028)
   **and** the RPS PvP-result dead-end were both fixed — `_PvpDuelResultView` / `_RpsPvpResultView` with
   standard nav + rematch/back; both certs advanced toward ✔. The next turn-key gap is **Blackjack

--- a/docs/ideas/no-dead-end-terminal-view-guard-2026-06-28.md
+++ b/docs/ideas/no-dead-end-terminal-view-guard-2026-06-28.md
@@ -1,6 +1,9 @@
 # Idea — a "no dead-end" arch guard for game terminal views
 
-> **Status:** `ideas` · captured 2026-06-28 (dispatch run, Q-0089 session idea).
+> **Status:** `historical` — SHIPPED 2026-06-28 (PR #1529) — built as the `no_dead_end` warn-tier rule in
+> `scripts/check_architecture.py` (config + allowlist in `architecture_rules/canonical_helpers.yaml`),
+> +7 tests, wired into the completion rubric's "No dead-end controls" line. Captured 2026-06-28
+> (dispatch run, Q-0089 session idea).
 > Route-in: the completion rubric's "No dead-end controls" line
 > ([`../planning/feature-completion/rubric-game.md`](../planning/feature-completion/rubric-game.md))
 > + the architecture checker (`scripts/check_architecture.py`).

--- a/docs/owner/claims/claude-funny-franklin-7aixg5.md
+++ b/docs/owner/claims/claude-funny-franklin-7aixg5.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-7aixg5` · scope: no-dead-end terminal-view arch guard (warn-tier checker + tests) · area: `scripts/check_architecture.py`, `architecture_rules/`, `tests/unit/scripts/` · 2026-06-28

--- a/docs/owner/claims/claude-funny-franklin-7aixg5.md
+++ b/docs/owner/claims/claude-funny-franklin-7aixg5.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-7aixg5` · scope: no-dead-end terminal-view arch guard (warn-tier checker + tests) · area: `scripts/check_architecture.py`, `architecture_rules/`, `tests/unit/scripts/` · 2026-06-28

--- a/docs/planning/feature-completion/rubric-game.md
+++ b/docs/planning/feature-completion/rubric-game.md
@@ -23,6 +23,9 @@ item; the unit cannot be `✔ certified` until the punch-list is empty and the o
       clear terminal result.
 - [ ] **No dead-end or placeholder controls** — no "coming soon", no disabled-with-no-explanation,
       no button that errors or no-ops (`command-integration-standard` § "no dead-end views").
+      *Partly enforced:* `scripts/check_architecture.py` (`no_dead_end` rule, warn-tier) flags a game-view
+      terminal handler that `self.stop()`s + renders a message without swapping to a nav-carrying view —
+      a heuristic backstop, not a substitute for the live walkthrough.
 - [ ] **Rewards/XP are wired** through the correct service (game-XP / economy), not duplicated.
 
 ## B. UI & buttons — "the right buttons in the right places"

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -417,6 +417,116 @@ def check_baseview_inheritance(files: list[Path], rules: dict) -> list[Violation
 
 
 # ---------------------------------------------------------------------------
+# No-dead-end terminal views (friction->guard, Q-0194)
+# ---------------------------------------------------------------------------
+
+_VIEW_BASES = {"discord.ui.View", "View", "BaseView", "HubView", "PersistentView"}
+# Message-producing calls — rendering a terminal message to the user.
+_MSG_CALLS = {"edit", "send", "edit_message", "safe_edit", "respond", "send_message"}
+
+
+def _call_name(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _analyze_terminal_handler(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[bool, bool, bool]:
+    """Return (stops, renders_message, swaps_or_delegates) for one method body.
+
+    - stops: calls ``self.stop()`` (marks it a terminal handler)
+    - renders_message: awaits/calls a message-producing call (edit/send/...)
+    - swaps_or_delegates: constructs a ``*View`` (a swap) OR awaits a non-message
+      coroutine (delegation that may render the swap elsewhere, e.g. ``_start_pvp``)
+    """
+    stops = renders = swaps = False
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            if (
+                name == "stop"
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                stops = True
+            if name and name.endswith("View") and name != "super":
+                swaps = True  # constructs a (result) view -> a swap
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call):
+            name = _call_name(node.value)
+            if name in _MSG_CALLS:
+                renders = True
+            elif name and name.endswith("View"):
+                swaps = True
+            elif name not in (None, "stop"):
+                swaps = True  # delegates to another coroutine
+    return stops, renders, swaps
+
+
+def check_no_dead_end_terminal_views(files: list[Path], rules: dict) -> list[Violation]:
+    cfg = rules.get("no_dead_end", {})
+    if not cfg:
+        return []
+    game_dirs = tuple(cfg.get("game_dirs", []))
+    exemptions = {
+        (e["view"], e["method"]) for e in cfg.get("exemptions", []) if "method" in e
+    }
+    severity = cfg.get("severity", "warning")
+    violations: list[Violation] = []
+
+    for filepath in files:
+        rel = str(filepath.relative_to(DISBOT_ROOT))
+        if not rel.startswith(game_dirs):
+            continue
+        if "test" in rel.lower():
+            continue
+        try:
+            tree = ast.parse(
+                filepath.read_text(encoding="utf-8", errors="replace"),
+                filename=str(filepath),
+            )
+        except (SyntaxError, OSError):
+            continue
+
+        for cls in ast.walk(tree):
+            if not isinstance(cls, ast.ClassDef):
+                continue
+            if not (set(_class_bases(cls)) & _VIEW_BASES):
+                continue
+            for fn in cls.body:
+                if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if (cls.name, fn.name) in exemptions:
+                    continue
+                stops, renders, swaps = _analyze_terminal_handler(fn)
+                if stops and renders and not swaps:
+                    violations.append(
+                        Violation(
+                            file=filepath,
+                            line=fn.lineno,
+                            check="no_dead_end",
+                            message=(
+                                f"`{cls.name}.{fn.name}` is a terminal handler "
+                                "(calls self.stop()) that renders a message but "
+                                "does not swap to a nav-carrying view — a finished "
+                                "game/duel must never be a dead-end (Q-0194). Swap to "
+                                "a result view with standard nav, or allowlist it in "
+                                "architecture_rules/canonical_helpers.yaml (no_dead_end) "
+                                "if it is genuinely terminal (e.g. a declined invite)."
+                            ),
+                            severity=severity,
+                        ),
+                    )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
 # File collection
 # ---------------------------------------------------------------------------
 
@@ -527,6 +637,7 @@ def main() -> int:
     all_violations += check_raw_sql(files, mutation_rules)
     all_violations += check_settings_key_literals(files, helpers_rules)
     all_violations += check_baseview_inheritance(files, helpers_rules)
+    all_violations += check_no_dead_end_terminal_views(files, helpers_rules)
 
     errors = [v for v in all_violations if v.severity == "error"]
     warnings = [v for v in all_violations if v.severity == "warning"]

--- a/tests/unit/scripts/test_check_architecture.py
+++ b/tests/unit/scripts/test_check_architecture.py
@@ -153,3 +153,95 @@ def test_counts_by_check(mod):
         ),
     ]
     assert mod._counts_by_check(vs) == {"layer_boundary": 2, "lazy_layer_boundary": 1}
+
+
+# ---------------------------------------------------------------------------
+# No-dead-end terminal views (friction->guard, Q-0194)
+# ---------------------------------------------------------------------------
+
+_NO_DEAD_END_RULES = {
+    "no_dead_end": {
+        "severity": "warning",
+        "game_dirs": ["views/games/", "views/rps/"],
+        "exemptions": [
+            {"view": "_ChallengeView", "method": "decline", "reason": "invite"},
+        ],
+    },
+}
+
+# A terminal handler that stop()s + renders the now-disabled self, never swapping
+# to a nav-carrying view — the dead-end bug class this guard exists to catch.
+_DEAD_END = (
+    "import discord\n"
+    "class GameOverView(discord.ui.View):\n"
+    "    async def finish(self, interaction):\n"
+    "        for item in self.children:\n"
+    "            item.disabled = True\n"
+    "        await interaction.response.edit_message(view=self)\n"
+    "        self.stop()\n"
+)
+
+# The correct shape — swaps to a freshly-constructed result view that carries nav.
+_SWAPS = (
+    "import discord\n"
+    "class GameView(discord.ui.View):\n"
+    "    async def finish(self, interaction):\n"
+    "        result = _ResultView()\n"
+    "        await interaction.response.edit_message(view=result)\n"
+    "        self.stop()\n"
+)
+
+# Delegates the swap to another coroutine (e.g. _start_pvp deals the next hand) —
+# not a dead-end, must not be flagged.
+_DELEGATES = (
+    "import discord\n"
+    "class GameView(discord.ui.View):\n"
+    "    async def accept(self, interaction):\n"
+    "        await interaction.response.edit_message(content='dealing', view=self)\n"
+    "        self.stop()\n"
+    "        await _start_next_round(interaction)\n"
+)
+
+
+def test_no_dead_end_flags_trapped_terminal_handler(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "views/games/over.py", _DEAD_END)
+    vs = mod.check_no_dead_end_terminal_views([f], _NO_DEAD_END_RULES)
+    assert len(vs) == 1
+    assert vs[0].check == "no_dead_end"
+    assert vs[0].severity == "warning"
+    assert "GameOverView.finish" in vs[0].message
+
+
+def test_no_dead_end_allows_view_swap(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "views/games/g.py", _SWAPS)
+    assert mod.check_no_dead_end_terminal_views([f], _NO_DEAD_END_RULES) == []
+
+
+def test_no_dead_end_allows_coroutine_delegation(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "views/games/g.py", _DELEGATES)
+    assert mod.check_no_dead_end_terminal_views([f], _NO_DEAD_END_RULES) == []
+
+
+def test_no_dead_end_respects_classmethod_allowlist(mod, tmp_path, monkeypatch):
+    src = _DEAD_END.replace("GameOverView", "_ChallengeView").replace(
+        "finish", "decline"
+    )
+    f = _write(mod, tmp_path, monkeypatch, "views/games/c.py", src)
+    assert mod.check_no_dead_end_terminal_views([f], _NO_DEAD_END_RULES) == []
+
+
+def test_no_dead_end_ignores_non_game_dirs(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "views/settings/s.py", _DEAD_END)
+    assert mod.check_no_dead_end_terminal_views([f], _NO_DEAD_END_RULES) == []
+
+
+def test_no_dead_end_ignores_handler_without_stop(mod, tmp_path, monkeypatch):
+    # Renders the disabled self but never stop()s -> not a terminal handler.
+    src = _DEAD_END.replace("        self.stop()\n", "")
+    f = _write(mod, tmp_path, monkeypatch, "views/games/n.py", src)
+    assert mod.check_no_dead_end_terminal_views([f], _NO_DEAD_END_RULES) == []
+
+
+def test_no_dead_end_disabled_when_unconfigured(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "views/games/over.py", _DEAD_END)
+    assert mod.check_no_dead_end_terminal_views([f], {}) == []


### PR DESCRIPTION
## What

Builds the **no-dead-end terminal-view arch guard** — the S1 ▶ Next offline-startable item and a textbook **friction→guard** enforcement (Q-0194 / "enforce, don't exhort" Q-0132).

The completion-first posture (Q-0209) keeps re-finding the same **trapped-view** bug one game at a time (Fishing #1521, Deathmatch + RPS PvP #1527, BUG-0028). This adds a conservative **warning-tier** rule to `scripts/check_architecture.py` that flags a game view's **terminal handler** (a method calling `self.stop()`) that re-renders / posts a terminal message without swapping to a nav-carrying view — so the class catches its own regression next time instead of relying on a manual completion assessment.

Allowlist-driven (same shape as `baseview_inheritance`), starts as a warning, disposable per the adopt-freely-with-a-kill-switch rule.

## Status

🔴 Born-red (in-progress session card). Flips to green as the final step once the checker + tests are in and the CI mirror is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Grtw43CS5Lw9bsxV4msTQW)_