### PR TITLE
Completion arc: registry↔ledger parity guard + offline deepening

### DIFF
--- a/.sessions/2026-06-29-completion-ledger-parity-guard.md
+++ b/.sessions/2026-06-29-completion-ledger-parity-guard.md
@@ -1,21 +1,111 @@
-# 2026-06-29 — Registry↔completion-ledger parity guard + offline deepening
+# 2026-06-29 — Registry↔completion-ledger parity guard + inventory sort/filter
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What I'm about to do
+## What this run did
 
-Empty-fire scheduled dispatch (no work order). Acting on the live **S1 ▶ Next** offline startable —
-completion-arc deepening — and on the previous run's (#1545) own ↪ Next priority list:
+Empty-fire scheduled dispatch (no work order). Acted on the live **S1 ▶ Next** offline startable
+(completion-arc deepening) and the previous run's (#1545) ↪ Next priority list. Shipped **three complete
+slices** in one PR (#1553), CI-green.
 
-1. **Registry↔completion-ledger parity guard** (slice 1) — build the checker the previous run proposed
-   as its Q-0089 session idea (and that the ledger README has flagged as a "noted follow-up" since the
-   arc began). Now that the completion ledger is at **36/36 ◐ assessed**, the next thing that will
-   drift is the ledger itself: a new certifiable subsystem added to `subsystem_registry.py` won't get a
-   ledger row + cert, and a retired/renamed subsystem leaves an orphan cert. A stdlib checker
-   (`scripts/check_completion_ledger_parity.py`, Q-0105 disposable header) asserts the registry ↔
-   ledger ↔ cert triangle is consistent. Offline / read-only / self-mergeable on green.
-2. A **second offline punch-list deepening** (slice 2) from the assessed certs — TBD after slice 1.
+### Slice 1 — registry↔completion-ledger parity guard (Q-0089 follow-up)
+The previous run proposed this as its Q-0089 session idea, and the ledger README has flagged
+"*a registry↔ledger parity guard is a noted follow-up*" since the arc began. Now that the completion
+ledger is at **36/36 ◐ assessed**, the next drift class is the ledger itself. Built
+`scripts/check_completion_ledger_parity.py` (stdlib, read-only, Q-0105 disposable header): asserts the
+registry ↔ ledger ↔ cert triangle — every certifiable registry subsystem (registry **minus** the
+documented routing-only/knowledge-domain exclusion set) has exactly one ledger row + a `units/<key>.md`
+cert, every cert maps to a live registry key (or the documented non-registry `setup` exception), no
+orphans/dupes. Pure `analyze()` core (injectable) + a `check()` disk-gatherer; advisory by default,
+`--strict` for CI. **12 tests** (each violation class A/B/C on synthetic data + a live committed-state
+regression that gates CI). Replaced the README "noted follow-up" line with the guard pointer.
 
-Born-red card opened first (Q-0133/Q-0189); flipped to `complete` as the deliberate last step.
+> The guard **immediately earned its keep**: on first run it flagged `btd6` as a certifiable registry
+> key with no cert — because the registry key has a digit and my initial exclusion set (and an earlier
+> manual key-scan with `[a-z_]+`) silently dropped it. `btd6` is a knowledge domain the README already
+> excludes; added it to `EXCLUDED`. A guard catching a gap in its own author's first draft is the point.
+
+### Slice 2 — inventory sort cycle (cert punch #5, sort half)
+The inventory category detail view was fixed rarest-first only. Added a `🔀 Sort:` cycle
+(Rarity / Quantity / Name) — pure `_sort_items()` total order (item key breaks ties), footer shows the
+active mode, button suppressed for a single-item category, cycling resets to page 0. +9 tests.
+
+### Slice 3 — inventory type filter (cert punch #5, filter half) → punch #5 CLOSED
+Added a `Filter by type…` select to the category view (shown only when a category mixes >1 item type;
+"All types" restores). Refactored `_CategoryView` so `_all` (sorted full set) and `_shown` (filtered
+slice) are distinct; `_apply()` recomputes the shown slice + page count and **clamps the page** when a
+filter shrinks the set; sort + filter compose. +6 tests (15 view tests total). Together with slice 2 this
+**fully closes inventory completion-cert punch #5**.
+
+**Bug-first fix-on-sight (Q-0166):** removed 2 stale claim files (`fv5s7p`, `fv5s7p-inv` — both merged
+branches, flagged by `check_stale_claims --strict`).
+
+## Verification
+- `python3.10 scripts/check_quality.py --full` → **All checks passed** (13088 passed, 48 skipped).
+- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors** (49 pre-existing warnings).
+- `python3.10 scripts/check_completion_ledger_parity.py --strict` → consistent.
+- `python3.10 scripts/completion_scoreboard.py --check` → up to date (36 assessed; unchanged).
+- `python3.10 scripts/check_consistency.py` → all rules pass (allowlisted the pre-existing `items[:3]`
+  hub preview — a top-3 embed preview with "+N more", flagged only because the file now also builds a
+  select; scoped by `::qualname` so the file's real select stays checked).
+- mypy clean on `disbot/cogs/inventory_cog.py`; economy→inventory nav lifecycle test still green.
+
+## 💡 Session idea (Q-0089)
+**A "select-options bounded source" annotation for `check_consistency`.** This run hit the
+`select_option_truncation` heuristic's coarseness: adding *any* `discord.ui.Select` to a file makes the
+checker flag *every* `[:N]` slice in that file, including unrelated embed-preview slices — so each new
+select forces a per-line `::qualname` allowlist entry that says "this slice isn't a select." The
+allowlist already has a whole "Embed / text displays, NOT selects" section proving this is a recurring
+tax. A cheaper fix: let the checker recognize a slice whose source is provably bounded (a literal list,
+a `sorted({...})` over a small fixed catalog, or an inline `# bounded:<reason>` marker) and skip it
+without a YAML round-trip — shrinking the allowlist to *genuine* truncations. Genuinely tied to this run
+(I paid the tax directly); a small AST refinement, not a new system.
+
+## ⟲ Previous-session review (Q-0102)
+The previous run (#1545, the 17-unit server-fn assessment sweep) did its best work in the **research
+fan-out** — one read-only agent per unit, with synthesis + Q-0120 spot-verification kept in the main
+session — clearing 17 independent units where a serial cadence would have taken many sessions. Its one
+genuine miss: it left its certs' punch-lists tagged `[offline]`/`[owner]` but **did not distinguish
+"offline = just build it" from "offline-looking but actually owner-decision-first."** Inventory punch #2
+("audit item grants") was tagged `offline/owner` and listed as a top offline pick — but it is really an
+*owner-granularity* decision (auditing every ore-dig would flood the audit channel), not a build task.
+**System improvement this run surfaced + acted on:** a punch-list line should separate *mechanical
+offline* from *decision-first* work, so a later empty-fire run doesn't barrel into a hot-path change
+with the wrong shape. I refined inventory punch #2 to state the question explicitly and contrast it with
+BUG-0029 (XP *role* grants, which legitimately belong on the audited seam) — turning a mis-tagged
+"offline pick" into a clear owner decision.
+
+## ⚐ Doc audit (Q-0104)
+Ran the automated half: `check_current_state_ledger --strict` (clean; benign newer-merge lag recorded by
+the #1560 pass), `check_docs --strict` (passed), `check_consistency` (passed), `completion_scoreboard
+--check` (up to date), `check_completion_ledger_parity --strict` (consistent). New owner decisions: none
+(the guard formalizes the *existing* README exclusion set in code; no new Q). Everything from this run
+lives in its durable home (the guard + tests, the inventory cog + tests, the inventory cert, the S1 ▶
+Next, this log). No chat-only residue.
+
+## 📤 Run report
+- **Did:** (1) built the registry↔completion-ledger parity guard (Q-0089 follow-up, 12 tests); (2)
+  closed inventory completion-cert punch #5 — sort cycle + type filter on the category view (15 tests);
+  (3) fix-on-sight stale-claim cleanup · **Outcome:** shipped (CI green, auto-merge armed)
+- **Shipped:** #1553 — `scripts/check_completion_ledger_parity.py` +
+  `tests/unit/scripts/test_check_completion_ledger_parity.py` · `disbot/cogs/inventory_cog.py`
+  (sort cycle + type filter) + `tests/unit/cogs/test_inventory_display_logic.py` (+15 cases) ·
+  `docs/planning/feature-completion/{README,units/inventory}.md` · `architecture_rules/consistency_exceptions.yml`
+  (one allowlist line) · S1 ▶ Next · 2 stale claims removed.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** **1 surfaced (not blocking this PR):** inventory punch #2 ("audit item
+  grants") needs an owner *granularity* call — which trail + what frequency — before building, because
+  the naive "audit every grant" would flood the admin audit channel (the coin trail is the
+  high-frequency `EVT_BALANCE_CHANGED` economy log, not `audit.action_recorded`). Documented in the
+  inventory cert punch #2. No *new* Q recorded (it's a refinement of an existing punch-list item).
+- **⚑ Owner manual steps:** none (no migration, no data step; runtime change auto-deploys on merge).
+- **⚑ Self-initiated:** yes — empty-fire dispatch; all three slices built without a dispatch/owner ask
+  (Q-0172). Grounded in the live S1 ▶ Next + the prior run's ↪ Next priority list + the ledger README's
+  own "noted follow-up" + Q-0209 completion-cert punch #5. The stale-claim cleanup is fix-on-sight (Q-0166).
+- **↪ Next:** inventory's remaining gaps are now **owner-gated** (#1 item actions · #2 item-grant audit
+  *granularity decision* · #3 capability cleanup) + the `◐ → ✔` live walkthrough. Other offline deepening
+  picks still open: **Blackjack split/insurance/surrender** engine work (games punch-list) · **logging
+  ignored-lists / channel+voice events** · inventory item-detail **density** (punch #4, minor). The new
+  parity guard now keeps the 36/36 ledger honest automatically as the registry evolves.

--- a/.sessions/2026-06-29-completion-ledger-parity-guard.md
+++ b/.sessions/2026-06-29-completion-ledger-parity-guard.md
@@ -1,0 +1,21 @@
+# 2026-06-29 — Registry↔completion-ledger parity guard + offline deepening
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What I'm about to do
+
+Empty-fire scheduled dispatch (no work order). Acting on the live **S1 ▶ Next** offline startable —
+completion-arc deepening — and on the previous run's (#1545) own ↪ Next priority list:
+
+1. **Registry↔completion-ledger parity guard** (slice 1) — build the checker the previous run proposed
+   as its Q-0089 session idea (and that the ledger README has flagged as a "noted follow-up" since the
+   arc began). Now that the completion ledger is at **36/36 ◐ assessed**, the next thing that will
+   drift is the ledger itself: a new certifiable subsystem added to `subsystem_registry.py` won't get a
+   ledger row + cert, and a retired/renamed subsystem leaves an orphan cert. A stdlib checker
+   (`scripts/check_completion_ledger_parity.py`, Q-0105 disposable header) asserts the registry ↔
+   ledger ↔ cert triangle is consistent. Offline / read-only / self-mergeable on green.
+2. A **second offline punch-list deepening** (slice 2) from the assessed certs — TBD after slice 1.
+
+Born-red card opened first (Q-0133/Q-0189); flipped to `complete` as the deliberate last step.

--- a/architecture_rules/consistency_exceptions.yml
+++ b/architecture_rules/consistency_exceptions.yml
@@ -186,6 +186,8 @@ select_option_truncation:
       reason: "render_pattern_preview(...)[:8] is a preview-embed slice, not a select."
     - pattern: views/ux_lab/layout_v2.py::LayoutWingView._build_gallery
       reason: "_AVATARS[:4] is a fixed demo avatar gallery (UX lab)."
+    - pattern: cogs/inventory_cog.py::UnifiedInventoryView.build_hub_embed
+      reason: "items[:3] is the hub embed's per-category top-3 preview (with an explicit '+N more' overflow note), not a select; the file is flagged only because _CategoryView now also builds a type-filter select."
     # --- Bounded fixed-catalog selects: the option source is an in-repo catalog
     #     that cannot realistically exceed 25; the [:25] slice is defensive. ---
     - pattern: views/btd6/paragon_view.py::_ParagonSelect

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -207,14 +207,61 @@ class _CategoryView(BaseView):
         super().__init__(author, timeout=180)
         self._category = category
         self._sort = _SORT_MODES[0]
-        self._items = _sort_items(items, self._sort)
+        # ``_all`` is every item in the category (sorted by the active mode); ``_shown``
+        # is the slice actually paged after the type filter is applied.
+        self._all = _sort_items(items, self._sort)
+        self._type_filter: str | None = None
         self._hub = hub
         self._page = 0
-        self._total_pages = max(1, (len(items) + self._PER_PAGE - 1) // self._PER_PAGE)
+        self._apply()
         self._rebuild_buttons()
+
+    @property
+    def _types(self) -> list[str]:
+        """Distinct item types present in this category (stable, alpha)."""
+        return sorted({meta.get("type", "Item") for _, _, meta in self._all})
+
+    def _apply(self) -> None:
+        """Recompute the shown slice + page count from the current sort + type filter."""
+        if self._type_filter is None:
+            self._shown = list(self._all)
+        else:
+            self._shown = [
+                i for i in self._all if i[2].get("type", "Item") == self._type_filter
+            ]
+        self._total_pages = max(
+            1,
+            (len(self._shown) + self._PER_PAGE - 1) // self._PER_PAGE,
+        )
+        self._page = min(self._page, self._total_pages - 1)
 
     def _rebuild_buttons(self) -> None:
         self.clear_items()
+        # Type filter — only when the category mixes more than one item type.
+        if len(self._types) > 1:
+            options = [
+                discord.SelectOption(
+                    label="All types",
+                    value="*",
+                    default=self._type_filter is None,
+                ),
+            ]
+            options += [
+                discord.SelectOption(
+                    label=t,
+                    value=t,
+                    default=self._type_filter == t,
+                )
+                for t in self._types
+            ]
+            type_select = discord.ui.Select(  # type: ignore[var-annotated]
+                placeholder="Filter by type…",
+                options=options,
+                row=0,
+            )
+            type_select.callback = self._on_filter  # type: ignore[method-assign]
+            self.add_item(type_select)
+
         if self._total_pages > 1:
             prev_btn = discord.ui.Button(  # type: ignore[var-annotated]
                 label="◀ Prev",
@@ -235,7 +282,7 @@ class _CategoryView(BaseView):
             self.add_item(next_btn)
 
         # Sort cycle — only worth offering when there is more than one item to order.
-        if len(self._items) > 1:
+        if len(self._all) > 1:
             sort_btn = discord.ui.Button(  # type: ignore[var-annotated]
                 label=f"🔀 Sort: {_SORT_LABEL[self._sort]}",
                 style=discord.ButtonStyle.primary,
@@ -267,7 +314,7 @@ class _CategoryView(BaseView):
         )
 
         start = self._page * self._PER_PAGE
-        page_items = self._items[start : start + self._PER_PAGE]
+        page_items = self._shown[start : start + self._PER_PAGE]
 
         lines = []
         for item_key, qty, meta in page_items:
@@ -278,10 +325,13 @@ class _CategoryView(BaseView):
             lines.append(f"{emoji} **{display_name}** × {qty}  `{rarity}` · {itype}")
 
         embed.description = "\n".join(lines) if lines else "Nothing here."
+        filter_note = (
+            "" if self._type_filter is None else f"{self._type_filter} only  •  "
+        )
         embed.set_footer(
             text=(
                 f"Page {self._page + 1}/{self._total_pages}  •  "
-                f"Sorted by {_SORT_LABEL[self._sort]}  •  Click ↩ Back to return."
+                f"Sorted by {_SORT_LABEL[self._sort]}  •  {filter_note}Click ↩ Back to return."
             ),
         )
         return embed
@@ -289,8 +339,17 @@ class _CategoryView(BaseView):
     async def _cycle_sort(self, interaction: discord.Interaction) -> None:
         idx = (_SORT_MODES.index(self._sort) + 1) % len(_SORT_MODES)
         self._sort = _SORT_MODES[idx]
-        self._items = _sort_items(self._items, self._sort)
+        self._all = _sort_items(self._all, self._sort)
         self._page = 0
+        self._apply()
+        self._rebuild_buttons()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_filter(self, interaction: discord.Interaction) -> None:
+        choice = interaction.data["values"][0]  # type: ignore[index,typeddict-item]
+        self._type_filter = None if choice == "*" else choice
+        self._page = 0
+        self._apply()
         self._rebuild_buttons()
         await interaction.response.edit_message(embed=self.build_embed(), view=self)
 

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -122,6 +122,36 @@ _RARITY_ORDER: dict[str, int] = {
     "Common": 3,
 }
 
+# Sort modes for the category detail view (punch #5). "rarity" is the default and
+# matches the rarest-first grouping order; the others let a large inventory be
+# re-ordered by quantity or name. Each is a stable total order (name tiebreak).
+_SORT_MODES: tuple[str, ...] = ("rarity", "quantity", "name")
+_SORT_LABEL: dict[str, str] = {
+    "rarity": "Rarity",
+    "quantity": "Quantity",
+    "name": "Name",
+}
+
+
+def _sort_items(
+    items: list[tuple[str, int, dict]],
+    mode: str,
+) -> list[tuple[str, int, dict]]:
+    """Return *items* ordered by *mode* — a pure, total order (item key breaks ties).
+
+    * ``rarity``   — rarest-first (the grouping default), key alpha within a tier.
+    * ``quantity`` — highest quantity first, key alpha within a quantity.
+    * ``name``     — item key alphabetical.
+    """
+    if mode == "quantity":
+        return sorted(items, key=lambda x: (-x[1], x[0]))
+    if mode == "name":
+        return sorted(items, key=lambda x: x[0])
+    return sorted(
+        items,
+        key=lambda x: (_RARITY_ORDER.get(x[2].get("rarity", ""), 99), x[0]),
+    )
+
 
 # ---------------------------------------------------------------------------
 # Shared async helper — used by both the cog command and economy_cog panel
@@ -176,7 +206,8 @@ class _CategoryView(BaseView):
     ) -> None:
         super().__init__(author, timeout=180)
         self._category = category
-        self._items = items
+        self._sort = _SORT_MODES[0]
+        self._items = _sort_items(items, self._sort)
         self._hub = hub
         self._page = 0
         self._total_pages = max(1, (len(items) + self._PER_PAGE - 1) // self._PER_PAGE)
@@ -202,6 +233,16 @@ class _CategoryView(BaseView):
             )
             next_btn.callback = self._next_page  # type: ignore[method-assign]
             self.add_item(next_btn)
+
+        # Sort cycle — only worth offering when there is more than one item to order.
+        if len(self._items) > 1:
+            sort_btn = discord.ui.Button(  # type: ignore[var-annotated]
+                label=f"🔀 Sort: {_SORT_LABEL[self._sort]}",
+                style=discord.ButtonStyle.primary,
+                row=1,
+            )
+            sort_btn.callback = self._cycle_sort  # type: ignore[method-assign]
+            self.add_item(sort_btn)
 
         back_btn = discord.ui.Button(  # type: ignore[var-annotated]
             label="↩ Back",
@@ -238,9 +279,20 @@ class _CategoryView(BaseView):
 
         embed.description = "\n".join(lines) if lines else "Nothing here."
         embed.set_footer(
-            text=f"Page {self._page + 1}/{self._total_pages}  •  Click ↩ Back to return.",
+            text=(
+                f"Page {self._page + 1}/{self._total_pages}  •  "
+                f"Sorted by {_SORT_LABEL[self._sort]}  •  Click ↩ Back to return."
+            ),
         )
         return embed
+
+    async def _cycle_sort(self, interaction: discord.Interaction) -> None:
+        idx = (_SORT_MODES.index(self._sort) + 1) % len(_SORT_MODES)
+        self._sort = _SORT_MODES[idx]
+        self._items = _sort_items(self._items, self._sort)
+        self._page = 0
+        self._rebuild_buttons()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
 
     async def _prev_page(self, interaction: discord.Interaction) -> None:
         self._page = max(0, self._page - 1)

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -111,7 +111,15 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   within games the **Blackjack split/insurance/surrender** engine work remains; server-fn deepening picks
   are listed in the assessments bullet below. **✅ DONE 2026-06-29 (#1550): Proof Channel** punch #1 + #2 —
   the lock/unlock now audit (`prize_access_grant`/`revoke`) and every mutation callback re-checks
-  `manage_channels` authority; cert advanced (only the binding-write UI + owner walkthrough remain). (Creatures' `◐ → ✔` still needs the owner live walkthrough +
+  `manage_channels` authority; cert advanced (only the binding-write UI + owner walkthrough remain).
+  **✅ DONE 2026-06-29 (PR #1553): Inventory punch #5 (sort + filter) CLOSED** — the category detail view
+  gained a `🔀 Sort:` cycle (Rarity / Quantity / Name, pure `_sort_items`) **and** a `Filter by type…`
+  select (shown only when a category mixes >1 type; `_apply` recomputes the shown slice + pages,
+  page-clamped); +15 tests. Inventory's remaining gaps are now the **owner-gated** ones (#1 item actions ·
+  #2 item-grant audit — *needs an owner call on audit-trail granularity, see note below* · #3 capability
+  cleanup) + live walkthrough. **Also shipped this PR: the registry↔completion-ledger parity guard**
+  (`scripts/check_completion_ledger_parity.py`, the Q-0089 follow-up the README flagged) — every
+  certifiable registry subsystem has exactly one ledger row + cert, enforced by a pytest regression. (Creatures' `◐ → ✔` still needs the owner live walkthrough +
   sign-off, punch-list #6/#7.)
 - `[owner]` **Feature-completion assessments — ALL 36 UNITS ◐ ASSESSED (100%; 0 certified).** The
   completion-first arc (Q-0209). The `▢ → ◐` assessment sweep is **COMPLETE** — every game + server-fn

--- a/docs/owner/claims/claude-funny-franklin-2fdlvx.md
+++ b/docs/owner/claims/claude-funny-franklin-2fdlvx.md
@@ -1,0 +1,3 @@
+# Claim — claude/funny-franklin-2fdlvx
+
+- branch: `claude/funny-franklin-2fdlvx` · scope: completion-arc offline deepening — registry↔completion-ledger parity guard (Q-0089 idea from #1545) + a second offline punch-list slice · expected files: `scripts/check_completion_ledger_parity.py`, `tests/unit/scripts/`, `docs/planning/feature-completion/` · date: 2026-06-29

--- a/docs/owner/claims/claude-funny-franklin-fv5s7p-inv.md
+++ b/docs/owner/claims/claude-funny-franklin-fv5s7p-inv.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-fv5s7p-inv` · scope: inventory completion-cert punch #7 (display-logic tests) · files: tests/unit/cogs/test_inventory_display_logic.py, docs/planning/feature-completion/units/inventory.md · 2026-06-29

--- a/docs/owner/claims/claude-funny-franklin-fv5s7p.md
+++ b/docs/owner/claims/claude-funny-franklin-fv5s7p.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-fv5s7p` · scope: proof_channel completion-deepening (audit + authority re-check) · files: disbot/cogs/proof_channel_cog.py, tests/unit/cogs/test_proof_channel_*.py, docs/planning/feature-completion/units/proof_channel.md · 2026-06-29

--- a/docs/planning/feature-completion/README.md
+++ b/docs/planning/feature-completion/README.md
@@ -193,7 +193,11 @@ the punch-list (open gaps), evidence links (tests · walkthrough), and the curre
 - **Not the production-readiness maps.** Those are the *risk/hardening* axis (see the table up top).
   A unit needs both; this is the completeness ceiling, that is the safety floor.
 - **Not a new source of truth for the unit list.** The spine is the subsystem registry; this ledger
-  references it. (A registry↔ledger parity guard is a noted follow-up.)
+  references it. The **registry↔ledger parity guard**
+  (`python3.10 scripts/check_completion_ledger_parity.py --strict`) enforces this: every certifiable
+  registry subsystem (registry minus the documented routing-only / knowledge-domain exclusion set) has
+  exactly one ledger row + a `units/<key>.md` cert, and every cert maps to a live registry key (or the
+  documented non-registry `setup` exception).
 - **Not a hard freeze on new features.** Completion-first is a *soft* default; the owner greenlights
   new units freely.
 - **Not self-certifying.** No unit reaches `✔` without owner sign-off (Q-0209).

--- a/docs/planning/feature-completion/units/inventory.md
+++ b/docs/planning/feature-completion/units/inventory.md
@@ -84,8 +84,15 @@
 ## Punch-list (clear these to certify)
 1. **Item actions** *(owner, deepening)* — decide + build use / sell / trade / gift / equip (today the
    browser is read-only). Biggest completeness gap.
-2. **Audit item grants** *(offline/owner, deepening)* — have `add_item` / mining `apply_inventory_deltas`
-   emit an item-grant audit event so the item trail matches the coin trail.
+2. **Audit item grants** *(owner-decision-first, deepening)* — the item-grant primitives
+   (`utils/db/inventory.add_item` / mining `apply_inventory_deltas`) emit no audit event. ⚠ **Needs an
+   owner granularity call before building** (flagged 2026-06-29, dispatch run): the *coin* trail is the
+   high-frequency `EVT_BALANCE_CHANGED` economy log, **not** the admin `audit.action_recorded` bus — so
+   "match the coin trail" must NOT mean firing `audit.action_recorded` on every ore dug / fish caught
+   (that would flood the server-log audit channel). The real question is *which* trail + *what*
+   granularity (a dedicated item-event analogous to the balance-change log? only admin/operator grants?).
+   Deferred rather than barreled into a hot-path change with the wrong shape. (Contrast BUG-0029: XP
+   *role* grants legitimately belong on the audited role seam — they are operator-visible, low-frequency.)
 3. **Capability enforcement** *(owner, minor)* — either enforce the declared `inventory.*` capabilities or
    remove the aspirational ones from the registry until their features exist.
 4. **Item-detail density** *(offline, minor)* — multi-line / dedicated fields for large inventories.

--- a/docs/planning/feature-completion/units/inventory.md
+++ b/docs/planning/feature-completion/units/inventory.md
@@ -40,9 +40,9 @@
 
 ### C. Convenience
 - [x] **Pagination** — 8 items/page with boundary-disabled nav; hub previews first 3 + count per category.
-- [~] **Sort/filter** — ⚠ **sort shipped (2026-06-29):** the category detail view has a
-      `🔀 Sort:` cycle (Rarity / Quantity / Name, footer shows the active mode); **type filter still
-      missing.** → punch #5 (filter half remains).
+- [x] **Sort/filter** — ✅ **DONE 2026-06-29:** the category detail view has a `🔀 Sort:` cycle
+      (Rarity / Quantity / Name, footer shows the active mode) **and** a `Filter by type…` select
+      (shown only when the category mixes >1 type; "All types" restores). → punch #5 cleared.
 - [x] **Clear feedback** — empty state + page footer; ⚠ item-detail line is dense (emoji·name·qty·rarity·
       type on one line) — readability degrades for large inventories. → punch #4.
 
@@ -89,9 +89,9 @@
 3. **Capability enforcement** *(owner, minor)* — either enforce the declared `inventory.*` capabilities or
    remove the aspirational ones from the registry until their features exist.
 4. **Item-detail density** *(offline, minor)* — multi-line / dedicated fields for large inventories.
-5. **Sort / filter UI** *(offline, deepening)* — ⚠ **sort DONE 2026-06-29 (dispatch run)** —
-   `🔀 Sort:` cycle (Rarity / Quantity / Name) on the category view, pure `_sort_items` + 9 tests.
-   **Remaining:** the **type filter** (show only one item type within a category).
+5. ~~**Sort / filter UI**~~ ✅ **DONE 2026-06-29 (dispatch run)** — `🔀 Sort:` cycle (Rarity /
+   Quantity / Name, pure `_sort_items`) **and** a `Filter by type…` select (`_apply` recomputes the
+   shown slice + pages, page-clamped) on the category view; +15 tests. (Sort + filter both shipped.)
 6. **Server configuration** *(owner, minor)* — decide whether items should be per-guild configurable; if
    so, add a SubsystemSchema.
 7. ~~**Display-logic tests**~~ ✅ **DONE 2026-06-29 (dispatch run)** — `test_inventory_display_logic.py`
@@ -102,8 +102,9 @@
 
 ## Evidence
 - **Tests:** `tests/unit/views/test_economy_inventory_edit.py` (navigation lifecycle) ·
-  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 19 cases: punch #7 merge/sort/
-  group/pagination + punch #5 sort cycle) · `tests/unit/invariants/test_no_view_level_purchase_writes.py`
+  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 25 cases: punch #7 merge/sort/
+  group/pagination + punch #5 sort cycle + type filter) ·
+  `tests/unit/invariants/test_no_view_level_purchase_writes.py`
 - **Walkthrough:** pending (punch #8)
 - **Owner sign-off:** pending (punch #9)
 

--- a/docs/planning/feature-completion/units/inventory.md
+++ b/docs/planning/feature-completion/units/inventory.md
@@ -40,7 +40,9 @@
 
 ### C. Convenience
 - [x] **Pagination** — 8 items/page with boundary-disabled nav; hub previews first 3 + count per category.
-- [ ] **Sort/filter** — ❌ no name/qty/rarity sort or type filter; fixed order only. → punch #5.
+- [~] **Sort/filter** — ⚠ **sort shipped (2026-06-29):** the category detail view has a
+      `🔀 Sort:` cycle (Rarity / Quantity / Name, footer shows the active mode); **type filter still
+      missing.** → punch #5 (filter half remains).
 - [x] **Clear feedback** — empty state + page footer; ⚠ item-detail line is dense (emoji·name·qty·rarity·
       type on one line) — readability degrades for large inventories. → punch #4.
 
@@ -87,7 +89,9 @@
 3. **Capability enforcement** *(owner, minor)* — either enforce the declared `inventory.*` capabilities or
    remove the aspirational ones from the registry until their features exist.
 4. **Item-detail density** *(offline, minor)* — multi-line / dedicated fields for large inventories.
-5. **Sort / filter UI** *(offline, deepening)* — sort by qty/name/rarity, filter by type.
+5. **Sort / filter UI** *(offline, deepening)* — ⚠ **sort DONE 2026-06-29 (dispatch run)** —
+   `🔀 Sort:` cycle (Rarity / Quantity / Name) on the category view, pure `_sort_items` + 9 tests.
+   **Remaining:** the **type filter** (show only one item type within a category).
 6. **Server configuration** *(owner, minor)* — decide whether items should be per-guild configurable; if
    so, add a SubsystemSchema.
 7. ~~**Display-logic tests**~~ ✅ **DONE 2026-06-29 (dispatch run)** — `test_inventory_display_logic.py`
@@ -98,8 +102,8 @@
 
 ## Evidence
 - **Tests:** `tests/unit/views/test_economy_inventory_edit.py` (navigation lifecycle) ·
-  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 10 cases, punch #7) ·
-  `tests/unit/invariants/test_no_view_level_purchase_writes.py`
+  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 19 cases: punch #7 merge/sort/
+  group/pagination + punch #5 sort cycle) · `tests/unit/invariants/test_no_view_level_purchase_writes.py`
 - **Walkthrough:** pending (punch #8)
 - **Owner sign-off:** pending (punch #9)
 

--- a/scripts/check_completion_ledger_parity.py
+++ b/scripts/check_completion_ledger_parity.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3.10
+"""Registry↔completion-ledger parity guard — keep the completion ledger honest as the registry evolves.
+
+The feature-completion ledger (`docs/planning/feature-completion/README.md`) certifies S1 bot
+units "done-done", and the README is explicit that **the registry is the spine** — the immutable
+list of units — while the ledger is a *living* index that merely references it:
+
+    > Not a new source of truth for the unit list. The spine is the subsystem registry; this ledger
+    > references it. (A registry↔ledger parity guard is a noted follow-up.)
+
+This *is* that noted follow-up. Now that the ledger is at 36/36 ◐ assessed, the next thing that
+will drift is the ledger itself: a new certifiable subsystem added to ``subsystem_registry.py``
+will not automatically get a ledger row + cert, a retired/renamed registry key leaves an orphan
+cert, and the documented exclusion set (routing-only hubs + knowledge domains) lives only in prose.
+This guard asserts the registry ↔ ledger ↔ cert triangle is consistent, so any of those drifts
+fails a check instead of sitting silently until someone re-reads the README.
+
+The unit list is derived three ways and must agree:
+
+1. **Registry** — top-level keys in ``disbot/utils/subsystem_registry.py`` ``SUBSYSTEMS``, minus the
+   documented exclusion set (``EXCLUDED`` below — routing-only hubs / dev-internal + knowledge
+   domains, mirroring the README "The unit = one registry entry" out-of-scope list). What remains is
+   the set of **certifiable** units.
+2. **Certs** — the ``**Unit:** `<key>` `` registry key each ``units/<file>.md`` certificate declares
+   (a non-backticked Unit line marks a documented *non-registry* unit — the ``setup`` wizard — which
+   must be on the ``NON_REGISTRY_UNITS`` allowlist).
+3. **Ledger rows** — the ``[cert](units/<file>.md)`` link in each ledger table row.
+
+Invariants (each is independent so one drift does not mask another):
+
+* **A. registry == certs** — every certifiable registry key has exactly one cert declaring it, and
+  every registry-backed cert maps to a live, non-excluded registry key (no missing cert, no orphan).
+* **B. ledger == certs on disk** — every ledger row links a cert file that exists, every cert file is
+  linked by exactly one ledger row (no unlinked cert, no dangling/duplicate link).
+* **C. exclusion/allowlist hygiene** — every ``EXCLUDED`` key and every ``NON_REGISTRY_UNITS`` key is
+  spelled correctly (the former is a live registry key; the latter has a cert + ledger row), and no
+  excluded registry key accidentally carries a cert.
+
+Reliability (Q-0105): **unverified** — confirm its flags against the actual ledger/registry over a
+few sessions before trusting its green. If it false-positives on a legitimate ledger shape (or
+misses a real parity break) over multiple sessions, **delete it** — it is a convenience guard for
+the completion-arc bookkeeping, not load-bearing. Pure stdlib, like ``completion_scoreboard.py``.
+
+Usage:
+    python3.10 scripts/check_completion_ledger_parity.py            # advisory report (exit 0)
+    python3.10 scripts/check_completion_ledger_parity.py --strict   # exit 1 on any parity break
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = REPO_ROOT / "disbot" / "utils" / "subsystem_registry.py"
+LEDGER_DIR = REPO_ROOT / "docs" / "planning" / "feature-completion"
+LEDGER = LEDGER_DIR / "README.md"
+UNITS_DIR = LEDGER_DIR / "units"
+
+# Registry keys that are NOT standalone certifiable units, mirroring the README
+# "The unit = one registry entry" out-of-scope list. Keep this in sync with that prose:
+#   - knowledge domains (their own sector/folio, not certified here)
+#   - routing-only hubs / dev-internal subsystems (infrastructure, not a user-facing feature)
+EXCLUDED = frozenset(
+    {
+        # knowledge domains
+        "btd6",
+        "project_moon",
+        # routing-only hubs / dev-internal
+        "games",
+        "community",
+        "server_management",
+        "ux_lab",
+        "general",
+        "four_twenty",
+    },
+)
+
+# Certifiable units that are deliberately NOT a registry subsystem (documented exceptions). Each
+# must still have a cert + ledger row; the cert declares a non-backticked Unit name + a registry note.
+NON_REGISTRY_UNITS = frozenset({"setup"})
+
+# A ledger row's cert link, e.g. ``[cert](units/blackjack.md)``.
+_CERT_LINK_RE = re.compile(r"\[cert\]\(units/([a-z0-9_]+)\.md\)")
+# A top-level SUBSYSTEMS key, e.g. ``    "blackjack": {`` (4-space indent, opens a dict).
+_REGISTRY_KEY_RE = re.compile(r'^    "([a-z0-9_]+)": \{', re.MULTILINE)
+# A cert's declared registry key, e.g. ``> **Unit:** `casino` · ...`` (None when non-backticked).
+_CERT_UNIT_RE = re.compile(r"\*\*Unit:\*\*\s*`([a-z0-9_]+)`")
+
+
+def registry_keys() -> set[str]:
+    """Top-level ``SUBSYSTEMS`` keys, scoped to the SUBSYSTEMS literal block."""
+    text = REGISTRY.read_text(encoding="utf-8")
+    start = text.find("SUBSYSTEMS: dict")
+    if start == -1:
+        raise SystemExit(
+            "check_completion_ledger_parity: could not find the SUBSYSTEMS dict in "
+            f"{REGISTRY.relative_to(REPO_ROOT)}",
+        )
+    return {m.group(1) for m in _REGISTRY_KEY_RE.finditer(text[start:])}
+
+
+def ledger_links() -> list[str]:
+    """Cert file stems referenced by ledger rows (order preserved, duplicates kept)."""
+    return _CERT_LINK_RE.findall(LEDGER.read_text(encoding="utf-8"))
+
+
+def cert_declared_key(cert: Path) -> str | None:
+    """The registry key a cert declares via its ``**Unit:** `<key>` `` line, or None if non-backticked."""
+    m = _CERT_UNIT_RE.search(cert.read_text(encoding="utf-8"))
+    return m.group(1) if m else None
+
+
+def check() -> list[str]:
+    """Gather the three views from disk and return parity violations (empty == clean)."""
+    cert_files = sorted(p.stem for p in UNITS_DIR.glob("*.md"))
+    declared: dict[str, str | None] = {
+        stem: cert_declared_key(UNITS_DIR / f"{stem}.md") for stem in cert_files
+    }
+    return analyze(registry_keys(), declared, ledger_links())
+
+
+def analyze(
+    reg: set[str],
+    declared: dict[str, str | None],
+    links: list[str],
+    units_on_disk: set[str] | None = None,
+) -> list[str]:
+    """Pure parity core — return human-readable violations (empty == clean).
+
+    Inputs (all derivable from disk by :func:`check`, injectable here for tests):
+
+    * ``reg`` — the set of live registry keys.
+    * ``declared`` — ``{cert_file_stem: declared_registry_key_or_None}`` for every cert on disk.
+    * ``links`` — the ordered list of cert file stems each ledger row links (duplicates kept).
+    * ``units_on_disk`` — the set of cert file stems that exist (defaults to ``declared.keys()``;
+      override only to model a ledger link to a missing file).
+    """
+    problems: list[str] = []
+
+    certifiable = reg - EXCLUDED
+    cert_files = sorted(declared)
+    on_disk = set(declared) if units_on_disk is None else units_on_disk
+    registry_backed = {k for k, v in declared.items() if v is not None}
+    non_registry = set(cert_files) - registry_backed
+    backed_keys = {
+        declared[stem] for stem in registry_backed
+    }  # the keys, not the file stems
+
+    # --- A. registry == certs (registry-backed) ---
+    for key in sorted(certifiable - backed_keys):
+        problems.append(
+            f"[A] registry key '{key}' is certifiable but no cert declares it "
+            f"(add docs/planning/feature-completion/units/<file>.md with `**Unit:** `{key}``)",
+        )
+    for stem in sorted(s for s in registry_backed if declared[s] not in certifiable):
+        key = declared[stem]
+        why = "not a registry key" if key not in reg else "is on the EXCLUDED list"
+        problems.append(
+            f"[A] cert 'units/{stem}.md' declares Unit `{key}`, which {why} "
+            f"(orphan cert — remove it, fix the Unit key, or update EXCLUDED/NON_REGISTRY_UNITS)",
+        )
+
+    # --- B. ledger rows == cert files on disk ---
+    seen: dict[str, int] = {}
+    for stem in links:
+        seen[stem] = seen.get(stem, 0) + 1
+        if stem not in on_disk:
+            problems.append(
+                f"[B] ledger links 'units/{stem}.md', which does not exist on disk",
+            )
+    for stem, n in sorted(seen.items()):
+        if n > 1:
+            problems.append(
+                f"[B] ledger links 'units/{stem}.md' {n} times (expected exactly one row)",
+            )
+    for stem in cert_files:
+        if stem not in seen:
+            problems.append(
+                f"[B] cert 'units/{stem}.md' exists but no ledger row links it (unlinked cert)",
+            )
+
+    # --- C. exclusion / allowlist hygiene ---
+    for key in sorted(EXCLUDED - reg):
+        problems.append(
+            f"[C] EXCLUDED key '{key}' is not a live registry key (typo, or it was renamed/removed)",
+        )
+    for stem in sorted(non_registry):
+        if stem not in NON_REGISTRY_UNITS:
+            problems.append(
+                f"[C] cert 'units/{stem}.md' has no `**Unit:** `key`` line and is not on "
+                "NON_REGISTRY_UNITS (every cert must declare a registry key or be an allowlisted exception)",
+            )
+    for stem in sorted(NON_REGISTRY_UNITS):
+        if stem not in on_disk:
+            problems.append(
+                f"[C] NON_REGISTRY_UNITS unit '{stem}' has no cert 'units/{stem}.md'",
+            )
+    for key in sorted(EXCLUDED & backed_keys):
+        problems.append(
+            f"[C] EXCLUDED key '{key}' carries a cert (an excluded routing-only/knowledge unit "
+            "should not be certified — remove the cert or move the key out of EXCLUDED)",
+        )
+
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Registry↔completion-ledger parity guard.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on any parity break (default is advisory, exit 0).",
+    )
+    args = parser.parse_args(argv)
+
+    problems = check()
+    if not problems:
+        print(
+            "check_completion_ledger_parity: registry ↔ ledger ↔ certs are consistent.",
+        )
+        return 0
+
+    print(
+        f"check_completion_ledger_parity: {len(problems)} parity break(s):",
+        file=sys.stderr,
+    )
+    for p in problems:
+        print(f"  {p}", file=sys.stderr)
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/cogs/test_inventory_display_logic.py
+++ b/tests/unit/cogs/test_inventory_display_logic.py
@@ -16,9 +16,11 @@ import discord
 import pytest
 
 from cogs.inventory_cog import (
+    _SORT_MODES,
     UnifiedInventoryView,
     _build_combined_inventory,
     _CategoryView,
+    _sort_items,
 )
 
 
@@ -155,3 +157,86 @@ async def test_next_and_prev_clamp_at_the_boundaries():
     await view._next_page(interaction)
     await view._next_page(interaction)  # one past the end
     assert view._page == view._total_pages - 1 == 2
+
+
+# ---------------------------------------------------------------------------
+# _sort_items + _CategoryView sort cycle (completion-cert punch #5)
+# ---------------------------------------------------------------------------
+
+
+def _mixed() -> list[tuple[str, int, dict]]:
+    # Deliberately unordered; distinct rarities, quantities, and names.
+    return [
+        ("stone", 5, {"rarity": "Common"}),
+        ("diamond", 1, {"rarity": "Epic"}),
+        ("iron", 9, {"rarity": "Uncommon"}),
+        ("gold", 3, {"rarity": "Rare"}),
+    ]
+
+
+def test_sort_by_rarity_is_rarest_first():
+    keys = [k for k, _, _ in _sort_items(_mixed(), "rarity")]
+    assert keys == ["diamond", "gold", "iron", "stone"]
+
+
+def test_sort_by_quantity_is_highest_first():
+    keys = [k for k, _, _ in _sort_items(_mixed(), "quantity")]
+    assert keys == ["iron", "stone", "gold", "diamond"]
+
+
+def test_sort_by_name_is_alphabetical():
+    keys = [k for k, _, _ in _sort_items(_mixed(), "name")]
+    assert keys == ["diamond", "gold", "iron", "stone"]
+
+
+def test_sort_breaks_ties_deterministically_by_key():
+    # Two Commons with equal quantity must order by key, not input order.
+    items = [("zeta", 2, {"rarity": "Common"}), ("alpha", 2, {"rarity": "Common"})]
+    assert [k for k, _, _ in _sort_items(items, "rarity")] == ["alpha", "zeta"]
+    assert [k for k, _, _ in _sort_items(items, "quantity")] == ["alpha", "zeta"]
+
+
+def test_unknown_rarity_sorts_last():
+    items = [("mystery", 1, {}), ("gold", 1, {"rarity": "Rare"})]
+    assert [k for k, _, _ in _sort_items(items, "rarity")] == ["gold", "mystery"]
+
+
+def test_category_view_defaults_to_rarity_sort():
+    view = _CategoryView(_member(), "Mining Materials", _mixed(), hub=_hub())
+    assert view._sort == "rarity"
+    assert [k for k, _, _ in view._items] == ["diamond", "gold", "iron", "stone"]
+
+
+def test_sort_button_present_with_multiple_items_absent_with_one():
+    many = _CategoryView(_member(), "Tools", _mixed(), hub=_hub())
+    assert any("Sort:" in getattr(c, "label", "") for c in many.children)
+    one = _CategoryView(_member(), "Tools", _mixed()[:1], hub=_hub())
+    assert not any("Sort:" in getattr(c, "label", "") for c in one.children)
+
+
+@pytest.mark.asyncio
+async def test_cycle_sort_advances_mode_resets_page_and_reorders():
+    view = _CategoryView(_member(), "Mining Materials", _mixed(), hub=_hub())
+    interaction = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    view._page = 0
+    await view._cycle_sort(interaction)
+    # rarity → quantity (the next mode in the cycle).
+    assert view._sort == _SORT_MODES[1] == "quantity"
+    assert [k for k, _, _ in view._items] == ["iron", "stone", "gold", "diamond"]
+    assert view._page == 0
+    assert "Sorted by Quantity" in view.build_embed().footer.text
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cycle_sort_wraps_back_to_rarity():
+    view = _CategoryView(_member(), "Mining Materials", _mixed(), hub=_hub())
+    interaction = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    for _ in range(len(_SORT_MODES)):
+        await view._cycle_sort(interaction)
+    assert view._sort == "rarity"  # full cycle returns to the default

--- a/tests/unit/cogs/test_inventory_display_logic.py
+++ b/tests/unit/cogs/test_inventory_display_logic.py
@@ -204,7 +204,7 @@ def test_unknown_rarity_sorts_last():
 def test_category_view_defaults_to_rarity_sort():
     view = _CategoryView(_member(), "Mining Materials", _mixed(), hub=_hub())
     assert view._sort == "rarity"
-    assert [k for k, _, _ in view._items] == ["diamond", "gold", "iron", "stone"]
+    assert [k for k, _, _ in view._all] == ["diamond", "gold", "iron", "stone"]
 
 
 def test_sort_button_present_with_multiple_items_absent_with_one():
@@ -225,7 +225,7 @@ async def test_cycle_sort_advances_mode_resets_page_and_reorders():
     await view._cycle_sort(interaction)
     # rarity → quantity (the next mode in the cycle).
     assert view._sort == _SORT_MODES[1] == "quantity"
-    assert [k for k, _, _ in view._items] == ["iron", "stone", "gold", "diamond"]
+    assert [k for k, _, _ in view._all] == ["iron", "stone", "gold", "diamond"]
     assert view._page == 0
     assert "Sorted by Quantity" in view.build_embed().footer.text
     interaction.response.edit_message.assert_awaited_once()
@@ -240,3 +240,92 @@ async def test_cycle_sort_wraps_back_to_rarity():
     for _ in range(len(_SORT_MODES)):
         await view._cycle_sort(interaction)
     assert view._sort == "rarity"  # full cycle returns to the default
+
+
+# ---------------------------------------------------------------------------
+# _CategoryView type filter (completion-cert punch #5, filter half)
+# ---------------------------------------------------------------------------
+
+
+def _typed() -> list[tuple[str, int, dict]]:
+    # Mixed item types within one category, so the filter is meaningful.
+    return [
+        ("stone", 5, {"rarity": "Common", "type": "Ore"}),
+        ("iron", 9, {"rarity": "Uncommon", "type": "Ore"}),
+        ("diamond", 1, {"rarity": "Epic", "type": "Gem"}),
+        ("wood", 2, {"rarity": "Common", "type": "Resource"}),
+    ]
+
+
+def _filter_interaction(value: str) -> MagicMock:
+    interaction = MagicMock()
+    interaction.data = {"values": [value]}
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def test_filter_select_present_only_with_multiple_types():
+    mixed = _CategoryView(_member(), "Mining Materials", _typed(), hub=_hub())
+    assert any(isinstance(c, discord.ui.Select) for c in mixed.children)
+    # A single-type category offers no filter.
+    one_type = _CategoryView(
+        _member(),
+        "Mining Materials",
+        [("stone", 1, {"rarity": "Common", "type": "Ore"})],
+        hub=_hub(),
+    )
+    assert not any(isinstance(c, discord.ui.Select) for c in one_type.children)
+
+
+def test_distinct_types_are_stable_and_alpha():
+    view = _CategoryView(_member(), "Mining Materials", _typed(), hub=_hub())
+    assert view._types == ["Gem", "Ore", "Resource"]
+
+
+@pytest.mark.asyncio
+async def test_filter_narrows_to_one_type_and_recomputes_pages():
+    view = _CategoryView(_member(), "Mining Materials", _typed(), hub=_hub())
+    await view._on_filter(_filter_interaction("Ore"))
+    assert view._type_filter == "Ore"
+    assert [k for k, _, _ in view._shown] == [
+        "iron",
+        "stone",
+    ]  # rarest-first within Ore
+    assert view._total_pages == 1
+    assert view._page == 0
+    assert "Ore only" in view.build_embed().footer.text
+
+
+@pytest.mark.asyncio
+async def test_filter_all_restores_full_set():
+    view = _CategoryView(_member(), "Mining Materials", _typed(), hub=_hub())
+    await view._on_filter(_filter_interaction("Gem"))
+    assert [k for k, _, _ in view._shown] == ["diamond"]
+    await view._on_filter(_filter_interaction("*"))
+    assert view._type_filter is None
+    assert len(view._shown) == 4
+
+
+@pytest.mark.asyncio
+async def test_filter_then_sort_keeps_filter():
+    view = _CategoryView(_member(), "Mining Materials", _typed(), hub=_hub())
+    await view._on_filter(_filter_interaction("Ore"))
+    await view._cycle_sort(
+        _filter_interaction("ignored")
+    )  # sort respects the active filter
+    assert view._type_filter == "Ore"
+    assert {k for k, _, _ in view._shown} == {"iron", "stone"}
+
+
+@pytest.mark.asyncio
+async def test_filter_clamps_page_when_fewer_items_remain():
+    # 20 Ore + 1 Gem → page 2 exists; filtering to Gem must clamp the page.
+    items = [(f"ore{i}", 1, {"rarity": "Common", "type": "Ore"}) for i in range(20)] + [
+        ("ruby", 1, {"rarity": "Rare", "type": "Gem"}),
+    ]
+    view = _CategoryView(_member(), "Mining Materials", items, hub=_hub())
+    view._page = 2  # deep into the Ore pages
+    await view._on_filter(_filter_interaction("Gem"))
+    assert view._total_pages == 1
+    assert view._page == 0

--- a/tests/unit/scripts/test_check_completion_ledger_parity.py
+++ b/tests/unit/scripts/test_check_completion_ledger_parity.py
@@ -1,0 +1,169 @@
+"""Tests for ``scripts/check_completion_ledger_parity.py`` — the registry↔ledger parity guard.
+
+Two layers:
+
+* the **pure core** (``analyze``) is driven with synthetic ``(reg, declared, links)`` inputs to
+  exercise every violation class (A registry↔certs · B ledger↔files · C exclusion/allowlist) plus
+  the clean baseline, with no disk access;
+* one **live regression test** asserts the committed repo state (registry · ledger · certs) passes,
+  so any real future parity break (a new registry subsystem with no cert, a renamed key, an orphan
+  cert) fails this test in CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_completion_ledger_parity.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location(
+        "check_completion_ledger_parity_ut",
+        _SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- a minimal, internally-consistent synthetic world (mirrors the real shapes) ---
+_REG = {
+    "alpha",
+    "beta",
+    "gamma",
+    "hub",
+    "btd6",
+}  # hub + btd6 stand in for excluded keys
+
+
+def _clean(mod):
+    """A consistent synthetic world: alpha/beta/gamma certifiable + the non-registry 'wiz'."""
+    reg = set(_REG)
+    declared = {"alpha": "alpha", "beta": "beta", "gamma": "gamma", "wiz": None}
+    links = ["alpha", "beta", "gamma", "wiz"]
+    return reg, declared, links
+
+
+@pytest.fixture
+def patched(mod, monkeypatch):
+    """Point the guard's EXCLUDED/NON_REGISTRY_UNITS at the synthetic world."""
+    monkeypatch.setattr(mod, "EXCLUDED", frozenset({"hub", "btd6"}))
+    monkeypatch.setattr(mod, "NON_REGISTRY_UNITS", frozenset({"wiz"}))
+    return mod
+
+
+def test_clean_world_has_no_problems(patched):
+    reg, declared, links = _clean(patched)
+    assert patched.analyze(reg, declared, links) == []
+
+
+def test_A_missing_cert_for_certifiable_key(patched):
+    reg, declared, links = _clean(patched)
+    del declared[
+        "gamma"
+    ]  # gamma is still a certifiable registry key but loses its cert
+    links = [s for s in links if s != "gamma"]
+    problems = patched.analyze(reg, declared, links)
+    assert any(p.startswith("[A]") and "'gamma'" in p for p in problems)
+
+
+def test_A_orphan_cert_declares_unknown_key(patched):
+    reg, declared, links = _clean(patched)
+    declared["ghost"] = "ghost"  # cert declares a key that is not in the registry
+    links.append("ghost")
+    problems = patched.analyze(reg, declared, links)
+    assert any(
+        p.startswith("[A]") and "ghost" in p and "not a registry key" in p
+        for p in problems
+    )
+
+
+def test_A_orphan_cert_declares_excluded_key(patched):
+    reg, declared, links = _clean(patched)
+    declared["hub"] = "hub"  # a cert for an EXCLUDED routing-only hub
+    links.append("hub")
+    problems = patched.analyze(reg, declared, links)
+    # surfaces under [A] (declares an excluded key) and/or [C] (excluded key carries a cert)
+    assert any("hub" in p and "EXCLUDED" in p for p in problems)
+
+
+def test_B_ledger_links_missing_file(patched):
+    reg, declared, links = _clean(patched)
+    links.append("phantom")  # a ledger row links a cert that is not on disk
+    problems = patched.analyze(reg, declared, links)
+    assert any(
+        p.startswith("[B]") and "phantom" in p and "does not exist" in p
+        for p in problems
+    )
+
+
+def test_B_duplicate_ledger_row(patched):
+    reg, declared, links = _clean(patched)
+    links.append("alpha")  # alpha linked twice
+    problems = patched.analyze(reg, declared, links)
+    assert any(
+        p.startswith("[B]") and "alpha" in p and "2 times" in p for p in problems
+    )
+
+
+def test_B_unlinked_cert(patched):
+    reg, declared, links = _clean(patched)
+    links = [
+        s for s in links if s != "beta"
+    ]  # beta cert exists but no ledger row links it
+    problems = patched.analyze(reg, declared, links)
+    assert any(
+        p.startswith("[B]") and "beta" in p and "no ledger row" in p for p in problems
+    )
+
+
+def test_C_typo_in_excluded_set(mod, monkeypatch):
+    monkeypatch.setattr(mod, "EXCLUDED", frozenset({"hub", "btd6", "notakey"}))
+    monkeypatch.setattr(mod, "NON_REGISTRY_UNITS", frozenset({"wiz"}))
+    reg, declared, links = _clean(mod)
+    problems = mod.analyze(reg, declared, links)
+    assert any(
+        p.startswith("[C]") and "notakey" in p and "not a live registry key" in p
+        for p in problems
+    )
+
+
+def test_C_non_registry_cert_not_allowlisted(patched):
+    reg, declared, links = _clean(patched)
+    declared["sneaky"] = None  # a non-backticked cert that is not on NON_REGISTRY_UNITS
+    links.append("sneaky")
+    problems = patched.analyze(reg, declared, links)
+    assert any(
+        p.startswith("[C]") and "sneaky" in p and "NON_REGISTRY_UNITS" in p
+        for p in problems
+    )
+
+
+def test_C_allowlisted_unit_missing_cert(patched):
+    reg, declared, links = _clean(patched)
+    del declared["wiz"]  # the documented non-registry unit loses its cert
+    links = [s for s in links if s != "wiz"]
+    problems = patched.analyze(reg, declared, links)
+    assert any(p.startswith("[C]") and "wiz" in p and "no cert" in p for p in problems)
+
+
+# --- live regression: the committed repo state must be parity-clean ---
+
+
+def test_committed_repo_state_is_consistent(mod):
+    problems = mod.check()
+    assert problems == [], "completion ledger parity broke:\n" + "\n".join(problems)
+
+
+def test_excluded_and_allowlist_are_disjoint(mod):
+    """An EXCLUDED routing-only key and a NON_REGISTRY_UNITS allowlist key can't be the same name."""
+    assert mod.EXCLUDED.isdisjoint(mod.NON_REGISTRY_UNITS)


### PR DESCRIPTION
Empty-fire scheduled dispatch (no work order). Acts on the live **S1 ▶ Next** offline startable
(completion-arc deepening) and the previous run's (#1545) ↪ Next priority list. **Three complete
slices**, CI-green; session card flipped to `complete`.

## Slice 1 — registry↔completion-ledger parity guard (Q-0089 follow-up)
The prior run's Q-0089 session idea, and the ledger README's long-standing "noted follow-up." Now that
the completion ledger is at **36/36 ◐ assessed**, the next drift class is the ledger itself.
`scripts/check_completion_ledger_parity.py` (stdlib, Q-0105 disposable header) asserts the registry ↔
ledger ↔ cert triangle: every certifiable registry subsystem (registry minus the documented
routing-only/knowledge-domain exclusion set) has exactly one ledger row + a `units/<key>.md` cert, every
cert maps to a live registry key (or the documented non-registry `setup` exception), no orphans/dupes.
Pure `analyze()` core + a `check()` disk-gatherer; advisory by default, `--strict` for CI. **12 tests**
(each violation class A/B/C + a live committed-state regression). On first run it **caught a real gap in
its own author's exclusion set** (`btd6`, a digit-keyed knowledge domain). README "noted follow-up" line
replaced with the guard pointer.

## Slice 2 — inventory sort cycle (completion-cert punch #5, sort half)
The category detail view gains a `🔀 Sort:` cycle (Rarity / Quantity / Name) — pure `_sort_items()`
total order (item key breaks ties), footer shows the active mode, suppressed for a single-item category,
cycling resets to page 0. +9 tests.

## Slice 3 — inventory type filter (completion-cert punch #5, filter half) → punch #5 CLOSED
A `Filter by type…` select (shown only when a category mixes >1 item type; "All types" restores).
`_CategoryView` refactored so `_all` (sorted full set) and `_shown` (filtered slice) are distinct;
`_apply()` recomputes the shown slice + page count and clamps the page; sort + filter compose. +6 tests
(15 view tests total). Together with slice 2, **fully closes inventory cert punch #5**.

Fix-on-sight (Q-0166): removed 2 stale claim files (merged branches). One `consistency_exceptions.yml`
allowlist line for the pre-existing `items[:3]` hub preview (a top-3 embed preview, flagged only because
the file now also builds a select).

**Verification:** `check_quality.py --full` → all checks passed (13088 passed) · `check_architecture
--mode strict` → 0 errors · parity guard / scoreboard / consistency / ledger all clean.

**Owner decision surfaced (non-blocking):** inventory punch #2 ("audit item grants") needs an owner
*granularity* call before building — naive "audit every grant" would flood the admin audit channel
(the coin trail is the high-frequency economy log, not `audit.action_recorded`). Documented in the
inventory cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136LX9wGv7Jy3Za748pdk75