### PR TITLE
feat(economy): !give / !pay — peer coin transfer command

### DIFF
--- a/.sessions/2026-06-29-economy-give-pay.md
+++ b/.sessions/2026-06-29-economy-give-pay.md
@@ -1,6 +1,8 @@
 # 2026-06-29 — Economy give/pay (S1 deepening win, slice 2)
 
-> **Status:** `in-progress` — born-red (Q-0133). Run type: routine · dispatch.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
+> Full CI mirror green (**12990 passed**, arch 0, reachability 0 gaps, lint/consistency clean);
+> `site.json`/`data.js`/`dashboard.json` regenerated (459→460 commands); PR #1541.
 
 **Branch:** `claude/give-pay-economy` (off `main` @ #1540 merge, `58c55473`).
 
@@ -24,3 +26,58 @@ Planned:
 
 Offline, contained, reversible (play-money, audited), test-covered → self-merge on green (Q-0113).
 Owner-flagged direction; no new external/irreversible surface. No DB migration.
+
+## What shipped
+
+1. **`cogs/economy_cog.py`** — new `!give @user <amount>` command (alias `pay`, 3/10s cooldown) routing
+   through `economy_service.transfer(...)` with `reason="gift"`, `actor_id=invoker`. Validation:
+   usage hint on missing args; reject bot target / self / non-positive amount (each short-circuits before
+   `transfer`); `InsufficientFundsError` → a friendly "you have N, tried to give M" message; success embed
+   showing both post-transfer balances + the standard `post_log_embed` audit line.
+2. **`tests/unit/cogs/test_economy_give.py`** — 7 tests: happy path forwards exact args + reports both
+   balances + fires the log; the four guard rails never call `transfer`; insufficient funds is friendly.
+3. **Generated artifacts** — regenerated `site.json`/`data.js`/`dashboard.json` (command count 459→460).
+
+## Why this is contained / safe
+
+Play-money only, and `transfer()` is already fully audited + atomic (one asyncpg transaction; an
+intermediate failure can't debit without crediting). No coins are *created* — only moved between existing
+balances — so it doesn't touch the no-P2W / free-for-everyone North Star. No DB migration, no external
+call, no new irreversible surface. Reachability guard: 0 new gaps (economy cog is homed).
+
+## Context delta
+
+- **Discovered:** the audited `transfer()` seam existed and was exactly shaped for this (returns both new
+  balances, raises a typed `InsufficientFundsError`, rejects self/non-positive) — the command is a thin,
+  well-guarded shell over it. The `check_command_reachability` guard confirmed no new gap (the worry with
+  any new prefix command).
+- **Decisions made alone:** rejected bot targets and self-transfer with friendly copy *before* calling
+  `transfer` (rather than letting `transfer`'s `ValueError` surface as a traceback); `reason="gift"` for
+  the audit row. Both reversible.
+- **🛠 Friction → guard:** none new — the regen drift (new command in the static scan) is the already-guarded
+  BUG-0018/0022 class; the reachability + site.json tests caught/confirmed everything.
+
+## 💡 Session idea (Q-0089)
+
+Contributed in slice 1's log (the leaderboard-provider registry-completeness guard). Per Q-0089 (one
+genuine idea per session, not per PR; forced filler is worse than none), no second idea this slice.
+
+## ⟲ Previous-session review (Q-0102)
+
+Covered in slice 1's log (review of #1505 / the BUG-0026 staleness note). No new predecessor for this
+same-session slice.
+
+## 📤 Run report
+
+- **Did:** shipped `!give`/`!pay` peer coin transfer (S1 completion-first deepening win, finding (b)).
+  · **Outcome:** shipped
+- **Shipped:** #1541 — feat(economy): !give / !pay peer coin transfer (self-merge on green, Q-0113)
+- **Run type:** `routine · dispatch`
+- **Class:** feature/deepening (contained, reversible, audited, test-covered)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (merge auto-deploys; no data/migration step)
+- **⚑ Self-initiated:** **yes** — empty-fire dispatch, no work order; picked the S1 ▶ Next flagged
+  deepening win (finding (b)), idea→ship open (Q-0172). Grounded in the assessment's own finding.
+- **↪ Next:** remaining Economy deepening (admin balance-adjust panel); the other leaderboard-provider
+  wins (Blackjack/Casino/Word-Chain/Farm — each needs a `utils/db` top-N read built first); or continue
+  the feature-completion server-fn assessments (Counters · Spotlight · Channels · Setup wizard · AI · …).

--- a/.sessions/2026-06-29-economy-give-pay.md
+++ b/.sessions/2026-06-29-economy-give-pay.md
@@ -1,0 +1,26 @@
+# 2026-06-29 — Economy give/pay (S1 deepening win, slice 2)
+
+> **Status:** `in-progress` — born-red (Q-0133). Run type: routine · dispatch.
+
+**Branch:** `claude/give-pay-economy` (off `main` @ #1540 merge, `58c55473`).
+
+## What I'm about to do (intentions)
+
+Slice 2 of this empty-fire dispatch run (slice 1 = #1540, Fishing leaderboard provider, merged). The
+S1 completion-first assessment flagged finding (b): **"Economy's missing public `give`/`pay` (the
+`transfer()` primitive exists)."** A peer coin-transfer command is the turn-key deepening win — the
+audited, atomic `economy_service.transfer()` already exists (one asyncpg transaction, writes
+`economy_audit_log`, emits `EVT_BALANCE_CHANGED`); it's just not surfaced as a user command.
+
+Planned:
+1. `cogs/economy_cog.py` — new `!give @user <amount>` command (aliases `pay`), routing through the
+   existing `economy_service.transfer(...)`. Validation: usage hint on missing args, reject bot target /
+   self / non-positive amount; friendly `InsufficientFundsError` message; success embed (both balances) +
+   the standard `post_log_embed` audit line. Member-tier, in the already-homed Economy cog → reachable.
+2. Tests: a focused `tests/unit/cogs/test_economy_give.py` — happy path calls `transfer` with the right
+   args + sends the embed; self / bot / non-positive / missing-args rejected (transfer NOT called);
+   insufficient funds → friendly message.
+3. Regenerate `site.json`/`data.js`/`dashboard.json` for the new command (static-scan, BUG-0018/0022).
+
+Offline, contained, reversible (play-money, audited), test-covered → self-merge on green (Q-0113).
+Owner-flagged direction; no new external/irreversible surface. No DB migration.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-29T00:09:35Z",
+    "generated_at": "2026-06-29T00:27:05Z",
     "build": {
-      "commit": "f0d7b714",
-      "subject": "wip(leaderboard): born-red card — Fishing leaderboard provider",
-      "committed_at": "2026-06-29T00:09:35Z"
+      "commit": "47f5f1dc",
+      "subject": "wip(economy): born-red card — give/pay command",
+      "committed_at": "2026-06-29T00:27:05Z"
     }
   },
   "counts": {
-    "commands": 459,
+    "commands": 460,
     "features": 43,
     "games": 12
   },
@@ -3120,6 +3120,27 @@
         },
         {
           "title": "Mining & Exploration — Brainstorm & Roadmap",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "give",
+      "aliases": [
+        "pay"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Give some of your coins to another member. !give @user <amount>",
+      "description": "Give some of your coins to another member.  !give @user <amount>",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Wager / money-flow map — generated trace of game coin paths",
           "status": "ideas"
         }
       ],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -2664,25 +2664,19 @@ const COMMANDS = [
     "name": "give",
     "area": "economy",
     "status": "in-progress",
-    "summary": "Admin-only: give resources to a user.",
-    "description": "Admin-only: give resources to a user.",
+    "summary": "Give some of your coins to another member. !give @user <amount>",
+    "description": "Give some of your coins to another member. !give @user <amount>",
     "usage": "!give",
-    "aliases": [],
+    "aliases": [
+      "pay"
+    ],
     "permissions": "anyone",
     "cooldown": null,
     "examples": [],
     "planned": [
       {
         "status": "idea",
-        "title": "Mining grid encounters — depth-gated sparse events (2026-06-22)"
-      },
-      {
-        "status": "idea",
-        "title": "The Explore hub — a federated open world (one world, each subsystem…"
-      },
-      {
-        "status": "idea",
-        "title": "Mining & Exploration — Brainstorm & Roadmap"
+        "title": "Wager / money-flow map — generated trace of game coin paths"
       }
     ]
   },
@@ -7003,7 +6997,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "f0d7b714",
+    "build": "47f5f1dc",
     "title": "New public bot website",
     "changes": [
       {
@@ -7015,7 +7009,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "f0d7b714",
+    "build": "47f5f1dc",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7027,7 +7021,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "f0d7b714",
+    "build": "47f5f1dc",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-29T00:09:35Z",
+    "generated_at": "2026-06-29T00:27:05Z",
     "build": {
-      "commit": "f0d7b714",
-      "subject": "wip(leaderboard): born-red card — Fishing leaderboard provider",
-      "committed_at": "2026-06-29T00:09:35Z"
+      "commit": "47f5f1dc",
+      "subject": "wip(economy): born-red card — give/pay command",
+      "committed_at": "2026-06-29T00:27:05Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 55,
-      "commands": 459,
+      "commands": 460,
       "setting_keys": 108,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2638,6 +2638,14 @@
       "file": "2026-06-29-fishing-leaderboard-provider.md",
       "date": "2026-06-29",
       "title": "2026-06-29 — Fishing leaderboard provider (S1 deepening win)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-29-economy-give-pay.md",
+      "date": "2026-06-29",
+      "title": "2026-06-29 — Economy give/pay (S1 deepening win, slice 2)",
       "status": "in-progress",
       "run_type": "",
       "self_initiated": false
@@ -3105,14 +3113,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": false
-    },
-    {
-      "file": "2026-06-24-ticket-setup-buttons.md",
-      "date": "2026-06-24",
-      "title": "2026-06-24 — Ticket setup: all buttons & dropdowns + auto-create",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -6599,6 +6599,19 @@
           "classification": "",
           "has_panel": true,
           "button_backed": true
+        },
+        {
+          "name": "give",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "pay"
+          ],
+          "brief": "Give some of your coins to another member. !give @user <amount>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
         },
         {
           "name": "joblist",

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -345,6 +345,89 @@ class EconomyCog(commands.Cog):
         embed.add_field(name="🏆 Level", value=str(xp_row["level"]), inline=True)
         await ctx.send(embed=embed)
 
+    # ------------------------------------------------------------------ !give
+
+    @commands.cooldown(rate=3, per=10, type=commands.BucketType.user)
+    @commands.command(name="give", aliases=["pay"])
+    async def give(
+        self,
+        ctx: commands.Context,
+        member: discord.Member = None,
+        amount: int = None,
+    ):
+        """Give some of your coins to another member.  !give @user <amount>
+
+        Moves coins atomically through the audited economy transfer seam —
+        you can only ever give coins you actually have, and both sides of the
+        move are written to the economy audit log.
+        """
+        if member is None or amount is None:
+            await ctx.send(
+                "Usage: `!give @user <amount>` — send some of your coins to "
+                "another member.",
+                delete_after=12,
+            )
+            return
+        if member.bot:
+            await ctx.send("🤖 You can't give coins to a bot.", delete_after=10)
+            return
+        if member.id == ctx.author.id:
+            await ctx.send(
+                "🙃 You can't give coins to yourself.",
+                delete_after=10,
+            )
+            return
+        if amount <= 0:
+            await ctx.send(
+                "❌ Amount must be a positive number of coins.",
+                delete_after=10,
+            )
+            return
+
+        try:
+            new_from, new_to = await economy_service.transfer(
+                ctx.guild.id,
+                ctx.author.id,
+                member.id,
+                amount,
+                reason="gift",
+                actor_id=ctx.author.id,
+            )
+        except economy_service.InsufficientFundsError:
+            balance = await db.get_coins(ctx.author.id, ctx.guild.id)
+            await ctx.send(
+                f"❌ You don't have enough coins — you have **{balance:,}** 🪙, "
+                f"but tried to give **{amount:,}** 🪙.",
+                delete_after=12,
+            )
+            return
+
+        embed = discord.Embed(
+            title="🤝 Coins Sent",
+            description=(
+                f"{ctx.author.mention} gave **{amount:,}** 🪙 to {member.mention}."
+            ),
+            color=ECONOMY_COLOR,
+        )
+        embed.add_field(
+            name=f"{ctx.author.display_name}'s balance",
+            value=f"**{new_from:,}** 🪙",
+            inline=True,
+        )
+        embed.add_field(
+            name=f"{member.display_name}'s balance",
+            value=f"**{new_to:,}** 🪙",
+            inline=True,
+        )
+        await ctx.send(embed=embed)
+
+        log_embed = discord.Embed(
+            title="🤝 Coins Transferred",
+            description=(f"{ctx.author.mention} → {member.mention}: **{amount:,}** 🪙"),
+            color=ECONOMY_COLOR,
+        )
+        await post_log_embed(self.bot, ctx.guild.id, log_embed)
+
     # ------------------------------------------------------------------ !setlogchannel
 
     @commands.command(name="setlogchannel")

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,11 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Economy `!give` / `!pay`** (#1541, completion-first deepening win) — a peer coin-transfer command
+  surfacing the already-audited `economy_service.transfer()` seam (atomic debit+credit, `economy_audit_log`,
+  `EVT_BALANCE_CHANGED`), closing the assessment's finding (b). Guard-railed (rejects bot target /
+  self / non-positive; friendly insufficient-funds message). Member-tier in the homed Economy cog
+  (reachable, 0 new gaps). +7 tests; no migration; self-merged on green.
 - **Fishing leaderboard provider** (#1540, completion-first deepening win) — fishing now appears in the
   unified `!leaderboard` hub + select menu (`FishingProvider`, top anglers by total fish caught, reusing
   the existing `db.top_fishers`), closing the "Fishing has its own `!fishtop`/`!trophies` boards but no
@@ -95,7 +100,8 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   run)** as a `FishingProvider` in the unified `!leaderboard` hub (top anglers by total caught, reusing
   `db.top_fishers`); **remaining gaps: Blackjack/Casino/Word-Chain/Farm** — each is still one
   `RankProvider` class + a `utils/db` top-N read (the next turn-key *deepening* wins); (b)
-  Economy's missing public `give`/`pay` (the `transfer()` primitive exists) + admin balance panel. **▶
+  Economy's public **`give`/`pay` now SHIPPED (#1541, this run)** — a peer coin-transfer command over
+  the existing audited `economy_service.transfer()` seam; remaining: an admin balance-adjust panel. **▶
   Next startable, offline:** **assess the remaining server-fns** — the unassessed set is now Counters ·
   Spotlight · Channels · Setup wizard · AI · Logging · Diagnostics · Help · Admin · Inventory · Treasury ·
   Cleanup · Automod · Image-moderation · Security · Proof-channel · Utility, one cert each under

--- a/docs/owner/claims/claude-give-pay-economy.md
+++ b/docs/owner/claims/claude-give-pay-economy.md
@@ -1,1 +1,0 @@
-- branch `claude/give-pay-economy` · scope: S1 deepening win — Economy give/pay command (peer coin transfer via existing audited `transfer()`) · area: `cogs/economy_cog.py`, tests, generated artifacts · 2026-06-29

--- a/docs/owner/claims/claude-give-pay-economy.md
+++ b/docs/owner/claims/claude-give-pay-economy.md
@@ -1,0 +1,1 @@
+- branch `claude/give-pay-economy` · scope: S1 deepening win — Economy give/pay command (peer coin transfer via existing audited `transfer()`) · area: `cogs/economy_cog.py`, tests, generated artifacts · 2026-06-29

--- a/tests/unit/cogs/test_economy_give.py
+++ b/tests/unit/cogs/test_economy_give.py
@@ -1,0 +1,170 @@
+"""Unit tests for the ``!give`` / ``!pay`` peer coin-transfer command.
+
+The command (``cogs.economy_cog.EconomyCog.give``) is the user surface over the
+already-audited ``services.economy_service.transfer`` seam (S1 completion-first
+deepening win — the assessment found the primitive existed but no command did).
+
+Pins:
+
+* The happy path forwards the right args to ``transfer`` and announces both
+  balances.
+* The guard rails — missing args, a bot target, self-transfer, a non-positive
+  amount — short-circuit and **never** call ``transfer`` (no audit-log write for
+  an invalid request).
+* ``InsufficientFundsError`` degrades to a friendly message, not a traceback.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+def _member(id_: int, name: str, *, bot: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id_,
+        display_name=name,
+        mention=f"<@{id_}>",
+        bot=bot,
+    )
+
+
+def _ctx(author: SimpleNamespace) -> MagicMock:
+    ctx = MagicMock()
+    ctx.author = author
+    ctx.guild = SimpleNamespace(id=99)
+    ctx.send = AsyncMock()
+    return ctx
+
+
+def _cog() -> object:
+    from cogs.economy_cog import EconomyCog
+
+    return EconomyCog(MagicMock())
+
+
+def _callback():
+    from cogs.economy_cog import EconomyCog
+
+    return EconomyCog.give.callback
+
+
+@pytest.mark.asyncio
+async def test_give_happy_path_forwards_to_transfer_and_reports_balances():
+    cog = _cog()
+    author = _member(1, "Alice")
+    target = _member(2, "Bob")
+    ctx = _ctx(author)
+
+    with (
+        patch(
+            "services.economy_service.transfer",
+            new_callable=AsyncMock,
+            return_value=(40, 160),
+        ) as mock_transfer,
+        patch(
+            "cogs.economy_cog.post_log_embed",
+            new_callable=AsyncMock,
+        ) as mock_log,
+    ):
+        await _callback()(cog, ctx, target, 60)
+
+    mock_transfer.assert_awaited_once_with(
+        99,
+        1,
+        2,
+        60,
+        reason="gift",
+        actor_id=1,
+    )
+    # A success embed naming both balances is sent, and the audit log line fires.
+    embed = ctx.send.await_args.kwargs["embed"]
+    assert "40" in embed.fields[0].value
+    assert "160" in embed.fields[1].value
+    mock_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_give_missing_args_shows_usage_and_does_not_transfer():
+    cog = _cog()
+    ctx = _ctx(_member(1, "Alice"))
+    with patch(
+        "services.economy_service.transfer",
+        new_callable=AsyncMock,
+    ) as mock_transfer:
+        await _callback()(cog, ctx, None, None)
+    mock_transfer.assert_not_awaited()
+    assert "Usage" in ctx.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_give_to_a_bot_is_rejected():
+    cog = _cog()
+    ctx = _ctx(_member(1, "Alice"))
+    with patch(
+        "services.economy_service.transfer",
+        new_callable=AsyncMock,
+    ) as mock_transfer:
+        await _callback()(cog, ctx, _member(2, "BotUser", bot=True), 10)
+    mock_transfer.assert_not_awaited()
+    assert "bot" in ctx.send.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_give_to_self_is_rejected():
+    cog = _cog()
+    author = _member(1, "Alice")
+    ctx = _ctx(author)
+    with patch(
+        "services.economy_service.transfer",
+        new_callable=AsyncMock,
+    ) as mock_transfer:
+        await _callback()(cog, ctx, author, 10)
+    mock_transfer.assert_not_awaited()
+    assert "yourself" in ctx.send.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", [0, -5])
+async def test_give_non_positive_amount_is_rejected(bad: int):
+    cog = _cog()
+    ctx = _ctx(_member(1, "Alice"))
+    with patch(
+        "services.economy_service.transfer",
+        new_callable=AsyncMock,
+    ) as mock_transfer:
+        await _callback()(cog, ctx, _member(2, "Bob"), bad)
+    mock_transfer.assert_not_awaited()
+    assert "positive" in ctx.send.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_give_insufficient_funds_is_a_friendly_message():
+    from services.economy_service import InsufficientFundsError
+
+    cog = _cog()
+    ctx = _ctx(_member(1, "Alice"))
+    with (
+        patch(
+            "services.economy_service.transfer",
+            new_callable=AsyncMock,
+            side_effect=InsufficientFundsError("nope"),
+        ),
+        patch(
+            "cogs.economy_cog.db.get_coins",
+            new_callable=AsyncMock,
+            return_value=25,
+        ),
+    ):
+        await _callback()(cog, ctx, _member(2, "Bob"), 100)
+    msg = ctx.send.await_args.args[0]
+    assert "enough" in msg.lower()
+    assert "25" in msg


### PR DESCRIPTION
## What & why

Slice 2 of an empty-fire dispatch run (slice 1 = #1540, Fishing leaderboard provider). The S1
completion-first assessment flagged finding **(b): "Economy's missing public `give`/`pay` (the
`transfer()` primitive exists)."**

The audited, atomic `economy_service.transfer()` already exists (one asyncpg transaction → debit +
credit + `economy_audit_log` write + `EVT_BALANCE_CHANGED` emit) but was never surfaced as a user
command. This adds the missing surface.

## Changes

- **`cogs/economy_cog.py`** — new `!give @user <amount>` command (alias `pay`) routing through the
  existing `economy_service.transfer(...)`. Validation: usage hint on missing args; reject bot target,
  self-transfer, and non-positive amounts; friendly `InsufficientFundsError` message; success embed
  showing both balances + the standard `post_log_embed` audit line. Member-tier, in the already-homed
  Economy cog → reachable via `!help economy` (no new reachability gap).
- **`tests/unit/cogs/test_economy_give.py`** — happy path calls `transfer` with the right args and sends
  the embed; self / bot / non-positive / missing-args all rejected (transfer NOT called); insufficient
  funds → friendly message.
- Regenerated `site.json` / `data.js` / `dashboard.json` for the new command (static-scan,
  BUG-0018/0022 class).

No new external/irreversible surface (play-money, fully audited), no DB migration → self-merge on green
(Q-0113). Owner-flagged direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018LCZw8PmtwLX1YnvhFqHqD)_