### PR TITLE
Blackjack completion cert: PvP panel bet selector (#2) + edge tests (#3)

### DIFF
--- a/.sessions/2026-06-30-blackjack-punchlist-2-3.md
+++ b/.sessions/2026-06-30-blackjack-punchlist-2-3.md
@@ -1,13 +1,92 @@
 # Session — Blackjack completion-cert punch-list #2 + #3
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What I'm about to do
-Empty-fire dispatch. Standing offline ▶ Next (Q-0209): clear the `◐ assessed` certs' punch-lists.
-The **Blackjack** cert (`docs/planning/feature-completion/units/blackjack.md`) names a focused,
-offline-buildable set: **#2 PvP bet selector in the panel** (Challenge Player is currently
-command-only / hardcoded bet=0) + **#3 edge tests** (tournament-timeout forfeit, guild-removal
-cleanup, natural-blackjack auto-payout). #1 (split/insurance/surrender) is an owner product call and
-#4/#5 are live-bot/owner — out of an offline run's scope. Closing #2 + #3 here.
+## What I did + why
+Empty-fire dispatch run. The standing offline ▶ Next (Q-0209) is to clear the `◐ assessed` completion
+certs' punch-lists. The **Blackjack** cert
+(`docs/planning/feature-completion/units/blackjack.md`) named a focused, offline-buildable set; closed
+the two offline items end-to-end in **PR #1565**:
+
+1. **Punch #2 — PvP bet selector in the panel.** The panel's "Challenge Player" flow hardcoded
+   `bet = 0  # PvP bet picker deferred to a future PR` in `_BlackjackOpponentSelect.callback`, so PvP
+   stakes were reachable only via the `!bj @player <bet>` command. The opponent select now validates
+   the target (self/bot rejected up-front, same copy as the challenge builder) then routes into a new
+   **`_BlackjackChallengeBetView`** stake picker — **Free play + 10/25/50/100 + Custom** — mirroring the
+   Solo Bet UX. A shared `_spawn_pvp(interaction, opponent, bet)` builds the challenge with the chosen
+   stake (preset buttons and a `_BlackjackChallengeCustomBetModal` both funnel through it).
+2. **Punch #3 — edge tests.** Added the three named-but-untested lifecycle paths:
+   **tournament-timeout forfeit** (`_TournBlackjackView.on_timeout` — bet deducted, round consumed,
+   controls disabled, advance-vs-finish branch on chips/rounds exhaustion), **guild-removal cleanup**
+   (`BlackjackCog.on_guild_remove` — tournament rows refund-and-clear, solo/PvP clear-no-refund, escrow
+   recovery; plus a refund-failure-doesn't-abort case), and **natural-blackjack auto-payout**
+   (`start_solo_blackjack` — 1.5× bet / flat free-win, `view=None`, active slot released).
+
+**Tests:** `tests/unit/cogs/test_blackjack_edge_cases.py` (7) + `tests/unit/views/test_blackjack_panel_pvp_bet.py`
+(5). Each pins behaviour that fails against the pre-fix code (the bet-selector tests assert the chosen
+stake reaches `build_blackjack_challenge_view`, not 0).
+
+**Verification:** `check_quality.py --full` GREEN (black/isort/ruff/docs/consistency + `mypy disbot/`
+clean + full pytest **13121 passed / 48 skipped / 2 xfailed**); `check_architecture.py --mode strict`
+0 errors (49 pre-existing warnings, none new; the one `blackjack_panel` layer note is the `[known]`
+views→cogs.actions tracked violation). CI's only red was the deliberate born-red `check_session_gate`
+hold, flipped green as the final step here.
+
+**Docs de-staled (Q-0166):** the Blackjack cert (rubric B/C/G ticks, punch-list #2/#3 ✅, Evidence,
+Verdict) and `docs/current-state/S1-bot.md` (two Blackjack pointers — the completion-deepening bullet
+and the games-deepening bullet now record #1565 and narrow the remaining Blackjack work to the
+owner-paced #1).
+
+Method note (Q-0120): verified the natural-payout / guild-remove / timeout-forfeit branches against
+live source before writing the tests, and confirmed `cogs.blackjack_cog.game_state_service` resolves to
+`services.game_state_service` (two imports bind the name; the later `from services import …` wins) so
+the `patch.object` targets the right object.
+
+## ⚑ Self-initiated
+none — this is dispatched completion-first work (the standing S1 ▶ Next: clear the `◐ assessed` certs'
+punch-lists, Q-0209). The split/insurance/surrender engine work (#1) was deliberately **not** built: it
+is flagged in the cert as an owner product call (implement-or-waive), and it carries money-safety shape
+(split = a second wager, insurance = a side bet) — out of an autonomous run's safe envelope.
+
+## 💡 Session idea
+A tiny **`check_consistency` rule: a panel "spawn" callback must not hardcode a wager/stake constant**
+(`bet = 0`, `amount = 0`) with a "deferred to a future PR" comment — i.e. flag a literal-zero stake
+passed into a `build_*_challenge`/`*_wager`/escrow call. This exact pattern (`bet = 0  # PvP bet picker
+deferred`) is how the Blackjack PvP panel silently shipped a stakes-less path that looked complete in
+the UI but wasn't — the same "looks done, isn't" class the feature-completion system exists to catch,
+but cheaper to catch in CI than in a per-unit assessment months later. (Captured, not built — it needs a
+small allowlist for genuinely free-play surfaces like Solo Free Play, so it's a curation pass, not a
+one-liner.)
+
+## ⟲ Previous-session review
+The previous run (#1550, Proof Channel punch #1 + #2) was strong and well-scoped — it closed an audit-trail
+gap and a modal-authority gap with 9 targeted tests, and it modeled the audit-emit pattern on an existing
+service rather than inventing one. One thing it surfaced but left for "later": its own `💡 Session idea`
+(an AST/consistency guard that "a Discord-side state mutation must emit `audit.action_recorded` or be
+allowlisted"). That idea and *this* session's idea are the **same shape** — "a feature written against the
+raw API skips the audited/parameterized seam, caught only by per-unit assessment." **System improvement
+this surfaces:** these per-session `💡` ideas keep landing in logs and never reaching `docs/ideas/` unless
+a later session happens to re-derive them — the grooming pass moves *existing* idea files, but a `💡` line
+buried in a `.sessions/` log isn't an idea file. Worth a cheap convention (or a Stop-hook nudge): a `💡`
+that's a concrete build proposal should be promoted to a one-paragraph `docs/ideas/` stub in the same
+session, not left as prose only a grep will find. (Noting here, not acting — it's a workflow-rule change,
+so it belongs in the router, not a self-edit.)
+
+## ✅ Doc audit (Q-0104)
+- `check_current_state_ledger.py --strict` — green at session start (Ledger: in sync ✓); this PR adds no
+  merged-PR rows (the #1565 row lands when it merges; the reconciliation failsafe / next session records it).
+- `check_docs --strict` + `check_consistency` — green (run under `check_quality --check-only`).
+- New owner decisions: none. No router Q added.
+- Nothing captured only in chat — the cert + S1-bot.md carry the durable record.
+
+## 📤 Run report
+
+- **Did:** Cleared the two offline Blackjack completion-cert punch-list items (PvP panel stake picker + 3 edge-path test groups) · **Outcome:** shipped
+- **Shipped:** #1565 — Blackjack PvP panel bet selector (cert #2) + tournament-timeout/guild-remove/natural-payout edge tests (cert #3); cert + S1-bot.md de-staled
+- **Run type:** `routine · dispatch` (Q-0165)
+- **⚑ Owner decisions needed:** Blackjack cert punch-list **#1** — implement-or-waive split / insurance / surrender (the one Blackjack item that needs an owner product call before it can be ticked or waived)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (Q-0172)
+- **↪ Next:** S1 completion-first — Blackjack now needs only owner/live-bot items (#1 product call, #4 walkthrough, #5 sign-off); the next offline `◐ assessed` punch-list to clear is the server-fn batch (see `S1-bot.md` assessments bullet). Standing offline ▶ Next (Q-0209) unchanged.

--- a/.sessions/2026-06-30-blackjack-punchlist-2-3.md
+++ b/.sessions/2026-06-30-blackjack-punchlist-2-3.md
@@ -1,0 +1,13 @@
+# Session — Blackjack completion-cert punch-list #2 + #3
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What I'm about to do
+Empty-fire dispatch. Standing offline ▶ Next (Q-0209): clear the `◐ assessed` certs' punch-lists.
+The **Blackjack** cert (`docs/planning/feature-completion/units/blackjack.md`) names a focused,
+offline-buildable set: **#2 PvP bet selector in the panel** (Challenge Player is currently
+command-only / hardcoded bet=0) + **#3 edge tests** (tournament-timeout forfeit, guild-removal
+cleanup, natural-blackjack auto-payout). #1 (split/insurance/surrender) is an owner product call and
+#4/#5 are live-bot/owner — out of an offline run's scope. Closing #2 + #3 here.

--- a/disbot/views/games/blackjack_panel.py
+++ b/disbot/views/games/blackjack_panel.py
@@ -82,8 +82,20 @@ def build_blackjack_challenge_picker_embed() -> discord.Embed:
     return discord.Embed(
         title="🃏 Blackjack — Challenge Player",
         description=(
-            "Pick the player you want to challenge. They'll see an "
-            "Accept / Decline prompt."
+            "Pick the player you want to challenge, then choose a stake. "
+            "They'll see an Accept / Decline prompt."
+        ),
+        color=GAME_COLOR,
+    )
+
+
+def build_blackjack_challenge_bet_embed(opponent: discord.Member) -> discord.Embed:
+    return discord.Embed(
+        title="🃏 Blackjack — Challenge Bet",
+        description=(
+            f"Choose the stake for your challenge against {opponent.mention}. "
+            "Free play is no-stakes; a bet escrows coins from both players at "
+            "accept and pays the winner."
         ),
         color=GAME_COLOR,
     )
@@ -330,21 +342,155 @@ class _BlackjackOpponentSelect(discord.ui.UserSelect):
                 ephemeral=True,
             )
             return
-        bet = 0  # PvP bet picker deferred to a future PR
-        embed, view, error = build_blackjack_challenge_view(
-            challenger,
-            opponent,
-            interaction.guild_id or 0,
-            bet,
-        )
-        if error or view is None:
+        # Validate the target before showing a stake picker — surface the
+        # same "can't challenge yourself / a bot" copy as the challenge
+        # builder, so the picker only appears for a playable opponent.
+        if opponent.id == challenger.id:
             await interaction.response.send_message(
-                error or "Could not start challenge.",
+                "You can't challenge yourself.",
                 ephemeral=True,
             )
             return
-        await interaction.response.edit_message(embed=embed, view=view)
-        view.message = interaction.message
+        if opponent.bot:
+            await interaction.response.send_message(
+                "You can't challenge a bot to PvP.",
+                ephemeral=True,
+            )
+            return
+        back_target: BackTarget | None = getattr(self.view, "_back_target", None)
+        await interaction.response.edit_message(
+            embed=build_blackjack_challenge_bet_embed(opponent),
+            view=_BlackjackChallengeBetView(
+                challenger,
+                opponent,
+                back_target=back_target,
+            ),
+        )
+
+
+class _BlackjackChallengeBetView(HubView):
+    """PvP stake picker shown after an opponent is selected.
+
+    Free play + 10/25/50/100 presets + Custom, mirroring the Solo Bet
+    picker so the cross-mode UX is consistent. Closes the panel's
+    command-only PvP gap — "Challenge Player" used to start every PvP
+    match at bet=0.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        opponent: discord.Member,
+        back_target: BackTarget | None = None,
+    ) -> None:
+        super().__init__(author)
+        self.add_item(_BlackjackChallengeBetButton(opponent, 0, label="Free play"))
+        for preset in _BET_PRESETS:
+            self.add_item(_BlackjackChallengeBetButton(opponent, preset))
+        self.add_item(_BlackjackChallengeCustomBetButton(opponent))
+        self.add_item(_make_blackjack_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
+
+
+class _BlackjackChallengeBetButton(discord.ui.Button):
+    def __init__(
+        self,
+        opponent: discord.Member,
+        bet: int,
+        *,
+        label: str | None = None,
+        row: int = 0,
+    ) -> None:
+        super().__init__(
+            label=label or f"{bet} 🪙",
+            style=(
+                discord.ButtonStyle.success if bet == 0 else discord.ButtonStyle.primary
+            ),
+            custom_id=f"blackjack_panel:challenge_bet:{bet}",
+            row=row,
+        )
+        self._opponent = opponent
+        self._bet = bet
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _spawn_pvp(interaction, self._opponent, self._bet)
+
+
+class _BlackjackChallengeCustomBetButton(discord.ui.Button):
+    def __init__(self, opponent: discord.Member, *, row: int = 1) -> None:
+        super().__init__(
+            label="Custom",
+            style=discord.ButtonStyle.secondary,
+            custom_id="blackjack_panel:challenge_bet:custom",
+            row=row,
+        )
+        self._opponent = opponent
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_modal(
+            _BlackjackChallengeCustomBetModal(self._opponent),
+        )
+
+
+class _BlackjackChallengeCustomBetModal(discord.ui.Modal, title="Custom Challenge Bet"):
+    bet_input: discord.ui.TextInput = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Bet (🪙 coins)",
+        placeholder="Enter a positive integer (or 0 for free play)",
+        required=True,
+        max_length=10,
+    )
+
+    def __init__(self, opponent: discord.Member) -> None:
+        super().__init__()
+        self._opponent = opponent
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = (self.bet_input.value or "").strip()
+        try:
+            bet = int(raw)
+        except ValueError:
+            await interaction.response.send_message(
+                "Bet must be an integer.",
+                ephemeral=True,
+            )
+            return
+        if bet < 0:
+            await interaction.response.send_message(
+                "Bet must be 0 or positive.",
+                ephemeral=True,
+            )
+            return
+        await _spawn_pvp(interaction, self._opponent, bet)
+
+
+async def _spawn_pvp(
+    interaction: discord.Interaction,
+    opponent: discord.Member,
+    bet: int,
+) -> None:
+    """Shared PvP-challenge spawn path for the panel's preset/custom bets."""
+    challenger = interaction.user
+    if not isinstance(challenger, discord.Member):
+        await interaction.response.send_message(
+            "Challenger must be a server member.",
+            ephemeral=True,
+        )
+        return
+    embed, view, error = build_blackjack_challenge_view(
+        challenger,
+        opponent,
+        interaction.guild_id or 0,
+        bet,
+    )
+    if error or view is None:
+        await interaction.response.send_message(
+            error or "Could not start challenge.",
+            ephemeral=True,
+        )
+        return
+    await interaction.response.edit_message(embed=embed, view=view)
+    view.message = interaction.message
 
 
 class _BlackjackTournamentSubView(HubView):

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -116,9 +116,13 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   reached via `!creatures` + both cogs' Help hooks, the **interactive dex browser** (element filter),
   the `entry_points` fix, and a **battle settle-once** guard — cert #1/#2/#3/#5 cleared (#4 was a
   no-op). **▶ Next turn-key picks:** **Creatures game panel for Welcome's missing command panel** is a
-  separate unit; the Mining how-to button (the ✔-ready candidate's last build gap) **shipped #1548**, so
-  within games the **Blackjack split/insurance/surrender** engine work remains; server-fn deepening picks
-  are listed in the assessments bullet below. **✅ DONE 2026-06-29 (#1550): Proof Channel** punch #1 + #2 —
+  separate unit; the Mining how-to button (the ✔-ready candidate's last build gap) **shipped #1548**.
+  **✅ DONE 2026-06-30 (#1565): Blackjack** punch #2 + #3 — the panel's PvP path now has a Free/preset/Custom
+  **stake picker** (was command-only / hardcoded bet=0) and the three named **edge paths are tested**
+  (tournament-timeout forfeit · guild-removal cleanup · natural-blackjack auto-payout); only the owner /
+  live-bot items remain (#1 split/insurance/surrender product call, #4 walkthrough, #5 sign-off).
+  server-fn deepening picks are listed in the assessments bullet below.
+  **✅ DONE 2026-06-29 (#1550): Proof Channel** punch #1 + #2 —
   the lock/unlock now audit (`prize_access_grant`/`revoke`) and every mutation callback re-checks
   `manage_channels` authority; cert advanced (only the binding-write UI + owner walkthrough remain).
   **✅ DONE 2026-06-29 (PR #1553): Inventory punch #5 (sort + filter) CLOSED** — the category detail view
@@ -157,8 +161,9 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   now `historical`). **✅ DONE
   2026-06-28 (#1527):** the Deathmatch PvP trapped views (+ the panel-PvP `ctx=None` crash, BUG-0028)
   **and** the RPS PvP-result dead-end were both fixed — `_PvpDuelResultView` / `_RpsPvpResultView` with
-  standard nav + rematch/back; both certs advanced toward ✔. The next turn-key gap is **Blackjack
-  punch-list #1** (split/insurance/surrender — bigger engine work, owner-paced). **▶ Owner decisions
+  standard nav + rematch/back; both certs advanced toward ✔. Blackjack's offline punch-list (#2 stake
+  picker + #3 edge tests) **shipped #1565**; its remaining **#1** (split/insurance/surrender — bigger
+  engine work) is **owner-paced** (the product call to implement-or-waive). **▶ Owner decisions
   waiting:** Word Chain re-classify, Counting XP/coin reward, Deathmatch optional coin-staking, plus
   every assessed unit's `◐ → ✔` live-walkthrough sign-off
   (`[needs-live-bot]`/`[owner]`).

--- a/docs/owner/claims/claude-funny-franklin-ixg88c.md
+++ b/docs/owner/claims/claude-funny-franklin-ixg88c.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-ixg88c` · scope: Blackjack completion-cert punch-list #2 (PvP panel bet selector) + #3 (edge tests) · files: `disbot/views/games/blackjack_panel.py`, `tests/unit/cogs/test_blackjack_*`, `tests/unit/views/test_blackjack_*`, the blackjack cert + S1-bot.md · 2026-06-30

--- a/docs/owner/claims/claude-funny-franklin-ixg88c.md
+++ b/docs/owner/claims/claude-funny-franklin-ixg88c.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-ixg88c` · scope: Blackjack completion-cert punch-list #2 (PvP panel bet selector) + #3 (edge tests) · files: `disbot/views/games/blackjack_panel.py`, `tests/unit/cogs/test_blackjack_*`, `tests/unit/views/test_blackjack_*`, the blackjack cert + S1-bot.md · 2026-06-30

--- a/docs/planning/feature-completion/units/blackjack.md
+++ b/docs/planning/feature-completion/units/blackjack.md
@@ -26,8 +26,9 @@
 ### B. UI & buttons — "right buttons in the right places"
 - [x] **Game panel exists** — Solo Free Play · Solo Bet · Challenge Player · Tournament · Status ·
       📖 Rules (`views/games/blackjack_panel.py:454-571`).
-- [ ] **Every action has a control in the right place** — yes for implemented actions; **PvP bet is
-      command-only** (`!bj @player [bet]`); the panel's "Challenge Player" has no bet selector. → punch-list #2.
+- [x] **Every action has a control in the right place** — yes for implemented actions; **PvP bet
+      selector added to the panel** (PR #1565): "Challenge Player" → opponent select → a Free/preset/Custom
+      stake picker (`_BlackjackChallengeBetView`, `blackjack_panel.py`), no longer command-only. → punch-list #2 ✅.
 - [x] **Rules affordance** — 📖 Rules on the panel.
 - [x] **Return navigation** — "◀ Back to Blackjack" on the result view (`solo_view.py:286-302`).
 - [x] **Terminal state correct** — disabled shells + result-view swap + `SettleOnceMixin` (PvP).
@@ -36,7 +37,8 @@
 ### C. Convenience — "the most convenient way"
 - [x] **No needless clicks** — bet presets 10/25/50/100/Custom (`blackjack_panel.py:173-214`).
 - [x] **Replay without retyping** — "🔁 Play again" reuses the same bet (`solo_view.py:286`).
-- [ ] **Quick re-bet** — "Play again" can't adjust the bet without going back to the picker. → minor (folded into #2).
+- [ ] **Quick re-bet** — "Play again" can't adjust the bet without going back to the picker. → minor
+      (solo-replay polish; PR #1565 shipped the PvP stake picker, not solo rebet — left as a small follow-up).
 - [x] **Reachable the natural way** — `!blackjack`/`!bj` + Games hub + Help.
 
 ### D. Edge cases & lifecycle — "works as intended"
@@ -62,34 +64,41 @@
 
 ### G. Tests & evidence (required for ✔)
 - [x] **Loop tests** — engine + solo/PvP/tournament persistence + replay (`tests/unit/.../test_blackjack_*`).
-- [ ] **Edge tests** — settle-once ✅; **tournament-timeout forfeit, guild-removal cleanup, and
-      natural-blackjack auto-payout are untested** (code paths exist). → punch-list #3.
+- [x] **Edge tests** — settle-once ✅; **tournament-timeout forfeit, guild-removal cleanup, and
+      natural-blackjack auto-payout now covered** (PR #1565 — `tests/unit/cogs/test_blackjack_edge_cases.py`,
+      7 cases). → punch-list #3 ✅.
 - [x] **Money tests** — escrow/settle covered via persistence + settle-once suites.
 - [ ] **Live walkthrough recorded** — pending. → punch-list #4.
 - [ ] **Owner ✔** — pending. → punch-list #5.
 
 ## Punch-list (clear these to certify)
 
-1. **Product decision: split / insurance / surrender.** Implement the three standard actions, **or**
-   the owner **waives** them as out-of-scope for SuperBot's blackjack (some bots deliberately omit
-   them). This is the one item that needs an owner call before it can be ticked or waived.
-2. **PvP bet selector in the panel** — add a bet picker to "Challenge Player" so PvP isn't
-   command-only; carries the quick-rebet convenience too.
-3. **Edge tests** — tournament-timeout forfeit, guild-removal cleanup, natural-blackjack payout.
+1. **Product decision: split / insurance / surrender.** ⏳ **owner call** — implement the three
+   standard actions, **or** the owner **waives** them as out-of-scope for SuperBot's blackjack (some
+   bots deliberately omit them). This is the one item that needs an owner call before it can be ticked
+   or waived.
+2. ✅ **PvP bet selector in the panel** (PR #1565) — "Challenge Player" now routes opponent select → a
+   Free/preset/Custom stake picker before building the challenge; PvP is no longer command-only.
+   (The quick-rebet solo-replay polish is left as a small follow-up — see the C. "Quick re-bet" row.)
+3. ✅ **Edge tests** (PR #1565) — tournament-timeout forfeit, guild-removal cleanup, natural-blackjack
+   payout, in `tests/unit/cogs/test_blackjack_edge_cases.py` (7 cases).
 4. **Live walkthrough** — `/verify-bot` boot + scripted click-through of solo / PvP / tournament,
-   with screenshots, attached here.
-5. **Owner sign-off** — maintainer plays it and confirms "nothing left to add or move."
+   with screenshots, attached here. ⏳ needs-live-bot.
+5. **Owner sign-off** — maintainer plays it and confirms "nothing left to add or move." ⏳ owner.
 
 ## Evidence
 
 - **Tests:** `tests/unit/services/test_blackjack_engine.py` · `tests/unit/cogs/test_blackjack_{solo,pvp,tournament}_persistence.py` ·
-  `tests/unit/views/test_blackjack_solo_replay.py` · `tests/unit/views/test_blackjack_pvp_settle_once.py`
+  `tests/unit/views/test_blackjack_solo_replay.py` · `tests/unit/views/test_blackjack_pvp_settle_once.py` ·
+  **`tests/unit/cogs/test_blackjack_edge_cases.py`** (timeout-forfeit / guild-remove / natural payout) ·
+  **`tests/unit/views/test_blackjack_panel_pvp_bet.py`** (PvP panel stake picker) — PR #1565
 - **Walkthrough:** pending (punch-list #4)
 - **Owner sign-off:** pending (punch-list #5)
 
 ## Verdict
 
 Blackjack is **substantially complete and production-safe** — all three modes, full money-safety,
-strong lifecycle handling, good test coverage. It is **not yet `✔ certified`**: it needs the owner's
-split/insurance/surrender call (#1), the PvP-panel bet selector (#2), three edge tests (#3), and the
-recorded walkthrough + sign-off (#4, #5). A focused session clears #2–#4; #1 and #5 are owner calls.
+strong lifecycle handling, good test coverage. **PR #1565 cleared the two offline-buildable punch-list
+items — #2 (PvP-panel bet selector) and #3 (edge tests).** It is **not yet `✔ certified`**: the
+remaining items all need the owner / a live bot — the split/insurance/surrender product call (#1), the
+recorded walkthrough (#4), and the owner sign-off (#5).

--- a/tests/unit/cogs/test_blackjack_edge_cases.py
+++ b/tests/unit/cogs/test_blackjack_edge_cases.py
@@ -1,0 +1,313 @@
+"""Blackjack edge-case / lifecycle tests — completion-cert punch-list #3.
+
+The Blackjack completion certificate
+(``docs/planning/feature-completion/units/blackjack.md``) flagged three
+code paths that exist but were untested:
+
+1. **Tournament-timeout forfeit** — a round view that times out must
+   deduct the round bet, decrement ``rounds_left``, disable its
+   controls, and either advance the player to the next round or mark
+   them done (chips/rounds exhausted) and run the done-check.
+2. **Guild-removal cleanup** — ``on_guild_remove`` must refund + clear
+   pre-debited *tournament* entries, clear solo/PvP rows **without**
+   refund (no pre-debit), and recover stranded PvP escrow.
+3. **Natural-blackjack auto-payout** — a dealt natural pays out
+   immediately (1.5× bet, or the free-win flat for bet=0), returns a
+   result with ``view=None``, and clears the active-game slot.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Tournament-timeout forfeit
+# ---------------------------------------------------------------------------
+
+
+def _make_round_view(rounds_left: int, chips: int):
+    from services.blackjack_state import (
+        TOURN_START_CHIPS,
+        _active,
+        _Game,
+        _TournPlayerState,
+    )
+    from views.blackjack.tournament_views import _TournBlackjackView
+
+    ps = _TournPlayerState(user_id=42, guild_id=7, rounds=rounds_left, channel_id=99)
+    ps.chips = chips
+    ps.rounds_left = rounds_left
+    game = _Game(42, 7, 0, tournament_chips=TOURN_START_CHIPS, channel_id=99)
+    view = _TournBlackjackView(
+        game=game,
+        player_state=ps,
+        channel=MagicMock(),
+        tourn=MagicMock(),
+        bot=MagicMock(),
+    )
+    view.message = AsyncMock()
+    # Pre-seed the active slot so we can assert the timeout clears it.
+    _active[(42, 7)] = game
+    return view, ps, _active
+
+
+@pytest.mark.asyncio
+async def test_tournament_timeout_forfeits_round_and_advances():
+    from services.blackjack_state import TOURN_BET_PER_ROUND
+
+    view, ps, active = _make_round_view(rounds_left=3, chips=1000)
+    view.tourn.results = {}
+
+    with (
+        patch(
+            "views.blackjack.tournament_views._start_tourn_round",
+            new_callable=AsyncMock,
+        ) as next_round,
+        patch(
+            "views.blackjack.tournament_views._check_tourn_done",
+            new_callable=AsyncMock,
+        ) as done,
+    ):
+        await view.on_timeout()
+
+    # Round bet deducted, one round consumed.
+    assert ps.chips == 1000 - TOURN_BET_PER_ROUND
+    assert ps.rounds_left == 2
+    # Still has chips + rounds → next round dealt, not finished.
+    next_round.assert_awaited_once()
+    done.assert_not_awaited()
+    assert ps.done is False
+    # Active slot cleared and controls disabled.
+    assert (42, 7) not in active
+    assert all(item.disabled for item in view.children)
+    view.message.edit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tournament_timeout_finishes_player_when_rounds_exhausted():
+    view, ps, _active = _make_round_view(rounds_left=1, chips=1000)
+    view.tourn.results = {}
+
+    with (
+        patch(
+            "views.blackjack.tournament_views._start_tourn_round",
+            new_callable=AsyncMock,
+        ) as next_round,
+        patch(
+            "views.blackjack.tournament_views._check_tourn_done",
+            new_callable=AsyncMock,
+        ) as done,
+    ):
+        await view.on_timeout()
+
+    assert ps.rounds_left == 0
+    assert ps.done is True
+    # Final chips recorded for the done-check, which runs; no next round.
+    assert view.tourn.results[ps.user_id] == ps.chips
+    done.assert_awaited_once()
+    next_round.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tournament_timeout_finishes_player_when_broke():
+    view, ps, _active = _make_round_view(rounds_left=5, chips=200)
+    view.tourn.results = {}
+
+    with (
+        patch(
+            "views.blackjack.tournament_views._start_tourn_round",
+            new_callable=AsyncMock,
+        ) as next_round,
+        patch(
+            "views.blackjack.tournament_views._check_tourn_done",
+            new_callable=AsyncMock,
+        ) as done,
+    ):
+        await view.on_timeout()
+
+    # 200 - 200 = 0 chips → forced out even though rounds remain.
+    assert ps.chips == 0
+    assert ps.done is True
+    done.assert_awaited_once()
+    next_round.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 2. Guild-removal cleanup
+# ---------------------------------------------------------------------------
+
+
+def _row(id_, *, guild_id=7, user_id=42, bet=0):
+    return {
+        "id": id_,
+        "guild_id": guild_id,
+        "user_id": user_id,
+        "state": {"bet": bet},
+    }
+
+
+@pytest.mark.asyncio
+async def test_on_guild_remove_refunds_tournament_clears_solo_pvp():
+    import cogs.blackjack_cog as cog_mod
+    from cogs.blackjack_cog import (
+        BLACKJACK_PVP_SUBSYSTEM,
+        BLACKJACK_SOLO_SUBSYSTEM,
+        BLACKJACK_TOURNAMENT_SUBSYSTEM,
+        BlackjackCog,
+    )
+
+    guild = MagicMock()
+    guild.id = 7
+
+    def _by_subsystem(subsystem, *, guild_id):
+        if subsystem == BLACKJACK_TOURNAMENT_SUBSYSTEM:
+            return [_row(1, bet=100), _row(2, bet=0, user_id=43)]
+        if subsystem == BLACKJACK_SOLO_SUBSYSTEM:
+            return [_row(10)]
+        if subsystem == BLACKJACK_PVP_SUBSYSTEM:
+            return [_row(20)]
+        return []
+
+    with (
+        patch.object(
+            cog_mod.game_state_service,
+            "list_active_for_subsystem",
+            new=AsyncMock(side_effect=_by_subsystem),
+        ),
+        patch.object(
+            cog_mod.game_state_service, "clear_by_id", new=AsyncMock()
+        ) as clear,
+        patch.object(cog_mod.economy_service, "refund", new=AsyncMock()) as refund,
+        patch.object(
+            cog_mod.game_wager_workflow, "recover_escrow", new=AsyncMock()
+        ) as recover,
+    ):
+        await BlackjackCog.on_guild_remove(MagicMock(), guild)
+
+    # Only the pre-debited tournament row (bet>0) is refunded; the bet=0
+    # tournament entry and the solo/PvP rows are not.
+    refund.assert_awaited_once()
+    assert refund.await_args.kwargs["amount"] == 100
+    assert refund.await_args.kwargs["user_id"] == 42
+    # Every row (tournament x2, solo, pvp) is cleared.
+    cleared_ids = {
+        c.args[0] if c.args else c.kwargs.get("id") for c in clear.await_args_list
+    }
+    assert cleared_ids == {1, 2, 10, 20}
+    # Stranded PvP escrow recovered for the departing guild.
+    recover.assert_awaited_once()
+    assert recover.await_args.kwargs["guild_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_on_guild_remove_survives_refund_failure():
+    """A refund error must not abort the rest of the cleanup."""
+    import cogs.blackjack_cog as cog_mod
+    from cogs.blackjack_cog import (
+        BLACKJACK_TOURNAMENT_SUBSYSTEM,
+        BlackjackCog,
+    )
+
+    guild = MagicMock()
+    guild.id = 7
+
+    def _by_subsystem(subsystem, *, guild_id):
+        if subsystem == BLACKJACK_TOURNAMENT_SUBSYSTEM:
+            return [_row(1, bet=100)]
+        return []
+
+    with (
+        patch.object(
+            cog_mod.game_state_service,
+            "list_active_for_subsystem",
+            new=AsyncMock(side_effect=_by_subsystem),
+        ),
+        patch.object(
+            cog_mod.game_state_service, "clear_by_id", new=AsyncMock()
+        ) as clear,
+        patch.object(
+            cog_mod.economy_service,
+            "refund",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        patch.object(
+            cog_mod.game_wager_workflow, "recover_escrow", new=AsyncMock()
+        ) as recover,
+    ):
+        await BlackjackCog.on_guild_remove(MagicMock(), guild)
+
+    # The row is still cleared and escrow recovery still runs despite the
+    # refund blowing up.
+    clear.assert_awaited()
+    recover.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 3. Natural-blackjack auto-payout
+# ---------------------------------------------------------------------------
+
+
+def _fake_actor(id_):
+    actor = MagicMock()
+    actor.id = id_
+    return actor
+
+
+@pytest.mark.asyncio
+async def test_natural_blackjack_pays_out_and_clears_slot():
+    from cogs.blackjack import actions
+    from services.blackjack_state import _active
+
+    user = _fake_actor(42)
+    guild = _fake_actor(7)
+    channel = _fake_actor(99)
+    _active.pop((42, 7), None)
+
+    with (
+        patch.object(actions, "_is_blackjack", return_value=True),
+        patch.object(
+            actions.economy_service, "credit", new=AsyncMock(return_value=160)
+        ) as credit,
+        patch.object(actions.db, "get_coins", new=AsyncMock(return_value=1000)),
+    ):
+        result = await actions.start_solo_blackjack(user, guild, channel, 100)
+
+    # Natural → immediate payout, no playable hand returned.
+    assert result.embed is not None
+    assert result.view is None
+    assert result.game is None
+    # 1.5x the 100 bet credited via the audited economy seam.
+    credit.assert_awaited_once()
+    assert credit.await_args.args[2] == 150
+    assert credit.await_args.kwargs["reason"] == "blackjack:natural_blackjack"
+    # The active slot is released so the player can deal again.
+    assert (42, 7) not in _active
+
+
+@pytest.mark.asyncio
+async def test_natural_blackjack_free_play_uses_flat_win():
+    from cogs.blackjack import actions
+    from services.blackjack_state import FREE_WIN_COINS, _active
+
+    user = _fake_actor(42)
+    guild = _fake_actor(7)
+    channel = _fake_actor(99)
+    _active.pop((42, 7), None)
+
+    with (
+        patch.object(actions, "_is_blackjack", return_value=True),
+        patch.object(
+            actions.economy_service,
+            "credit",
+            new=AsyncMock(return_value=FREE_WIN_COINS),
+        ) as credit,
+    ):
+        result = await actions.start_solo_blackjack(user, guild, channel, 0)
+
+    assert result.view is None
+    credit.assert_awaited_once()
+    # bet=0 → flat free-win payout, not 0.
+    assert credit.await_args.args[2] == FREE_WIN_COINS
+    assert (42, 7) not in _active

--- a/tests/unit/views/test_blackjack_panel_pvp_bet.py
+++ b/tests/unit/views/test_blackjack_panel_pvp_bet.py
@@ -1,0 +1,170 @@
+"""PvP bet selector in the Blackjack panel — completion-cert punch-list #2.
+
+Before this, the panel's "Challenge Player" flow hardcoded ``bet = 0``
+(``_BlackjackOpponentSelect.callback``) — PvP stakes were reachable only
+via the ``!bj @player <bet>`` command. The opponent select now routes
+into a ``_BlackjackChallengeBetView`` stake picker (Free + presets +
+Custom) before the challenge is built, mirroring the Solo Bet UX.
+
+These tests pin:
+* picking an opponent opens the bet picker (not an immediate bet-0 game);
+* a self/bot target is rejected *before* the picker is shown;
+* a preset/custom bet flows through to ``build_blackjack_challenge_view``
+  with the chosen stake (not 0).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.games import blackjack_panel
+from views.games.blackjack_panel import (
+    _BlackjackChallengeBetButton,
+    _BlackjackChallengeBetView,
+    _BlackjackChallengeSelectView,
+    _BlackjackOpponentSelect,
+)
+
+
+def _member(id_: int, *, bot: bool = False) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = id_
+    m.bot = bot
+    m.mention = f"<@{id_}>"
+    return m
+
+
+def _interaction(user: MagicMock, guild_id: int = 7) -> MagicMock:
+    inter = MagicMock(spec=discord.Interaction)
+    inter.user = user
+    inter.guild_id = guild_id
+    inter.message = MagicMock()
+    inter.response = MagicMock()
+    inter.response.edit_message = AsyncMock()
+    inter.response.send_message = AsyncMock()
+    return inter
+
+
+def _opponent_select(
+    challenger: MagicMock, opponent: MagicMock
+) -> _BlackjackOpponentSelect:
+    view = _BlackjackChallengeSelectView(challenger)
+    select = next(c for c in view.children if isinstance(c, _BlackjackOpponentSelect))
+    # discord.py populates ``.values`` from the payload; stub it directly.
+    type(select).values = property(lambda self: [opponent])
+    return select
+
+
+@pytest.mark.asyncio
+async def test_selecting_opponent_opens_bet_picker():
+    challenger = _member(1)
+    opponent = _member(2)
+    select = _opponent_select(challenger, opponent)
+    inter = _interaction(challenger)
+
+    try:
+        await select.callback(inter)
+    finally:
+        del type(select).values
+
+    inter.response.edit_message.assert_awaited_once()
+    new_view = inter.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, _BlackjackChallengeBetView)
+    # The picker offers Free play + the four presets + Custom.
+    bet_buttons = [
+        c for c in new_view.children if isinstance(c, _BlackjackChallengeBetButton)
+    ]
+    assert {b._bet for b in bet_buttons} == {0, 10, 25, 50, 100}
+
+
+@pytest.mark.asyncio
+async def test_selecting_self_is_rejected_before_picker():
+    challenger = _member(1)
+    select = _opponent_select(challenger, challenger)
+    inter = _interaction(challenger)
+
+    try:
+        await select.callback(inter)
+    finally:
+        del type(select).values
+
+    inter.response.send_message.assert_awaited_once()
+    assert "yourself" in inter.response.send_message.await_args.args[0].lower()
+    inter.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_selecting_bot_is_rejected_before_picker():
+    challenger = _member(1)
+    bot_opponent = _member(2, bot=True)
+    select = _opponent_select(challenger, bot_opponent)
+    inter = _interaction(challenger)
+
+    try:
+        await select.callback(inter)
+    finally:
+        del type(select).values
+
+    inter.response.send_message.assert_awaited_once()
+    assert "bot" in inter.response.send_message.await_args.args[0].lower()
+    inter.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preset_bet_builds_challenge_with_chosen_stake():
+    challenger = _member(1)
+    opponent = _member(2)
+    view = _BlackjackChallengeBetView(challenger, opponent)
+    button = next(
+        c
+        for c in view.children
+        if isinstance(c, _BlackjackChallengeBetButton) and c._bet == 50
+    )
+    inter = _interaction(challenger)
+
+    fake_view = MagicMock()
+    with patch.object(
+        blackjack_panel,
+        "build_blackjack_challenge_view",
+        return_value=(MagicMock(), fake_view, None),
+    ) as build:
+        await button.callback(inter)
+
+    build.assert_called_once()
+    # bet (4th positional arg) is the chosen 50, not 0.
+    assert build.call_args.args[3] == 50
+    assert build.call_args.args[0] is challenger
+    assert build.call_args.args[1] is opponent
+    inter.response.edit_message.assert_awaited_once()
+    assert fake_view.message is inter.message
+
+
+@pytest.mark.asyncio
+async def test_challenge_build_error_is_surfaced_ephemerally():
+    challenger = _member(1)
+    opponent = _member(2)
+    view = _BlackjackChallengeBetView(challenger, opponent)
+    button = next(
+        c
+        for c in view.children
+        if isinstance(c, _BlackjackChallengeBetButton) and c._bet == 10
+    )
+    inter = _interaction(challenger)
+
+    with patch.object(
+        blackjack_panel,
+        "build_blackjack_challenge_view",
+        return_value=(
+            MagicMock(),
+            None,
+            "There's already a PvP game between these players.",
+        ),
+    ):
+        await button.callback(inter)
+
+    inter.response.send_message.assert_awaited_once()
+    assert inter.response.send_message.await_args.kwargs.get("ephemeral") is True
+    inter.response.edit_message.assert_not_awaited()


### PR DESCRIPTION
Empty-fire dispatch run. Standing offline ▶ Next (Q-0209): clear the `◐ assessed` completion certs' punch-lists.

Closes the two **offline-buildable** items on the Blackjack cert (`docs/planning/feature-completion/units/blackjack.md`):

- **Punch-list #2 — PvP bet selector in the panel.** "Challenge Player" was command-only / hardcoded `bet = 0` in the panel; the opponent select now flows into a bet-preset picker (10/25/50/100 + Custom) before building the challenge, matching the Solo Bet UX.
- **Punch-list #3 — edge tests.** Adds the three named-but-untested paths: tournament-timeout forfeit, guild-removal cleanup (tournament refund + solo/PvP clear-no-refund), and natural-blackjack auto-payout.

Out of scope for an offline run: #1 split/insurance/surrender (owner product call), #4 live walkthrough, #5 owner sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158yYF7SLhgNeH2uPYC79ik)_