### PR TITLE
Diagnostics + counters completion-deepening (hub completeness + loop backoff)

### DIFF
--- a/.sessions/2026-06-30-diagnostics-counters-deepening.md
+++ b/.sessions/2026-06-30-diagnostics-counters-deepening.md
@@ -1,0 +1,22 @@
+# 2026-06-30 — Diagnostics + Counters completion-deepening
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
+
+**PR:** (opening) — diagnostics hub completeness + counters loop backoff.
+**Branch:** `claude/funny-franklin-d1m4wk`
+**Run type:** `routine · dispatch`
+
+## What this run is about to do
+
+Empty-fire dispatch → advance the standing S1 completion-first ▶ Next (clear assessed certs'
+offline punch-lists, Q-0209). Two contained, offline, self-mergeable slices:
+
+- **PR 1 — Diagnostics punch #1 (hub completeness):** wire `startup` + `findings` into the
+  `!platform` hub's Validation category select (+ their `_dispatch` branches, audience-preserving)
+  so the panel's own honesty caveat ("startup/findings remain typed-only") becomes a closed gap —
+  these surfaces become button-reachable, not typed-only. Update the docstring + cert.
+- **PR 2 — Counters punch #3 (loop backoff):** per-guild cooldown/backoff so a persistently-failing
+  guild sync isn't silently retried-and-failed forever.
+
+CI mirror green + arch strict before each self-merge.

--- a/.sessions/2026-06-30-diagnostics-counters-deepening.md
+++ b/.sessions/2026-06-30-diagnostics-counters-deepening.md
@@ -1,22 +1,91 @@
 # 2026-06-30 — Diagnostics + Counters completion-deepening
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 <!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
 
-**PR:** (opening) — diagnostics hub completeness + counters loop backoff.
+**PR:** [#1575](https://github.com/menno420/superbot/pull/1575) — diagnostics hub completeness + counters loop backoff.
 **Branch:** `claude/funny-franklin-d1m4wk`
 **Run type:** `routine · dispatch`
 
-## What this run is about to do
+## What this run did
 
-Empty-fire dispatch → advance the standing S1 completion-first ▶ Next (clear assessed certs'
-offline punch-lists, Q-0209). Two contained, offline, self-mergeable slices:
+Empty-fire dispatch (no work order) → advanced the standing S1 completion-first ▶ Next (clear
+assessed certs' offline punch-lists, Q-0209). No contained OPEN bug to jump the queue (BUG-0009
+plan-level, BUG-0011 VPS-repro, BUG-0019 #1 owner-gated). Shipped two contained, offline,
+self-merge-on-green slices in one PR.
 
-- **PR 1 — Diagnostics punch #1 (hub completeness):** wire `startup` + `findings` into the
-  `!platform` hub's Validation category select (+ their `_dispatch` branches, audience-preserving)
-  so the panel's own honesty caveat ("startup/findings remain typed-only") becomes a closed gap —
-  these surfaces become button-reachable, not typed-only. Update the docstring + cert.
-- **PR 2 — Counters punch #3 (loop backoff):** per-guild cooldown/backoff so a persistently-failing
-  guild sync isn't silently retried-and-failed forever.
+### PR 1 — Diagnostics punch #1 (hub completeness)
 
-CI mirror green + arch strict before each self-merge.
+The `!platform` hub's docstring + completion cert flagged `startup`/`findings` as typed-only by
+design — an honest but incomplete gap. Closed it by **making the claim true** (the goal-serving
+fix over a docstring edit): `startup` + `findings` (both read-only health reports) are now grouped
+into the hub's **Runtime/status** category select with audience-preserving `_dispatch` branches
+mirroring the typed commands (`startup` prefers the stored settled snapshot re-projected to the
+caller's audience; `findings` shows the default `open` status, the typed `!platform findings
+<status>` keeps the filter). The `finding` *lifecycle mutation* stays excluded from the read-only
+Selects — the segregated Mutations row is the only write surface. Updated the panel docstring + the
+lockstep hub-view test together (the test file itself mandated this) + 2 new dispatch tests.
+Confirmed the smoke-checklist `!platform diagnostics` clause was already fixed (P2 sweep).
+
+### PR 2 — Counters punch #3 (loop backoff)
+
+The rename loop attempted every guild every tick with no backoff → a persistently-failing guild
+(permission/cache fault, deleted bound channel) was re-attempted every 10 min forever (log spam +
+wasted API calls + rate-limit re-hammering). Added `services.counter_service.GuildSyncBackoff` —
+a pure, discord-free, tick-based exponential backoff (skip 1 → 2 → 4 … capped at 6 ticks) — wired
+into `CountersCog._counter_sync_loop`. A repeatedly-failing guild is skipped for a growing number of
+loop ticks but **never dropped forever** (the cap guarantees an ≥hourly retry at the 10-min cadence),
+and one clean sync resets it. Per-process/ephemeral state (ADR-002 — a restart re-attempts every
+guild once). The fail-safe per-guild try/except is preserved (now `logger.warning` with `exc_info`
++ the failure-streak/backoff context).
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **13,289 passed**, 48 skipped, 2 xfailed.
+- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors** (49 pre-existing warnings).
+- `check_current_state_ledger --strict` → benign newest-merge lag only (Q-0166 exception).
+  `check_docs --strict` → all checks passed.
+- +12 tests this PR (4 hub-view: 2 dispatch + the updated coverage/exclusion pair; 6 pure backoff +
+  2 loop-wiring).
+
+## Session enders
+
+**💡 Session idea (Q-0089):** *"Audience-aware hub `_dispatch` lift — a `_dispatch_health(name, …)`
+helper."* Three platform-hub surfaces now (`health`, `startup`, `findings`) re-resolve the caller's
+health audience inside `_dispatch` with near-identical `resolve_audience` + project/gate boilerplate.
+A tiny shared helper that resolves the audience once and hands it to the per-surface builders would
+de-duplicate that and make the next health surface a one-liner. Small, genuine, not forced — logged
+here, not yet an idea file (below the file-worthy bar).
+
+**⟲ Previous-session review (Q-0102):** the previous run (#1572, AI review-log triage round 1) did
+the *honest* thing well — it reverted/curated rather than shipping a confabulated DDT counter-list,
+and flagged that the prod Postgres backlog isn't readable from the code env instead of pretending.
+What it (and the broader completion arc) could improve: the completion certs' offline punch-lists
+are scattered across 36 unit files, so "what's the next turn-key pick?" requires reading several
+certs by hand. **System improvement surfaced:** a `scripts/check_completion_punchlist.py` (or a
+`--punchlist` mode on the existing parity checker) that greps every `units/*.md` for un-`✅`'d
+punch-list items tagged `(offline…)` and prints them ranked — turning the dispatch "next pick"
+decision from a manual multi-file read into one command. (Logged as a candidate, not built this run.)
+
+**📋 Doc audit (Q-0104):** cert files updated (diagnostic #1, counters #3); S1 ▶ Next sharpened;
+ledger/docs checkers green. Nothing from this run is captured only in chat. #1575 is intentionally
+**not** added to current-state Recently-shipped (merged-PRs-only; the next session reconciles).
+
+## 📤 Run report
+
+- **Did:** diagnostics hub-completeness (startup/findings grouped) + counters per-guild loop backoff · **Outcome:** shipped
+- **Shipped:** #1575 — diagnostic cert punch #1 + counters cert punch #3 (2 offline completion-deepening slices)
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (dispatched standing ▶ Next — S1 completion-deepening, Q-0209)
+- **↪ Next:** Diagnostics punch #2 (apply `_PaginatorView` to long findings/consistency output) + #5 (health-metrics reconcile) · Cleanup #4 (spam-window setting with a Settings widget)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (auto-merge on green) |
+| CI-red rounds | 0 (born-red gate only; no real-failure rounds) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (Q-0089) |

--- a/disbot/cogs/counters_cog.py
+++ b/disbot/cogs/counters_cog.py
@@ -37,6 +37,9 @@ class CountersCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        # Per-guild exponential backoff so a persistently-failing guild isn't
+        # re-attempted every tick forever (counters completion cert punch #3).
+        self._backoff = counter_service.GuildSyncBackoff()
 
     async def cog_load(self) -> None:
         from cogs.counters.schemas import register_schemas
@@ -51,15 +54,31 @@ class CountersCog(commands.Cog):
 
     @tasks.loop(minutes=_COUNTER_LOOP_MINUTES)
     async def _counter_sync_loop(self) -> None:
-        """Sync every guild's bound counter channels (fail-safe per guild)."""
+        """Sync every guild's bound counter channels (fail-safe + backed-off).
+
+        Each guild is fail-safe (one guild's fault never stops the loop) and
+        rate-limited by per-guild exponential backoff: a guild that keeps
+        failing is skipped for a growing number of ticks (capped, so it is
+        never dropped forever), and one clean sync resets it.
+        """
         for guild in list(self.bot.guilds):
+            guild_id = getattr(guild, "id", 0)
+            if not self._backoff.should_attempt(guild_id):
+                continue
             try:
                 await counter_service.sync_guild(guild)
             except Exception:  # noqa: BLE001 — one guild's fault must not stop the loop
-                logger.exception(
-                    "counters: sync_guild failed for guild=%s",
-                    getattr(guild, "id", "?"),
+                skip = self._backoff.record_failure(guild_id)
+                logger.warning(
+                    "counters: sync_guild failed for guild=%s (failure #%d) — "
+                    "backing off %d loop tick(s)",
+                    guild_id,
+                    self._backoff.fail_streak(guild_id),
+                    skip,
+                    exc_info=True,
                 )
+            else:
+                self._backoff.record_success(guild_id)
 
     @_counter_sync_loop.before_loop
     async def _before_counter_sync_loop(self) -> None:

--- a/disbot/services/counter_service.py
+++ b/disbot/services/counter_service.py
@@ -130,3 +130,66 @@ async def _emit_updated(guild: discord.Guild, renamed: int) -> None:
         await bus.emit(EVT_COUNTERS_UPDATED, guild_id=guild.id, renamed=renamed)
     except Exception:  # noqa: BLE001 — advisory event; never fail the loop
         logger.exception("counters: updated emit failed")
+
+
+# -- per-guild failure backoff (counters completion cert punch #3) ----------
+#
+# The rename loop attempts every guild every tick.  Without backoff a guild
+# whose ``sync_guild`` keeps raising (a permission/cache fault, a deleted bound
+# channel) is re-attempted every loop forever — log spam + wasted API calls,
+# and during a Discord rename rate-limit it would keep re-hammering the cap.
+# ``GuildSyncBackoff`` makes a repeatedly-failing guild skip a growing number of
+# loop ticks (1, 2, 4, … capped), so a broken guild is retried at most once per
+# cap window and **never dropped forever** (the cap guarantees an eventual
+# retry, and one clean sync resets it).  State is per-process and ephemeral
+# (ADR-002): a restart simply re-attempts every guild once.
+
+_BACKOFF_MAX_TICKS = 6  # cap: at a 10-min loop, a broken guild retries ≥hourly.
+
+
+class GuildSyncBackoff:
+    """Tick-based exponential backoff for per-guild sync failures.
+
+    Pure and discord-free so the loop's skip/retry policy is unit-testable in
+    isolation.  One instance per cog; ``should_attempt`` is called once per
+    guild per loop tick, with ``record_success``/``record_failure`` reporting
+    the outcome.
+    """
+
+    def __init__(self, max_ticks: int = _BACKOFF_MAX_TICKS) -> None:
+        self._max_ticks = max(1, max_ticks)
+        self._fail_streak: dict[int, int] = {}
+        self._cooldown: dict[int, int] = {}
+
+    def should_attempt(self, guild_id: int) -> bool:
+        """Return ``True`` if this guild is eligible to sync on this tick.
+
+        A guild in cooldown skips the tick (its remaining count is decremented
+        toward eligibility); a guild with no cooldown is attempted.
+        """
+        remaining = self._cooldown.get(guild_id, 0)
+        if remaining > 0:
+            self._cooldown[guild_id] = remaining - 1
+            return False
+        return True
+
+    def record_success(self, guild_id: int) -> None:
+        """Clear all failure state for a guild that synced cleanly."""
+        self._fail_streak.pop(guild_id, None)
+        self._cooldown.pop(guild_id, None)
+
+    def record_failure(self, guild_id: int) -> int:
+        """Record a failed sync; return the number of ticks it will now skip.
+
+        The skip count grows exponentially with the consecutive-failure streak
+        (1, 2, 4, 8, …) capped at ``max_ticks`` so retries never stop entirely.
+        """
+        streak = self._fail_streak.get(guild_id, 0) + 1
+        self._fail_streak[guild_id] = streak
+        skip = min(self._max_ticks, 2 ** (streak - 1))
+        self._cooldown[guild_id] = skip
+        return skip
+
+    def fail_streak(self, guild_id: int) -> int:
+        """Current consecutive-failure count for a guild (0 when healthy)."""
+        return self._fail_streak.get(guild_id, 0)

--- a/disbot/views/diagnostic/platform_panel.py
+++ b/disbot/views/diagnostic/platform_panel.py
@@ -5,10 +5,15 @@ no subcommand. It groups the read-only ``!platform <subcommand>``
 families into four category Selects (Runtime/status, Catalogues,
 Resources/rollout, Validation), an Overview button that returns
 to the category listing, and a Flag manager button that opens the
-editable per-guild flag manager. Not every subcommand is grouped:
-``startup``/``findings`` (and other later additions) remain
-typed-only until deliberately added to a category — keep this list
-honest when extending (health readiness map, P2 sweep 2026-06-12).
+editable per-guild flag manager. The read-only health family —
+``health``/``startup``/``findings`` — is grouped under Runtime/status
+(``findings`` shows the default ``open`` status; the typed
+``!platform findings <status>`` keeps the status filter). The
+``finding`` *lifecycle mutation* is deliberately NOT grouped here: the
+four category Selects are strictly read-only, so the only write surface
+is the segregated Mutations row. Keep this list honest when extending
+(diagnostic completion cert punch #1, 2026-06-30; health readiness map,
+P2 sweep 2026-06-12).
 
 Selects update the panel in place via ``safe_defer`` +
 ``safe_edit``, identical to ``_DiagnosticsHubView`` and
@@ -39,6 +44,7 @@ from services.diagnostic_embeds import (
     build_caches_embed,
     build_consistency_embed,
     build_customization_embed,
+    build_findings_embed,
     build_flags_embed,
     build_health_embed,
     build_identity_embed,
@@ -56,6 +62,7 @@ from services.diagnostic_embeds import (
     build_settings_registry_embed,
     build_setup_readiness_embed,
     build_slow_embed,
+    build_startup_health_embed,
     build_status_embed,
     build_tasks_embed,
     build_views_embed,
@@ -64,6 +71,8 @@ from views.base import HubView
 
 _RUNTIME_OPTIONS = (
     ("health", "🩺", "Deterministic operational health snapshot (redacted)"),
+    ("startup", "🚀", "Settled-startup health report (extension load, gateway, DB)"),
+    ("findings", "📋", "Persistent operational-health findings (open, redacted)"),
     ("status", "🛠", "Uptime, cogs, guilds, scheduler, failed subsystems"),
     ("runtime", "🛰", "snapshot_all roll-up across every provider"),
     ("lifecycle", "♻️", "Lifecycle phase, pending requests, recent events"),
@@ -182,6 +191,38 @@ async def _dispatch(name: str, interaction: discord.Interaction) -> discord.Embe
         )
         snapshot = await health_snapshot_service.collect_snapshot(request, bot=bot)
         return build_health_embed(snapshot)
+    if name == "startup":
+        from services import health_snapshot_service
+        from services.health_contracts import HealthSnapshotRequest
+
+        audience = await health_snapshot_service.resolve_audience(bot, interaction.user)
+        stored = health_snapshot_service.get_last_startup_snapshot()
+        if stored is not None:
+            snapshot = health_snapshot_service.project_for_audience(stored, audience)
+        else:
+            snapshot = await health_snapshot_service.collect_snapshot(
+                HealthSnapshotRequest(
+                    purpose="startup",
+                    audience=audience,
+                    guild_id=guild.id if guild is not None else None,
+                ),
+                bot=bot,
+            )
+        return build_startup_health_embed(snapshot)
+    if name == "findings":
+        from services import health_findings_service, health_snapshot_service
+        from services.health_contracts import HealthAudience
+
+        audience = await health_snapshot_service.resolve_audience(bot, interaction.user)
+        is_owner = audience is HealthAudience.PLATFORM_OWNER
+        rows = await health_findings_service.list_by_status("open", limit=15)
+        counts = await health_findings_service.count_by_status()
+        return build_findings_embed(
+            rows,
+            status="open",
+            counts=counts,
+            is_owner=is_owner,
+        )
     if name == "status":
         return build_status_embed(bot)  # type: ignore[arg-type]
     if name == "runtime":

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -175,9 +175,15 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   cutoff in the pure `services/history_cleanup.py`; +12 tests). Punch #1 (panel authority re-check)
   found **already covered** (stale cert note corrected). Cleanup's remaining gaps: #4 spam-window
   setting (needs a config-input widget — deferred) + the owner walkthrough/sign-off (#5/#6).
-  **▶ Next turn-key picks:** **Counters** loop backoff (punch #3) · **Diagnostics** list pagination
-  (punch #2) · Cleanup #4 (spam-window setting *with* a Settings widget). *(Counters punch #1/#2/#4/#5
-  ✅ #1568.)*
+  **✅ DONE 2026-06-30 (#1575): Diagnostics punch #1 + Counters punch #3.** Diagnostics #1 (hub
+  completeness) — `startup` + `findings` (read-only health reports) grouped into the `!platform` hub's
+  Runtime/status select (audience-preserving `_dispatch`; the `finding` mutation stays out of the
+  read-only Selects). Counters #3 (loop backoff) — `GuildSyncBackoff` (pure tick-based exponential
+  backoff, capped) wired into the rename loop so a persistently-failing guild is skipped for a growing
+  number of ticks but never dropped forever. **▶ Next turn-key picks:** **Diagnostics** list pagination
+  (punch #2 — apply `_PaginatorView` to long findings/consistency output) + #5 (health-metrics
+  reconcile) · Cleanup #4 (spam-window setting *with* a Settings widget). *(Counters punch
+  #1/#2/#4/#5 ✅ #1568; #3 ✅ #1575.)*
 - `[owner]` **Feature-completion assessments — ALL 36 UNITS ◐ ASSESSED (100%; 0 certified).** The
   completion-first arc (Q-0209). The `▢ → ◐` assessment sweep is **COMPLETE** — every game + server-fn
   now has a rubric-filled, source-grounded certificate under

--- a/docs/owner/claims/claude__funny-franklin-d1m4wk.md
+++ b/docs/owner/claims/claude__funny-franklin-d1m4wk.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-d1m4wk` · diagnostics + counters completion-deepening · `disbot/views/diagnostic/`, `disbot/cogs/diagnostic/`, `disbot/cogs/counter*`, `disbot/services/counter*` + tests · 2026-06-30

--- a/docs/owner/claims/claude__funny-franklin-d1m4wk.md
+++ b/docs/owner/claims/claude__funny-franklin-d1m4wk.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-d1m4wk` · diagnostics + counters completion-deepening · `disbot/views/diagnostic/`, `disbot/cogs/diagnostic/`, `disbot/cogs/counter*`, `disbot/services/counter*` + tests · 2026-06-30

--- a/docs/planning/feature-completion/units/counters.md
+++ b/docs/planning/feature-completion/units/counters.md
@@ -88,8 +88,12 @@
 1. ✅ **Preset templates** — DONE 2026-06-30. `TEMPLATE_PRESETS` catalog + `!counterpreset [name]`
    (list / apply-all-three via the audited `SettingsMutationPipeline`).
 2. ✅ **Slash surface** — DONE 2026-06-30. `/counters` ephemeral status (reuses `_policy_embed`).
-3. **Loop backoff** *(offline, deepening)* — per-guild cooldown / backoff so a persistently-failing guild
-   isn't silently skipped forever. *(Still open — stateful, assessed separately from the 2026-06-30 batch.)*
+3. ✅ **Loop backoff** — DONE 2026-06-30 (PR #1575). `services.counter_service.GuildSyncBackoff` (pure,
+   discord-free, tick-based exponential backoff: skip 1 → 2 → 4 … capped at 6 ticks) wired into
+   `CountersCog._counter_sync_loop`: a guild whose `sync_guild` keeps raising is skipped for a growing
+   number of loop ticks (never dropped forever — the cap guarantees an ≥hourly retry at the 10-min
+   cadence), and one clean sync resets it. Per-process/ephemeral state (ADR-002). +8 tests (6 pure +
+   2 loop-wiring).
 4. ✅ **Channel-type handling** — DONE 2026-06-30. `sync_guild` renames any bound `GuildChannel`
    (voice/text/category all tested); a non-guild target (DM) is skipped — pinned by parametrized tests.
 5. ✅ **Integration test** — DONE 2026-06-30. `test_counter_integration.py` drives the **real**

--- a/docs/planning/feature-completion/units/diagnostic.md
+++ b/docs/planning/feature-completion/units/diagnostic.md
@@ -83,9 +83,12 @@
 - [ ] **Owner ✔** — pending → punch #4.
 
 ## Punch-list (clear these to certify)
-1. **Platform-hub completeness claim** *(offline, minor)* — `startup`/`findings` are typed-only by design;
-   either add them to the hub category selects or correct the panel docstring + the smoke checklist's
-   stale `!platform diagnostics` reference.
+1. ✅ **Platform-hub completeness claim** — DONE 2026-06-30 (PR #1575). `startup` + `findings` (both
+   read-only health reports) are now grouped into the `!platform` hub's **Runtime/status** category
+   select (audience-preserving `_dispatch` branches; `findings` shows the default `open` status, the
+   typed `!platform findings <status>` keeps the status filter). The panel docstring + the lockstep
+   hub-view test were updated together; the `finding` *lifecycle mutation* stays excluded from the
+   read-only Selects (the segregated Mutations row is the only write surface).
 2. **Pagination for dense subviews** *(owner, minor/deepening)* — apply the existing `_PaginatorView` to
    long findings/consistency output.
 3. **Maintainer live health walk** *(needs-live-bot / owner)* — boot, `!platform health` as admin vs owner

--- a/tests/unit/cogs/test_counters_cog.py
+++ b/tests/unit/cogs/test_counters_cog.py
@@ -147,3 +147,55 @@ async def test_counters_slash_outside_guild_is_graceful():
     await cog.counters_slash.callback(cog, interaction)
     msg = interaction.response.send_message.await_args.args[0]
     assert "only available in a server" in msg
+
+
+# ---------------------------------------------------------------------------
+# _counter_sync_loop — per-guild backoff wiring (completion cert punch #3)
+# ---------------------------------------------------------------------------
+
+
+def _loop_cog(guild_ids: list[int]) -> CountersCog:
+    from services import counter_service
+
+    cog = CountersCog.__new__(CountersCog)
+    cog.bot = MagicMock()
+    cog.bot.guilds = [MagicMock(id=gid) for gid in guild_ids]
+    cog._backoff = counter_service.GuildSyncBackoff()
+    return cog
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_a_failing_guild_on_the_next_tick(monkeypatch):
+    from services import counter_service
+
+    cog = _loop_cog([1])
+    sync = AsyncMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(counter_service, "sync_guild", sync)
+
+    # Tick 1: attempted (raises) → records a failure → cooldown 1 tick.
+    await cog._counter_sync_loop.coro(cog)
+    assert sync.await_count == 1
+    assert cog._backoff.fail_streak(1) == 1
+
+    # Tick 2: skipped (backed off) — sync_guild not called again.
+    await cog._counter_sync_loop.coro(cog)
+    assert sync.await_count == 1
+
+    # Tick 3: eligible again, retried.
+    await cog._counter_sync_loop.coro(cog)
+    assert sync.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_loop_success_keeps_a_healthy_guild_attempted_every_tick(monkeypatch):
+    from services import counter_service
+
+    cog = _loop_cog([1])
+    sync = AsyncMock(return_value=0)
+    monkeypatch.setattr(counter_service, "sync_guild", sync)
+
+    await cog._counter_sync_loop.coro(cog)
+    await cog._counter_sync_loop.coro(cog)
+    # A clean sync never backs off → attempted on every tick.
+    assert sync.await_count == 2
+    assert cog._backoff.fail_streak(1) == 0

--- a/tests/unit/services/test_counter_service.py
+++ b/tests/unit/services/test_counter_service.py
@@ -208,3 +208,63 @@ async def test_sync_skips_non_guild_channel(monkeypatch):
     renamed = await counter_service.sync_guild(guild)
     assert renamed == 0
     dm.edit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# GuildSyncBackoff — per-guild exponential backoff (completion cert punch #3)
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_attempts_a_fresh_guild():
+    bo = counter_service.GuildSyncBackoff()
+    assert bo.should_attempt(1) is True
+    assert bo.fail_streak(1) == 0
+
+
+def test_backoff_grows_exponentially_and_caps():
+    bo = counter_service.GuildSyncBackoff(max_ticks=6)
+    # 1, 2, 4, then capped at 6 (would be 8, 16, …).
+    assert bo.record_failure(1) == 1
+    assert bo.record_failure(1) == 2
+    assert bo.record_failure(1) == 4
+    assert bo.record_failure(1) == 6
+    assert bo.record_failure(1) == 6
+    assert bo.fail_streak(1) == 5
+
+
+def test_backoff_skips_then_re_attempts_after_cooldown():
+    bo = counter_service.GuildSyncBackoff(max_ticks=6)
+    bo.record_failure(1)  # cooldown = 1 tick
+    # The next tick is skipped (cooldown decrements to 0)...
+    assert bo.should_attempt(1) is False
+    # ...and the tick after that is eligible again.
+    assert bo.should_attempt(1) is True
+
+
+def test_backoff_never_drops_a_guild_forever():
+    """Even at max streak the guild is retried within ``max_ticks`` ticks."""
+    bo = counter_service.GuildSyncBackoff(max_ticks=3)
+    for _ in range(10):
+        bo.record_failure(1)
+    skips = 0
+    while not bo.should_attempt(1):
+        skips += 1
+        assert skips <= 3, "backoff exceeded its cap — guild dropped forever"
+    assert skips == 3  # capped exactly at max_ticks
+
+
+def test_backoff_success_resets_state():
+    bo = counter_service.GuildSyncBackoff()
+    bo.record_failure(1)
+    bo.record_failure(1)
+    bo.record_success(1)
+    assert bo.fail_streak(1) == 0
+    assert bo.should_attempt(1) is True
+
+
+def test_backoff_is_per_guild():
+    bo = counter_service.GuildSyncBackoff()
+    bo.record_failure(1)
+    # A failure on guild 1 must not back off guild 2.
+    assert bo.should_attempt(2) is True
+    assert bo.fail_streak(2) == 0

--- a/tests/unit/views/test_platform_hub_view.py
+++ b/tests/unit/views/test_platform_hub_view.py
@@ -118,6 +118,8 @@ def test_select_values_cover_every_platform_subcommand():
     expected = {
         # Runtime / status
         "health",
+        "startup",
+        "findings",
         "status",
         "runtime",
         "lifecycle",
@@ -150,16 +152,15 @@ def test_select_values_cover_every_platform_subcommand():
     assert seen == expected, seen.symmetric_difference(expected)
 
 
-def test_typed_only_platform_commands_are_intentionally_excluded():
-    """``startup``/``findings`` (read-only) and ``finding`` (a mutation) are
-    deliberately NOT grouped into the read-only hub — they remain typed-only.
+def test_finding_mutation_is_excluded_from_readonly_hub():
+    """The ``finding`` *lifecycle mutation* must never appear in the read-only
+    category Selects — the only write surface is the segregated Mutations row.
 
-    Pinning the exclusion keeps the platform_panel docstring honest (health
-    readiness map P1-2 / P2 sweep): the four category Selects are read-only, so
-    the ``finding`` lifecycle mutation must never appear there, and the verbose
-    ``startup``/``findings`` reports stay power-user text paths. If a future
-    session deliberately groups one of these, update both this test and the
-    module docstring together.
+    ``startup``/``findings`` (both read-only reports) were grouped into
+    Runtime/status on 2026-06-30 (diagnostic completion cert punch #1), so they
+    are no longer excluded; this test now pins only the mutation exclusion. If a
+    future session changes what is grouped, update both this test and the module
+    docstring together.
     """
     view = _PlatformHubView(_author())
     grouped = {
@@ -168,10 +169,12 @@ def test_typed_only_platform_commands_are_intentionally_excluded():
         if isinstance(child, discord.ui.Select)
         for opt in child.options
     }
-    assert {"startup", "findings", "finding"}.isdisjoint(grouped), (
-        "typed-only platform commands leaked into the read-only hub: "
-        f"{{'startup', 'findings', 'finding'}} & {grouped}"
+    assert "finding" not in grouped, (
+        "the `finding` lifecycle mutation leaked into the read-only hub: "
+        f"{grouped}"
     )
+    # The read-only health reports are now intentionally reachable.
+    assert {"startup", "findings"} <= grouped
 
 
 def test_overview_button_is_on_last_row_and_secondary_style():
@@ -385,6 +388,83 @@ async def test_dispatch_consistency_uses_collect_report():
     collector.assert_awaited_once_with(bot=interaction.client, guild=interaction.guild)
     builder.assert_called_once_with(fake_report)
     assert embed.title == "consistency"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_startup_prefers_stored_snapshot_projected_to_audience():
+    """The hub mirrors `!platform startup`: a stored settled snapshot is
+    re-projected to the caller's audience (no fresh collection)."""
+    guild = MagicMock()
+    guild.id = 7
+    interaction = _fake_interaction(bot=MagicMock(spec=commands.Bot), guild=guild)
+    interaction.user = MagicMock()
+    stored = MagicMock()
+    projected = MagicMock()
+    with (
+        patch(
+            "services.health_snapshot_service.resolve_audience",
+            new_callable=AsyncMock,
+            return_value="admin",
+        ),
+        patch(
+            "services.health_snapshot_service.get_last_startup_snapshot",
+            return_value=stored,
+        ),
+        patch(
+            "services.health_snapshot_service.project_for_audience",
+            return_value=projected,
+        ) as projector,
+        patch(
+            "services.health_snapshot_service.collect_snapshot",
+            new_callable=AsyncMock,
+        ) as collector,
+        patch(
+            "views.diagnostic.platform_panel.build_startup_health_embed",
+            return_value=discord.Embed(title="🚀 Startup health"),
+        ) as builder,
+    ):
+        embed = await _dispatch("startup", interaction)
+    projector.assert_called_once_with(stored, "admin")
+    collector.assert_not_awaited()  # stored snapshot → no fresh collection
+    builder.assert_called_once_with(projected)
+    assert "Startup health" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_findings_lists_open_with_audience_redaction():
+    """The hub mirrors `!platform findings` defaulting to the open status;
+    owner detail is gated on the resolved audience."""
+    from services.health_contracts import HealthAudience
+
+    guild = MagicMock()
+    interaction = _fake_interaction(bot=MagicMock(spec=commands.Bot), guild=guild)
+    interaction.user = MagicMock()
+    rows = [{"category": "db", "message": "x", "status": "open"}]
+    with (
+        patch(
+            "services.health_snapshot_service.resolve_audience",
+            new_callable=AsyncMock,
+            return_value=HealthAudience.GUILD_ADMIN,
+        ),
+        patch(
+            "services.health_findings_service.list_by_status",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ) as lister,
+        patch(
+            "services.health_findings_service.count_by_status",
+            new_callable=AsyncMock,
+            return_value={"open": 1},
+        ),
+        patch(
+            "views.diagnostic.platform_panel.build_findings_embed",
+            return_value=discord.Embed(title="🩺 Health findings — open"),
+        ) as builder,
+    ):
+        embed = await _dispatch("findings", interaction)
+    lister.assert_awaited_once_with("open", limit=15)
+    builder.assert_called_once_with(rows, status="open", counts={"open": 1}, is_owner=False)
+    assert "Health findings" in (embed.title or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Empty-fire dispatch run → advancing the standing S1 completion-first ▶ Next (clear assessed certs' offline punch-lists, Q-0209).

**Born-red** (Q-0133) — session card opens `in-progress`, flips to `complete` as the final step.

## Slices

- **PR 1 — Diagnostics punch #1 (hub completeness):** wire `startup` + `findings` into the `!platform` hub's Validation category select (+ audience-preserving `_dispatch` branches) so the panel's own honesty caveat ("startup/findings remain typed-only") becomes a closed gap — those surfaces become button-reachable, not typed-only.
- **PR 2 — Counters punch #3 (loop backoff):** per-guild cooldown/backoff so a persistently-failing guild sync isn't silently retried-and-failed forever.

CI mirror green + arch strict before each self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmbNDA7AZHhx7NCQY8uJzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmbNDA7AZHhx7NCQY8uJzh)_