### PR TITLE
Inventory completion-cert punch #7: display-logic test coverage

### DIFF
--- a/.sessions/2026-06-29-inventory-display-logic-tests.md
+++ b/.sessions/2026-06-29-inventory-display-logic-tests.md
@@ -1,0 +1,49 @@
+# Session — Inventory display-logic coverage (Q-0209 completion-cert punch #7)
+
+> **Status:** `complete`
+
+**Run type:** routine · dispatch
+
+## What I did + why
+Second slice of the same empty-fire dispatch run (first slice: proof-channel deepening, PR #1550).
+S1 posture is completion-first (Q-0209). The **Inventory** completion certificate
+(`docs/planning/feature-completion/units/inventory.md`) flagged rubric G: *only the navigation lifecycle
+is tested* — the **display logic itself** (`_build_combined_inventory` merge/group/sort, `_CategoryView`
+pagination) was untested. Closed punch #7 with `tests/unit/cogs/test_inventory_display_logic.py` (10
+cases), a pure-additive, zero-runtime-risk slice that advances another `◐ assessed` cert toward ✔:
+
+- **`_build_combined_inventory`** — two-table merge with **summed overlapping keys** (an item in both
+  the economy + mining tables), catalogue category grouping, **rarest-first** sort (Epic→Common),
+  unknown item → `Other`, zero/negative quantities dropped, empty inventories → `{}`.
+- **`_CategoryView` pagination** — total-pages round-up for a partial last page, single-page nav
+  suppression (only Back, no Prev/Next), empty-category single-page "Nothing here." render, footer page
+  position, and prev/next boundary clamping.
+
+No runtime change — tests only. Cert rubric G + punch #7 + evidence + verdict de-staled.
+
+## ⚑ Self-initiated
+none — dispatched completion-first work (the standing S1 ▶ Next: clear the `◐ assessed` certs'
+punch-lists, Q-0209).
+
+## 💡 Session idea
+(Carried from this run's first slice — recorded once, in PR #1550's session log: an enforced
+audit-seam guard generalizing the BUG-0029 + proof-channel audit gaps. No second forced idea — Q-0089
+bars filler.)
+
+## ⟲ Previous-session review
+See PR #1550's session log for the substantive previous-session (#1546) review; this is the same run's
+second slice, so the meaningful review is recorded there to avoid duplicate filler.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PR:** (this PR — inventory display-logic tests)
+- **⚑ Self-initiated:** none
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none (tests only; no deploy/data step)
+- **Bug-book:** no new bugs.
+
+## Next ▶ (handoff)
+Inventory cert: punch #7 done. Remaining are owner-paced/deepening (item actions #1, audit item grants
+#2, capability cleanup #3, density #4, sort/filter #5, server-config decision #6) + the live
+walkthrough/sign-off (#8/#9). Next empty-fire dispatch can take another `◐ assessed` cert punch-list or
+promote the audit-seam guard idea (PR #1550 log) into an enforced check.

--- a/docs/owner/claims/claude-funny-franklin-fv5s7p-inv.md
+++ b/docs/owner/claims/claude-funny-franklin-fv5s7p-inv.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-fv5s7p-inv` · scope: inventory completion-cert punch #7 (display-logic tests) · files: tests/unit/cogs/test_inventory_display_logic.py, docs/planning/feature-completion/units/inventory.md · 2026-06-29

--- a/docs/planning/feature-completion/units/inventory.md
+++ b/docs/planning/feature-completion/units/inventory.md
@@ -68,9 +68,12 @@
 - [x] **Discoverable in Help** — `build_help_menu_view` hook; surfaced as an Economy child.
 
 ### G. Tests & evidence (required for ✔)
-- [ ] **Behavior tests** — ⚠ only the navigation lifecycle is tested
-      (`test_economy_inventory_edit.py`); `_build_combined_inventory`/`_CategoryView.build_embed`/rarity
-      sort/pagination boundaries are **untested**. → punch #7.
+- [x] **Behavior tests** — ✅ **display logic now covered (punch #7, 2026-06-29).**
+      `test_inventory_display_logic.py` pins `_build_combined_inventory` (two-table merge + summed
+      overlapping keys · category grouping · rarest-first sort · unknown→Other · zero/negative drop ·
+      empty→`{}`) and `_CategoryView` pagination (round-up, single-page nav suppression, empty-page
+      render, footer position, prev/next boundary clamp). The navigation lifecycle stays covered by
+      `test_economy_inventory_edit.py`.
 - [x] **Authority tests** — view ownership via `BaseView` (inherited; no inventory-specific test).
 - [N/A] **Mutation-seam tests** — no mutations in this unit (upstream workflows tested separately).
 - [ ] **Live walkthrough recorded** — pending → punch #8.
@@ -87,13 +90,15 @@
 5. **Sort / filter UI** *(offline, deepening)* — sort by qty/name/rarity, filter by type.
 6. **Server configuration** *(owner, minor)* — decide whether items should be per-guild configurable; if
    so, add a SubsystemSchema.
-7. **Display-logic tests** *(offline, minor)* — cover the merge/sort/pagination/empty paths.
+7. ~~**Display-logic tests**~~ ✅ **DONE 2026-06-29 (dispatch run)** — `test_inventory_display_logic.py`
+   covers the merge/sum/sort/group/unknown/zero-drop/empty + pagination-boundary paths (10 cases).
 8. **Live walkthrough** *(owner / live-bot)* — `/verify-bot` boot + click-through (hub → category → page →
    back), with screenshots.
 9. **Owner sign-off** — maintainer confirms "it does its job the most convenient way."
 
 ## Evidence
 - **Tests:** `tests/unit/views/test_economy_inventory_edit.py` (navigation lifecycle) ·
+  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 10 cases, punch #7) ·
   `tests/unit/invariants/test_no_view_level_purchase_writes.py`
 - **Walkthrough:** pending (punch #8)
 - **Owner sign-off:** pending (punch #9)
@@ -102,6 +107,7 @@
 Inventory is a **correct, well-routed read-only item browser** (unified mining+economy view, paginated,
 rarity-sorted, reachable via command/hub/Help). It is **the least mature** server-fn assessed so far on
 the *ceiling* axis: it deliberately ships no item actions, item grants are unaudited upstream, the
-declared mutation capabilities are unenforced placeholders, there is no server config, and only the
-navigation lifecycle is tested. None of this is a safety hazard (it's read-only), but a `◐ → ✔` path
-needs an owner decision on item actions + audit + capability cleanup (#1–#3) before it is "done-done."
+declared mutation capabilities are unenforced placeholders, and there is no server config. The
+display-logic test gap is now closed (punch #7, 2026-06-29). None of this is a safety hazard (it's
+read-only), but a `◐ → ✔` path needs an owner decision on item actions + audit + capability cleanup
+(#1–#3) before it is "done-done."

--- a/tests/unit/cogs/test_inventory_display_logic.py
+++ b/tests/unit/cogs/test_inventory_display_logic.py
@@ -1,0 +1,157 @@
+"""Inventory display-logic coverage (Q-0209 completion-cert punch #7).
+
+The inventory unit's only prior tests covered the Economy→Inventory navigation
+lifecycle; the completion certificate flagged the **display logic** itself —
+`_build_combined_inventory` (merge of the two inventory tables, category
+grouping, rarest-first sort, drop-empty) and `_CategoryView` pagination
+boundaries — as untested. These pin that logic so the merge/sort/empty/page
+paths can't silently regress.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.inventory_cog import (
+    UnifiedInventoryView,
+    _build_combined_inventory,
+    _CategoryView,
+)
+
+
+def _member(uid: int = 1) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = uid
+    m.display_name = "tester"
+    m.display_avatar = MagicMock(url="https://example/avatar.png")
+    return m
+
+
+def _patch_inventories(eco: dict, mine: dict):
+    """Patch the two DB reads `_build_combined_inventory` depends on."""
+    return patch.multiple(
+        "cogs.inventory_cog.db",
+        get_inventory=AsyncMock(return_value=eco),
+        get_mining_inventory=AsyncMock(return_value=mine),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_combined_inventory — merge / group / sort / drop-empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merges_both_tables_and_sums_overlapping_keys():
+    # "toolkit" is in both the economy and mining tables → quantities sum.
+    with _patch_inventories(eco={"toolkit": 2}, mine={"toolkit": 3, "stone": 5}):
+        grouped = await _build_combined_inventory(1, 99)
+
+    tools = {k: q for k, q, _ in grouped["Tools"]}
+    assert tools["toolkit"] == 5  # 2 + 3 summed across the two tables
+    mats = {k: q for k, q, _ in grouped["Mining Materials"]}
+    assert mats["stone"] == 5
+
+
+@pytest.mark.asyncio
+async def test_groups_by_catalogue_category_and_sorts_rarest_first():
+    with _patch_inventories(
+        eco={},
+        mine={"stone": 1, "diamond": 1, "gold": 1, "iron": 1},
+    ):
+        grouped = await _build_combined_inventory(1, 99)
+
+    # All four are Mining Materials; order must be Epic→Rare→Uncommon→Common.
+    keys = [k for k, _, _ in grouped["Mining Materials"]]
+    assert keys == ["diamond", "gold", "iron", "stone"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_item_falls_into_other_category():
+    with _patch_inventories(eco={"mystery_widget": 1}, mine={}):
+        grouped = await _build_combined_inventory(1, 99)
+
+    assert "Other" in grouped
+    assert grouped["Other"][0][0] == "mystery_widget"
+
+
+@pytest.mark.asyncio
+async def test_zero_and_negative_quantities_are_dropped():
+    with _patch_inventories(eco={"car": 0}, mine={"stone": -3, "gold": 2}):
+        grouped = await _build_combined_inventory(1, 99)
+
+    # Only the positive-qty gold survives; the empty categories never appear.
+    assert grouped == {
+        "Mining Materials": [("gold", 2, grouped["Mining Materials"][0][2])],
+    }
+
+
+@pytest.mark.asyncio
+async def test_empty_inventories_return_no_categories():
+    with _patch_inventories(eco={}, mine={}):
+        grouped = await _build_combined_inventory(1, 99)
+    assert grouped == {}
+
+
+# ---------------------------------------------------------------------------
+# _CategoryView — pagination boundaries
+# ---------------------------------------------------------------------------
+
+
+def _items(n: int) -> list[tuple[str, int, dict]]:
+    return [(f"item{i}", i + 1, {"emoji": "📦", "rarity": "Common"}) for i in range(n)]
+
+
+def _hub() -> MagicMock:
+    hub = MagicMock(spec=UnifiedInventoryView)
+    hub.target = _member()
+    return hub
+
+
+def test_total_pages_rounds_up_for_a_partial_last_page():
+    view = _CategoryView(_member(), "Tools", _items(9), hub=_hub())
+    # 9 items @ 8/page → 2 pages.
+    assert view._total_pages == 2
+
+
+def test_single_page_when_items_fit():
+    view = _CategoryView(_member(), "Tools", _items(8), hub=_hub())
+    assert view._total_pages == 1
+    # No prev/next when there is only one page — just the Back button.
+    labels = [getattr(c, "label", "") for c in view.children]
+    assert not any("Prev" in lab or "Next" in lab for lab in labels)
+    assert any("Back" in lab for lab in labels)
+
+
+def test_empty_category_still_renders_one_page():
+    view = _CategoryView(_member(), "Tools", [], hub=_hub())
+    assert view._total_pages == 1
+    embed = view.build_embed()
+    assert embed.description == "Nothing here."
+
+
+def test_page_footer_reports_position():
+    view = _CategoryView(_member(), "Tools", _items(20), hub=_hub())
+    assert view._total_pages == 3
+    embed = view.build_embed()
+    assert "Page 1/3" in embed.footer.text
+
+
+@pytest.mark.asyncio
+async def test_next_and_prev_clamp_at_the_boundaries():
+    view = _CategoryView(_member(), "Tools", _items(20), hub=_hub())
+    interaction = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    # Prev at page 0 stays at 0.
+    await view._prev_page(interaction)
+    assert view._page == 0
+    # Walk to the last page and confirm Next clamps there.
+    await view._next_page(interaction)
+    await view._next_page(interaction)
+    await view._next_page(interaction)  # one past the end
+    assert view._page == view._total_pages - 1 == 2


### PR DESCRIPTION
Second slice of an empty-fire dispatch run (first slice: proof-channel deepening, #1550). S1 posture is completion-first (Q-0209).

The **Inventory** completion certificate flagged rubric G: *only the navigation lifecycle is tested* — the display logic itself was untested. This closes punch #7 with `tests/unit/cogs/test_inventory_display_logic.py` (10 cases), advancing another `◐ assessed` cert toward ✔:

- **`_build_combined_inventory`** — two-table merge with summed overlapping keys, catalogue category grouping, rarest-first sort, unknown→`Other`, zero/negative-qty drop, empty→`{}`.
- **`_CategoryView` pagination** — total-pages round-up, single-page nav suppression, empty-page render, footer position, prev/next boundary clamp.

Tests only — no runtime change. Cert rubric G + punch #7 + evidence + verdict de-staled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7Ak6TqBzvgYLr8Gw7ekXr)_