### PR TITLE
Session-slug-uniqueness guard (close BUG-0027 clobber risk) + Mining how-to button

### DIFF
--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -100,6 +100,7 @@ Run these in order and fix any failures before proceeding:
 ```bash
 python3.10 scripts/check_docs.py --strict
 python3.10 scripts/check_session_log.py --strict      # Q-0089 idea + Q-0102 review present
+python3.10 scripts/check_session_slug_unique.py       # BUG-0027: a session card slug reused from origin/main (silent-clobber)? rename it
 python3.10 scripts/check_current_state_ledger.py --strict  # merged PRs are in the ledger
 python3.10 scripts/check_plan_code_drift.py            # Q-0181: a plan-badged doc whose code already shipped? rebadge -> historical
 python3.10 scripts/check_sector_next_freshness.py     # a per-sector ▶ Next pointing at a SHIPPED (historical) plan? re-point it (Q-0166)

--- a/.sessions/2026-06-29-session-slug-unique-guard.md
+++ b/.sessions/2026-06-29-session-slug-unique-guard.md
@@ -1,0 +1,21 @@
+# 2026-06-29 — Session-slug-uniqueness guard (close BUG-0027's residual clobber risk) + Mining how-to button
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): in-progress while open; flip to complete as the final close step. -->
+
+**Run type:** routine · dispatch
+
+## What I'm about to do (born-red intent)
+Empty-fire dispatch. Two contained, offline, self-mergeable slices:
+1. **`check_session_slug_unique.py`** — the previous run's own Q-0089 idea (#1524). A
+   `[session-close-gate]` checker that FAILS when a PR's session card path *already exists
+   in `origin/main`* and the card is an active (non-re-badge) session card — catching the
+   slug collision at author time so it never reaches the clobber+merge stage BUG-0027 hit.
+   The gate fix (#1524) neutralized the *premature-merge* harm; this closes the residual
+   *silent-clobber* harm at the root. Wire into `/session-close` Step 4 (the meta-check
+   `check_session_close_gate.py` enforces the wiring stays).
+2. **Mining how-to button** — the Mining completion cert's last build gap (✔-ready candidate);
+   mirrors the Creatures how-to that closed #1546's cert.
+
+Also: deleted the stale claim `funny-franklin-ca1e1q.md` (the already-merged #1524
+RPS/Deathmatch/Chicken-farm session left it behind — docs drift, fix-on-sight Q-0166).

--- a/.sessions/2026-06-29-session-slug-unique-guard.md
+++ b/.sessions/2026-06-29-session-slug-unique-guard.md
@@ -1,21 +1,96 @@
 # 2026-06-29 — Session-slug-uniqueness guard (close BUG-0027's residual clobber risk) + Mining how-to button
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 <!-- born-red flow (Q-0133): in-progress while open; flip to complete as the final close step. -->
 
 **Run type:** routine · dispatch
+**PR:** [#1548](https://github.com/menno420/superbot/pull/1548)
+**Branch:** `claude/funny-franklin-dt7i3j`
 
-## What I'm about to do (born-red intent)
-Empty-fire dispatch. Two contained, offline, self-mergeable slices:
-1. **`check_session_slug_unique.py`** — the previous run's own Q-0089 idea (#1524). A
-   `[session-close-gate]` checker that FAILS when a PR's session card path *already exists
-   in `origin/main`* and the card is an active (non-re-badge) session card — catching the
-   slug collision at author time so it never reaches the clobber+merge stage BUG-0027 hit.
-   The gate fix (#1524) neutralized the *premature-merge* harm; this closes the residual
-   *silent-clobber* harm at the root. Wire into `/session-close` Step 4 (the meta-check
-   `check_session_close_gate.py` enforces the wiring stays).
-2. **Mining how-to button** — the Mining completion cert's last build gap (✔-ready candidate);
-   mirrors the Creatures how-to that closed #1546's cert.
+## What this run did
+Empty-fire dispatch advancing the S3/S4 self-improving-workflow lane + the S1 completion-first arc.
+Two contained, offline, self-mergeable slices.
 
-Also: deleted the stale claim `funny-franklin-ca1e1q.md` (the already-merged #1524
-RPS/Deathmatch/Chicken-farm session left it behind — docs drift, fix-on-sight Q-0166).
+### 1. `check_session_slug_unique.py` — close BUG-0027's residual silent-clobber harm
+The previous run's own routed Q-0089 idea (#1524 session log). BUG-0027 (#1524) fixed the born-red
+merge-gate so a slug-collision card can't *auto-merge* a partial PR — but the **silent clobber** (a
+new session reusing an existing `.sessions/` slug *overwrites* the prior session's log) still happened
+*before* the gate engaged, and CI is too late to stop it (the prior log is already overwritten in the
+commit). This adds the author-time guard: a `[session-close-gate]` checker that fails when a touched
+session card path **already exists in `origin/main`** and the card is an active (non-re-badge) session
+card, with a rename hint.
+- Reuses `check_session_gate`'s `gate_session_cards` / `parse_status` / `_TERMINAL_OK_STATUSES` as the
+  single source of truth for session-card status semantics (the two guards can't drift). A
+  reconciliation re-badge of an *old* log to a terminal status (`historical`/`archived`/…) is exempt.
+- Wired into `/session-close` Step 4; the `check_session_close_gate.py` meta-check now confirms 8
+  sentinel-bearing checkers are all wired (was 7).
+- **Ground-truth verified (Q-0120):** `_exists_in_main` returns True for a real in-`main` card and
+  False for this run's unique slug — not just the mocked unit tests. +14 tests.
+
+### 2. Mining how-to button — completion-cert punch-list #1 (Q-0209)
+The Mining cert's last *build* gap (the most feature-complete game; only the owner live walk + sign-off
+remained). Added a dedicated **📖 How-to** button at the hub (`mining:how_to`) opening a one-screen
+"how mining works" onboarding panel (`views/mining/how_to_panel.py::MiningHowToView`), returning via
+the established "↩ Mining Hub" back button — so it is not a dead-end terminal (the #1529 `no_dead_end`
+guard is satisfied; verified clean). The cert's six-actions pin was updated to seven (a sanctioned
+help/onboarding control, not game-action re-bloat). +3 tests; cert punch-list #1 marked DONE.
+
+Also: deleted the stale claim `funny-franklin-ca1e1q.md` left behind by the already-merged #1524
+session (docs drift, fix-on-sight Q-0166).
+
+## Verification
+- `check_quality.py --full` GREEN (13031 passed, 48 skipped, 2 xfailed). `check_architecture --mode
+  strict` 0 errors (pre-existing `[known]` warnings only; no_dead_end clean). `check_docs --strict` ✓,
+  `check_session_close_gate` ✓, ledger exit 0 (16-PR benign newest-merge lag = recon routine's lane,
+  Q-0124). Formatters/ruff reconciled green.
+
+## 💡 Session idea (Q-0089)
+**Idea:** a `--list-orphan-claims` mode on `check_lane_overlap.py` (or a tiny `check_stale_claims.py`)
+that flags `docs/owner/claims/*.md` whose branch has **no open PR** (its session already merged/closed)
+— the exact stale-claim class I cleaned up by hand this run (`funny-franklin-ca1e1q.md`).
+**Why:** claims are supposed to be deleted at session close, but a routine that ends abnormally (or
+forgets) leaves an orphan that misleads the next run's overlap scan into thinking a lane is active.
+Cheap (stdlib + one `list_pull_requests` or a `git branch -r` check), "enforce don't exhort", and
+directly tied to drift I saw. Routed as an idea (a claims-GC automation already exists per Q-0206 — this
+would extend/verify it rather than duplicate), not a unilateral add.
+
+## ⟲ Previous-session review (Q-0102)
+The previous dispatch run (2026-06-28 RPS/Deathmatch/Chicken-farm assessments + the BUG-0027 gate fix)
+did genuinely strong work — it caught its *own* born-red gate failing open mid-run and root-fixed it,
+which is exactly the self-auditing the loop is meant to do. **What it left for this run (correctly, as
+a routed idea):** the residual *clobber* half of BUG-0027 — its own session log explicitly flagged that
+the gate fix neutralized the premature-merge but the silent-overwrite still happens before the gate
+engages, and routed the unique-slug guard as a Q-0089 idea rather than building it. That hand-off worked
+perfectly: this run picked up the routed idea and shipped it. **System improvement surfaced:** the
+chain *did* work, but only because the idea was written down — there's no machine link from "a routed
+Q-0089 idea tied to an OPEN/partial bug" to "a later dispatch run sees it as startable." The bug-book
+already has `check_bug_book_rootfix_backlog.py` for deferred *root-fixes*; a parallel surfacing for
+**routed-idea-closes-a-known-gap** would make these hand-offs not depend on the next agent re-reading
+the prior log. (Captured loosely; not built — would want owner framing on where it lives.)
+
+## Doc audit (Q-0104)
+Durable homes updated: mining cert punch-list #1 → DONE + the rubric "how-to affordance" row flipped to
+✅ (`feature-completion/units/mining.md`); `/session-close` Step 4 gained the new checker; stale claim
+deleted. No new owner *decision* (both slices are a fix + a sanctioned cert punch-list item; the
+six→seven hub-button change is justified inline by the Q-0209 cert). `current-state` Recently-shipped
+left to the next session/recon (PR #1548 not yet merged — benign lag convention). Claim file deleted at
+close.
+
+## 📤 Run report
+- **Did:** built `check_session_slug_unique.py` (close BUG-0027 residual clobber, the prior run's Q-0089
+  idea) + wired it into `/session-close`; added the Mining 📖 How-to button (cert punch-list #1);
+  cleaned a stale claim. · **Outcome:** shipped (PR #1548), auto-merge armed.
+- **Shipped:** PR #1548 — `scripts/check_session_slug_unique.py` (+14 tests) + SKILL.md Step-4 wiring;
+  `disbot/views/mining/how_to_panel.py` + hub button (+3 tests, cert updated); deleted stale claim
+  `funny-franklin-ca1e1q.md`.
+- **Run type:** routine · dispatch
+- **⚑ Owner decisions needed:** none new.
+- **⚑ Owner manual steps:** none. (Mining how-to is live on the next auto-deploy; no data step.)
+- **⚑ Self-initiated:** yes — both slices were self-initiated on an empty fire. Slice 1 is the prior
+  run's routed Q-0089 idea (closing BUG-0027's residual harm — bugs-first); slice 2 is the dispatched
+  completion-first ▶ Next (cert punch-list). No brand-new feature invented; no plan promotion needed.
+- **↪ Next:** continue the completion-first arc — the remaining offline cert punch-list pick is
+  **Blackjack split/insurance/surrender** (bigger engine work, owner-paced) or another assessed unit's
+  offline deepening (Inventory item-grant audit · Proof-channel lock/unlock audit). The `◐ → ✔`
+  certifications themselves are `[owner]`/`[needs-live-bot]` (live walkthroughs). Bug-book:
+  BUG-0009/0011/0019#1 stay OPEN. Consider the orphan-claim guard above if claim drift recurs.

--- a/disbot/views/mining/how_to_panel.py
+++ b/disbot/views/mining/how_to_panel.py
@@ -1,0 +1,76 @@
+"""Mining How-to panel — a one-screen "how mining works" guide for new players.
+
+Mining completion-cert punch-list #1 (``docs/planning/feature-completion/units/mining.md``):
+the hub already carries an inline ``_ACTIONS_GUIDE`` routing list and per-panel blurbs, but
+there was no single dedicated 📖 How-to button at the hub — the bar Fishing/Blackjack already
+meet. This adds it: a static, one-screen onboarding guide reached from the main hub, returning
+via the established "↩ Mining Hub" back button (mirrors ``character_hub``).
+
+A child of the mining hub: ``HubView`` + ``SUBSYSTEM = "mining"`` (invoker lock + standard nav),
+no game logic of its own. The back button swaps to a nav-carrying view (``MiningHubView``), so it
+is not a dead-end terminal handler (the #1529 ``no_dead_end`` arch guard).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ui_constants import MINING_COLOR
+from views.base import HubView
+
+_HOW_TO = (
+    "New to mining? Here's the whole loop in one screen.\n\n"
+    "**1. ⛏️ Mine** — open the grid and roam the underground with the movement buttons, then "
+    "**Mine here** to dig the ore under you. Deeper depths hold richer ore (and need a better "
+    "💡 light to see — grab a torch, then a lantern).\n"
+    "**2. 🌲 Harvest** — chop wood, the basic crafting material. No tools needed.\n"
+    "**3. 🧰 Gear** — equip your best tool, light, and combat gear. **Equip Best** does it in one "
+    "click; matching set pieces give a bonus.\n"
+    "**4. 🔨 Workshop** — turn raw resources into better gear and structures: **Craft** (build it), "
+    "**Repair** (worn tools), **🔥 Forge** (gates the top gear tiers), **🛒 Market** (buy/sell).\n"
+    "**5. 🧍 Character** — everything about you: **Inventory** · **Stats** · **🌳 Skills** (spend "
+    "points to specialize) · **🏦 Vault** (stash loot safely, off your pack) · **🏠 Home**.\n\n"
+    "**Watch your 🎒 pack** — it holds a limited number of *item types*; sell or vault what you "
+    "don't need. **Watch durability** — tools wear down and break; repair or re-craft them at the "
+    "Workshop. Level up by mining and harvesting to unlock deeper ladders and skill points."
+)
+
+
+def build_how_to_embed() -> discord.Embed:
+    """The static "how mining works" onboarding guide (no per-player state)."""
+    embed = discord.Embed(
+        title="📖 How mining works",
+        description=_HOW_TO,
+        color=MINING_COLOR,
+    )
+    embed.set_footer(text="Only you can interact with this panel.")
+    return embed
+
+
+class MiningHowToView(HubView):
+    """The How-to panel — a static guide with a back button to the mining hub."""
+
+    SUBSYSTEM = "mining"
+
+    def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    @discord.ui.button(label="↩ Mining Hub", style=discord.ButtonStyle.secondary, row=2)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        from views.mining.main_panel import MiningHubView, build_overview_embed
+
+        embed = await build_overview_embed(
+            self._author.id,
+            self.guild_id,
+            name=getattr(self._author, "display_name", None),
+        )
+        await interaction.response.edit_message(
+            embed=embed,
+            view=MiningHubView(),
+            attachments=[],
+        )
+        self.stop()
+
+
+__all__ = ["MiningHowToView", "build_how_to_embed"]

--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -50,7 +50,8 @@ _ACTIONS_GUIDE = (
     "**🗺️ Explore** — the open-world explorer (fishing, roam, quests — early)\n"
     "**🧍 Character** — you: overview · inventory · stats · skills · vault · home\n"
     "**🧰 Gear** — equip your best tools, lights, and combat gear\n"
-    "**🔨 Workshop** — craft & build · repair · 🔥 forge · 🛒 market (all here)"
+    "**🔨 Workshop** — craft & build · repair · 🔥 forge · 🛒 market (all here)\n"
+    "**📖 How-to** — new here? the whole mining loop on one screen"
 )
 
 
@@ -363,6 +364,31 @@ class MiningHubView(PersistentView):
 
         embed = build_workshop_hub_embed()
         view = MiningWorkshopHubView(interaction.user, interaction.guild_id)
+        await _edit_in_place(interaction, embed=embed, view=view)
+
+    @discord.ui.button(
+        label="📖 How-to",
+        style=discord.ButtonStyle.grey,
+        custom_id="mining:how_to",
+        row=2,
+    )
+    async def how_to_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        # Completion-cert punch-list #1: a dedicated one-screen how-mining-works
+        # guide (the bar Fishing/Blackjack meet). Renders in place; returns via
+        # the panel's own "↩ Mining Hub" back button.
+        from views.mining.how_to_panel import MiningHowToView, build_how_to_embed
+
+        embed = build_how_to_embed()
+        view = MiningHowToView(interaction.user, interaction.guild_id)
         await _edit_in_place(interaction, embed=embed, view=view)
 
 

--- a/docs/owner/claims/funny-franklin-ca1e1q.md
+++ b/docs/owner/claims/funny-franklin-ca1e1q.md
@@ -1,1 +1,0 @@
-- branch: claude/funny-franklin-ca1e1q · scope: feature-completion assessments (unassessed games: RPS, Deathmatch, Chicken farm + contained UX gap fixes) · area: docs/planning/feature-completion/units/ + disbot/views/<game> if trapped-view fixes · date: 2026-06-28

--- a/docs/owner/claims/funny-franklin-dt7i3j.md
+++ b/docs/owner/claims/funny-franklin-dt7i3j.md
@@ -1,1 +1,0 @@
-- branch: claude/funny-franklin-dt7i3j · scope: session-slug-uniqueness guard (check_session_slug_unique.py + /session-close wiring) + Mining how-to button · area: scripts/ + .claude/skills/session-close/ + disbot/views/mining/ · date: 2026-06-29

--- a/docs/owner/claims/funny-franklin-dt7i3j.md
+++ b/docs/owner/claims/funny-franklin-dt7i3j.md
@@ -1,0 +1,1 @@
+- branch: claude/funny-franklin-dt7i3j · scope: session-slug-uniqueness guard (check_session_slug_unique.py + /session-close wiring) + Mining how-to button · area: scripts/ + .claude/skills/session-close/ + disbot/views/mining/ · date: 2026-06-29

--- a/docs/planning/feature-completion/units/mining.md
+++ b/docs/planning/feature-completion/units/mining.md
@@ -46,10 +46,12 @@
 - [x] **Every action has a control** — primary actions on the hub; sub-actions on the Character-hub,
       Workshop-hub, Gear, Market, Vault, Skills, Forge, Home, Titles sub-panels; modals
       (vault move / save-loadout / build) submit → refresh parent in place.
-- [ ] **Rules / how-to affordance** — **partial:** the hub embed carries an inline `_ACTIONS_GUIDE`
-      routing guide and per-panel "how to use" blurbs, and the Recipe browser is `📖 Recipes`, but
-      there is no single dedicated 📖 How-to button at the hub (the bar Fishing/Blackjack meet). →
-      punch-list #1 (minor).
+- [x] **Rules / how-to affordance** — ✅ **shipped (punch-list #1, 2026-06-29).** A dedicated
+      **📖 How-to** button at the hub (`mining:how_to`, `main_panel.py`) opens a one-screen
+      "how mining works" onboarding guide (`views/mining/how_to_panel.py`, `MiningHowToView`),
+      returning via the established "↩ Mining Hub" back button — the bar Fishing/Blackjack meet.
+      The inline `_ACTIONS_GUIDE` routing guide and per-panel blurbs remain. Tests:
+      `test_mining_how_to.py`.
 - [x] **Return navigation everywhere** — ✅ **no trapped views.** Every panel is a `HubView` with
       `SUBSYSTEM = "mining"` so `attach_standard_nav` adds 📚 Help + ↩ Games (12 views verified); the
       action-loop `MineGridView` is a `BaseView` (120 s, intentional) but carries explicit
@@ -113,9 +115,9 @@
 
 ## Punch-list (clear these to certify)
 
-1. **How-to affordance** *(offline, minor)* — add a dedicated 📖 How-to button at the Mining hub (or
-   a one-screen "how mining works" panel), mirroring Fishing/Blackjack. The inline `_ACTIONS_GUIDE`
-   covers routing but a first-time player has no single rules surface.
+1. ~~**How-to affordance**~~ ✅ **DONE 2026-06-29** (dispatch run, PR #1548) — a dedicated 📖 How-to
+   button at the Mining hub opens a one-screen "how mining works" panel (`MiningHowToView`),
+   mirroring Fishing/Blackjack. The only remaining punch-list items are the owner-paced #2/#3.
 2. **Live walkthrough** *(owner / live-bot)* — `/verify-bot` boot + scripted click-through (mine the
    grid → descend → harvest → craft → market sell/buy → gear/loadout → workshop repair → vault
    deposit → skills → forge → titles → back to hub), with screenshots.

--- a/scripts/check_session_slug_unique.py
+++ b/scripts/check_session_slug_unique.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3.10
+"""Session-slug uniqueness guard — fail when a PR reuses an existing `.sessions/` slug.
+
+[session-close-gate] Invoked from ``/session-close`` Step 4 (``check_session_close_gate.py``
+enforces that this stays wired in).
+
+Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch):
+- Why: this closes the *residual* harm BUG-0027 (PR #1523/#1524) left behind. That bug had two
+  stacked faults: (1) a slug collision (a new dispatch run reused an existing ``.sessions/`` slug)
+  caused ``git add`` to record the born-red card as a **modification**, not an addition, so the
+  merge-gate's added-only scan failed open and a partial PR auto-merged; and (2) the collision
+  **silently clobbered** the prior session's complete log in ``main``. #1524 fixed fault (1) at the
+  root (the gate now scans added-OR-modified cards). Fault (2) — the silent clobber — still happens
+  *before* the gate ever engages: by the time CI runs, the prior log has already been overwritten in
+  the working tree and committed. The only way to stop the clobber is to catch the collision **at
+  author time**, which is what this checker does: a session card path that already exists in
+  ``origin/main`` is a reused slug → rename it to a unique slug *before* it overwrites the old log.
+- The fix is the previous dispatch run's own Q-0089 idea (#1524 session log): a guard that fails when
+  a PR's new ``.sessions/`` card path already exists in ``origin/main``. "Enforce, don't exhort"
+  (Q-0132 / the Q-0194 friction→guard rule): the recurring-task slug-collision class is structural
+  (date+topic slugs for a task type that fires repeatedly), so a checker beats a journal note.
+- Distinguishing a collision from a *legitimate* re-badge: a normal session card never exists in
+  ``main`` when the session opens it, so across ``origin/main...HEAD`` it is an **addition**, never a
+  modification — it can't trip this guard. The one legitimate reason to *modify* an existing
+  ``.sessions/`` card is a reconciliation pass re-badging an **old** log to a terminal status
+  (``historical``/``archived``/…); those are carved out via ``check_session_gate._TERMINAL_OK_STATUSES``
+  (the single source of truth for session-card status semantics, imported here so the two guards can
+  never disagree). So: a card that exists in ``main`` AND is touched by this PR AND is **not** a
+  terminal re-badge == a reused active-session slug == a collision.
+- Added: 2026-06-29 (autonomous dispatch run, S3/S4 mechanism — the previous run's Q-0089 idea).
+  **Unverified** — confirm its output against ground truth over a few sessions before trusting it.
+  **Delete this script if it proves noisy/unreliable over multiple sessions**; it is a disposable
+  convenience guard, not load-bearing. Run from ``/session-close`` Step 4 (author time), not CI —
+  the whole point is to catch the collision *before* the clobber commit, which CI is too late for.
+
+What it checks (read-only; exits 1 on a collision, 0 when clean):
+- Find the ``.sessions/*.md`` cards this PR touches (added or modified vs ``origin/main``, plus
+  not-yet-committed staged/untracked cards so a pre-push run reflects what the PR will contain).
+- For each, ask git whether that exact path **already exists in ``origin/main``** (``git cat-file -e``).
+- A card that exists in ``main`` is a reused slug. If its (HEAD) status is a terminal re-badge token
+  it is an allowed reconciliation modification; otherwise it is a collision → FAIL with a rename hint.
+
+Usage::
+
+    python3.10 scripts/check_session_slug_unique.py            # auto (vs origin/main)
+    python3.10 scripts/check_session_slug_unique.py --base SHA --head SHA   # explicit range
+    python3.10 scripts/check_session_slug_unique.py --quiet     # exit code only
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# One source of truth for session-card status parsing + the terminal re-badge carve-out:
+# import them from the merge-gate so the two guards can never drift apart.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_session_gate import (  # noqa: E402
+    _TERMINAL_OK_STATUSES,
+    REPO_ROOT,
+    gate_session_cards,
+    parse_status,
+)
+
+# A session-card slug that is the *base* against which a collision is measured: a card already in
+# ``main``. The single legitimate modify-an-existing-card case is a reconciliation re-badge to a
+# terminal status — every other touch of an in-main card is a reused slug. Re-exported for tests.
+_REBADGE_OK_STATUSES = _TERMINAL_OK_STATUSES
+
+
+def _exists_in_main(rel_path: str) -> bool:
+    """True if ``rel_path`` already exists in ``origin/main`` (a reused slug).
+
+    Uses ``git cat-file -e origin/main:<path>`` — the cheap object-existence probe the original
+    Q-0089 idea named. Returns ``False`` on any git failure (no ref, detached env): a guard that
+    cannot read git must not block (the merge-gate + the rule are the backstop).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "cat-file", "-e", f"origin/main:{rel_path}"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def collisions(base: str | None, head: str | None) -> list[tuple[Path, str]]:
+    """Return (card, status) for each touched session card that reuses an in-``main`` slug.
+
+    A card collides when its path already exists in ``origin/main`` AND its current status is not a
+    terminal re-badge token (those are legitimate reconciliation modifications, carved out). The
+    candidate set is the merge-gate's added-OR-modified card list, so this and the gate agree on
+    *which* cards a PR touches.
+    """
+    found: list[tuple[Path, str]] = []
+    for card in gate_session_cards(base, head):
+        try:
+            rel = card.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            rel = card.as_posix()
+        if not _exists_in_main(rel):
+            continue  # net-new slug — the normal case, never a collision.
+        try:
+            status = (
+                parse_status(card.read_text(encoding="utf-8")) or "(no Status badge)"
+            )
+        except OSError:
+            status = "(unreadable)"
+        if status in _REBADGE_OK_STATUSES:
+            continue  # a reconciliation re-badge of an old log — allowed.
+        found.append((card, status))
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="SuperBot session-slug uniqueness guard.",
+    )
+    parser.add_argument("--base", help="base commit SHA (explicit range)")
+    parser.add_argument("--head", help="head commit SHA (explicit range)")
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress output; return exit code only",
+    )
+    args = parser.parse_args(argv)
+
+    hits = collisions(args.base, args.head)
+    if not hits:
+        if not args.quiet:
+            print(
+                "check_session_slug_unique: OK — no session card reuses an existing "
+                "origin/main slug ✓",
+            )
+        return 0
+
+    if not args.quiet:
+        print(
+            "check_session_slug_unique: COLLISION — a session card path already exists in "
+            "origin/main:",
+        )
+        for card, status in hits:
+            rel = (
+                card.relative_to(REPO_ROOT) if card.is_relative_to(REPO_ROOT) else card
+            )
+            print(f"  - {rel}: Status `{status}` — this slug is already taken in main.")
+        ok = ", ".join(sorted(_REBADGE_OK_STATUSES))
+        print(
+            "\nReusing an existing .sessions/ slug for a new session SILENTLY CLOBBERS the prior "
+            "session's log (BUG-0027 / the #1523 collision). Rename your card to a unique slug "
+            "(e.g. add a disambiguating word) before it overwrites the old one.\n"
+            f"  (A reconciliation pass re-badging an *old* log to a terminal status — {ok} — is "
+            "exempt; that is a legitimate modify-in-place.)",
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_session_slug_unique.py
+++ b/tests/unit/scripts/test_check_session_slug_unique.py
@@ -1,0 +1,127 @@
+"""Tests for scripts/check_session_slug_unique.py — the slug-collision guard (BUG-0027 residual).
+
+Closes the residual *silent-clobber* harm: a new session reusing an existing ``.sessions/`` slug
+overwrites the prior session's log. The guard fires when a touched card path already exists in
+``origin/main`` and the card is an active (non-re-badge) session card.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SPEC = importlib.util.spec_from_file_location(
+    "check_session_slug_unique",
+    _REPO_ROOT / "scripts" / "check_session_slug_unique.py",
+)
+assert _SPEC and _SPEC.loader
+guard = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(guard)
+
+
+def _write_card(tmp_path: Path, name: str, status: str) -> Path:
+    card = tmp_path / name
+    card.write_text(f"# {name}\n\n> **Status:** `{status}`\n", encoding="utf-8")
+    return card
+
+
+# --- collisions: the core distinction --------------------------------------
+
+
+def test_net_new_slug_is_not_a_collision(monkeypatch, tmp_path):
+    """A card that does NOT exist in origin/main is the normal case — never a collision."""
+    card = _write_card(tmp_path, "2026-06-29-fresh.md", "in-progress")
+    monkeypatch.setattr(guard, "gate_session_cards", lambda b, h: [card])
+    monkeypatch.setattr(guard, "_exists_in_main", lambda rel: False)
+    assert guard.collisions(None, None) == []
+
+
+def test_reused_slug_active_card_is_a_collision(monkeypatch, tmp_path):
+    """A card that exists in main AND is an active (in-progress) session card collides."""
+    card = _write_card(tmp_path, "2026-06-29-dup.md", "in-progress")
+    monkeypatch.setattr(guard, "gate_session_cards", lambda b, h: [card])
+    monkeypatch.setattr(guard, "_exists_in_main", lambda rel: True)
+    assert guard.collisions(None, None) == [(card, "in-progress")]
+
+
+def test_reused_slug_complete_card_is_still_a_collision(monkeypatch, tmp_path):
+    """Even a `complete` card collides — a finished new session reusing a slug still clobbers.
+
+    Only a terminal *re-badge* status (historical/archived/…) is exempt; `complete` is an active
+    session's done-state, not a reconciliation re-badge.
+    """
+    card = _write_card(tmp_path, "2026-06-29-dup.md", "complete")
+    monkeypatch.setattr(guard, "gate_session_cards", lambda b, h: [card])
+    monkeypatch.setattr(guard, "_exists_in_main", lambda rel: True)
+    assert guard.collisions(None, None) == [(card, "complete")]
+
+
+def test_reconciliation_rebadge_is_exempt(monkeypatch, tmp_path):
+    """A reconciliation pass re-badging an OLD log to `historical` is a legitimate modify-in-place."""
+    for status in sorted(guard._REBADGE_OK_STATUSES):
+        card = _write_card(tmp_path, f"2026-06-29-old-{status}.md", status)
+        monkeypatch.setattr(guard, "gate_session_cards", lambda b, h, c=card: [c])
+        monkeypatch.setattr(guard, "_exists_in_main", lambda rel: True)
+        assert guard.collisions(None, None) == [], f"{status} should be exempt"
+
+
+# --- _exists_in_main: git probe --------------------------------------------
+
+
+def test_exists_in_main_true_on_zero_returncode(monkeypatch):
+    class _R:
+        returncode = 0
+
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: _R())
+    assert guard._exists_in_main(".sessions/x.md") is True
+
+
+def test_exists_in_main_false_on_missing(monkeypatch):
+    class _R:
+        returncode = 1
+
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: _R())
+    assert guard._exists_in_main(".sessions/x.md") is False
+
+
+def test_exists_in_main_false_on_oserror(monkeypatch):
+    def _boom(*a, **k):
+        raise OSError("no git")
+
+    monkeypatch.setattr(guard.subprocess, "run", _boom)
+    assert guard._exists_in_main(".sessions/x.md") is False
+
+
+# --- main / exit codes ------------------------------------------------------
+
+
+def test_main_clean_passes(monkeypatch, capsys):
+    monkeypatch.setattr(guard, "collisions", lambda b, h: [])
+    assert guard.main(["--base", "a", "--head", "b"]) == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_collision_fails_with_rename_hint(monkeypatch, capsys, tmp_path):
+    card = _write_card(tmp_path, "2026-06-29-dup.md", "in-progress")
+    monkeypatch.setattr(guard, "collisions", lambda b, h: [(card, "in-progress")])
+    assert guard.main([]) == 1
+    out = capsys.readouterr().out
+    assert "COLLISION" in out
+    assert "unique slug" in out
+
+
+def test_main_quiet_suppresses_output(monkeypatch, capsys):
+    monkeypatch.setattr(guard, "collisions", lambda b, h: [])
+    assert guard.main(["--quiet"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+# --- the sentinel is declared (kept wired by check_session_close_gate) ------
+
+
+def test_declares_session_close_gate_sentinel():
+    src = (_REPO_ROOT / "scripts" / "check_session_slug_unique.py").read_text(
+        encoding="utf-8"
+    )
+    assert "[session-close-gate]" in src

--- a/tests/unit/views/test_mining_how_to.py
+++ b/tests/unit/views/test_mining_how_to.py
@@ -1,0 +1,44 @@
+"""Mining How-to panel — completion-cert punch-list #1 (Q-0209).
+
+Pins the dedicated 📖 How-to affordance at the mining hub: the hub exposes a
+``mining:how_to`` button, and the How-to panel is a static guide that returns to the
+mining hub via a "↩ Mining Hub" back button (not a dead-end terminal — #1529).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from views.mining.how_to_panel import MiningHowToView, build_how_to_embed
+from views.mining.main_panel import MiningHubView
+
+
+def test_hub_exposes_how_to_button():
+    view = MiningHubView()
+    ids = [getattr(c, "custom_id", None) for c in view.children]
+    assert "mining:how_to" in ids
+
+
+def test_how_to_embed_is_a_one_screen_guide():
+    embed = build_how_to_embed()
+    assert embed.title and "How mining works" in embed.title
+    # The guide covers the core loop's top actions so a new player isn't lost.
+    desc = embed.description or ""
+    for cue in ("Mine", "Harvest", "Gear", "Workshop", "Character"):
+        assert cue in desc, f"how-to guide should mention {cue!r}"
+
+
+def test_how_to_view_has_back_to_mining_hub_not_a_dead_end():
+    """The panel carries a back button (a nav-carrying return), so it is not a
+    trapped terminal view (the #1529 no_dead_end class)."""
+    view = MiningHowToView(author=_FakeUser(), guild_id=123)
+    labels = [getattr(c, "label", "") for c in view.children]
+    assert any("Mining Hub" in (lbl or "") for lbl in labels)
+
+
+class _FakeUser:
+    id = 42
+    display_name = "Miner"
+
+    def __init__(self) -> None:
+        pass

--- a/tests/unit/views/test_mining_no_root_overview.py
+++ b/tests/unit/views/test_mining_no_root_overview.py
@@ -49,10 +49,13 @@ def test_mining_hub_view_action_buttons_still_present():
         assert expected_id in ids, f"Missing action button {expected_id!r}; got {ids}"
 
 
-def test_mining_hub_view_is_exactly_the_six_option_a_actions():
-    """The Option A declutter (PR2, 2026-06-19): the main hub is exactly six
-    buttons. Everything else moved into the Character / Explore / Workshop
-    sub-hubs or the Mine action. Pinned so the panel can't quietly re-bloat.
+def test_mining_hub_view_is_exactly_the_six_actions_plus_how_to():
+    """The Option A declutter (PR2, 2026-06-19): six game-action buttons —
+    everything else moved into the Character / Explore / Workshop sub-hubs or the
+    Mine action. The mining completion cert (Q-0209) then added one **help/onboarding**
+    control, the dedicated 📖 How-to button (punch-list #1 — the bar Fishing/Blackjack
+    meet), which is distinct from the six game actions. Pinned so the panel can't quietly
+    re-bloat *beyond* that sanctioned set.
     """
     view = MiningHubView()
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
@@ -71,8 +74,9 @@ def test_mining_hub_view_is_exactly_the_six_option_a_actions():
         "mining:character",
         "mining:gear",
         "mining:workshop",
+        "mining:how_to",
     }
-    assert len(ids) == 6
+    assert len(ids) == 7
     # The moved/folded actions are gone from the persistent main panel.
     for gone in (
         "mining:inventory",


### PR DESCRIPTION
Empty-fire dispatch run (routine · dispatch). Two contained, offline, self-mergeable slices.

## 1. `check_session_slug_unique.py` — close BUG-0027's residual clobber risk (Q-0089 idea from #1524)

BUG-0027 (#1524) fixed the born-red merge-gate so a slug-collision card can't *auto-merge* a partial PR. But the residual harm — the **silent clobber** (a new session reusing an existing `.sessions/` slug overwrites the prior session's log) — still happened *before* the gate engaged. This adds the previous run's own routed Q-0089 idea: a `[session-close-gate]` checker that fails when a PR's session card path **already exists in `origin/main`** and the card is an active (non-re-badge) session card, with a rename hint — catching the collision at author time. Wired into `/session-close` Step 4 (the `check_session_close_gate.py` meta-check enforces the wiring stays).

## 2. Mining how-to button

The Mining completion cert's last build gap (the ✔-ready candidate); mirrors the Creatures how-to that closed #1546's cert.

Also cleans up a stale claim file left by the already-merged #1524 session (fix-on-sight, Q-0166).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136q6z8stimcVZBdwj5NNjn

---
_Generated by [Claude Code](https://claude.ai/code/session_0136q6z8stimcVZBdwj5NNjn)_