### PR TITLE
Welcome: multiple / random greeting messages (completion deepening, punch-list #2)

### DIFF
--- a/.sessions/2026-06-30-welcome-random-messages.md
+++ b/.sessions/2026-06-30-welcome-random-messages.md
@@ -1,0 +1,17 @@
+# 2026-06-30 — Welcome multiple/random greeting messages (S1 completion deepening)
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Run type: `routine · dispatch`.
+
+**Branch:** `claude/funny-franklin-7y6goi`.
+
+## What I'm about to do (intentions)
+
+Dispatch run, no specific work order → advance the next S1 completion-first slice. Picked the
+**Welcome** unit's punch-list **#2** (best-in-class options): ship **multiple / random welcome
+messages** (Carl-bot / MEE6 / Dyno parity) — a discrete, additive, migration-free deepening.
+
+An operator can now define several greeting (and farewell) variants separated by a `---` line; the
+bot picks one at random per join/leave. Single-message config stays **byte-identical** (one variant =
+that message). No migration (the welcome settings are scalar KV values). Updates the validator to
+cap per-variant length + variant count, the cog status preview to show the variant count, and the
+welcome completion cert to mark #2 partially cleared.

--- a/.sessions/2026-06-30-welcome-random-messages.md
+++ b/.sessions/2026-06-30-welcome-random-messages.md
@@ -1,17 +1,113 @@
-# 2026-06-30 — Welcome multiple/random greeting messages (S1 completion deepening)
+# 2026-06-30 — Welcome random messages + opt-in DM greeting (S1 completion deepening)
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Run type: `routine · dispatch`.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: `routine · dispatch`.
+> Full CI mirror green (`check_quality.py --full` → **All checks passed ✓**, 13313+ pass; black/isort/
+> ruff + mypy clean; arch strict 0 new). PR #1579.
 
 **Branch:** `claude/funny-franklin-7y6goi`.
 
-## What I'm about to do (intentions)
+## What I did (intentions → shipped)
 
-Dispatch run, no specific work order → advance the next S1 completion-first slice. Picked the
-**Welcome** unit's punch-list **#2** (best-in-class options): ship **multiple / random welcome
-messages** (Carl-bot / MEE6 / Dyno parity) — a discrete, additive, migration-free deepening.
+Dispatch run, no specific work order → advanced the next S1 completion-first slice (Q-0209). Picked
+the **Welcome** unit's completion-cert punch-list **#2** (best-in-class options) and shipped **two**
+of its items in one cohesive batch:
 
-An operator can now define several greeting (and farewell) variants separated by a `---` line; the
-bot picks one at random per join/leave. Single-message config stays **byte-identical** (one variant =
-that message). No migration (the welcome settings are scalar KV values). Updates the validator to
-cap per-variant length + variant count, the cog status preview to show the variant count, and the
-welcome completion cert to mark #2 partially cleared.
+**1 · Multiple / random messages.** An operator stores several greeting / farewell / DM variants in
+one message setting, separated by a `---` line; the bot picks one **at random** per greeting
+(Carl-bot / MEE6 / Dyno parity).
+- `welcome_config.split_message_variants` + `pick_message` — pure, seeded-rng-testable; a value with
+  no `---` is a single variant → **byte-identical** for every existing config.
+- `welcome_service.format_join_embed` / `format_leave_embed` select a variant (`rng` injectable).
+- `_validate_message` now caps **per variant** length (≤500) + variant count (≤10).
+- `!welcome` status preview renders the first variant + a "1 of N random variants" note (never the
+  raw `---` separators).
+
+**2 · Opt-in DM greeting.** A new `dm_enabled` flag + dedicated `dm_message` template also DMs the
+joining member the greeting — **independent** of the channel greeting, **fail-safe on closed DMs**
+(`discord.Forbidden`/HTTP/any error swallowed → the join dispatch always completes). The DM body
+supports the same `---` random variants.
+- `WelcomePolicy.dm_on_join` predicate (needs only master + dm flag, no channel); folded into
+  `any_action_enabled`. `format_dm_embed` + `_send_dm`. New `dm_enabled`/`dm_message` SettingSpecs +
+  `WELCOME_DM_ENABLED`/`WELCOME_DM_MESSAGE` keys; defaults single-sourced in `welcome_config`.
+
+**Migration-free** throughout (welcome settings are scalar KV); DM off by default.
+
+## Files
+
+- `disbot/services/welcome_config.py` · `disbot/services/welcome_service.py`
+- `disbot/cogs/welcome/schemas.py` · `disbot/cogs/welcome_cog.py`
+- `disbot/utils/settings_keys/welcome.py` (+ `__init__.py` export)
+- Tests: `tests/unit/services/test_welcome_config.py` · `…/test_welcome_service.py` ·
+  `tests/unit/cogs/test_welcome_schemas.py` · **new** `tests/unit/cogs/test_welcome_cog.py` (+51
+  welcome tests total).
+- Docs/artifacts: welcome completion cert (#2 narrowed) · `current-state/S1-bot.md` recently-shipped ·
+  `settings-customization-command-map.md` (new keys) · regenerated `dashboard.json` / `site.json` /
+  `botsite/site/data.js` for the two new setting keys.
+
+## Why this is contained / safe
+
+Additive + default-off (DM off; a single message = one variant) → every existing guild renders
+byte-identically; no data backfill, no migration. All config still flows through the audited
+`SettingsMutationPipeline`; the DM send is read-only of the member and swallows every failure, so a
+DM that can't be delivered never affects the channel greeting, the entry-role grant, or the join
+dispatch. Architecture strict: 0 new violations.
+
+## Context delta
+
+- The welcome message settings are scalar KV (the module docstrings stress "no migration"), so the
+  variant feature is a pure render-time split on the existing field — no schema change. The validator
+  shift from a whole-value length cap to a **per-variant** cap is back-compatible (single message =
+  one variant, same gate).
+- **Wide blast radius caught by the full mirror:** adding two `settings_keys` reddened three things a
+  `--check-only` pass misses — `settings-customization-command-map.md` (a doc test asserts every
+  `WELCOME_*` constant + SettingSpec name appears), `dashboard.json` freshness, and the
+  `dashboard.json`/`site.json`/`data.js` sync tests. Fixed the doc + regenerated the artifacts with
+  `scripts/export_dashboard_data.py` (the intended path; BUG-0022 only stopped the *test suite* from
+  clobbering data.js, not the explicit export). **Lesson for next session: any new `settings_keys`
+  constant means "update the command-map doc + re-run `export_dashboard_data.py`" — run the *full*
+  mirror, not `--check-only`, when touching settings keys.**
+- **🛠 Friction → guard:** the doc-reference + artifact-freshness tests already *enforce* this
+  (they're why CI would have caught it) — no new guard needed; the existing checkers did their job.
+  The gap was purely my running `--check-only` first; noted above so the next session reaches for
+  `--full` on a settings-keys change.
+
+## 💡 Session idea (Q-0089)
+
+**Welcome "test greeting" button/command** — a `!welcome test` (or a button on the `!welcome` status
+embed) that fires the *actual* greeting pipeline once against the invoking admin (channel post + DM if
+enabled), so an operator can see a random variant land for real before a member ever joins. Closes the
+"I configured it but can't tell what it looks like live" gap that random variants make sharper (you
+can't eyeball which of 5 variants posts). Cheap: reuse `format_join_embed`/`format_dm_embed` +
+`_post`/`_send_dm` with the admin as the member. Dedup-checked `docs/ideas/` — no welcome-preview
+idea exists. Worth having: it's the live-walkthrough half of the Welcome cert (#5) turned into a
+self-serve operator tool, and generalizes to any greeting-style subsystem.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (PR #1571, reaction-roles "Who's in?" roster) was a clean, tightly-scoped
+owner-directed follow-on — good: read-only, no migration, gated on the same opt-in flag, +12 tests,
+honest about the truncation tail. One thing it *could* have done: the roster and the #1570 counter
+both compute over `guild.members`, and a "Who's in?" with hundreds of holders truncates to the field
+cap — the session noted it but didn't add a follow-up idea for a paginated roster. **System
+improvement it surfaces:** the completion-cert flow is working well for *deepening*, but the certs all
+sit at `◐` with **0 certified** because every one needs an owner live-walkthrough (#5/#6). My Q-0089
+idea above (a self-serve "test greeting" preview) is one concrete pattern to make the walkthrough
+half cheaper to assemble — worth generalizing: each unit cert could name a "how an agent can
+pre-stage the walkthrough evidence offline" line, shrinking the owner's step to a yes/no.
+
+## 📤 Run report footer
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1579 (Welcome random messages + opt-in DM greeting) — self-merge on green (small, contained,
+  default-off completion deepening; not a substantial plan step).
+- **Bugs:** none fixed/opened this run (no bug-book entries touched).
+- **⚑ Self-initiated:** Welcome completion-cert punch-list #2 (random messages + DM greeting) — no
+  dispatch payload named it; selected as the next S1 completion-first slice (idea→build is open,
+  Q-0172). Flagged here for owner review.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (migration-free; merge auto-deploys via Railway — no seed-data, no
+  restart).
+- **Next ▶:** Welcome cert #2 remainder — **join-delay age-gating** (skip greeting/role for accounts
+  younger than a configurable threshold; anti-raid, additive, default 0 = off) and **ping-then-delete**
+  (post the greeting then auto-delete after N seconds). Both discrete additive slices on the same
+  policy model; each its own PR. Cert: `docs/planning/feature-completion/units/welcome.md` punch-list.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T08:46:10Z",
+    "generated_at": "2026-06-30T12:22:28Z",
     "build": {
-      "commit": "097949e",
-      "subject": "PR1: BTD6 boss-fight estimator core (deterministic DPS/cost/kill-time)",
-      "committed_at": "2026-06-30T08:46:10Z"
+      "commit": "3b19ec12",
+      "subject": "Welcome: multiple/random greeting messages (completion punch-list #2)",
+      "committed_at": "2026-06-30T12:22:28Z"
     }
   },
   "counts": {
@@ -796,6 +796,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -842,6 +846,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -892,6 +900,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -940,6 +952,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1073,6 +1089,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1119,6 +1139,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1199,6 +1223,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1245,6 +1273,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1408,6 +1440,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1454,6 +1490,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1502,6 +1542,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1548,6 +1592,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1612,6 +1660,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1658,6 +1710,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1757,6 +1813,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1803,6 +1863,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -1915,6 +1979,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -1961,6 +2029,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -2069,6 +2141,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -2115,6 +2191,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -2182,6 +2262,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
         },
@@ -2228,6 +2312,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -2412,6 +2500,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "Frequency-driven preset suggestions from the review log",
           "status": "ideas"
@@ -4054,6 +4146,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4092,6 +4188,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -4134,6 +4234,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4173,6 +4277,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4211,6 +4319,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -4333,6 +4445,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4371,6 +4487,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -4411,6 +4531,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4450,6 +4574,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4488,6 +4616,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -4530,6 +4662,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4570,6 +4706,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -4612,6 +4752,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4652,6 +4796,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -4694,6 +4842,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -4734,6 +4886,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5043,6 +5199,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5081,6 +5241,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5121,6 +5285,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5159,6 +5327,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5286,6 +5458,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5324,6 +5500,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5435,6 +5615,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5473,6 +5657,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5513,6 +5701,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5551,6 +5743,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5593,6 +5789,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5632,6 +5832,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5670,6 +5874,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5877,6 +6085,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5915,6 +6127,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -5955,6 +6171,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -5994,6 +6214,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6033,6 +6257,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6071,6 +6299,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6111,6 +6343,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6149,6 +6385,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6189,6 +6429,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6227,6 +6471,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6267,6 +6515,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6305,6 +6557,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6345,6 +6601,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6384,6 +6644,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6422,6 +6686,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6497,6 +6765,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6536,6 +6808,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6574,6 +6850,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6658,6 +6938,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6696,6 +6980,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6736,6 +7024,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6775,6 +7067,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6813,6 +7109,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -6875,6 +7175,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6914,6 +7218,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -6952,6 +7260,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7049,6 +7361,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7087,6 +7403,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7127,6 +7447,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7166,6 +7490,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7205,6 +7533,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7243,6 +7575,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7283,6 +7619,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7321,6 +7661,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7361,6 +7705,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7400,6 +7748,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7439,6 +7791,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7477,6 +7833,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7571,6 +7931,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7610,6 +7974,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7648,6 +8016,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7825,6 +8197,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7864,6 +8240,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -7902,6 +8282,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -7966,6 +8350,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8005,6 +8393,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8043,6 +8435,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8158,6 +8554,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8196,6 +8596,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8236,6 +8640,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8275,6 +8683,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8314,6 +8726,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8352,6 +8768,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8392,6 +8812,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8431,6 +8855,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8469,6 +8897,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8509,6 +8941,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8547,6 +8983,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8586,6 +9026,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8642,6 +9086,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8680,6 +9128,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8742,6 +9194,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8781,6 +9237,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8820,6 +9280,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8858,6 +9322,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -8898,6 +9366,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8937,6 +9409,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -8975,6 +9451,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -9015,6 +9495,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9053,6 +9537,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -9093,6 +9581,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9131,6 +9623,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -9171,6 +9667,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9209,6 +9709,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -9249,6 +9753,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9288,6 +9796,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9326,6 +9838,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -9398,6 +9914,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9437,6 +9957,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9475,6 +9999,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
@@ -9537,6 +10065,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9576,6 +10108,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
+        {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"
         },
@@ -9614,6 +10150,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
+          "status": "ideas"
+        },
         {
           "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
           "status": "ideas"

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -282,6 +282,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -291,10 +295,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -314,6 +314,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -323,10 +327,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -370,6 +370,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -379,10 +383,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -426,6 +426,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -435,10 +439,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -672,6 +672,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -681,10 +685,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -702,6 +702,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -711,10 +715,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -734,6 +734,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -743,10 +747,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -766,6 +766,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -775,10 +779,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -798,6 +798,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -807,10 +811,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -830,6 +830,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -839,10 +843,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -862,6 +862,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -871,10 +875,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -1798,6 +1798,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -1807,10 +1811,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -1828,6 +1828,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -1837,10 +1841,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2062,6 +2062,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -2071,10 +2075,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -2266,6 +2266,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -2275,10 +2279,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2296,6 +2296,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -2305,10 +2309,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2326,6 +2326,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -2335,10 +2339,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2676,6 +2676,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -2685,10 +2689,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -2826,6 +2826,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -2835,10 +2839,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2884,6 +2884,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -2893,10 +2897,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -2988,6 +2988,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -2997,10 +3001,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -3158,6 +3158,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -3167,10 +3171,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -3188,6 +3188,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -3197,10 +3201,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -3285,6 +3285,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -3294,10 +3298,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -3797,6 +3797,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -3806,10 +3810,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -3887,6 +3887,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -3896,10 +3900,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -3981,6 +3981,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -3990,10 +3994,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -4063,6 +4063,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -4072,10 +4076,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -4179,6 +4179,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -4188,10 +4192,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -4229,6 +4229,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -4238,10 +4242,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -4274,6 +4274,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -4283,10 +4287,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -4322,6 +4322,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -4331,10 +4335,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -4675,6 +4675,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -4684,10 +4688,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -4723,6 +4723,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -4732,10 +4736,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -4883,6 +4883,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -4892,10 +4896,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -4984,6 +4984,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -4993,10 +4997,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5250,6 +5250,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -5259,10 +5263,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -5643,6 +5643,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5652,10 +5656,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5673,6 +5673,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5682,10 +5686,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5703,6 +5703,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5712,10 +5716,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5733,6 +5733,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5742,10 +5746,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5851,6 +5851,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -5860,10 +5864,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -5881,6 +5881,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5890,10 +5894,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5911,6 +5911,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5920,10 +5924,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5941,6 +5941,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5950,10 +5954,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -5971,6 +5971,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -5980,10 +5984,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -6001,6 +6001,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -6010,10 +6014,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -6031,6 +6031,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -6040,10 +6044,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -6148,6 +6148,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -6157,10 +6161,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -6395,6 +6395,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
       },
       {
@@ -6404,10 +6408,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — a generated \"deterministic floor catalogue\" index"
       }
     ]
   },
@@ -6825,6 +6825,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "\"Compute, don't refuse\" — a capability sweep over the review log"
+      },
+      {
+        "status": "idea",
         "title": "Frequency-driven preset suggestions from the review log"
       },
       {
@@ -6834,10 +6838,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
-      },
-      {
-        "status": "idea",
-        "title": "AI reports corrections → an audience-routed AI ticket service"
       }
     ]
   },
@@ -7171,7 +7171,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "097949e",
+    "build": "3b19ec12",
     "title": "New public bot website",
     "changes": [
       {
@@ -7183,7 +7183,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "097949e",
+    "build": "3b19ec12",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7195,7 +7195,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "097949e",
+    "build": "3b19ec12",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T11:29:23Z",
+    "generated_at": "2026-06-30T12:22:28Z",
     "build": {
-      "commit": "09fe4236",
-      "subject": "Merge pull request #1575 from menno420/claude/funny-franklin-d1m4wk",
-      "committed_at": "2026-06-30T11:29:23Z"
+      "commit": "3b19ec12",
+      "subject": "Welcome: multiple/random greeting messages (completion punch-list #2)",
+      "committed_at": "2026-06-30T12:22:28Z"
     },
     "counts": {
       "functions": 43,
@@ -16,9 +16,9 @@
       "env_vars": 39,
       "cogs": 55,
       "commands": 473,
-      "setting_keys": 108,
+      "setting_keys": 110,
       "setting_domains": 16,
-      "typed_settings": 88,
+      "typed_settings": 90,
       "visible_subsystems": 43,
       "synonyms": 87,
       "bot_changelog": 3
@@ -2676,6 +2676,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-06-30-welcome-random-messages.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — Welcome multiple/random greeting messages (S1 completion deepening)",
+      "status": "in-progress",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-30-reaction-roles-signup-counter.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — Reaction-roles live sign-up counter (S1 deepening)",
@@ -2716,6 +2724,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-30-btd6-track-lengths-rbs.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — BTD6 track lengths (Red Bloon Seconds) + estimator escape-margin",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-30-btd6-boss-fight-estimator.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — BTD6 boss-fight estimator (estimate, don't refuse)",
@@ -2727,6 +2743,14 @@
       "file": "2026-06-30-bot-owner-permissions-override.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — Bot-owner platform-admin override (full config authority in any guild)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-30-bot-owner-override-completeness.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — Bot-owner override: completeness follow-up (view gates + command decorators)",
       "status": "complete",
       "run_type": "",
       "self_initiated": true
@@ -3130,30 +3154,6 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-btd6-absence-guard-layer-b.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — BTD6 absence-guard Layer B (grounded-contradiction slice)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-audit-review-btd6-corpus.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — Reviewed the codex unfinished-work audit (PR #1509); shipped a BTD6 regression-corpus expansion",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-ai-answer-review-log.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — AI answer review-log (didn't-know + user corrections)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -3543,7 +3543,7 @@
       "usages": [
         {
           "file": "disbot/cogs/hermes_cog.py",
-          "line": 51,
+          "line": 52,
           "layer": "cogs",
           "has_default": true
         }
@@ -3559,7 +3559,7 @@
       "usages": [
         {
           "file": "disbot/cogs/hermes_cog.py",
-          "line": 49,
+          "line": 50,
           "layer": "cogs",
           "has_default": true
         }
@@ -3575,7 +3575,7 @@
       "usages": [
         {
           "file": "disbot/cogs/hermes_cog.py",
-          "line": 50,
+          "line": 51,
           "layer": "cogs",
           "has_default": true
         }
@@ -3591,7 +3591,7 @@
       "usages": [
         {
           "file": "disbot/cogs/hermes_cog.py",
-          "line": 52,
+          "line": 53,
           "layer": "cogs",
           "has_default": true
         }
@@ -10581,7 +10581,7 @@
           "constant": "WELCOME_JOIN_MESSAGE",
           "key": "welcome_join_message",
           "type": "str",
-          "hint": "Greeting template.  Placeholders: {user} (mention), {server} (name), {count} (member number).",
+          "hint": "Greeting template.  Placeholders: {user} (mention), {server} (name), {count} (member number).  Add several variants separated by a '---' line to greet joiners with a random one each time.",
           "allowed_values": [],
           "default": "👋 Welcome {user} to **{server}**! You're member #{count}."
         },
@@ -10589,7 +10589,7 @@
           "constant": "WELCOME_LEAVE_MESSAGE",
           "key": "welcome_leave_message",
           "type": "str",
-          "hint": "Farewell template.  Placeholders: {user} (name), {server} (name), {count} (remaining members).",
+          "hint": "Farewell template.  Placeholders: {user} (name), {server} (name), {count} (remaining members).  Add several variants separated by a '---' line to post a random one each time.",
           "allowed_values": [],
           "default": "👋 **{user}** has left {server}. We're now {count} members."
         },
@@ -10600,6 +10600,22 @@
           "hint": "Role granted the moment a member joins (e.g. a base Member role).  Leave unset for none.  Granted through moderation's audited role path.",
           "allowed_values": [],
           "default": ""
+        },
+        {
+          "constant": "WELCOME_DM_ENABLED",
+          "key": "welcome_dm_enabled",
+          "type": "bool",
+          "hint": "Also send the joining member a direct-message greeting (in addition to the channel greeting).  Off by default; needs no channel.  Silently skipped for members with DMs closed.",
+          "allowed_values": [],
+          "default": false
+        },
+        {
+          "constant": "WELCOME_DM_MESSAGE",
+          "key": "welcome_dm_message",
+          "type": "str",
+          "hint": "Direct-message greeting template.  Placeholders: {user} (mention), {server} (name), {count} (member number).  Add several variants separated by a '---' line to DM a random one each time.",
+          "allowed_values": [],
+          "default": "👋 Welcome to **{server}**, {user}! Glad to have you — you're member #{count}."
         },
         {
           "constant": "WELCOME_CARD_ENABLED",

--- a/disbot/cogs/welcome/schemas.py
+++ b/disbot/cogs/welcome/schemas.py
@@ -33,6 +33,8 @@ from services.welcome_config import (
     DEFAULT_LEAVE_ENABLED,
     DEFAULT_LEAVE_MESSAGE,
     MAX_MESSAGE_LENGTH,
+    MAX_MESSAGE_VARIANTS,
+    split_message_variants,
 )
 from utils.settings_keys import (
     WELCOME_CARD_ENABLED,
@@ -73,18 +75,30 @@ def _validate_id(value: object) -> None:
 
 
 def _validate_message(value: object) -> None:
-    """A non-empty template within the length cap.
+    """One or more non-empty variants, each within the per-variant length cap.
 
     Placeholders (``{user}``/``{server}``/``{count}``) are substituted at
     render time by ``welcome_config.render_template`` (injection-safe), so any
-    text is accepted here — only emptiness and length are gated.
+    text is accepted here — only emptiness, variant count, and per-variant
+    length are gated.  Multiple ``---``-separated variants are picked from at
+    random on each greeting; a single message (no separator) validates exactly
+    as before (one variant, capped at ``MAX_MESSAGE_LENGTH``).
     """
     if not isinstance(value, str):
         raise ValueError(f"expected a message template string, got {value!r}")
-    if not value.strip():
+    variants = split_message_variants(value)
+    if not variants:
         raise ValueError("message template cannot be empty")
-    if len(value) > MAX_MESSAGE_LENGTH:
-        raise ValueError(f"message template must be <= {MAX_MESSAGE_LENGTH} characters")
+    if len(variants) > MAX_MESSAGE_VARIANTS:
+        raise ValueError(
+            f"at most {MAX_MESSAGE_VARIANTS} message variants "
+            f"(separate them with a '---' line), got {len(variants)}",
+        )
+    for variant in variants:
+        if len(variant) > MAX_MESSAGE_LENGTH:
+            raise ValueError(
+                f"each message variant must be <= {MAX_MESSAGE_LENGTH} characters",
+            )
 
 
 WELCOME_SETTINGS: tuple[SettingSpec, ...] = (
@@ -140,7 +154,8 @@ WELCOME_SETTINGS: tuple[SettingSpec, ...] = (
         capability_required=_WELCOME_CAPABILITY,
         hint=(
             "Greeting template.  Placeholders: {user} (mention), {server} "
-            "(name), {count} (member number)."
+            "(name), {count} (member number).  Add several variants separated "
+            "by a '---' line to greet joiners with a random one each time."
         ),
         validator=_validate_message,
     ),
@@ -152,7 +167,8 @@ WELCOME_SETTINGS: tuple[SettingSpec, ...] = (
         capability_required=_WELCOME_CAPABILITY,
         hint=(
             "Farewell template.  Placeholders: {user} (name), {server} "
-            "(name), {count} (remaining members)."
+            "(name), {count} (remaining members).  Add several variants "
+            "separated by a '---' line to post a random one each time."
         ),
         validator=_validate_message,
     ),

--- a/disbot/cogs/welcome/schemas.py
+++ b/disbot/cogs/welcome/schemas.py
@@ -26,6 +26,8 @@ from core.runtime.subsystem_schema import (
 from services.welcome_config import (
     DEFAULT_CARD_ENABLED,
     DEFAULT_CHANNEL,
+    DEFAULT_DM_ENABLED,
+    DEFAULT_DM_MESSAGE,
     DEFAULT_ENABLED,
     DEFAULT_ENTRY_ROLE,
     DEFAULT_JOIN_ENABLED,
@@ -39,6 +41,8 @@ from services.welcome_config import (
 from utils.settings_keys import (
     WELCOME_CARD_ENABLED,
     WELCOME_CHANNEL,
+    WELCOME_DM_ENABLED,
+    WELCOME_DM_MESSAGE,
     WELCOME_ENABLED,
     WELCOME_ENTRY_ROLE,
     WELCOME_JOIN_ENABLED,
@@ -198,6 +202,32 @@ WELCOME_SETTINGS: tuple[SettingSpec, ...] = (
             "greeting when image rendering is unavailable."
         ),
         validator=_validate_bool,
+    ),
+    SettingSpec(
+        name="dm_enabled",
+        value_type=bool,
+        default=DEFAULT_DM_ENABLED,
+        settings_key=WELCOME_DM_ENABLED,
+        capability_required=_WELCOME_CAPABILITY,
+        hint=(
+            "Also send the joining member a direct-message greeting (in "
+            "addition to the channel greeting).  Off by default; needs no "
+            "channel.  Silently skipped for members with DMs closed."
+        ),
+        validator=_validate_bool,
+    ),
+    SettingSpec(
+        name="dm_message",
+        value_type=str,
+        default=DEFAULT_DM_MESSAGE,
+        settings_key=WELCOME_DM_MESSAGE,
+        capability_required=_WELCOME_CAPABILITY,
+        hint=(
+            "Direct-message greeting template.  Placeholders: {user} (mention), "
+            "{server} (name), {count} (member number).  Add several variants "
+            "separated by a '---' line to DM a random one each time."
+        ),
+        validator=_validate_message,
     ),
 )
 

--- a/disbot/cogs/welcome_cog.py
+++ b/disbot/cogs/welcome_cog.py
@@ -99,27 +99,35 @@ class WelcomeCog(commands.Cog):
             color=GENERAL_COLOR,
         )
         # Show the rendered templates with a sample member/count so the
-        # operator sees exactly what posts, placeholders expanded.
+        # operator sees exactly what posts, placeholders expanded.  When the
+        # message holds multiple "---"-separated variants, preview the first
+        # and note that one is chosen at random per greeting.
         sample_count = max(guild.member_count or 1, 1)
-        embed.add_field(
-            name="Join message preview",
-            value=welcome_config.render_template(
-                policy.join_message,
-                member_name="@NewMember",
+
+        def _preview(template: str, sample_name: str) -> tuple[str, str]:
+            variants = welcome_config.split_message_variants(template) or [template]
+            rendered = welcome_config.render_template(
+                variants[0],
+                member_name=sample_name,
                 guild_name=guild.name,
                 member_count=sample_count,
-            ),
+            )
+            suffix = (
+                f" (1 of {len(variants)} random variants)" if len(variants) > 1 else ""
+            )
+            return rendered, suffix
+
+        join_preview, join_suffix = _preview(policy.join_message, "@NewMember")
+        embed.add_field(
+            name=f"Join message preview{join_suffix}",
+            value=join_preview,
             inline=False,
         )
         if policy.leave_enabled:
+            leave_preview, leave_suffix = _preview(policy.leave_message, "NewMember")
             embed.add_field(
-                name="Leave message preview",
-                value=welcome_config.render_template(
-                    policy.leave_message,
-                    member_name="NewMember",
-                    guild_name=guild.name,
-                    member_count=sample_count,
-                ),
+                name=f"Leave message preview{leave_suffix}",
+                value=leave_preview,
                 inline=False,
             )
         embed.set_footer(text="Configure in !settings → Welcome.")

--- a/disbot/cogs/welcome_cog.py
+++ b/disbot/cogs/welcome_cog.py
@@ -90,6 +90,7 @@ class WelcomeCog(commands.Cog):
             "",
             f"👋 **Greet on join** — {_flag(policy.join_enabled)}",
             f"🚪 **Farewell on leave** — {_flag(policy.leave_enabled)}",
+            f"✉️ **DM on join** — {_flag(policy.dm_enabled)}",
             f"📢 **Channel:** {channel_str}",
             f"🎟️ **Entry role:** {role_str}",
         ]
@@ -128,6 +129,13 @@ class WelcomeCog(commands.Cog):
             embed.add_field(
                 name=f"Leave message preview{leave_suffix}",
                 value=leave_preview,
+                inline=False,
+            )
+        if policy.dm_enabled:
+            dm_preview, dm_suffix = _preview(policy.dm_message, "@NewMember")
+            embed.add_field(
+                name=f"DM message preview{dm_suffix}",
+                value=dm_preview,
                 inline=False,
             )
         embed.set_footer(text="Configure in !settings → Welcome.")

--- a/disbot/services/welcome_config.py
+++ b/disbot/services/welcome_config.py
@@ -57,6 +57,14 @@ DEFAULT_LEAVE_MESSAGE = "👋 **{user}** has left {server}. We're now {count} me
 # until an operator opts the card in.
 DEFAULT_CARD_ENABLED = False
 
+# DM greeting (completion punch-list #2): also send the joining member the
+# greeting as a direct message.  Off by default — needs no channel; supports
+# the same placeholders + "---" random variants as the channel greeting.
+DEFAULT_DM_ENABLED = False
+DEFAULT_DM_MESSAGE = (
+    "👋 Welcome to **{server}**, {user}! Glad to have you — you're member #{count}."
+)
+
 # Template length cap — keeps an embed description well within Discord's limit
 # even after placeholder expansion.  Applied **per variant** (see below): with
 # multiple random variants only one renders at a time, so each is capped, not
@@ -121,6 +129,8 @@ class WelcomePolicy:
     join_message: str = DEFAULT_JOIN_MESSAGE
     leave_message: str = DEFAULT_LEAVE_MESSAGE
     card_enabled: bool = DEFAULT_CARD_ENABLED
+    dm_enabled: bool = DEFAULT_DM_ENABLED
+    dm_message: str = DEFAULT_DM_MESSAGE
 
     @property
     def greet_on_join(self) -> bool:
@@ -143,9 +153,19 @@ class WelcomePolicy:
         return self.enabled and self.entry_role_id is not None
 
     @property
+    def dm_on_join(self) -> bool:
+        """True when a join should DM the member the greeting (no channel needed)."""
+        return self.enabled and self.dm_enabled
+
+    @property
     def any_action_enabled(self) -> bool:
         """True when at least one welcome action could fire (gated by enabled)."""
-        return self.greet_on_join or self.greet_on_leave or self.assigns_entry_role
+        return (
+            self.greet_on_join
+            or self.greet_on_leave
+            or self.assigns_entry_role
+            or self.dm_on_join
+        )
 
 
 def parse_id(raw: object) -> int | None:
@@ -234,6 +254,18 @@ async def load_policy(guild_id: int) -> WelcomePolicy:
         "card_enabled",
         DEFAULT_CARD_ENABLED,
     )
+    dm_enabled = await resolve_value(
+        guild_id,
+        SUBSYSTEM,
+        "dm_enabled",
+        DEFAULT_DM_ENABLED,
+    )
+    dm_message = await resolve_value(
+        guild_id,
+        SUBSYSTEM,
+        "dm_message",
+        DEFAULT_DM_MESSAGE,
+    )
 
     return WelcomePolicy(
         enabled=enabled,
@@ -244,12 +276,16 @@ async def load_policy(guild_id: int) -> WelcomePolicy:
         join_message=join_message,
         leave_message=leave_message,
         card_enabled=card_enabled,
+        dm_enabled=dm_enabled,
+        dm_message=dm_message,
     )
 
 
 __all__ = [
     "DEFAULT_CARD_ENABLED",
     "DEFAULT_CHANNEL",
+    "DEFAULT_DM_ENABLED",
+    "DEFAULT_DM_MESSAGE",
     "DEFAULT_ENABLED",
     "DEFAULT_ENTRY_ROLE",
     "DEFAULT_JOIN_ENABLED",

--- a/disbot/services/welcome_config.py
+++ b/disbot/services/welcome_config.py
@@ -26,6 +26,8 @@ imports are stdlib only.
 
 from __future__ import annotations
 
+import random
+import re
 from dataclasses import dataclass
 
 SUBSYSTEM = "welcome"
@@ -56,8 +58,50 @@ DEFAULT_LEAVE_MESSAGE = "👋 **{user}** has left {server}. We're now {count} me
 DEFAULT_CARD_ENABLED = False
 
 # Template length cap — keeps an embed description well within Discord's limit
-# even after placeholder expansion.
+# even after placeholder expansion.  Applied **per variant** (see below): with
+# multiple random variants only one renders at a time, so each is capped, not
+# the combined stored value.
 MAX_MESSAGE_LENGTH = 500
+
+# Multiple / random messages (completion punch-list #2): an operator may store
+# several greeting/farewell variants in one message setting, separated by a
+# line of three-or-more dashes (a markdown horizontal rule).  One variant is
+# chosen at random per join/leave, so a server can rotate its greeting.  A
+# single-variant value (the default, and every existing config) behaves
+# byte-identically — the lone variant is always the chosen one.
+MAX_MESSAGE_VARIANTS = 10
+
+# A separator line is solely three-or-more dashes (after stripping surrounding
+# whitespace), e.g. ``---``.  ``re.MULTILINE`` so ``^``/``$`` anchor each line.
+_VARIANT_SEPARATOR_RE = re.compile(r"^\s*-{3,}\s*$", re.MULTILINE)
+
+
+def split_message_variants(template: str) -> list[str]:
+    """Split a message setting into its non-empty, stripped variants.
+
+    Variants are separated by a ``---`` line (see :data:`_VARIANT_SEPARATOR_RE`).
+    Returns the real variants in order; an empty list when the value holds no
+    non-empty variant (only whitespace / bare separators) — the *write*-time
+    validator rejects that case, and :func:`pick_message` falls back to the raw
+    template so the render path stays fail-open.  A value with no separator
+    yields a single-element list, so existing single-message configs are
+    unchanged.
+    """
+    return [
+        part.strip() for part in _VARIANT_SEPARATOR_RE.split(template) if part.strip()
+    ]
+
+
+def pick_message(template: str, *, rng: random.Random | None = None) -> str:
+    """Choose one message variant at random (fail-open to the raw template).
+
+    With a single variant the choice is deterministic (that variant), so an
+    unchanged single-message config renders identically.  ``rng`` is injectable
+    for deterministic tests; production uses the module-global ``random``.
+    """
+    variants = split_message_variants(template) or [template]
+    chooser = rng if rng is not None else random
+    return chooser.choice(variants)
 
 
 @dataclass(frozen=True)
@@ -213,8 +257,11 @@ __all__ = [
     "DEFAULT_LEAVE_ENABLED",
     "DEFAULT_LEAVE_MESSAGE",
     "MAX_MESSAGE_LENGTH",
+    "MAX_MESSAGE_VARIANTS",
     "WelcomePolicy",
     "load_policy",
     "parse_id",
+    "pick_message",
     "render_template",
+    "split_message_variants",
 ]

--- a/disbot/services/welcome_service.py
+++ b/disbot/services/welcome_service.py
@@ -23,6 +23,7 @@ The cog (:mod:`cogs.welcome_cog`) is glue: it filters bots and delegates to
 from __future__ import annotations
 
 import logging
+import random
 from typing import Any
 
 import discord
@@ -48,10 +49,17 @@ def format_join_embed(
     member: discord.Member,
     policy: welcome_config.WelcomePolicy,
     member_count: int,
+    *,
+    rng: random.Random | None = None,
 ) -> discord.Embed:
-    """Build the greeting embed for a joining ``member``."""
+    """Build the greeting embed for a joining ``member``.
+
+    When the join message holds multiple ``---``-separated variants, one is
+    chosen at random (``rng`` injectable for deterministic tests); a
+    single-variant message renders identically.
+    """
     description = welcome_config.render_template(
-        policy.join_message,
+        welcome_config.pick_message(policy.join_message, rng=rng),
         member_name=member.mention,
         guild_name=member.guild.name,
         member_count=member_count,
@@ -67,14 +75,18 @@ def format_leave_embed(
     member: discord.Member,
     policy: welcome_config.WelcomePolicy,
     member_count: int,
+    *,
+    rng: random.Random | None = None,
 ) -> discord.Embed:
     """Build the farewell embed for a departing ``member``.
 
     Uses the plain name (not a mention) — the member has left, so a mention
     would render as a raw id for anyone who never shared a mutual server.
+    Multiple ``---``-separated farewell variants pick one at random (``rng``
+    injectable for tests); a single-variant message renders identically.
     """
     description = welcome_config.render_template(
-        policy.leave_message,
+        welcome_config.pick_message(policy.leave_message, rng=rng),
         member_name=member.display_name,
         guild_name=member.guild.name,
         member_count=member_count,

--- a/disbot/services/welcome_service.py
+++ b/disbot/services/welcome_service.py
@@ -71,6 +71,28 @@ def format_join_embed(
     return embed
 
 
+def format_dm_embed(
+    member: discord.Member,
+    policy: welcome_config.WelcomePolicy,
+    member_count: int,
+    *,
+    rng: random.Random | None = None,
+) -> discord.Embed:
+    """Build the direct-message greeting embed for a joining ``member``.
+
+    Mirrors :func:`format_join_embed` but renders the dedicated ``dm_message``
+    template (which supports the same ``---`` random variants).  No avatar
+    thumbnail — a DM already shows the recipient who they are.
+    """
+    description = welcome_config.render_template(
+        welcome_config.pick_message(policy.dm_message, rng=rng),
+        member_name=member.mention,
+        guild_name=member.guild.name,
+        member_count=member_count,
+    )
+    return discord.Embed(description=description, color=_JOIN_COLOR)
+
+
 def format_leave_embed(
     member: discord.Member,
     policy: welcome_config.WelcomePolicy,
@@ -162,6 +184,26 @@ async def _post(
     return True
 
 
+async def _send_dm(member: discord.Member, embed: discord.Embed) -> None:
+    """DM the joining ``member`` the greeting — fail-safe (logs, never raises).
+
+    A closed-DM member raises :class:`discord.Forbidden`; that (and any other
+    send fault) is swallowed so a DM that can't be delivered never affects the
+    channel greeting, the entry-role grant, or the join dispatch.
+    """
+    try:
+        await member.send(embed=embed)
+    except discord.Forbidden:
+        logger.info(
+            "welcome: member %s has DMs closed — skipping DM greeting",
+            member.id,
+        )
+    except discord.HTTPException as exc:
+        logger.warning("welcome: HTTP error sending DM greeting: %s", exc)
+    except Exception:  # noqa: BLE001 — fail-safe wrapper
+        logger.exception("welcome: unexpected error sending DM greeting")
+
+
 async def _grant_entry_role(member: discord.Member, role_id: int) -> None:
     """Grant the entry role through the audited role-automation seam.
 
@@ -226,10 +268,10 @@ async def _emit_greeted(member: discord.Member) -> None:
 async def handle_member_join(member: discord.Member) -> None:
     """Greet a joining member + grant the entry role, per the guild policy.
 
-    Fully fail-safe: a fault loading the policy, granting the role, or posting
-    the greeting is logged and swallowed so the join dispatch always completes.
-    The two actions are independent — a role-grant failure does not skip the
-    greeting and vice versa.
+    Fully fail-safe: a fault loading the policy, granting the role, posting the
+    channel greeting, or sending the optional DM greeting is logged and
+    swallowed so the join dispatch always completes.  The actions are
+    independent — any one failing does not skip the others.
     """
     guild = getattr(member, "guild", None)
     if guild is None:
@@ -246,10 +288,13 @@ async def handle_member_join(member: discord.Member) -> None:
     if policy.assigns_entry_role and policy.entry_role_id is not None:
         await _grant_entry_role(member, policy.entry_role_id)
 
+    # The channel greeting and the optional DM greeting are independent — a
+    # member with closed DMs still gets the channel greeting and vice versa.
+    count = _member_count(guild)
+
     if policy.greet_on_join:
         channel = _resolve_text_channel(guild, policy.channel_id)
         if channel is not None:
-            count = _member_count(guild)
             embed = format_join_embed(member, policy, count)
             file: discord.File | None = None
             if policy.show_join_card:
@@ -258,6 +303,9 @@ async def handle_member_join(member: discord.Member) -> None:
                     embed.set_image(url=f"attachment://{_WELCOME_CARD_FILENAME}")
             if await _post(channel, embed, file):
                 await _emit_greeted(member)
+
+    if policy.dm_on_join:
+        await _send_dm(member, format_dm_embed(member, policy, count))
 
 
 async def handle_member_leave(member: discord.Member) -> None:

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -138,6 +138,8 @@ from utils.settings_keys.security import (
 from utils.settings_keys.welcome import (
     WELCOME_CARD_ENABLED,
     WELCOME_CHANNEL,
+    WELCOME_DM_ENABLED,
+    WELCOME_DM_MESSAGE,
     WELCOME_ENABLED,
     WELCOME_ENTRY_ROLE,
     WELCOME_JOIN_ENABLED,
@@ -251,6 +253,8 @@ __all__ = [
     "WARN_TIMEOUT_MINS",
     "WELCOME_CARD_ENABLED",
     "WELCOME_CHANNEL",
+    "WELCOME_DM_ENABLED",
+    "WELCOME_DM_MESSAGE",
     "WELCOME_ENABLED",
     "WELCOME_ENTRY_ROLE",
     "WELCOME_JOIN_ENABLED",

--- a/disbot/utils/settings_keys/welcome.py
+++ b/disbot/utils/settings_keys/welcome.py
@@ -32,6 +32,13 @@ WELCOME_LEAVE_MESSAGE = "welcome_leave_message"
 # Optional entry role granted on join — a role id (str).  Empty grants none.
 WELCOME_ENTRY_ROLE = "welcome_entry_role"
 
+# Optional DM greeting — when on, the joining member is also sent the greeting
+# as a direct message (in addition to / independent of the channel greeting).
+# Off by default; needs no channel.  The DM body supports the same
+# {user}/{server}/{count} placeholders and the same "---" random variants.
+WELCOME_DM_ENABLED = "welcome_dm_enabled"
+WELCOME_DM_MESSAGE = "welcome_dm_message"
+
 # Welcome phase 2 (Q-0110): attach a rendered PIL greeting card to the join
 # embed.  Off by default; degrades to embed-only when Pillow is unavailable.
 WELCOME_CARD_ENABLED = "welcome_card_enabled"

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -196,6 +196,16 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   (punch #2 — apply `_PaginatorView` to long findings/consistency output) + #5 (health-metrics
   reconcile) · Cleanup #4 (spam-window setting *with* a Settings widget). *(Counters punch
   #1/#2/#4/#5 ✅ #1568; #3 ✅ #1575.)*
+  **✅ DONE 2026-06-30 (#1579): Welcome punch #2 (best-in-class options) — 2 of 4 CLOSED.**
+  **Multiple/random messages** (`---`-separated variants on the join/leave/DM message, one picked at
+  random per greeting — pure `welcome_config.split_message_variants`/`pick_message`; validator caps
+  per-variant length + ≤10 variants; `!welcome` preview shows "1 of N random variants") **+ opt-in DM
+  greeting** (`dm_enabled`/`dm_message`, fail-safe on closed DMs, independent of the channel greeting).
+  Migration-free, default-off, byte-identical for existing configs; +51 welcome tests. **▶ Next
+  turn-key picks (Welcome #2 remainder):** **join-delay age-gating** (skip greeting/role for accounts
+  younger than a configurable threshold — anti-raid, additive, default 0 = off) + **ping-then-delete**
+  (post then auto-delete after N seconds). Each its own PR on the same policy model. (Welcome #1
+  bespoke panel + #3 binding-seam + #4 cog-tests + #5/#6 owner walkthrough still open.)
 - `[owner]` **Feature-completion assessments — ALL 36 UNITS ◐ ASSESSED (100%; 0 certified).** The
   completion-first arc (Q-0209). The `▢ → ◐` assessment sweep is **COMPLETE** — every game + server-fn
   now has a rubric-filled, source-grounded certificate under

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,18 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Welcome — random greeting messages + opt-in DM greeting** (PR #1579, completion-first deepening,
+  Welcome cert punch-list #2) — two best-in-class options in one batch (Carl-bot / MEE6 / Dyno parity).
+  **(1) Multiple/random messages:** an operator stores several greeting / farewell / DM variants in one
+  message setting separated by a `---` line; the bot picks one **at random** per greeting (pure
+  `welcome_config.split_message_variants` / `pick_message`, seeded-rng-testable; embed builders select a
+  variant; validator caps per-variant length + ≤10 variants; `!welcome` preview shows "1 of N random
+  variants"). **(2) DM greeting:** opt-in `dm_enabled` + dedicated `dm_message` also DMs the joiner the
+  greeting — independent of the channel greeting, **fail-safe on closed DMs** (`discord.Forbidden`
+  swallowed). **Migration-free** (welcome settings are scalar KV) and **byte-identical** for every
+  existing config (single message = one variant; DM off by default). +51 welcome tests; regenerated
+  dashboard/site artifacts + command-map doc for the new keys; self-merge on green. Welcome cert #2
+  narrowed (remaining: join-delay age-gating · ping-then-delete).
 - **Reaction-roles RSVP roster ("Who's in?")** (PR #1571, owner-directed follow-on to #1570) — counted
   menus gain a persistent **👥 Who's in?** button that posts an **ephemeral** roster listing the members
   who currently hold each option (`build_roster_embed` in `role_menu_counter`; member names truncated to

--- a/docs/owner/claims/claude-funny-franklin-7y6goi.md
+++ b/docs/owner/claims/claude-funny-franklin-7y6goi.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-7y6goi` · scope: Welcome completion-first deepening (multiple/random greeting messages, punch-list #2) · area: `disbot/services/welcome_*`, `disbot/cogs/welcome*`, tests · 2026-06-30

--- a/docs/owner/claims/claude-funny-franklin-7y6goi.md
+++ b/docs/owner/claims/claude-funny-franklin-7y6goi.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-7y6goi` · scope: Welcome completion-first deepening (multiple/random greeting messages, punch-list #2) · area: `disbot/services/welcome_*`, `disbot/cogs/welcome*`, tests · 2026-06-30

--- a/docs/planning/feature-completion/units/welcome.md
+++ b/docs/planning/feature-completion/units/welcome.md
@@ -26,10 +26,12 @@
 - [x] **Core promise delivered** — join greeting + leave farewell (embed, avatar thumbnail, placeholder
       template) + optional entry-role grant (`welcome_service.py` `handle_member_join`/`handle_member_leave`/
       `_grant_entry_role`). Bots filtered at the listener (`welcome_cog.py:48`).
-- [ ] **Every best-in-class sub-option exists** — ❌ **partial.** Has: channel greeting, farewell,
-      autorole, custom template (3 placeholders `{user}/{server}/{count}`), embed, image card (phase 2).
-      **Missing vs Carl-bot/MEE6/Dyno:** DM greeting variant · multiple/random welcome messages ·
-      ping-then-delete · join-delay age-gating. → punch-list #2.
+- [ ] **Every best-in-class sub-option exists** — ◐ **partial (narrowing).** Has: channel greeting,
+      farewell, autorole, custom template (3 placeholders `{user}/{server}/{count}`), embed, image card
+      (phase 2), **multiple/random welcome+farewell messages** (`---`-separated variants, one picked at
+      random per greeting — `welcome_config.split_message_variants`/`pick_message`, 2026-06-30).
+      **Still missing vs Carl-bot/MEE6/Dyno:** DM greeting variant · ping-then-delete · join-delay
+      age-gating. → punch-list #2 (remainder).
 - [x] **Failure modes honest / fail-safe** — no channel → suppress greeting (entry-role still
       proceeds); send `Forbidden`/`HTTPException` classified + logged, never raised; policy-load fault
       caught + swallowed; unknown placeholders render literally (injection-safe `str.replace`,
@@ -114,9 +116,11 @@
    `!settings` · back to Community/Help), so Welcome matches the server-fn panel bar instead of
    relying on the generic settings group. *(Or the owner waives this — the settings group + setup step
    may be deemed sufficient for an admin-tier config function.)*
-2. **Best-in-class options (rubric A)** *(owner-paced, deepening)* — DM greeting variant · multiple /
-   random welcome messages · join-delay age-gating · ping-then-delete. Each is a discrete additive
-   slice on the existing policy model.
+2. **Best-in-class options (rubric A)** *(owner-paced, deepening)* — ~~multiple / random welcome
+   messages~~ ✅ **shipped 2026-06-30** (PR #1579 — `---`-separated variants on both the join and leave
+   message, one chosen at random per greeting; migration-free, single-message configs byte-identical).
+   **Remaining:** DM greeting variant · join-delay age-gating · ping-then-delete. Each is a discrete
+   additive slice on the existing policy model.
 3. **Channel/role via the binding pipeline** *(offline, consistency)* — consider routing the channel +
    entry-role pointers through `BindingMutationPipeline` (the canonical resource-pointer seam) rather
    than id-bearing settings specs.

--- a/docs/planning/feature-completion/units/welcome.md
+++ b/docs/planning/feature-completion/units/welcome.md
@@ -28,10 +28,11 @@
       `_grant_entry_role`). Bots filtered at the listener (`welcome_cog.py:48`).
 - [ ] **Every best-in-class sub-option exists** — ◐ **partial (narrowing).** Has: channel greeting,
       farewell, autorole, custom template (3 placeholders `{user}/{server}/{count}`), embed, image card
-      (phase 2), **multiple/random welcome+farewell messages** (`---`-separated variants, one picked at
-      random per greeting — `welcome_config.split_message_variants`/`pick_message`, 2026-06-30).
-      **Still missing vs Carl-bot/MEE6/Dyno:** DM greeting variant · ping-then-delete · join-delay
-      age-gating. → punch-list #2 (remainder).
+      (phase 2), **multiple/random welcome+farewell+DM messages** (`---`-separated variants, one picked
+      at random per greeting — `welcome_config.split_message_variants`/`pick_message`, 2026-06-30), and
+      an **opt-in DM greeting** (`dm_enabled`/`dm_message`, fail-safe on closed DMs — 2026-06-30).
+      **Still missing vs Carl-bot/MEE6/Dyno:** ping-then-delete · join-delay age-gating. → punch-list
+      #2 (remainder).
 - [x] **Failure modes honest / fail-safe** — no channel → suppress greeting (entry-role still
       proceeds); send `Forbidden`/`HTTPException` classified + logged, never raised; policy-load fault
       caught + swallowed; unknown placeholders render literally (injection-safe `str.replace`,
@@ -117,9 +118,11 @@
    relying on the generic settings group. *(Or the owner waives this — the settings group + setup step
    may be deemed sufficient for an admin-tier config function.)*
 2. **Best-in-class options (rubric A)** *(owner-paced, deepening)* — ~~multiple / random welcome
-   messages~~ ✅ **shipped 2026-06-30** (PR #1579 — `---`-separated variants on both the join and leave
-   message, one chosen at random per greeting; migration-free, single-message configs byte-identical).
-   **Remaining:** DM greeting variant · join-delay age-gating · ping-then-delete. Each is a discrete
+   messages~~ ✅ **shipped 2026-06-30** (PR #1579 — `---`-separated variants on the join, leave **and**
+   DM message, one chosen at random per greeting; migration-free, single-message configs
+   byte-identical) · ~~DM greeting~~ ✅ **shipped 2026-06-30** (PR #1579 — opt-in `dm_enabled` +
+   dedicated `dm_message`; DMs the joiner the greeting, fail-safe on closed DMs, independent of the
+   channel greeting). **Remaining:** join-delay age-gating · ping-then-delete. Each is a discrete
    additive slice on the existing policy model.
 3. **Channel/role via the binding pipeline** *(offline, consistency)* — consider routing the channel +
    entry-role pointers through `BindingMutationPipeline` (the canonical resource-pointer seam) rather

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -999,14 +999,19 @@ through `services/role_automation.py` (audited — no parallel role/audit path).
 8. **help_menu_direct_navigation_hook**: `build_help_menu_view` (policy summary).
 9. **existing_SettingSpec_declarations**: `enabled`, `join_enabled`,
    `leave_enabled`, `channel`, `join_message`, `leave_message`, `entry_role`,
-   `card_enabled` (`disbot/cogs/welcome/schemas.py`). The master flag defaults
-   OFF; defaults are the single source of truth in
+   `card_enabled`, `dm_enabled`, `dm_message` (`disbot/cogs/welcome/schemas.py`).
+   The master flag defaults OFF; defaults are the single source of truth in
    `disbot/services/welcome_config.py`. `card_enabled` is the welcome **phase 2**
    (Q-0110) toggle — attaches a rendered PIL greeting card to the join embed,
-   off by default, degrading to embed-only when Pillow is unavailable.
+   off by default, degrading to embed-only when Pillow is unavailable. The
+   `join_message`/`leave_message`/`dm_message` templates accept multiple
+   `---`-separated **random variants** (one picked per greeting); `dm_enabled`
+   also DMs the joiner the greeting (off by default, silently skipped when DMs
+   are closed).
 10. **existing_settings_keys**: `WELCOME_ENABLED`, `WELCOME_JOIN_ENABLED`,
     `WELCOME_LEAVE_ENABLED`, `WELCOME_CHANNEL`, `WELCOME_JOIN_MESSAGE`,
-    `WELCOME_LEAVE_MESSAGE`, `WELCOME_ENTRY_ROLE`, `WELCOME_CARD_ENABLED`
+    `WELCOME_LEAVE_MESSAGE`, `WELCOME_ENTRY_ROLE`, `WELCOME_CARD_ENABLED`,
+    `WELCOME_DM_ENABLED`, `WELCOME_DM_MESSAGE`
     (`disbot/utils/settings_keys/welcome.py`). Stored as scalar guild settings —
     **no migration**. The `channel`/`entry_role` settings carry
     `input_hint="channel"`/`"role"` (channel-id-as-str duality).

--- a/tests/unit/cogs/test_welcome_cog.py
+++ b/tests/unit/cogs/test_welcome_cog.py
@@ -57,6 +57,25 @@ def test_policy_embed_multi_variant_shows_count_and_first_variant():
     assert "---" not in field.value
 
 
+def test_policy_embed_shows_dm_preview_when_dm_enabled():
+    policy = WelcomePolicy(
+        enabled=True,
+        dm_enabled=True,
+        dm_message="DM hi {user}",
+    )
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    field = _field_by_name_prefix(embed, "DM message preview")
+    assert field.value == "DM hi @NewMember"
+    # DM on/off is surfaced in the status body.
+    assert "DM on join" in embed.description
+
+
+def test_policy_embed_no_dm_preview_when_dm_disabled():
+    policy = WelcomePolicy(enabled=True, dm_enabled=False)
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    assert not any(f.name.startswith("DM message preview") for f in embed.fields)
+
+
 def test_policy_embed_leave_variant_note_when_leave_enabled():
     policy = WelcomePolicy(
         enabled=True,

--- a/tests/unit/cogs/test_welcome_cog.py
+++ b/tests/unit/cogs/test_welcome_cog.py
@@ -1,0 +1,69 @@
+"""Unit tests for the welcome cog status surface (cogs.welcome_cog).
+
+Focused on ``_policy_embed`` — the read-only status preview rendered by
+``!welcome`` and the Help hook — and specifically the multiple/random-message
+preview (completion punch-list #2): the preview shows the **first** variant with
+a "1 of N random variants" note instead of dumping the raw separator-laden value.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import discord
+
+from cogs.welcome_cog import WelcomeCog
+from services.welcome_config import WelcomePolicy
+
+
+def _guild() -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.id = 1
+    g.name = "Demo"
+    g.member_count = 1235
+    g.get_channel.return_value = None
+    g.get_role.return_value = None
+    return g
+
+
+def _field_by_name_prefix(
+    embed: discord.Embed, prefix: str
+) -> discord.embeds.EmbedProxy:
+    for field in embed.fields:
+        if field.name.startswith(prefix):
+            return field
+    raise AssertionError(f"no field starting with {prefix!r}")
+
+
+def test_policy_embed_single_message_has_no_variant_note():
+    policy = WelcomePolicy(enabled=True, join_message="Welcome {user}!")
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    field = _field_by_name_prefix(embed, "Join message preview")
+    # A single message: no "random variants" suffix, placeholders expanded.
+    assert field.name == "Join message preview"
+    assert field.value == "Welcome @NewMember!"
+
+
+def test_policy_embed_multi_variant_shows_count_and_first_variant():
+    policy = WelcomePolicy(
+        enabled=True,
+        join_message="First {user}\n---\nSecond {user}\n---\nThird {user}",
+    )
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    field = _field_by_name_prefix(embed, "Join message preview")
+    assert field.name == "Join message preview (1 of 3 random variants)"
+    # Shows the FIRST variant rendered — never the raw "---" separators.
+    assert field.value == "First @NewMember"
+    assert "---" not in field.value
+
+
+def test_policy_embed_leave_variant_note_when_leave_enabled():
+    policy = WelcomePolicy(
+        enabled=True,
+        leave_enabled=True,
+        leave_message="Bye {user}\n---\nFarewell {user}",
+    )
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    field = _field_by_name_prefix(embed, "Leave message preview")
+    assert field.name == "Leave message preview (1 of 2 random variants)"
+    assert field.value == "Bye NewMember"

--- a/tests/unit/cogs/test_welcome_schemas.py
+++ b/tests/unit/cogs/test_welcome_schemas.py
@@ -47,6 +47,8 @@ _EXPECTED_DEFAULTS = {
     "leave_message": welcome_config.DEFAULT_LEAVE_MESSAGE,
     "entry_role": welcome_config.DEFAULT_ENTRY_ROLE,
     "card_enabled": welcome_config.DEFAULT_CARD_ENABLED,
+    "dm_enabled": welcome_config.DEFAULT_DM_ENABLED,
+    "dm_message": welcome_config.DEFAULT_DM_MESSAGE,
 }
 
 

--- a/tests/unit/cogs/test_welcome_schemas.py
+++ b/tests/unit/cogs/test_welcome_schemas.py
@@ -103,6 +103,39 @@ def test_message_validator_rejects_empty_and_overlong():
         validator("x" * (welcome_config.MAX_MESSAGE_LENGTH + 1))
 
 
+def test_message_validator_accepts_multiple_variants():
+    from cogs.welcome.schemas import WELCOME_SETTINGS
+
+    validator = {s.name: s for s in WELCOME_SETTINGS}["join_message"].validator
+    # Several "---"-separated variants are valid (random-greeting feature).
+    validator("Hi {user}\n---\nWelcome {user}\n---\nHey {user}")
+
+
+def test_message_validator_caps_variant_count():
+    from cogs.welcome.schemas import WELCOME_SETTINGS
+
+    validator = {s.name: s for s in WELCOME_SETTINGS}["join_message"].validator
+    too_many = "\n---\n".join(
+        f"msg {i}" for i in range(welcome_config.MAX_MESSAGE_VARIANTS + 1)
+    )
+    with pytest.raises(ValueError):
+        validator(too_many)
+
+
+def test_message_validator_caps_each_variant_length():
+    from cogs.welcome.schemas import WELCOME_SETTINGS
+
+    validator = {s.name: s for s in WELCOME_SETTINGS}["join_message"].validator
+    # The combined value is long, but each variant is within the per-variant
+    # cap → accepted (the cap is per variant, since only one renders at a time).
+    ok = "\n---\n".join(["x" * welcome_config.MAX_MESSAGE_LENGTH] * 3)
+    validator(ok)
+    # One over-long variant is still rejected.
+    bad = "fine\n---\n" + "x" * (welcome_config.MAX_MESSAGE_LENGTH + 1)
+    with pytest.raises(ValueError):
+        validator(bad)
+
+
 def test_bool_validator_guards_non_bool():
     from cogs.welcome.schemas import WELCOME_SETTINGS
 

--- a/tests/unit/services/test_welcome_config.py
+++ b/tests/unit/services/test_welcome_config.py
@@ -65,6 +65,17 @@ def test_action_predicates_require_master_and_resource():
     assert role_only.any_action_enabled
     assert not role_only.greet_on_join
 
+    # DM greeting needs only the master + dm flag (no channel) and counts as an
+    # action on its own.
+    dm_only = WelcomePolicy(enabled=True, join_enabled=False, dm_enabled=True)
+    assert dm_only.dm_on_join
+    assert dm_only.any_action_enabled
+    assert not dm_only.greet_on_join
+    # Master off → DM suppressed like every other action.
+    assert not WelcomePolicy(enabled=False, dm_enabled=True).dm_on_join
+    # DM defaults off.
+    assert not WelcomePolicy(enabled=True).dm_on_join
+
 
 def test_defaults_master_off_join_on():
     pol = WelcomePolicy()

--- a/tests/unit/services/test_welcome_config.py
+++ b/tests/unit/services/test_welcome_config.py
@@ -119,3 +119,68 @@ async def test_load_policy_blank_channel_degrades_to_none(monkeypatch):
     pol = await welcome_config.load_policy(guild_id=1)
     assert pol.channel_id is None
     assert not pol.greet_on_join  # no destination → no greeting
+
+
+# ---------------------------------------------------------------------------
+# Multiple / random messages (completion punch-list #2)
+# ---------------------------------------------------------------------------
+
+
+def test_split_message_variants_single_message_is_one_variant():
+    # No separator → exactly the one message, unchanged (back-compat).
+    assert welcome_config.split_message_variants("Welcome {user}!") == [
+        "Welcome {user}!"
+    ]
+
+
+def test_split_message_variants_splits_on_dash_rule_and_strips():
+    raw = "Hey {user}!\n---\nWelcome aboard {user}\n-----\n  Glad you're here  "
+    assert welcome_config.split_message_variants(raw) == [
+        "Hey {user}!",
+        "Welcome aboard {user}",
+        "Glad you're here",
+    ]
+
+
+def test_split_message_variants_drops_empty_blocks_and_bare_separators():
+    # Whitespace-only / separator-only blocks are not real variants.
+    assert welcome_config.split_message_variants("   \n---\n---\n  ") == []
+    # A dash line inside otherwise-empty text yields no variants.
+    assert welcome_config.split_message_variants("---") == []
+
+
+def test_split_message_variants_requires_three_dashes():
+    # A two-dash line is content, not a separator.
+    assert welcome_config.split_message_variants("a\n--\nb") == ["a\n--\nb"]
+
+
+def test_pick_message_single_variant_is_deterministic():
+    import random
+
+    # One variant → always that variant, regardless of rng.
+    for seed in range(5):
+        assert (
+            welcome_config.pick_message("only one", rng=random.Random(seed))
+            == "only one"
+        )
+
+
+def test_pick_message_chooses_among_variants_with_seeded_rng():
+    import random
+
+    raw = "one\n---\ntwo\n---\nthree"
+    variants = {
+        welcome_config.pick_message(raw, rng=random.Random(s)) for s in range(20)
+    }
+    # Every pick is a real variant…
+    assert variants <= {"one", "two", "three"}
+    # …and across seeds we see more than one (it actually randomises).
+    assert len(variants) > 1
+
+
+def test_pick_message_fails_open_on_empty_template():
+    import random
+
+    # Degenerate value (no real variants) → returns the raw template, never
+    # raises, so the render path stays fail-open.
+    assert welcome_config.pick_message("---", rng=random.Random(0)) == "---"

--- a/tests/unit/services/test_welcome_service.py
+++ b/tests/unit/services/test_welcome_service.py
@@ -62,6 +62,40 @@ def test_leave_embed_uses_plain_name():
     assert embed.description == "Astro left Demo"
 
 
+def test_join_embed_picks_a_random_variant():
+    import random
+
+    member = _member()
+    policy = WelcomePolicy(
+        join_message="Hi {user}\n---\nWelcome {user}\n---\nHey {user}"
+    )
+    # Every render is one of the variants, placeholders expanded…
+    rendered = {
+        welcome_service.format_join_embed(
+            member, policy, 1, rng=random.Random(s)
+        ).description
+        for s in range(20)
+    }
+    assert rendered <= {"Hi <@200>", "Welcome <@200>", "Hey <@200>"}
+    # …and it genuinely varies across seeds.
+    assert len(rendered) > 1
+
+
+def test_leave_embed_picks_a_random_variant():
+    import random
+
+    member = _member()
+    policy = WelcomePolicy(leave_message="Bye {user}\n---\nFarewell {user}")
+    rendered = {
+        welcome_service.format_leave_embed(
+            member, policy, 1, rng=random.Random(s)
+        ).description
+        for s in range(20)
+    }
+    assert rendered <= {"Bye Astro", "Farewell Astro"}
+    assert len(rendered) > 1
+
+
 # ---------------------------------------------------------------------------
 # handle_member_join
 # ---------------------------------------------------------------------------
@@ -124,7 +158,9 @@ async def test_join_grants_entry_role(monkeypatch):
         welcome_service.welcome_config,
         "load_policy",
         AsyncMock(
-            return_value=WelcomePolicy(enabled=True, join_enabled=False, entry_role_id=777),
+            return_value=WelcomePolicy(
+                enabled=True, join_enabled=False, entry_role_id=777
+            ),
         ),
     )
     apply = AsyncMock()

--- a/tests/unit/services/test_welcome_service.py
+++ b/tests/unit/services/test_welcome_service.py
@@ -96,6 +96,14 @@ def test_leave_embed_picks_a_random_variant():
     assert len(rendered) > 1
 
 
+def test_dm_embed_renders_dm_message_with_mention():
+    member = _member()
+    policy = WelcomePolicy(dm_message="Welcome {user} to {server} (#{count})")
+    embed = welcome_service.format_dm_embed(member, policy, 7)
+    assert embed.description == "Welcome <@200> to Demo (#7)"
+    assert embed.color == discord.Color.green()
+
+
 # ---------------------------------------------------------------------------
 # handle_member_join
 # ---------------------------------------------------------------------------
@@ -145,6 +153,80 @@ async def test_join_posts_greeting_and_emits(monkeypatch):
     emit.assert_awaited_once()
     assert emit.await_args.args[0] == welcome_service.EVT_WELCOME_MEMBER_GREETED
     assert emit.await_args.kwargs["user_id"] == 200
+
+
+@pytest.mark.asyncio
+async def test_join_sends_dm_greeting(monkeypatch):
+    member = _member()
+    member.send = AsyncMock()
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=False,  # no channel greeting
+                dm_enabled=True,
+                dm_message="Hey {user}!",
+            ),
+        ),
+    )
+
+    await welcome_service.handle_member_join(member)
+
+    member.send.assert_awaited_once()
+    embed = member.send.await_args.kwargs["embed"]
+    assert embed.description == "Hey <@200>!"
+    # No channel was configured → no channel post attempted.
+    member.guild.get_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_join_dm_closed_is_swallowed(monkeypatch):
+    member = _member()
+    member.send = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "closed"))
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True, join_enabled=False, dm_enabled=True
+            ),
+        ),
+    )
+
+    # A member with DMs closed must not raise — the join dispatch completes.
+    await welcome_service.handle_member_join(member)
+    member.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_join_channel_greeting_and_dm_are_independent(monkeypatch):
+    channel = _text_channel()
+    member = _member()
+    member.send = AsyncMock()
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                channel_id=100,
+                dm_enabled=True,
+            ),
+        ),
+    )
+    import core.events
+
+    monkeypatch.setattr(core.events.bus, "emit", AsyncMock())
+
+    await welcome_service.handle_member_join(member)
+
+    # Both the channel greeting and the DM fire.
+    channel.send.assert_awaited_once()
+    member.send.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

S1 completion-first deepening (Q-0209). Clears part of the **Welcome** unit's completion punch-list
**#2** (best-in-class options): **multiple / random welcome messages** — Carl-bot / MEE6 / Dyno
parity.

An operator can now define several greeting (and farewell) variants separated by a `---` line; the
bot picks one **at random** per join/leave. A single-message config stays **byte-identical** (one
variant = that message). **No migration** — welcome settings are scalar KV values.

## Status

🔴 Born-red session card (Q-0133) — flips to `complete` as the final step once CI is green.

## Changes (planned)
- `services/welcome_config.py` — `split_message_variants` + `pick_message` (pure, seeded-rng-testable).
- `services/welcome_service.py` — join/leave embed builders select a random variant.
- `cogs/welcome/schemas.py` — per-variant length cap + variant-count cap; documented separator hint.
- `cogs/welcome_cog.py` — status preview shows the variant count.
- Tests + welcome completion cert update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuPdqtqES6oBbLbjBMDG1b)_