### PR TITLE
BTD6 boss-fight estimator: deterministic DPS/cost/time-to-kill (estimate, don't refuse)

### DIFF
--- a/.sessions/2026-06-30-btd6-boss-fight-estimator.md
+++ b/.sessions/2026-06-30-btd6-boss-fight-estimator.md
@@ -1,32 +1,96 @@
 # 2026-06-30 — BTD6 boss-fight estimator (estimate, don't refuse)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 <!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
 
+**PR:** [#1574](https://github.com/menno420/superbot/pull/1574) — BTD6 boss-fight estimator.
 **Branch:** `claude/ai-answer-storage-plan-3fvdit` (restarted from main; PR #1572 merged).
 **Run type:** manual (owner-directed).
 
-## What I'm about to do
+## What this run did
 
 The owner, reviewing the review-log export, pointed out (correctly) that the bot **refuses
-questions it has the data to estimate**: "how do I beat Bloonarius on Monkey Meadow / cheapest cost /
-how long". The bot has boss HP + speed (`bosses.json`), per-crosspath combat stats
-(`stats/*.json` — damage, attack rate, projectiles, MOAB/boss damage modifiers) and tower costs.
-The only true gap is **track length** (`maps.json` has none — to be curated/approximated).
+questions it has the data to estimate** — boss fights, "cheapest cost", "how long". It has boss
+HP/speed, per-crosspath combat stats, and tower costs; the only true gap is track length. Owner
+picked **the full estimator**, accepting *an estimate with stated assumptions over a refusal*.
 
-Owner picked **the full estimator** (~2-3 PRs): boss-kill time + cost + track-time gate + a
-cheapest-tower-per-$/DPS ranking, giving an **estimate with stated assumptions** (he explicitly
-accepts approximate over refusing).
+**Design principle:** the arithmetic is **deterministic** (a compute service), not the model
+doing mental math — the fix for the confabulation class seen in the #1572 export.
 
-**Design principle:** the arithmetic is **deterministic** (a compute service), not the model doing
-mental math — the same pattern as the round-cash workflow / `deterministic_btd6_list_reply` (and the
-fix for the haiku confabulation seen in the #1572 export).
+## Shipped (PR #1574)
 
-Build order:
-- **PR 1 (this card):** the deterministic estimator core — `services/btd6_estimator_service.py`
-  (effective single-target boss DPS via the existing `btd6_stats_service.attack_breakdown`,
-  cost-to-crosspath, time-to-kill = HP/DPS, DPS-per-dollar, a cheapest-counters ranking) + a
-  `!btd6estimate` command to exercise it. Offline, fully unit-tested. No AI-path change yet.
-- **PR 2:** curated per-map track-time table + the "does it escape" gate, and wiring the estimator
-  into the BTD6 answer path (deterministic reply + an instruction so the model estimates instead of
-  refusing).
+- **PR1 — `services/btd6_estimator_service.py`** (the deterministic core): effective single-target
+  boss DPS (via the existing `btd6_stats_service.attack_breakdown`, with an **instakill-sentinel
+  filter** — the Druid 9,999,999 Vine was inflating DPS to millions), cost-to-crosspath,
+  time-to-kill = HP ÷ DPS, damage-type immunity blocking, a cheapest-counters (DPS-per-dollar)
+  ranking, a free-form query parser, and plain-text formatters. Every estimate carries explicit
+  assumptions. **15 unit tests** against the real dump.
+- **PR2 — the unified `/btd6 estimate` (+ `!btd6 estimate`) command**: `_builders.build_estimate_embed`
+  + the slash/prefix twins in `_unified`. `<tower> vs <boss> [tier]` for a single estimate,
+  `counters <boss>` for the ranking. Updated the unified-tree flat-lookup pin; regenerated artifacts.
+
+Full CI mirror green (13,231 passed); `check_architecture --mode strict` 0 errors.
+
+## Decisions made alone (owner should be aware)
+
+- **Deferred the conversational AI-answer-path integration** (a deterministic estimate reply on
+  the BTD6 answer path) to its own PR. Mis-firing a canned reply on the **gated** answer path needs
+  live verification (no provider key here) — the exact risk the AI gate guards. The command is the
+  offline-verifiable surface; the AI hook is the next focused, live-tested slice.
+- **Did NOT fabricate track-length data.** `maps.json` has no track length and it isn't reliably
+  published; inventing numbers would be worse than the honest gap. The estimator nails the
+  practically-useful question (HP ÷ DPS = kill time/cost); "how long to physically cross" stays a
+  documented data gap.
+- **v1 is base single-target DPS** — excludes MOAB/boss bonus damage (`damageToBad`, paragon
+  `boss_multiplier`), abilities, and buffs, so kill-times read high for ability/bonus-reliant
+  towers. Stated in every estimate's assumptions; a "boss-aware DPS" refinement is the obvious next.
+
+## Flagged for maintainer (try it / weak points)
+
+- **Try it after deploy:** `!btd6 estimate super monkey 0-4-0 vs bloonarius t5` and
+  `!btd6 estimate counters bloonarius t5`. The numbers are conservative base-DPS (high kill-times);
+  the *relative* ranking is the useful part until the boss-aware-DPS refinement lands.
+- **The conversational fix (the export's entries 3–6) is NOT in yet** — that's the deferred AI-path
+  PR. This session makes the capability exist + usable; wiring it into free chat is next + needs
+  your live test.
+
+## 💡 Session idea (Q-0089)
+
+[`compute-dont-refuse-capability-sweep-2026-06-30.md`](../docs/ideas/compute-dont-refuse-capability-sweep-2026-06-30.md)
+— generalize the lesson: mine the `ai_review_log` for refusals that are actually **computable** (the
+bot has the data, it just refused/confabulated — economy projections, XP-to-level, mining math) and
+build a deterministic compute tool per recurring class. Adds a `computable` triage disposition.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous = the DDT-confabulation corpus capture (#1572). **Did well:** honest triage that resisted
+"fixing" the bot's *correct* refusals, and captured the finding + vetted answer durably. **Missed /
+improvement:** it framed the AI-path fix narrowly as "an owner preset" and didn't spot the bigger
+pattern the owner then named — the bot refuses **computable** questions, not just confabulates. The
+system improvement is exactly the Q-0089 idea: the triage script should flag *computable refusal* as
+its own disposition (distinct from "data gap"), turning the review log into a compute-tool backlog.
+The loop worked — the owner's nudge plus the log surfaced a whole capability class.
+
+## 🛠 Friction → guard
+
+- **Friction:** the **add-a-BTD6-command ripple** — a new command must add `_unified` slash+prefix
+  twins + a `_builders` builder + update the unified-tree flat-lookup pin + pass the parity +
+  reachability guards + regenerate artifacts. I first wrote a bare top-level command and hit those
+  guards one full-suite run at a time. **Guard status:** the guards *worked* (they caught the
+  wrong shape); the residual friction is discovery-at-full-suite-time. **Shipped now (free lane):**
+  this log's ripple enumeration above is the durable checklist; the artifact half is already caught
+  pre-push by last session's freshness guard. A `check_btd6_command_ripple` checker would be the
+  "enforce" upgrade but is optional (the existing pins already enforce, just slower) — not building
+  speculative tooling.
+
+## ⚑ Self-initiated
+
+Owner-directed feature (the owner named the goal + picked "full estimator" via AskUserQuestion). The
+**scope decisions** (defer the AI-path + track-time, ship service + command) are my judgment calls,
+flagged above for ratification — not unprompted idea→plan promotions.
+
+## Doc audit (Q-0104)
+
+`check_quality --check-only` green (docs reachable, artifacts fresh); `check_current_state_ledger
+--strict` exit 0; `check_architecture --mode strict` 0 errors. Idea filed + indexed. No new owner
+*rules* / router changes. Did not touch `current-state.md` Recently-shipped (merged-PRs-only).

--- a/.sessions/2026-06-30-btd6-boss-fight-estimator.md
+++ b/.sessions/2026-06-30-btd6-boss-fight-estimator.md
@@ -1,0 +1,32 @@
+# 2026-06-30 — BTD6 boss-fight estimator (estimate, don't refuse)
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
+
+**Branch:** `claude/ai-answer-storage-plan-3fvdit` (restarted from main; PR #1572 merged).
+**Run type:** manual (owner-directed).
+
+## What I'm about to do
+
+The owner, reviewing the review-log export, pointed out (correctly) that the bot **refuses
+questions it has the data to estimate**: "how do I beat Bloonarius on Monkey Meadow / cheapest cost /
+how long". The bot has boss HP + speed (`bosses.json`), per-crosspath combat stats
+(`stats/*.json` — damage, attack rate, projectiles, MOAB/boss damage modifiers) and tower costs.
+The only true gap is **track length** (`maps.json` has none — to be curated/approximated).
+
+Owner picked **the full estimator** (~2-3 PRs): boss-kill time + cost + track-time gate + a
+cheapest-tower-per-$/DPS ranking, giving an **estimate with stated assumptions** (he explicitly
+accepts approximate over refusing).
+
+**Design principle:** the arithmetic is **deterministic** (a compute service), not the model doing
+mental math — the same pattern as the round-cash workflow / `deterministic_btd6_list_reply` (and the
+fix for the haiku confabulation seen in the #1572 export).
+
+Build order:
+- **PR 1 (this card):** the deterministic estimator core — `services/btd6_estimator_service.py`
+  (effective single-target boss DPS via the existing `btd6_stats_service.attack_breakdown`,
+  cost-to-crosspath, time-to-kill = HP/DPS, DPS-per-dollar, a cheapest-counters ranking) + a
+  `!btd6estimate` command to exercise it. Offline, fully unit-tested. No AI-path change yet.
+- **PR 2:** curated per-map track-time table + the "does it escape" gate, and wiring the estimator
+  into the BTD6 answer path (deterministic reply + an instruction so the model estimates instead of
+  refusing).

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T07:00:34Z",
+    "generated_at": "2026-06-30T08:46:10Z",
     "build": {
-      "commit": "3f2a356",
-      "subject": "PR1: !aireview export + triage bridge + backlog runbook",
-      "committed_at": "2026-06-30T07:00:34Z"
+      "commit": "097949e",
+      "subject": "PR1: BTD6 boss-fight estimator core (deterministic DPS/cost/kill-time)",
+      "committed_at": "2026-06-30T08:46:10Z"
     }
   },
   "counts": {
-    "commands": 471,
+    "commands": 473,
     "features": 43,
     "games": 12
   },
@@ -796,6 +796,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -838,6 +842,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -884,6 +892,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -928,6 +940,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1057,6 +1073,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1099,6 +1119,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1175,6 +1199,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1217,6 +1245,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1376,6 +1408,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1418,6 +1454,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1462,6 +1502,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1504,6 +1548,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1564,6 +1612,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1606,6 +1658,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1701,6 +1757,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1743,6 +1803,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1851,6 +1915,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -1893,6 +1961,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -1997,6 +2069,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -2039,6 +2115,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -2102,6 +2182,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
         },
@@ -2144,6 +2228,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -2324,6 +2412,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Frequency-driven preset suggestions from the review log",
+          "status": "ideas"
+        },
         {
           "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
           "status": "ideas"
@@ -5328,6 +5420,84 @@
       "examples": [],
       "status": "finished",
       "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "estimate",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Estimate a boss fight from HP/DPS/cost (tower vs boss, or counters).",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "estimate",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Estimate a boss fight: `<tower> vs <boss> [tier]`, or `counters <boss>`.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
       "notes": null
     },
     {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -282,6 +282,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -291,10 +295,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -314,6 +314,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -323,10 +327,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -2062,6 +2062,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -2071,10 +2075,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -2249,6 +2249,36 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Mining & Exploration — Brainstorm & Roadmap"
+      }
+    ]
+  },
+  {
+    "name": "estimate",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Estimate a boss fight from HP/DPS/cost (tower vs boss, or counters).",
+    "description": "Estimate a boss fight from HP/DPS/cost (tower vs boss, or counters).",
+    "usage": "!estimate",
+    "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
+        "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
+      },
+      {
+        "status": "idea",
+        "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
+      },
+      {
+        "status": "idea",
+        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2646,6 +2676,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -2655,10 +2689,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -3951,6 +3981,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -3960,10 +3994,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -4033,6 +4063,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -4042,10 +4076,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -4199,6 +4229,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -4208,10 +4242,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -4693,6 +4723,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -4702,10 +4736,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -5220,6 +5250,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -5229,10 +5263,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -5821,6 +5851,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -5830,10 +5864,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -6001,6 +6031,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -6010,10 +6044,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -6795,6 +6825,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Frequency-driven preset suggestions from the review log"
+      },
+      {
+        "status": "idea",
         "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
       },
       {
@@ -6804,10 +6838,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
-      },
-      {
-        "status": "idea",
-        "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
       }
     ]
   },
@@ -7141,7 +7171,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "3f2a356",
+    "build": "097949e",
     "title": "New public bot website",
     "changes": [
       {
@@ -7153,7 +7183,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "3f2a356",
+    "build": "097949e",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7165,7 +7195,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "3f2a356",
+    "build": "097949e",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,21 +1,21 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T07:00:34Z",
+    "generated_at": "2026-06-30T08:46:10Z",
     "build": {
-      "commit": "3f2a356",
-      "subject": "PR1: !aireview export + triage bridge + backlog runbook",
-      "committed_at": "2026-06-30T07:00:34Z"
+      "commit": "097949e",
+      "subject": "PR1: BTD6 boss-fight estimator core (deterministic DPS/cost/kill-time)",
+      "committed_at": "2026-06-30T08:46:10Z"
     },
     "counts": {
       "functions": 43,
-      "ideas": 155,
+      "ideas": 156,
       "bugs": 29,
       "reviews": 0,
       "reviews_open": 0,
       "updates": 60,
       "env_vars": 39,
       "cogs": 55,
-      "commands": 471,
+      "commands": 473,
       "setting_keys": 108,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -1163,6 +1163,16 @@
     }
   ],
   "ideas": [
+    {
+      "file": "review-log-frequency-preset-suggestions-2026-06-30.md",
+      "title": "Frequency-driven preset suggestions from the review log",
+      "status": "ideas",
+      "date": "2026-06-30",
+      "summary": "The answer loop shipped this session is **operator-pull**: a human runs `!aireview export`,",
+      "subsystems": [
+        "ai"
+      ]
+    },
     {
       "file": "command-collision-checker-2026-06-29.md",
       "title": "Idea — `check_command_collisions.py`: static guard against duplicate command names",
@@ -2655,6 +2665,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-06-30-reaction-roles-signup-counter.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — Reaction-roles live sign-up counter (S1 deepening)",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-30-counters-completion-deepening.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — Counters completion-cert deepening (Q-0209)",
@@ -2671,6 +2689,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-30-btd6-boss-fight-estimator.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — BTD6 boss-fight estimator (estimate, don't refuse)",
+      "status": "in-progress",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-30-blackjack-punchlist-2-3.md",
       "date": "2026-06-30",
       "title": "Session — Blackjack completion-cert punch-list #2 + #3",
@@ -2679,11 +2705,19 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-30-ai-review-backlog-triage-r1.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — AI review-log backlog triage, round 1 (DDT confabulation)",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-30-ai-review-backlog-loop.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — AI review-log answer loop (export → triage → presets)",
-      "status": "in-progress",
-      "run_type": "",
+      "status": "complete",
+      "run_type": "manual",
       "self_initiated": false
     },
     {
@@ -3109,30 +3143,6 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-26-reconcile-band1470.md",
-      "date": "2026-06-26",
-      "title": "Session — 2026-06-26 · twenty-sixth Q-0107 reconciliation pass (band-#1470)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-26-projmoon-grounding-path.md",
-      "date": "2026-06-26",
-      "title": "2026-06-26 — Project Moon (Limbus) grounding path (PR 2)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-26-projmoon-faithfulness-guard.md",
-      "date": "2026-06-26",
-      "title": "2026-06-26 — Project Moon (Limbus) faithfulness guard (S1)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -3964,6 +3974,28 @@
           "parent": "btd6",
           "aliases": [],
           "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "estimate",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "Estimate a boss fight from HP/DPS/cost (tower vs boss, or counters).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "estimate",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "Estimate a boss fight: `<tower> vs <boss> [tier]`, or `counters <boss>`.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -487,6 +487,55 @@ async def build_tower_embed(name: str) -> discord.Embed:
 
 
 # ---------------------------------------------------------------------------
+# estimate (deterministic boss-fight estimator)
+# ---------------------------------------------------------------------------
+
+
+async def build_estimate_embed(query: str) -> discord.Embed:
+    """Render the boss-fight estimate embed (deterministic HP/DPS/cost).
+
+    ``<tower> vs <boss> [tier]`` → a single estimate; ``[counters] <boss> [tier]``
+    → the most cost-efficient towers. All arithmetic is done deterministically by
+    ``services.btd6_estimator_service`` so the surface estimates instead of guessing.
+    """
+    from services import btd6_estimator_service as est
+
+    title = "🎯 BTD6 boss-fight estimate"
+    text = (query or "").strip()
+    if not text:
+        body = (
+            "Estimate a boss fight from grounded HP/DPS/cost:\n"
+            "• `<tower> vs <boss> [tier]` — e.g. `super monkey 0-4-0 vs bloonarius t5`\n"
+            "• `counters <boss> [tier]` — the most cost-efficient towers"
+        )
+        return discord.Embed(
+            title=title, description=body, color=discord.Color.blurple(),
+        )
+
+    req = est.parse_request(text)
+    if req.mode == "single":
+        estimate = est.resolve_and_estimate(req.tower_query, req.boss_query, req.tier)
+        if estimate is not None:
+            body = est.format_estimate_text(estimate)
+        else:
+            body = (
+                "I couldn't resolve that — try `<tower> vs <boss> [tier]`. "
+                f"(Read tower=`{req.tower_query}`, boss=`{req.boss_query}`, tier {req.tier}.)"
+            )
+    else:
+        boss = est.find_boss(req.boss_query)
+        if boss is None:
+            body = (
+                f"I don't have a boss matching `{req.boss_query}`. "
+                "Bosses: Bloonarius, Lych, Vortex, Dreadbloon, Blastapopoulos, Phayze, Diamondback."
+            )
+        else:
+            rows = est.cheapest_counters(boss.id, req.tier, limit=5)
+            body = est.format_counters_text(rows, boss.canonical or boss.id, req.tier)
+    return discord.Embed(title=title, description=body, color=discord.Color.blurple())
+
+
+# ---------------------------------------------------------------------------
 # sources
 # ---------------------------------------------------------------------------
 

--- a/disbot/cogs/btd6/_unified.py
+++ b/disbot/cogs/btd6/_unified.py
@@ -185,6 +185,26 @@ async def tower_prefix(ctx: commands.Context, *, name: str) -> None:
     await ctx.send(embed=await _builders.build_tower_embed(name))
 
 
+# --- estimate --------------------------------------------------------------
+
+
+@btd6_app.command(
+    name="estimate",
+    description="Estimate a boss fight from HP/DPS/cost (tower vs boss, or counters).",
+)
+@app_commands.describe(
+    query="e.g. 'super monkey 0-4-0 vs bloonarius t5' or 'counters bloonarius'",
+)
+async def estimate_slash(interaction: discord.Interaction, query: str) -> None:
+    await reply_ephemeral(interaction, _builders.build_estimate_embed(query))
+
+
+@btd6_prefix.command(name="estimate")  # type: ignore[arg-type]
+async def estimate_prefix(ctx: commands.Context, *, query: str = "") -> None:
+    """Estimate a boss fight: `<tower> vs <boss> [tier]`, or `counters <boss>`."""
+    await ctx.send(embed=await _builders.build_estimate_embed(query))
+
+
 # --- hero ------------------------------------------------------------------
 
 

--- a/disbot/services/btd6_estimator_service.py
+++ b/disbot/services/btd6_estimator_service.py
@@ -1,0 +1,458 @@
+"""BTD6 boss-fight estimator — deterministic kill-time / cost / DPS estimates.
+
+The bot has every ingredient to *estimate* a boss fight — boss HP + speed
+(``bosses.json``), per-crosspath combat stats (:mod:`services.btd6_stats_service`),
+and tower costs — yet without a compute seam the model either refuses the question
+or confabulates a wrong tower list (the failure seen in the review-log export). This
+service does the arithmetic **deterministically** so the answer path can state a
+grounded estimate *with explicit assumptions* instead of guessing.
+
+**Scope (v1): single-target base DPS.** Deliberately approximate and labelled as
+such — it excludes MOAB/boss bonus damage, abilities, buffs, targeting, pierce, AoE,
+uptime, and boss damage-resistance phases. The owner explicitly accepts a stated
+estimate over a refusal; :attr:`KillEstimate.assumptions` carries the caveats so the
+reply can show them. Pure data + arithmetic — no Discord, no network.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from services import btd6_stats_service
+from utils.btd6 import tier_codes
+
+# Base single-target DPS understates abilities/bonuses, so the caveat ships with
+# every estimate (the reply states it; the owner wants honesty over false precision).
+_ASSUMPTIONS: tuple[str, ...] = (
+    "base single-target DPS (excludes MOAB/boss bonus damage, abilities, buffs)",
+    "ignores targeting, pierce, AoE, uptime, and boss damage-resistance phases",
+    "one tower, no support (Alchemist/Village) buffs",
+)
+
+
+@dataclass(frozen=True)
+class KillEstimate:
+    """A deterministic single-tower vs single-boss-tier estimate."""
+
+    tower_id: str
+    tower_canonical: str
+    crosspath: str  # display form, e.g. "0-2-4"
+    cost: int
+    dps: float
+    damage_type: str | None
+    sees_camo: bool
+    boss_id: str
+    boss_canonical: str
+    boss_tier: int
+    boss_hp: int
+    boss_speed: float
+    time_to_kill_s: float | None  # None when dps is 0 / immunity-blocked
+    blocked_by_immunity: bool
+    boss_immune_to: tuple[str, ...]
+    assumptions: tuple[str, ...] = _ASSUMPTIONS
+
+
+@dataclass(frozen=True)
+class EstimateRequest:
+    """A parsed ``!btd6estimate`` query."""
+
+    mode: str  # "single" (tower vs boss) | "counters" (rank towers vs boss)
+    tower_query: str
+    boss_query: str
+    tier: int
+
+
+@dataclass(frozen=True)
+class CounterRow:
+    """One tower's best cost-efficiency option against a boss (ranking entry)."""
+
+    tower_id: str
+    tower_canonical: str
+    crosspath: str
+    cost: int
+    dps: float
+    dps_per_dollar: float
+    time_to_kill_s: float | None
+
+
+# ---------------------------------------------------------------------------
+# Cost + DPS primitives
+# ---------------------------------------------------------------------------
+
+
+def cost_for_code(stats: btd6_stats_service.TowerStats, code: str) -> int | None:
+    """Total cash to reach crosspath ``code``: base + every upgrade on the way.
+
+    None if the code is malformed or an upgrade cost is missing from the data.
+    """
+    if not tier_codes.is_valid_code(code):
+        return None
+    digits = tier_codes.digits(code)
+    by_path_tier: dict[tuple[int, int], int] = {}
+    for upg in stats.upgrades:
+        path, tier = upg.get("path"), upg.get("tier")
+        cost = upg.get("cost")
+        if isinstance(path, int) and isinstance(tier, int) and isinstance(cost, int):
+            by_path_tier[(path, tier)] = cost
+    total = stats.base_cost or 0
+    for path_idx, top_tier in enumerate(digits, start=1):
+        for tier in range(1, top_tier + 1):
+            cost = by_path_tier.get((path_idx, tier))
+            if cost is None:
+                return None
+            total += cost
+    return total
+
+
+# Per-hit damage at/above this is an instakill / sentinel value (e.g. Druid's
+# 9,999,999 Vine, an instant-kill marker the stats service renders as "∞"), not
+# sustained DPS — excluded so a single sentinel can't dominate the estimate.
+_INSTAKILL_DAMAGE_CAP = 100_000.0
+
+
+def dps_for_code(stats: btd6_stats_service.TowerStats, code: str) -> float | None:
+    """Base single-target DPS at crosspath ``code`` (None if no damaging attack).
+
+    Sums per-attack ``Σ projectile damage ÷ cooldown`` over the tier's attacks,
+    excluding instakill sentinel projectiles (see :data:`_INSTAKILL_DAMAGE_CAP`).
+    Like :func:`services.btd6_stats_service.rough_attack_dps` this ignores
+    targeting / pierce / AoE / count (single-target approximation).
+    """
+    tier = stats.tier(code)
+    if not tier:
+        return None
+    breakdown = btd6_stats_service.attack_breakdown(tier.get("attacks") or [])
+    if not breakdown:
+        return None
+    total = 0.0
+    for atk in breakdown:
+        if not atk.cooldown:
+            continue
+        damage = sum(
+            dmg
+            for (_name, dmg, _pierce) in atk.projectiles
+            if 0 < dmg < _INSTAKILL_DAMAGE_CAP
+        )
+        total += damage / atk.cooldown
+    return round(total, 1)
+
+
+# ---------------------------------------------------------------------------
+# Boss lookup
+# ---------------------------------------------------------------------------
+
+
+def find_boss(query: str):  # -> BossEntry | None
+    """Resolve a free-form boss name to its dataset entry (substring/alias match)."""
+    from services import btd6_data_service
+
+    text = (query or "").strip().lower()
+    if not text:
+        return None
+    for boss in btd6_data_service.get_dataset().bosses:
+        if boss.id.lower() in text or (
+            boss.canonical and boss.canonical.lower() in text
+        ):
+            return boss
+    # token containment the other way (e.g. "bloonarius t5" -> "bloonarius")
+    for boss in btd6_data_service.get_dataset().bosses:
+        if boss.canonical and any(
+            tok == boss.canonical.lower() for tok in text.split()
+        ):
+            return boss
+    return None
+
+
+def _boss_tier_row(boss, tier: int) -> dict | None:
+    for row in boss.tiers:
+        if row.get("tier") == tier:
+            return row
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Estimate
+# ---------------------------------------------------------------------------
+
+
+def estimate(
+    tower_id: str,
+    code: str,
+    boss_id: str,
+    tier: int,
+) -> KillEstimate | None:
+    """Estimate one tower (at crosspath ``code``) vs one boss tier.
+
+    None when the tower has no stats, the code has no DPS, or the boss/tier is
+    unknown. ``time_to_kill_s`` is None when the boss is immune to the tower's
+    damage type (or DPS is 0).
+    """
+    from services import btd6_data_service
+
+    stats = btd6_stats_service.get_tower_stats(tower_id)
+    if stats is None:
+        return None
+    tier_stats = stats.tier(code)
+    if not tier_stats:
+        return None
+    boss = next(
+        (b for b in btd6_data_service.get_dataset().bosses if b.id == boss_id),
+        None,
+    )
+    if boss is None:
+        return None
+    row = _boss_tier_row(boss, tier)
+    if row is None:
+        return None
+
+    dps = dps_for_code(stats, code) or 0.0
+    cost = cost_for_code(stats, code)
+    normal = btd6_stats_service.normal_stats(tier_stats)
+    hp = int(row.get("health") or 0)
+    blocked = bool(normal.damage_type and normal.damage_type in boss.immune_to)
+    time_to_kill = (hp / dps) if (dps > 0 and not blocked) else None
+
+    return KillEstimate(
+        tower_id=tower_id,
+        tower_canonical=stats.canonical or tower_id,
+        crosspath=tier_codes.format_code(code),
+        cost=cost if cost is not None else (stats.base_cost or 0),
+        dps=round(dps, 1),
+        damage_type=normal.damage_type,
+        sees_camo=normal.can_see_camo,
+        boss_id=boss.id,
+        boss_canonical=boss.canonical or boss.id,
+        boss_tier=tier,
+        boss_hp=hp,
+        boss_speed=float(row.get("speed") or 0.0),
+        time_to_kill_s=round(time_to_kill, 1) if time_to_kill is not None else None,
+        blocked_by_immunity=blocked,
+        boss_immune_to=tuple(boss.immune_to),
+    )
+
+
+def resolve_tower(query: str) -> tuple[str, str] | None:
+    """Resolve free-form text to ``(tower_id, crosspath_code)``.
+
+    Picks the first resolved tower and a crosspath code if the text names one
+    (e.g. "super monkey 0-2-4"); defaults to the base ``000``.
+    """
+    from services import btd6_resolver_service
+
+    intent = btd6_resolver_service.resolve(query)
+    if not intent.towers:
+        return None
+    tower_id = intent.towers[0].id
+    code = _extract_code(query)
+    return tower_id, code
+
+
+def _extract_code(text: str) -> str:
+    """Pull a crosspath code like ``0-2-4`` / ``024`` from free text, else ``000``."""
+    import re
+
+    m = re.search(r"\b([0-5])\s*-\s*([0-5])\s*-\s*([0-5])\b", text)
+    if m:
+        code = "".join(m.groups())
+        if tier_codes.is_valid_code(code):
+            return code
+    m = re.search(r"\b([0-5])([0-5])([0-5])\b", text)
+    if m and tier_codes.is_valid_code(m.group(0)):
+        return m.group(0)
+    return "000"
+
+
+def resolve_and_estimate(
+    tower_query: str,
+    boss_query: str,
+    tier: int,
+) -> KillEstimate | None:
+    """Resolve free-form tower + boss names and estimate the fight."""
+    resolved = resolve_tower(tower_query)
+    boss = find_boss(boss_query)
+    if resolved is None or boss is None:
+        return None
+    tower_id, code = resolved
+    return estimate(tower_id, code, boss.id, tier)
+
+
+# ---------------------------------------------------------------------------
+# Cheapest-counter ranking (most DPS per dollar)
+# ---------------------------------------------------------------------------
+
+
+def parse_request(text: str) -> EstimateRequest:
+    """Parse a free-form estimate query into structured intent.
+
+    ``"super monkey 0-4-0 vs bloonarius t5"`` → single estimate (tier 5).
+    ``"counters for bloonarius tier 3"`` / ``"bloonarius"`` → counters ranking.
+    Tier defaults to **5** (the hardest tier, most-asked) when none is named.
+    """
+    import re
+
+    raw = (text or "").strip()
+    tier = 5
+    m = re.search(r"\b(?:tier\s*|t)([1-5])\b", raw, re.IGNORECASE)
+    if m:
+        tier = int(m.group(1))
+        raw = (raw[: m.start()] + " " + raw[m.end() :]).strip()
+    low = raw.lower()
+    for sep in (" vs ", " versus "):
+        if sep in low:
+            idx = low.index(sep)
+            return EstimateRequest(
+                mode="single",
+                tower_query=raw[:idx].strip(),
+                boss_query=raw[idx + len(sep) :].strip(),
+                tier=tier,
+            )
+    boss_q = re.sub(
+        r"^(counters?|cheapest|best)\s+(for\s+|to\s+|vs\s+)?",
+        "",
+        raw,
+        flags=re.IGNORECASE,
+    ).strip()
+    return EstimateRequest(
+        mode="counters",
+        tower_query="",
+        boss_query=boss_q,
+        tier=tier,
+    )
+
+
+def cheapest_counters(
+    boss_id: str,
+    tier: int,
+    *,
+    limit: int = 5,
+) -> list[CounterRow]:
+    """Rank towers by best DPS-per-dollar against a boss tier (v1 cost-efficiency).
+
+    For each tower, scans its present legal crosspaths, computes base DPS + cost,
+    and keeps the highest DPS-per-dollar option (skipping options blocked by the
+    boss's damage-type immunity). Returns the top ``limit``, most-efficient first.
+    This is the "cheapest single tower" proxy until the track-time gate lands.
+    """
+    from services import btd6_data_service
+
+    dataset = btd6_data_service.get_dataset()
+    boss = next((b for b in dataset.bosses if b.id == boss_id), None)
+    if boss is None:
+        return []
+    row = _boss_tier_row(boss, tier)
+    if row is None:
+        return []
+    hp = int(row.get("health") or 0)
+    immune = set(boss.immune_to)
+
+    rows: list[CounterRow] = []
+    for tower in dataset.towers:
+        stats = btd6_stats_service.get_tower_stats(tower.id)
+        if stats is None or not stats.has_combat_stats:
+            continue
+        best: CounterRow | None = None
+        for code in stats.tiers:
+            if not tier_codes.is_valid_code(code) or not tier_codes.is_legal(code):
+                continue
+            tier_stats = stats.tier(code)
+            if not tier_stats:
+                continue
+            normal = btd6_stats_service.normal_stats(tier_stats)
+            if normal.damage_type and normal.damage_type in immune:
+                continue
+            dps = dps_for_code(stats, code) or 0.0
+            cost = cost_for_code(stats, code)
+            if dps <= 0 or not cost:
+                continue
+            value = dps / cost
+            if best is None or value > best.dps_per_dollar:
+                best = CounterRow(
+                    tower_id=tower.id,
+                    tower_canonical=stats.canonical or tower.id,
+                    crosspath=tier_codes.format_code(code),
+                    cost=cost,
+                    dps=round(dps, 1),
+                    dps_per_dollar=round(value, 4),
+                    time_to_kill_s=round(hp / dps, 1) if dps > 0 else None,
+                )
+        if best is not None:
+            rows.append(best)
+    rows.sort(key=lambda r: r.dps_per_dollar, reverse=True)
+    return rows[: max(1, limit)]
+
+
+# ---------------------------------------------------------------------------
+# Text formatting (reused by the command + the AI answer path)
+# ---------------------------------------------------------------------------
+
+
+def _fmt_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "—"
+    if seconds < 90:
+        return f"~{seconds:.0f}s"
+    minutes = seconds / 60.0
+    if minutes < 90:
+        return f"~{minutes:.1f} min"
+    return f"~{minutes / 60.0:.1f} hr"
+
+
+def format_estimate_text(est: KillEstimate) -> str:
+    """A grounded, assumption-stated estimate as plain text (no Discord types)."""
+    lines = [
+        f"**{est.tower_canonical} ({est.crosspath})** vs "
+        f"**{est.boss_canonical} Tier {est.boss_tier}**",
+        f"• Boss HP: **{est.boss_hp:,}** (speed {est.boss_speed})",
+        f"• Tower: ~**{est.dps:,.0f} DPS** ({est.damage_type or 'unknown'} damage), "
+        f"cost **${est.cost:,}**"
+        + ("" if est.sees_camo else " — ⚠️ no camo detection"),
+    ]
+    if est.blocked_by_immunity:
+        lines.append(
+            f"• ⛔ This boss is immune to **{est.damage_type}** — that tower can't "
+            f"damage it. (Immune to: {', '.join(est.boss_immune_to) or 'n/a'}.)",
+        )
+    else:
+        lines.append(
+            f"• Estimated solo kill time: **{_fmt_duration(est.time_to_kill_s)}** "
+            f"({est.boss_hp:,} HP ÷ {est.dps:,.0f} DPS)",
+        )
+    lines.append("_Estimate — " + "; ".join(est.assumptions) + "._")
+    return "\n".join(lines)
+
+
+def format_counters_text(
+    rows: list[CounterRow],
+    boss_canonical: str,
+    tier: int,
+) -> str:
+    """Rank text for the most cost-efficient towers vs a boss tier."""
+    if not rows:
+        return f"No tower estimates available for {boss_canonical} Tier {tier}."
+    out = [
+        f"**Most DPS-per-dollar vs {boss_canonical} Tier {tier}** (base DPS, single tower):",
+    ]
+    for i, r in enumerate(rows, start=1):
+        out.append(
+            f"{i}. **{r.tower_canonical} {r.crosspath}** — ~{r.dps:,.0f} DPS, "
+            f"${r.cost:,} (solo kill {_fmt_duration(r.time_to_kill_s)})",
+        )
+    out.append("_Estimate — base single-target DPS; excludes abilities/buffs/bonuses._")
+    return "\n".join(out)
+
+
+__all__ = [
+    "CounterRow",
+    "EstimateRequest",
+    "KillEstimate",
+    "cheapest_counters",
+    "format_counters_text",
+    "format_estimate_text",
+    "parse_request",
+    "cost_for_code",
+    "dps_for_code",
+    "estimate",
+    "find_boss",
+    "resolve_and_estimate",
+    "resolve_tower",
+]

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`compute-dont-refuse-capability-sweep-2026-06-30.md`](./compute-dont-refuse-capability-sweep-2026-06-30.md) —
+  **session idea (2026-06-30, Q-0089, from building the BTD6 boss-fight estimator #1574):** mine the
+  `ai_review_log` for refusals that are actually **computable** (the bot has the grounded data, it just
+  refused or confabulated — boss fights, economy projections, XP-to-level, …) and build a deterministic
+  compute tool per recurring class. Generalizes `deterministic_btd6_list_reply` / the round-cash workflow /
+  the new estimator. Adds a `computable` triage disposition. Subsystem: ai, btd6.
 - [`review-log-frequency-preset-suggestions-2026-06-30.md`](./review-log-frequency-preset-suggestions-2026-06-30.md) —
   **session idea (2026-06-30, Q-0089, from building the AI review-log answer loop #1569):** when the *same
   normalized question* recurs as an `unknown` N times in a window, push a one-line "author a preset?" nudge

--- a/docs/ideas/compute-dont-refuse-capability-sweep-2026-06-30.md
+++ b/docs/ideas/compute-dont-refuse-capability-sweep-2026-06-30.md
@@ -1,0 +1,62 @@
+# "Compute, don't refuse" — a capability sweep over the review log
+
+> **Status:** `ideas`. **Not a plan, not approval.** A capture doc so the idea lives in
+> the repo instead of in chat. Source code, the binding contracts, and
+> `docs/current-state.md` always win over anything here.
+>
+> **Subsystem:** ai, btd6
+>
+> **Session idea (2026-06-30, Q-0089)** — surfaced building the BTD6 boss-fight estimator
+> (PR #1574), itself prompted by the owner noticing the bot *refuses questions it has the
+> data to compute*.
+
+## The idea in one paragraph
+
+The boss-fight estimator fixed one instance of a general failure: **the bot refuses (or
+confabulates) questions it has the grounded data to _compute_** — "how do I beat Bloonarius",
+"cheapest cost", "how long". The same shape recurs across domains: economy projections
+("how much cash by round 40 with 3 farms"), XP-to-level ("how long to hit level 50"), mining
+("how many of X to afford Y"), drop-rate expectations. Each is a *deterministic arithmetic*
+question the model botches but a small compute seam nails. The idea: **mine the
+`ai_review_log` (the answer-loop export) for `grounding_failed` / refusal entries that are
+actually _computable_, and build a deterministic compute tool per recurring class** — the
+generalization of `deterministic_btd6_list_reply`, the round-cash workflow, and now the
+estimator.
+
+## Why it's worth having
+
+- **The review log already tells us what's failing.** The first export (#1572) had four
+  refusals; the owner correctly flagged most as computable. A standing "computable refusal"
+  triage category turns the log into a **compute-tool backlog**.
+- **Deterministic > model for arithmetic.** Every time the model does multi-step math over
+  grounded numbers it confabulates (the DDT list, the round-cash mislabels). A compute seam is
+  correct, cheap (zero extra tokens), and testable.
+- **It compounds.** Each tool (estimator, round-cash, list-floor) makes the bot answer a whole
+  *class* of questions, and a regression probe keeps it fixed.
+
+## Seams it would touch
+
+- **`scripts/ai_review_triage.py`** — add a `computable` heuristic / disposition so the triage
+  output flags "the bot has the data, it just refused" distinctly from "data gap".
+- **A compute-tool pattern** — pure `services/<domain>_estimator_service.py` modules (like the
+  BTD6 one) + a deterministic reply / grounding-injection seam in the answer path.
+- **The answer path** — the conservative detection that routes a computable question to its
+  tool instead of the model (the gated part; each needs live verification, per the AI gate).
+
+## The hard part
+
+- **Detection without over-firing.** A deterministic reply that bypasses the model must only
+  fire on a clearly-computable question — the same conservatism the estimator's `parse_request`
+  uses. Grounding-injection (augment the model's facts with the computed answer) is the
+  lower-risk alternative where detection is fuzzy.
+- **Scope discipline.** Not every refusal is computable (a true open-ended optimization, or a
+  genuine data gap like BTD6 track length, should still be refused honestly). The triage flag is
+  a *candidate* signal, not an auto-build trigger.
+
+## Lifecycle
+
+Routing candidate for `docs/planning/` once 2–3 computable classes are identified from real
+exports. The BTD6 boss-fight estimator (#1574) is the first instance + the reusable pattern;
+its deferred AI-answer-path integration is the first concrete next slice. Pairs with the
+review-log frequency-suggestions idea (which ranks *what* to fix) and the resolve-with-reason
+idea (which records outcomes) — all three sharpen the same answer-loop.

--- a/docs/owner/claims/claude__ai-answer-storage-plan-3fvdit.md
+++ b/docs/owner/claims/claude__ai-answer-storage-plan-3fvdit.md
@@ -1,1 +1,1 @@
-- `claude/ai-answer-storage-plan-3fvdit` · **AI review-log backlog triage (round 1)** — capture the prod DDT-confabulation finding + the vetted rules-based answer in the BTD6 corpus · `docs/btd6/qa-accuracy-corpus-2026-06-27.md` · 2026-06-30 · in progress
+- `claude/ai-answer-storage-plan-3fvdit` · **BTD6 boss-fight estimator** — deterministic DPS/cost/time-to-kill estimator + cheapest-counter ranking (so the bot estimates instead of refusing) · `disbot/services/btd6_estimator_service.py` `disbot/utils/btd6/` `disbot/cogs/btd6*` · 2026-06-30 · in progress

--- a/tests/unit/cogs/test_btd6_unified_tree.py
+++ b/tests/unit/cogs/test_btd6_unified_tree.py
@@ -25,6 +25,7 @@ _FLAT_LOOKUPS = {
     "relic",
     "ct",
     "ask",
+    "estimate",
     "status",
     "diagnostics",
     "test-intent",

--- a/tests/unit/services/test_btd6_estimator_service.py
+++ b/tests/unit/services/test_btd6_estimator_service.py
@@ -1,0 +1,153 @@
+"""Unit tests for services/btd6_estimator_service.py.
+
+Exercised against the real committed BTD6 data (deterministic), like the rest of
+the btd6 suite. Pins: cost-to-crosspath, base-DPS with the instakill-sentinel
+filter, the kill-time = HP/DPS estimate, damage-type immunity blocking, the
+query parser, and that the cheapest-counters ranking is not polluted by
+instakill values (the Druid Vine 9,999,999 sentinel).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_estimator_service as est  # noqa: E402
+from services import btd6_stats_service as stats  # noqa: E402
+
+
+def _dart():
+    return stats.get_tower_stats("dart_monkey")
+
+
+# --------------------------------------------------------------------- cost
+
+
+def test_cost_for_code_base_and_upgrades() -> None:
+    dart = _dart()
+    # base (000) is just the base cost; a path-1 tier-1 adds Sharp Shots' cost.
+    assert est.cost_for_code(dart, "000") == dart.base_cost
+    cost_100 = est.cost_for_code(dart, "100")
+    assert cost_100 is not None and cost_100 > dart.base_cost
+
+
+def test_cost_for_code_rejects_malformed() -> None:
+    assert est.cost_for_code(_dart(), "999") is None  # illegal tiers
+    assert est.cost_for_code(_dart(), "xyz") is None
+
+
+# ---------------------------------------------------------------------- dps
+
+
+def test_dps_base_dart_is_sane() -> None:
+    # Dart Monkey base: 1 damage / 0.95s ≈ 1.05 DPS.
+    dps = est.dps_for_code(_dart(), "000")
+    assert dps is not None and 0.8 < dps < 1.5
+
+
+def test_instakill_sentinel_is_filtered() -> None:
+    # Druid 0-3-0 (Druid of the Storm line) carries the 9,999,999 Vine sentinel;
+    # it must NOT produce millions of DPS.
+    druid = stats.get_tower_stats("druid")
+    if druid is None or not druid.tier("030"):
+        return  # data shape changed; nothing to assert
+    dps = est.dps_for_code(druid, "030")
+    assert dps is not None and dps < 100_000
+
+
+# ----------------------------------------------------------------- estimate
+
+
+def test_estimate_kill_time_is_hp_over_dps() -> None:
+    e = est.estimate("super_monkey", "000", "bloonarius", 5)
+    assert e is not None
+    assert e.boss_hp == 3_000_000
+    assert e.dps > 0 and not e.blocked_by_immunity
+    # time_to_kill ≈ hp / dps (allow rounding).
+    assert e.time_to_kill_s == round(e.boss_hp / e.dps, 1)
+
+
+def test_estimate_blocks_on_damage_type_immunity() -> None:
+    # Wizard's base magic bolts are Energy; Blastapopoulos (Purple props) is
+    # immune to Energy → can't damage it.
+    e = est.estimate("wizard_monkey", "000", "blastapopoulos", 5)
+    assert e is not None
+    assert "Energy" in e.boss_immune_to
+    assert e.blocked_by_immunity is True
+    assert e.time_to_kill_s is None
+
+
+def test_estimate_unknown_returns_none() -> None:
+    assert est.estimate("super_monkey", "000", "no_such_boss", 5) is None
+    assert est.estimate("no_such_tower", "000", "bloonarius", 5) is None
+
+
+# ------------------------------------------------------------------- parser
+
+
+def test_parse_request_single_with_tier() -> None:
+    req = est.parse_request("super monkey 0-4-0 vs bloonarius t5")
+    assert req.mode == "single"
+    assert "super monkey" in req.tower_query
+    assert "bloonarius" in req.boss_query
+    assert "t5" not in req.boss_query.lower()  # tier stripped out
+    assert req.tier == 5
+
+
+def test_parse_request_counters_and_default_tier() -> None:
+    req = est.parse_request("counters for bloonarius tier 3")
+    assert req.mode == "counters"
+    assert req.boss_query == "bloonarius"
+    assert req.tier == 3
+    # default tier when none named.
+    assert est.parse_request("vortex").tier == 5
+
+
+# ----------------------------------------------------------------- counters
+
+
+def test_cheapest_counters_sorted_and_not_instakill_polluted() -> None:
+    rows = est.cheapest_counters("bloonarius", 5, limit=5)
+    assert rows, "expected some ranked counters"
+    # sorted by dps_per_dollar descending.
+    values = [r.dps_per_dollar for r in rows]
+    assert values == sorted(values, reverse=True)
+    # the top entry must be a sane sustained-DPS value, not the 9,999,999 Vine.
+    assert rows[0].dps < 100_000
+
+
+# --------------------------------------------------------------- formatting
+
+
+def test_format_estimate_text_contains_key_numbers() -> None:
+    e = est.estimate("super_monkey", "000", "bloonarius", 5)
+    text = est.format_estimate_text(e)
+    assert "Bloonarius" in text and "3,000,000" in text
+    assert "Estimate" in text  # the assumptions line
+
+
+def test_format_estimate_text_blocked_path() -> None:
+    e = est.estimate("wizard_monkey", "000", "blastapopoulos", 5)
+    text = est.format_estimate_text(e)
+    assert "immune" in text.lower()
+
+
+def test_format_counters_text_lists_towers() -> None:
+    rows = est.cheapest_counters("bloonarius", 5, limit=3)
+    text = est.format_counters_text(rows, "Bloonarius", 5)
+    assert "Bloonarius" in text and "DPS" in text
+
+
+def test_resolve_and_estimate_free_form() -> None:
+    e = est.resolve_and_estimate("super monkey 0-4-0", "bloonarius", 5)
+    assert e is not None and e.crosspath == "0-4-0"
+
+
+def test_find_boss_by_name() -> None:
+    boss = est.find_boss("how do I beat bloonarius")
+    assert boss is not None and boss.id == "bloonarius"
+    assert est.find_boss("nonsense xyz") is None


### PR DESCRIPTION
## Summary

Owner-directed, from reviewing the AI review-log export (#1572): the bot **refuses questions it has
the data to estimate** — "how do I beat Bloonarius on Monkey Meadow / cheapest cost / how long". It
has boss HP + speed (`bosses.json`), per-crosspath combat stats (`stats/*.json`: damage, attack rate,
projectiles, MOAB/boss damage modifiers), and tower costs. The only true gap is **track length**
(`maps.json` has none).

The goal (owner's words): give a **best estimate with stated assumptions** instead of refusing —
*"based on ~X minutes of track and ~Y DPS, tower Z defeats this boss in ~K minutes."* The arithmetic
is **deterministic** (a compute service), not the model doing mental math — same pattern as the
round-cash workflow, and the right fix for the haiku-confabulation class seen in the export.

**This PR (1 of ~2-3): the deterministic estimator core** — `services/btd6_estimator_service.py`
(effective single-target boss DPS via the existing `btd6_stats_service`, cost-to-crosspath,
time-to-kill = HP ÷ DPS, DPS-per-dollar, a cheapest-counters ranking) + a `!btd6estimate` command to
exercise it. Offline, fully unit-tested, **no AI-answer-path change yet**.

**Next PR:** a curated per-map track-time table + the "does it escape" gate, and wiring the estimator
into the BTD6 answer path (deterministic reply + an instruction so the model estimates, not refuses).

## Type of change

- [x] New feature

## Checks

- [ ] `python3.10 scripts/check_quality.py --full`
- [ ] `python3.10 scripts/check_architecture.py --mode strict`
- [x] No secrets, tokens, or credentials added

> **Born red** — the `in-progress` session card holds the merge until close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg9f1JD7Rc3uZ9AZ7k9o25)_