### PR TITLE
Welcome: join-delay age-gating + ping-then-delete (completion cert punch-list #2 remainder)

### DIFF
--- a/.sessions/2026-06-30-welcome-age-gate-delete-after.md
+++ b/.sessions/2026-06-30-welcome-age-gate-delete-after.md
@@ -1,15 +1,96 @@
 # 2026-06-30 — Welcome age-gating + ping-then-delete (completion-first deepening)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What this run is doing
-Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closing the **Welcome**
-completion cert's punch-list #2 remainder (best-in-class options): **join-delay age-gating**
-(skip greeting/DM/entry-role for accounts younger than a configurable threshold — anti-raid,
-additive, default 0 = off) and **ping-then-delete** (auto-delete the channel greeting/farewell
-after N seconds — default 0 = keep). Both additive on the existing scalar welcome policy model;
-no migration; byte-identical for every existing config.
+## What this run did
+Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closed the **Welcome** completion
+cert's **punch-list #2 remainder** (best-in-class options) — the last two named gaps vs
+Carl-bot/MEE6/Dyno — in one focused PR (#1581). **Punch-list #2 is now CLOSED.**
 
-(Born-red card; flipped to complete as the final step.)
+### Join-delay age-gating (anti-raid)
+- **`welcome_config.account_is_too_young(created_at, *, min_age_days, now)`** — a pure, tz-aware helper
+  (fail-open on `min_age_days <= 0`, a `None` created_at, or a naive/aware mismatch — better to greet a
+  legit member than silently drop them).
+- **`WelcomePolicy.min_account_age_days`** + `age_gate_enabled` property; resolved in `load_policy`.
+- **`welcome_service.handle_member_join`** gates right after `any_action_enabled`: a below-threshold
+  account gets **no greeting, no DM, no entry role** (logged). `_account_too_young` wraps the pure
+  helper with `discord.utils.utcnow()`.
+- Setting `welcome_min_account_age_days` (int, default 0 = off, capped 0..365), `numeric_presets` (0/1/7).
+
+### Ping-then-delete
+- **`WelcomePolicy.greeting_delete_after`** property → `float | None`; `_post` forwards `delete_after`
+  to discord.py's native `send`, applied to **both** the channel greeting and the farewell. The **DM
+  greeting is never deleted**.
+- Setting `welcome_delete_after_seconds` (int, default 0 = keep, capped 0..3600), `numeric_presets`
+  (0/30/60).
+
+Both are additive scalar settings on the existing welcome policy model — **no migration**, default-off,
+**byte-identical** for every existing config. Surfaced in the `!welcome` status embed when set.
+
+### Tests (+18) / docs
+- `test_welcome_config.py` — the age-gate helper (off / below / at-threshold / unknown-age fail-open /
+  mixed-awareness) + the two policy properties + a defaults-stay-off pin.
+- `test_welcome_service.py` — too-young skips greeting/DM/role; old-enough greets; gate-off greets a
+  brand-new account; unknown-age fails open; `delete_after` forwarded on join + leave; off ⇒ `None`;
+  DM never carries `delete_after`.
+- `test_welcome_schemas.py` — int validators (bounds + bool/str rejection) + `numeric_presets` hint +
+  the defaults-match-config pin updated for both new specs.
+- `test_welcome_cog.py` — the `!welcome` embed shows/hides the age-gate + auto-delete lines.
+- De-staled the Welcome completion cert (punch #2 CLOSED), the settings command-map doc (both new
+  keys/specs), and regenerated the 4 generated artifacts (site.json / data.js / dashboard.json —
+  `setting_keys` 110 → 112).
+
+## Verification
+- `python3.10 scripts/check_quality.py --full` GREEN (the only failures were the expected
+  settings-doc + artifact-freshness checks, fixed by listing the new keys/specs + regenerating).
+- `python3.10 scripts/check_architecture.py --mode strict` — 0 errors (warnings pre-existing).
+- `check_docs --strict` / `check_current_state_ledger --strict` — clean (only benign newest-merge lag).
+- **Process note (for the next run):** a stray `python3.10 -m black .` / `isort .` reformatted ~370
+  unrelated files (CI excludes `tests/`, so they were never red); reverted everything outside the
+  intended keep-list before pushing. The Stop hook prints the right command — trust
+  `check_quality.py`, never bare `black .` (CLAUDE.md §"Match CI exactly").
+
+## Handoff — next ▶
+**Welcome punch-list #2 is fully CLOSED** — every named best-in-class option now exists. Welcome's
+remaining gaps are all `[owner]`/minor: #1 bespoke command panel (or owner waiver) · #3 binding-pipeline
+seam · #4 cog-integration test · #5/#6 owner walkthrough + sign-off.
+
+**Next turn-key offline completion-first picks (other units):**
+- **Diagnostics** list pagination (cert punch #2 — apply `_PaginatorView` to long findings/consistency
+  output) + #5 (health-metrics reconcile).
+- **Cleanup #4** — surface the spam dedupe window as a real per-guild setting *with* a config-input
+  widget (a constant rename isn't "configurable" — deferred by the #1566 run).
+See `docs/planning/feature-completion/units/`.
+
+## 💡 Session idea
+**Anti-raid defaults in the Essential Setup "block spam" step.** The new welcome age-gate +
+auto-delete are exactly the knobs a server owner wants pre-set after a raid scare, but they're only
+reachable via `!settings → Welcome`. The Essential Setup spine already has a "block spam" step — it
+could offer a one-tap **"Raid protection"** toggle that sets a sensible `min_account_age_days` (e.g. 1
+day) alongside the automod spam rule, so a fresh server gets layered anti-raid defaults without
+hunting through settings. Small, additive, composes the two subsystems through their existing audited
+seams. Dedup-checked `docs/ideas/` — not present.
+
+## ⟲ Previous-session review
+The previous run (#1579, Welcome random messages + DM greeting) was a clean, well-scoped
+completion-first slice that did the *harder* half of punch-list #2 first (random variants touch the
+embed builders + validator + preview) and left the two additive single-knob options (this run) — a
+sensible ordering. One thing it could have done while in the file: it added `dm_enabled`/`dm_message`
+but didn't surface the new options in the Essential Setup spine, so the discoverability gap the cert
+flags (#1 panel) widened slightly with each new setting. **System improvement surfaced this run:** the
+`test_spec_defaults_match_config_defaults` set-equality assertion is doing real work — it forced this
+run to register both new specs in the doc + test in lockstep, catching drift at the source. That
+"defaults are one source of truth, pinned by a set-equality test" pattern is worth replicating for the
+other subsystem schemas that don't yet have it.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PR:** #1581 (Welcome age-gating + ping-then-delete) — self-merge on green.
+- **⚑ Self-initiated:** none (completion-first arc is the standing S1 dispatch lane; this is the named
+  Welcome cert punch-list #2 remainder, not an unprompted idea→plan promotion).
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (no migration, no data step; the settings are scalar KV — merge
+  auto-deploys).
+- **Bugs:** none opened; none fixed.

--- a/.sessions/2026-06-30-welcome-age-gate-delete-after.md
+++ b/.sessions/2026-06-30-welcome-age-gate-delete-after.md
@@ -1,0 +1,15 @@
+# 2026-06-30 — Welcome age-gating + ping-then-delete (completion-first deepening)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What this run is doing
+Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closing the **Welcome**
+completion cert's punch-list #2 remainder (best-in-class options): **join-delay age-gating**
+(skip greeting/DM/entry-role for accounts younger than a configurable threshold — anti-raid,
+additive, default 0 = off) and **ping-then-delete** (auto-delete the channel greeting/farewell
+after N seconds — default 0 = keep). Both additive on the existing scalar welcome policy model;
+no migration; byte-identical for every existing config.
+
+(Born-red card; flipped to complete as the final step.)

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T12:42:33Z",
+    "generated_at": "2026-06-30T15:11:38Z",
     "build": {
-      "commit": "40656d9e",
-      "subject": "Welcome deepening: close-out — cert #2 narrowed, S1 ledger, session log complete",
-      "committed_at": "2026-06-30T12:42:33Z"
+      "commit": "1a32363b",
+      "subject": "Welcome age-gating + ping-then-delete: born-red session card + claim",
+      "committed_at": "2026-06-30T15:11:38Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7171,7 +7171,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "40656d9e",
+    "build": "1a32363b",
     "title": "New public bot website",
     "changes": [
       {
@@ -7183,7 +7183,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "40656d9e",
+    "build": "1a32363b",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7195,7 +7195,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "40656d9e",
+    "build": "1a32363b",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T12:42:33Z",
+    "generated_at": "2026-06-30T15:11:38Z",
     "build": {
-      "commit": "40656d9e",
-      "subject": "Welcome deepening: close-out — cert #2 narrowed, S1 ledger, session log complete",
-      "committed_at": "2026-06-30T12:42:33Z"
+      "commit": "1a32363b",
+      "subject": "Welcome age-gating + ping-then-delete: born-red session card + claim",
+      "committed_at": "2026-06-30T15:11:38Z"
     },
     "counts": {
       "functions": 43,
@@ -16,9 +16,9 @@
       "env_vars": 39,
       "cogs": 55,
       "commands": 473,
-      "setting_keys": 110,
+      "setting_keys": 112,
       "setting_domains": 16,
-      "typed_settings": 90,
+      "typed_settings": 92,
       "visible_subsystems": 43,
       "synonyms": 87,
       "bot_changelog": 3
@@ -2684,6 +2684,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-30-welcome-age-gate-delete-after.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — Welcome age-gating + ping-then-delete (completion-first deepening)",
+      "status": "in-progress",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-30-reaction-roles-signup-counter.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — Reaction-roles live sign-up counter (S1 deepening)",
@@ -3143,14 +3151,6 @@
       "file": "2026-06-27-btd6-eval-corpus-action.md",
       "date": "2026-06-27",
       "title": "2026-06-27 — BTD6 QA corpus wired into the evals (offline grounding test + live action suite)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-btd6-ddt-counter-grounding.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — BTD6: ground VERIFIED DDT counter towers (fix the over-refusal)",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -10624,6 +10624,22 @@
           "hint": "Attach a rendered welcome card image to the join greeting (phase 2).  Off by default; falls back to the embed-only greeting when image rendering is unavailable.",
           "allowed_values": [],
           "default": false
+        },
+        {
+          "constant": "WELCOME_MIN_ACCOUNT_AGE_DAYS",
+          "key": "welcome_min_account_age_days",
+          "type": "int",
+          "hint": "Anti-raid: skip the greeting, DM, and entry role for a joining member whose Discord account is younger than this many days.  0 disables it (every account is greeted).",
+          "allowed_values": [],
+          "default": 0
+        },
+        {
+          "constant": "WELCOME_DELETE_AFTER_SECONDS",
+          "key": "welcome_delete_after_seconds",
+          "type": "int",
+          "hint": "Ping-then-delete: auto-delete the channel greeting/farewell this many seconds after it posts, to keep a busy channel tidy.  0 keeps the message.  The DM greeting is never deleted.",
+          "allowed_values": [],
+          "default": 0
         }
       ]
     },

--- a/disbot/cogs/welcome/schemas.py
+++ b/disbot/cogs/welcome/schemas.py
@@ -26,6 +26,7 @@ from core.runtime.subsystem_schema import (
 from services.welcome_config import (
     DEFAULT_CARD_ENABLED,
     DEFAULT_CHANNEL,
+    DEFAULT_DELETE_AFTER_SECONDS,
     DEFAULT_DM_ENABLED,
     DEFAULT_DM_MESSAGE,
     DEFAULT_ENABLED,
@@ -34,13 +35,19 @@ from services.welcome_config import (
     DEFAULT_JOIN_MESSAGE,
     DEFAULT_LEAVE_ENABLED,
     DEFAULT_LEAVE_MESSAGE,
+    DEFAULT_MIN_ACCOUNT_AGE_DAYS,
+    MAX_DELETE_AFTER_SECONDS,
     MAX_MESSAGE_LENGTH,
     MAX_MESSAGE_VARIANTS,
+    MAX_MIN_ACCOUNT_AGE_DAYS,
+    MIN_DELETE_AFTER_SECONDS,
+    MIN_MIN_ACCOUNT_AGE_DAYS,
     split_message_variants,
 )
 from utils.settings_keys import (
     WELCOME_CARD_ENABLED,
     WELCOME_CHANNEL,
+    WELCOME_DELETE_AFTER_SECONDS,
     WELCOME_DM_ENABLED,
     WELCOME_DM_MESSAGE,
     WELCOME_ENABLED,
@@ -49,6 +56,7 @@ from utils.settings_keys import (
     WELCOME_JOIN_MESSAGE,
     WELCOME_LEAVE_ENABLED,
     WELCOME_LEAVE_MESSAGE,
+    WELCOME_MIN_ACCOUNT_AGE_DAYS,
 )
 
 _WELCOME_CAPABILITY = "welcome.settings.configure"
@@ -76,6 +84,22 @@ def _validate_id(value: object) -> None:
         int(token)
     except ValueError:
         raise ValueError(f"'{token}' is not a numeric id") from None
+
+
+def _bounded_int(value: object, lo: int, hi: int) -> None:
+    # ``isinstance(True, int)`` is True, so guard the bool type explicitly.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"expected int, got {value!r}")
+    if not (lo <= value <= hi):
+        raise ValueError(f"must be between {lo} and {hi}")
+
+
+def _validate_min_account_age_days(value: object) -> None:
+    _bounded_int(value, MIN_MIN_ACCOUNT_AGE_DAYS, MAX_MIN_ACCOUNT_AGE_DAYS)
+
+
+def _validate_delete_after_seconds(value: object) -> None:
+    _bounded_int(value, MIN_DELETE_AFTER_SECONDS, MAX_DELETE_AFTER_SECONDS)
 
 
 def _validate_message(value: object) -> None:
@@ -228,6 +252,36 @@ WELCOME_SETTINGS: tuple[SettingSpec, ...] = (
             "separated by a '---' line to DM a random one each time."
         ),
         validator=_validate_message,
+    ),
+    SettingSpec(
+        name="min_account_age_days",
+        value_type=int,
+        default=DEFAULT_MIN_ACCOUNT_AGE_DAYS,
+        settings_key=WELCOME_MIN_ACCOUNT_AGE_DAYS,
+        capability_required=_WELCOME_CAPABILITY,
+        hint=(
+            "Anti-raid: skip the greeting, DM, and entry role for a joining "
+            "member whose Discord account is younger than this many days.  "
+            "0 disables it (every account is greeted)."
+        ),
+        validator=_validate_min_account_age_days,
+        input_hint="numeric_presets",
+        presets=(0, 1, 7),
+    ),
+    SettingSpec(
+        name="delete_after_seconds",
+        value_type=int,
+        default=DEFAULT_DELETE_AFTER_SECONDS,
+        settings_key=WELCOME_DELETE_AFTER_SECONDS,
+        capability_required=_WELCOME_CAPABILITY,
+        hint=(
+            "Ping-then-delete: auto-delete the channel greeting/farewell this "
+            "many seconds after it posts, to keep a busy channel tidy.  "
+            "0 keeps the message.  The DM greeting is never deleted."
+        ),
+        validator=_validate_delete_after_seconds,
+        input_hint="numeric_presets",
+        presets=(0, 30, 60),
     ),
 )
 

--- a/disbot/cogs/welcome_cog.py
+++ b/disbot/cogs/welcome_cog.py
@@ -94,6 +94,16 @@ class WelcomeCog(commands.Cog):
             f"📢 **Channel:** {channel_str}",
             f"🎟️ **Entry role:** {role_str}",
         ]
+        if policy.age_gate_enabled:
+            lines.append(
+                "🛡️ **Min account age:** "
+                f"{policy.min_account_age_days}d "
+                "(younger accounts skipped — anti-raid)",
+            )
+        if policy.greeting_delete_after is not None:
+            lines.append(
+                f"🧹 **Auto-delete greeting after:** {policy.delete_after_seconds}s",
+            )
         embed = discord.Embed(
             title="👋 Welcome",
             description="\n".join(lines),

--- a/disbot/services/welcome_config.py
+++ b/disbot/services/welcome_config.py
@@ -26,6 +26,7 @@ imports are stdlib only.
 
 from __future__ import annotations
 
+import datetime as dt
 import random
 import re
 from dataclasses import dataclass
@@ -64,6 +65,26 @@ DEFAULT_DM_ENABLED = False
 DEFAULT_DM_MESSAGE = (
     "👋 Welcome to **{server}**, {user}! Glad to have you — you're member #{count}."
 )
+
+# Join-delay age-gating (completion punch-list #2 remainder): skip the whole
+# welcome action (channel greeting, DM greeting, AND the entry-role grant) for a
+# joining member whose Discord account is younger than this many days.  An
+# anti-raid guard — fresh throwaway accounts in a raid don't get auto-greeted or
+# auto-roled into the server.  ``0`` disables it (every account greeted), so a
+# fresh guild behaves byte-identically.  Capped at one year (well past any sane
+# verification window) so a typo can't lock the server out of greetings forever.
+DEFAULT_MIN_ACCOUNT_AGE_DAYS = 0
+MIN_MIN_ACCOUNT_AGE_DAYS = 0
+MAX_MIN_ACCOUNT_AGE_DAYS = 365
+
+# Ping-then-delete (completion punch-list #2 remainder): auto-delete the
+# **channel** greeting/farewell message this many seconds after it posts (via
+# discord.py's native ``delete_after``), so a high-traffic join/leave channel
+# stays uncluttered.  ``0`` keeps the message forever (the v1 behaviour).  The
+# DM greeting is never affected.  Capped at one hour.
+DEFAULT_DELETE_AFTER_SECONDS = 0
+MIN_DELETE_AFTER_SECONDS = 0
+MAX_DELETE_AFTER_SECONDS = 3600
 
 # Template length cap — keeps an embed description well within Discord's limit
 # even after placeholder expansion.  Applied **per variant** (see below): with
@@ -112,6 +133,32 @@ def pick_message(template: str, *, rng: random.Random | None = None) -> str:
     return chooser.choice(variants)
 
 
+def account_is_too_young(
+    created_at: dt.datetime | None,
+    *,
+    min_age_days: int,
+    now: dt.datetime,
+) -> bool:
+    """True when an account created at ``created_at`` is below the age gate.
+
+    ``min_age_days <= 0`` disables the gate (always ``False``).  A ``None``
+    ``created_at`` (unknown age) is treated as **old enough** — fail-open to a
+    greeting, matching the read model's posture everywhere else (better to greet
+    a legit member whose creation date we couldn't read than to silently drop
+    them).  Both datetimes are expected tz-aware UTC (Discord's ``created_at``
+    and :func:`discord.utils.utcnow` both are); a naive ``created_at`` is also
+    tolerated by comparing only when both share awareness.
+    """
+    if min_age_days <= 0 or created_at is None:
+        return False
+    try:
+        age = now - created_at
+    except TypeError:
+        # Mixed naive/aware comparison — don't gate on a malformed timestamp.
+        return False
+    return age < dt.timedelta(days=min_age_days)
+
+
 @dataclass(frozen=True)
 class WelcomePolicy:
     """Resolved welcome behaviour for one guild.
@@ -131,6 +178,24 @@ class WelcomePolicy:
     card_enabled: bool = DEFAULT_CARD_ENABLED
     dm_enabled: bool = DEFAULT_DM_ENABLED
     dm_message: str = DEFAULT_DM_MESSAGE
+    min_account_age_days: int = DEFAULT_MIN_ACCOUNT_AGE_DAYS
+    delete_after_seconds: int = DEFAULT_DELETE_AFTER_SECONDS
+
+    @property
+    def age_gate_enabled(self) -> bool:
+        """True when the join-delay account-age gate is active."""
+        return self.min_account_age_days > 0
+
+    @property
+    def greeting_delete_after(self) -> float | None:
+        """Seconds after which a channel greeting/farewell self-deletes, or None.
+
+        Returns ``None`` (keep forever — the v1 behaviour) when the setting is
+        ``0``, else the value as a float for discord.py's ``delete_after``.
+        """
+        return (
+            float(self.delete_after_seconds) if self.delete_after_seconds > 0 else None
+        )
 
     @property
     def greet_on_join(self) -> bool:
@@ -266,6 +331,18 @@ async def load_policy(guild_id: int) -> WelcomePolicy:
         "dm_message",
         DEFAULT_DM_MESSAGE,
     )
+    min_account_age_days = await resolve_value(
+        guild_id,
+        SUBSYSTEM,
+        "min_account_age_days",
+        DEFAULT_MIN_ACCOUNT_AGE_DAYS,
+    )
+    delete_after_seconds = await resolve_value(
+        guild_id,
+        SUBSYSTEM,
+        "delete_after_seconds",
+        DEFAULT_DELETE_AFTER_SECONDS,
+    )
 
     return WelcomePolicy(
         enabled=enabled,
@@ -278,12 +355,15 @@ async def load_policy(guild_id: int) -> WelcomePolicy:
         card_enabled=card_enabled,
         dm_enabled=dm_enabled,
         dm_message=dm_message,
+        min_account_age_days=min_account_age_days,
+        delete_after_seconds=delete_after_seconds,
     )
 
 
 __all__ = [
     "DEFAULT_CARD_ENABLED",
     "DEFAULT_CHANNEL",
+    "DEFAULT_DELETE_AFTER_SECONDS",
     "DEFAULT_DM_ENABLED",
     "DEFAULT_DM_MESSAGE",
     "DEFAULT_ENABLED",
@@ -292,9 +372,15 @@ __all__ = [
     "DEFAULT_JOIN_MESSAGE",
     "DEFAULT_LEAVE_ENABLED",
     "DEFAULT_LEAVE_MESSAGE",
+    "DEFAULT_MIN_ACCOUNT_AGE_DAYS",
+    "MAX_DELETE_AFTER_SECONDS",
     "MAX_MESSAGE_LENGTH",
     "MAX_MESSAGE_VARIANTS",
+    "MAX_MIN_ACCOUNT_AGE_DAYS",
+    "MIN_DELETE_AFTER_SECONDS",
+    "MIN_MIN_ACCOUNT_AGE_DAYS",
     "WelcomePolicy",
+    "account_is_too_young",
     "load_policy",
     "parse_id",
     "pick_message",

--- a/disbot/services/welcome_service.py
+++ b/disbot/services/welcome_service.py
@@ -165,13 +165,21 @@ async def _post(
     channel: discord.abc.Messageable,
     embed: discord.Embed,
     file: discord.File | None = None,
+    *,
+    delete_after: float | None = None,
 ) -> bool:
-    """Send ``embed`` (plus optional ``file``) — fail-safe (logs, never raises)."""
+    """Send ``embed`` (plus optional ``file``) — fail-safe (logs, never raises).
+
+    ``delete_after`` (ping-then-delete) is forwarded to discord.py's native
+    ``send`` so the message self-deletes after that many seconds; ``None`` keeps
+    it.  Only ``None`` is passed to ``send`` when unset so the call shape is
+    unchanged for every existing config.
+    """
     try:
         if file is not None:
-            await channel.send(embed=embed, file=file)
+            await channel.send(embed=embed, file=file, delete_after=delete_after)
         else:
-            await channel.send(embed=embed)
+            await channel.send(embed=embed, delete_after=delete_after)
     except discord.Forbidden:
         logger.warning("welcome: missing send permission in greeting channel")
         return False
@@ -285,6 +293,19 @@ async def handle_member_join(member: discord.Member) -> None:
     if not policy.any_action_enabled:
         return
 
+    # Join-delay age-gating (anti-raid): a member whose account is younger than
+    # the configured threshold gets NO greeting, NO DM, and NO entry role.
+    # Off (skipped) when the gate is unset, so existing configs are unchanged.
+    if policy.age_gate_enabled and _account_too_young(member, policy):
+        logger.info(
+            "welcome: member %s account too young (< %d days) — skipping "
+            "greeting/DM/entry-role in guild %s",
+            member.id,
+            policy.min_account_age_days,
+            guild.id,
+        )
+        return
+
     if policy.assigns_entry_role and policy.entry_role_id is not None:
         await _grant_entry_role(member, policy.entry_role_id)
 
@@ -301,7 +322,12 @@ async def handle_member_join(member: discord.Member) -> None:
                 file = render_join_card(member, count)
                 if file is not None:
                     embed.set_image(url=f"attachment://{_WELCOME_CARD_FILENAME}")
-            if await _post(channel, embed, file):
+            if await _post(
+                channel,
+                embed,
+                file,
+                delete_after=policy.greeting_delete_after,
+            ):
                 await _emit_greeted(member)
 
     if policy.dm_on_join:
@@ -328,7 +354,23 @@ async def handle_member_leave(member: discord.Member) -> None:
     channel = _resolve_text_channel(guild, policy.channel_id)
     if channel is not None:
         embed = format_leave_embed(member, policy, _member_count(guild))
-        await _post(channel, embed)
+        await _post(channel, embed, delete_after=policy.greeting_delete_after)
+
+
+def _account_too_young(
+    member: discord.Member,
+    policy: welcome_config.WelcomePolicy,
+) -> bool:
+    """True when ``member``'s account is below the policy's age gate.
+
+    Thin wrapper over the pure :func:`welcome_config.account_is_too_young` that
+    supplies the current time; fail-open (greets) on a missing ``created_at``.
+    """
+    return welcome_config.account_is_too_young(
+        getattr(member, "created_at", None),
+        min_age_days=policy.min_account_age_days,
+        now=discord.utils.utcnow(),
+    )
 
 
 def _member_count(guild: Any) -> int:

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -138,6 +138,7 @@ from utils.settings_keys.security import (
 from utils.settings_keys.welcome import (
     WELCOME_CARD_ENABLED,
     WELCOME_CHANNEL,
+    WELCOME_DELETE_AFTER_SECONDS,
     WELCOME_DM_ENABLED,
     WELCOME_DM_MESSAGE,
     WELCOME_ENABLED,
@@ -146,6 +147,7 @@ from utils.settings_keys.welcome import (
     WELCOME_JOIN_MESSAGE,
     WELCOME_LEAVE_ENABLED,
     WELCOME_LEAVE_MESSAGE,
+    WELCOME_MIN_ACCOUNT_AGE_DAYS,
 )
 from utils.settings_keys.xp import (
     XP_ANNOUNCE_CHANNEL,
@@ -253,6 +255,7 @@ __all__ = [
     "WARN_TIMEOUT_MINS",
     "WELCOME_CARD_ENABLED",
     "WELCOME_CHANNEL",
+    "WELCOME_DELETE_AFTER_SECONDS",
     "WELCOME_DM_ENABLED",
     "WELCOME_DM_MESSAGE",
     "WELCOME_ENABLED",
@@ -261,6 +264,7 @@ __all__ = [
     "WELCOME_JOIN_MESSAGE",
     "WELCOME_LEAVE_ENABLED",
     "WELCOME_LEAVE_MESSAGE",
+    "WELCOME_MIN_ACCOUNT_AGE_DAYS",
     "XP_ANNOUNCE_CHANNEL",
     "XP_COOLDOWN",
     "XP_MAX",

--- a/disbot/utils/settings_keys/welcome.py
+++ b/disbot/utils/settings_keys/welcome.py
@@ -42,3 +42,12 @@ WELCOME_DM_MESSAGE = "welcome_dm_message"
 # Welcome phase 2 (Q-0110): attach a rendered PIL greeting card to the join
 # embed.  Off by default; degrades to embed-only when Pillow is unavailable.
 WELCOME_CARD_ENABLED = "welcome_card_enabled"
+
+# Join-delay age-gating (completion punch-list #2): skip greeting/DM/entry-role
+# for a joining member whose account is younger than this many days (anti-raid).
+# 0 disables it (every account greeted).
+WELCOME_MIN_ACCOUNT_AGE_DAYS = "welcome_min_account_age_days"
+
+# Ping-then-delete (completion punch-list #2): auto-delete the channel
+# greeting/farewell message this many seconds after it posts.  0 keeps it.
+WELCOME_DELETE_AFTER_SECONDS = "welcome_delete_after_seconds"

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,16 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Welcome — join-delay age-gating + ping-then-delete** (PR #1581, completion-first deepening,
+  Welcome cert punch-list #2 remainder — **#2 now CLOSED**) — the last two best-in-class options vs
+  Carl-bot/MEE6/Dyno. **Join-delay age gate:** a `min_account_age_days` setting (default 0 = off) — a
+  joining member whose Discord account is younger than the threshold gets **no greeting, no DM, no
+  entry role** (anti-raid; pure `welcome_config.account_is_too_young`, fail-open on unknown age).
+  **Ping-then-delete:** a `delete_after_seconds` setting (default 0 = keep) — the channel
+  greeting/farewell auto-deletes after N seconds via discord.py's native `delete_after` (the DM is
+  never deleted). Both are additive default-off `int` settings (`numeric_presets` hints) on the
+  existing scalar welcome policy model — **no migration**, byte-identical for existing configs; +18
+  tests; self-merged on green.
 - **Welcome — random greeting messages + opt-in DM greeting** (PR #1579, completion-first deepening,
   Welcome cert punch-list #2) — two best-in-class options in one batch (Carl-bot / MEE6 / Dyno parity).
   **(1) Multiple/random messages:** an operator stores several greeting / farewell / DM variants in one
@@ -196,16 +206,18 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   (punch #2 — apply `_PaginatorView` to long findings/consistency output) + #5 (health-metrics
   reconcile) · Cleanup #4 (spam-window setting *with* a Settings widget). *(Counters punch
   #1/#2/#4/#5 ✅ #1568; #3 ✅ #1575.)*
-  **✅ DONE 2026-06-30 (#1579): Welcome punch #2 (best-in-class options) — 2 of 4 CLOSED.**
-  **Multiple/random messages** (`---`-separated variants on the join/leave/DM message, one picked at
-  random per greeting — pure `welcome_config.split_message_variants`/`pick_message`; validator caps
-  per-variant length + ≤10 variants; `!welcome` preview shows "1 of N random variants") **+ opt-in DM
-  greeting** (`dm_enabled`/`dm_message`, fail-safe on closed DMs, independent of the channel greeting).
-  Migration-free, default-off, byte-identical for existing configs; +51 welcome tests. **▶ Next
-  turn-key picks (Welcome #2 remainder):** **join-delay age-gating** (skip greeting/role for accounts
-  younger than a configurable threshold — anti-raid, additive, default 0 = off) + **ping-then-delete**
-  (post then auto-delete after N seconds). Each its own PR on the same policy model. (Welcome #1
-  bespoke panel + #3 binding-seam + #4 cog-tests + #5/#6 owner walkthrough still open.)
+  **✅ DONE 2026-06-30 (#1579 + #1581): Welcome punch #2 (best-in-class options) — ALL 4 CLOSED.**
+  **Multiple/random messages** + **opt-in DM greeting** (#1579), then **join-delay age-gating**
+  (`min_account_age_days` — skip greeting/DM/entry-role for accounts younger than N days, anti-raid;
+  pure `welcome_config.account_is_too_young`, fail-open on unknown age) **+ ping-then-delete**
+  (`delete_after_seconds` — auto-delete the channel greeting/farewell after N seconds via discord.py's
+  native `delete_after`; DM never deleted) (#1581). Both 2026-06-30 additions are default-off `int`
+  settings (`numeric_presets` hints), migration-free, byte-identical for existing configs; +18 tests.
+  **Welcome punch-list #2 is now CLOSED** — every named best-in-class option exists. Remaining Welcome
+  gaps: #1 bespoke panel (or owner waiver) · #3 binding-seam · #4 cog-tests · #5/#6 owner walkthrough.
+  **▶ Next turn-key picks (other units):** Diagnostics list pagination (punch #2 — apply `_PaginatorView`
+  to long findings/consistency output) + #5 (health-metrics reconcile) · Cleanup #4 (spam-window
+  setting *with* a Settings widget).
 - `[owner]` **Feature-completion assessments — ALL 36 UNITS ◐ ASSESSED (100%; 0 certified).** The
   completion-first arc (Q-0209). The `▢ → ◐` assessment sweep is **COMPLETE** — every game + server-fn
   now has a rubric-filled, source-grounded certificate under

--- a/docs/owner/claims/claude__funny-franklin-3055jf.md
+++ b/docs/owner/claims/claude__funny-franklin-3055jf.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-3055jf` · scope: Welcome completion cert punch-list #2 remainder (join-delay age-gating + ping-then-delete) · area: disbot/services/welcome_config.py, disbot/services/welcome_service.py, disbot/cogs/welcome/schemas.py, disbot/cogs/welcome_cog.py, disbot/utils/settings_keys/welcome.py · 2026-06-30

--- a/docs/owner/claims/claude__funny-franklin-3055jf.md
+++ b/docs/owner/claims/claude__funny-franklin-3055jf.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-3055jf` · scope: Welcome completion cert punch-list #2 remainder (join-delay age-gating + ping-then-delete) · area: disbot/services/welcome_config.py, disbot/services/welcome_service.py, disbot/cogs/welcome/schemas.py, disbot/cogs/welcome_cog.py, disbot/utils/settings_keys/welcome.py · 2026-06-30

--- a/docs/planning/feature-completion/units/welcome.md
+++ b/docs/planning/feature-completion/units/welcome.md
@@ -15,10 +15,11 @@
 > leavers, and optionally grants an entry role, with placeholder templates and an optional PIL card.
 > It is **fail-safe and fully audited** (greeting faults swallowed; entry-role via the audited
 > `role_automation.apply`; all config through `SettingsMutationPipeline`), with strong unit coverage.
-> The two honest gaps against the server-fn rubric: it has **no bespoke command panel** (config is the
-> generic `!settings → Welcome` widget group + a read-only `!welcome` status embed), and it is missing
-> a few **best-in-class welcome options** (DM greeting · multiple/random messages · join-delay
-> age-gating). Both are owner-paced.
+> The remaining honest gap against the server-fn rubric is the **no bespoke command panel** item
+> (config is the generic `!settings → Welcome` widget group + a read-only `!welcome` status embed) plus
+> the owner walkthrough/sign-off. The **best-in-class welcome options are now complete** (2026-06-30:
+> DM greeting · multiple/random messages · join-delay age-gating · ping-then-delete) — punch-list #2 is
+> CLOSED.
 
 ## Rubric (server function)
 
@@ -26,13 +27,17 @@
 - [x] **Core promise delivered** — join greeting + leave farewell (embed, avatar thumbnail, placeholder
       template) + optional entry-role grant (`welcome_service.py` `handle_member_join`/`handle_member_leave`/
       `_grant_entry_role`). Bots filtered at the listener (`welcome_cog.py:48`).
-- [ ] **Every best-in-class sub-option exists** — ◐ **partial (narrowing).** Has: channel greeting,
+- [x] **Every best-in-class sub-option exists** — ✅ **closed 2026-06-30.** Has: channel greeting,
       farewell, autorole, custom template (3 placeholders `{user}/{server}/{count}`), embed, image card
       (phase 2), **multiple/random welcome+farewell+DM messages** (`---`-separated variants, one picked
-      at random per greeting — `welcome_config.split_message_variants`/`pick_message`, 2026-06-30), and
-      an **opt-in DM greeting** (`dm_enabled`/`dm_message`, fail-safe on closed DMs — 2026-06-30).
-      **Still missing vs Carl-bot/MEE6/Dyno:** ping-then-delete · join-delay age-gating. → punch-list
-      #2 (remainder).
+      at random per greeting — `welcome_config.split_message_variants`/`pick_message`, 2026-06-30), an
+      **opt-in DM greeting** (`dm_enabled`/`dm_message`, fail-safe on closed DMs — 2026-06-30), a
+      **join-delay age gate** (`min_account_age_days` — anti-raid: skip greeting/DM/entry-role for
+      accounts younger than N days, default 0 = off; `welcome_config.account_is_too_young`), and
+      **ping-then-delete** (`delete_after_seconds` — auto-delete the channel greeting/farewell after N
+      seconds via discord.py's native `delete_after`, default 0 = keep). The two 2026-06-30 additions
+      close the last named gaps vs Carl-bot/MEE6/Dyno; both default-off and byte-identical for existing
+      configs.
 - [x] **Failure modes honest / fail-safe** — no channel → suppress greeting (entry-role still
       proceeds); send `Forbidden`/`HTTPException` classified + logged, never raised; policy-load fault
       caught + swallowed; unknown placeholders render literally (injection-safe `str.replace`,
@@ -122,8 +127,10 @@
    DM message, one chosen at random per greeting; migration-free, single-message configs
    byte-identical) · ~~DM greeting~~ ✅ **shipped 2026-06-30** (PR #1579 — opt-in `dm_enabled` +
    dedicated `dm_message`; DMs the joiner the greeting, fail-safe on closed DMs, independent of the
-   channel greeting). **Remaining:** join-delay age-gating · ping-then-delete. Each is a discrete
-   additive slice on the existing policy model.
+   channel greeting) · ~~join-delay age-gating~~ ✅ **shipped 2026-06-30** (`min_account_age_days` — skip
+   greeting/DM/entry-role for accounts younger than N days, default 0 = off; anti-raid) · ~~ping-then-delete~~
+   ✅ **shipped 2026-06-30** (`delete_after_seconds` — auto-delete the channel greeting/farewell after N
+   seconds, default 0 = keep). **Punch-list #2 CLOSED** — every named best-in-class option now exists.
 3. **Channel/role via the binding pipeline** *(offline, consistency)* — consider routing the channel +
    entry-role pointers through `BindingMutationPipeline` (the canonical resource-pointer seam) rather
    than id-bearing settings specs.

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -999,7 +999,8 @@ through `services/role_automation.py` (audited — no parallel role/audit path).
 8. **help_menu_direct_navigation_hook**: `build_help_menu_view` (policy summary).
 9. **existing_SettingSpec_declarations**: `enabled`, `join_enabled`,
    `leave_enabled`, `channel`, `join_message`, `leave_message`, `entry_role`,
-   `card_enabled`, `dm_enabled`, `dm_message` (`disbot/cogs/welcome/schemas.py`).
+   `card_enabled`, `dm_enabled`, `dm_message`, `min_account_age_days`,
+   `delete_after_seconds` (`disbot/cogs/welcome/schemas.py`).
    The master flag defaults OFF; defaults are the single source of truth in
    `disbot/services/welcome_config.py`. `card_enabled` is the welcome **phase 2**
    (Q-0110) toggle — attaches a rendered PIL greeting card to the join embed,
@@ -1007,11 +1008,16 @@ through `services/role_automation.py` (audited — no parallel role/audit path).
    `join_message`/`leave_message`/`dm_message` templates accept multiple
    `---`-separated **random variants** (one picked per greeting); `dm_enabled`
    also DMs the joiner the greeting (off by default, silently skipped when DMs
-   are closed).
+   are closed). `min_account_age_days` is the **join-delay age gate** (anti-raid:
+   skip greeting/DM/entry-role for accounts younger than N days, `0` = off) and
+   `delete_after_seconds` is **ping-then-delete** (auto-delete the channel
+   greeting/farewell after N seconds, `0` = keep) — both default-off `int`
+   settings with `numeric_presets` hints.
 10. **existing_settings_keys**: `WELCOME_ENABLED`, `WELCOME_JOIN_ENABLED`,
     `WELCOME_LEAVE_ENABLED`, `WELCOME_CHANNEL`, `WELCOME_JOIN_MESSAGE`,
     `WELCOME_LEAVE_MESSAGE`, `WELCOME_ENTRY_ROLE`, `WELCOME_CARD_ENABLED`,
-    `WELCOME_DM_ENABLED`, `WELCOME_DM_MESSAGE`
+    `WELCOME_DM_ENABLED`, `WELCOME_DM_MESSAGE`, `WELCOME_MIN_ACCOUNT_AGE_DAYS`,
+    `WELCOME_DELETE_AFTER_SECONDS`
     (`disbot/utils/settings_keys/welcome.py`). Stored as scalar guild settings —
     **no migration**. The `channel`/`entry_role` settings carry
     `input_hint="channel"`/`"role"` (channel-id-as-str duality).

--- a/tests/unit/cogs/test_welcome_cog.py
+++ b/tests/unit/cogs/test_welcome_cog.py
@@ -86,3 +86,23 @@ def test_policy_embed_leave_variant_note_when_leave_enabled():
     field = _field_by_name_prefix(embed, "Leave message preview")
     assert field.name == "Leave message preview (1 of 2 random variants)"
     assert field.value == "Bye NewMember"
+
+
+def test_policy_embed_shows_age_gate_when_set():
+    policy = WelcomePolicy(enabled=True, min_account_age_days=7)
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    assert "Min account age" in embed.description
+    assert "7d" in embed.description
+    # …and is absent when the gate is off.
+    off = WelcomeCog._policy_embed(_guild(), WelcomePolicy(enabled=True))
+    assert "Min account age" not in off.description
+
+
+def test_policy_embed_shows_auto_delete_when_set():
+    policy = WelcomePolicy(enabled=True, delete_after_seconds=30)
+    embed = WelcomeCog._policy_embed(_guild(), policy)
+    assert "Auto-delete greeting after" in embed.description
+    assert "30s" in embed.description
+    # …and is absent when off.
+    off = WelcomeCog._policy_embed(_guild(), WelcomePolicy(enabled=True))
+    assert "Auto-delete greeting after" not in off.description

--- a/tests/unit/cogs/test_welcome_schemas.py
+++ b/tests/unit/cogs/test_welcome_schemas.py
@@ -49,6 +49,8 @@ _EXPECTED_DEFAULTS = {
     "card_enabled": welcome_config.DEFAULT_CARD_ENABLED,
     "dm_enabled": welcome_config.DEFAULT_DM_ENABLED,
     "dm_message": welcome_config.DEFAULT_DM_MESSAGE,
+    "min_account_age_days": welcome_config.DEFAULT_MIN_ACCOUNT_AGE_DAYS,
+    "delete_after_seconds": welcome_config.DEFAULT_DELETE_AFTER_SECONDS,
 }
 
 
@@ -144,3 +146,44 @@ def test_bool_validator_guards_non_bool():
     validator = {s.name: s for s in WELCOME_SETTINGS}["enabled"].validator
     with pytest.raises(ValueError):
         validator("yes")
+
+
+def test_min_account_age_validator_bounds_and_type():
+    from cogs.welcome.schemas import WELCOME_SETTINGS
+
+    validator = {s.name: s for s in WELCOME_SETTINGS}["min_account_age_days"].validator
+    validator(0)  # disabled
+    validator(7)  # in range
+    validator(welcome_config.MAX_MIN_ACCOUNT_AGE_DAYS)  # boundary ok
+    with pytest.raises(ValueError):
+        validator(-1)  # below minimum
+    with pytest.raises(ValueError):
+        validator(welcome_config.MAX_MIN_ACCOUNT_AGE_DAYS + 1)  # above cap
+    with pytest.raises(ValueError):
+        validator(True)  # bool is not an int here
+    with pytest.raises(ValueError):
+        validator("7")  # str rejected
+
+
+def test_delete_after_validator_bounds_and_type():
+    from cogs.welcome.schemas import WELCOME_SETTINGS
+
+    validator = {s.name: s for s in WELCOME_SETTINGS}["delete_after_seconds"].validator
+    validator(0)  # keep
+    validator(30)  # in range
+    validator(welcome_config.MAX_DELETE_AFTER_SECONDS)  # boundary ok
+    with pytest.raises(ValueError):
+        validator(-1)
+    with pytest.raises(ValueError):
+        validator(welcome_config.MAX_DELETE_AFTER_SECONDS + 1)
+    with pytest.raises(ValueError):
+        validator(True)
+
+
+def test_new_int_specs_carry_numeric_preset_hint():
+    from cogs.welcome.schemas import WELCOME_SETTINGS
+
+    by_name = {s.name: s for s in WELCOME_SETTINGS}
+    for name in ("min_account_age_days", "delete_after_seconds"):
+        assert by_name[name].input_hint == "numeric_presets"
+        assert by_name[name].presets and 0 in by_name[name].presets

--- a/tests/unit/services/test_welcome_config.py
+++ b/tests/unit/services/test_welcome_config.py
@@ -195,3 +195,78 @@ def test_pick_message_fails_open_on_empty_template():
     # Degenerate value (no real variants) → returns the raw template, never
     # raises, so the render path stays fail-open.
     assert welcome_config.pick_message("---", rng=random.Random(0)) == "---"
+
+
+# ---------------------------------------------------------------------------
+# Join-delay age-gating helper (account_is_too_young)
+# ---------------------------------------------------------------------------
+
+
+def test_account_is_too_young_gate_off_is_always_false():
+    import datetime as dt
+
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    created = now - dt.timedelta(days=0)  # created right now
+    # min_age_days=0 disables the gate entirely.
+    assert (
+        welcome_config.account_is_too_young(created, min_age_days=0, now=now) is False
+    )
+
+
+def test_account_is_too_young_below_threshold_is_true():
+    import datetime as dt
+
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    created = now - dt.timedelta(days=2)  # 2 days old
+    assert welcome_config.account_is_too_young(created, min_age_days=7, now=now) is True
+
+
+def test_account_is_too_young_at_or_above_threshold_is_false():
+    import datetime as dt
+
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    created = now - dt.timedelta(days=10)  # 10 days old, gate is 7
+    assert (
+        welcome_config.account_is_too_young(created, min_age_days=7, now=now) is False
+    )
+
+
+def test_account_is_too_young_unknown_age_fails_open():
+    import datetime as dt
+
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    # None created_at → treated as old enough (greet), never raises.
+    assert welcome_config.account_is_too_young(None, min_age_days=7, now=now) is False
+
+
+def test_account_is_too_young_mixed_awareness_does_not_raise():
+    import datetime as dt
+
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    naive = dt.datetime(2026, 1, 1)  # naive — comparison would TypeError
+    # Tolerated: returns False rather than raising.
+    assert welcome_config.account_is_too_young(naive, min_age_days=7, now=now) is False
+
+
+# ---------------------------------------------------------------------------
+# Policy convenience properties (age gate + delete-after)
+# ---------------------------------------------------------------------------
+
+
+def test_age_gate_enabled_property():
+    assert WelcomePolicy(min_account_age_days=0).age_gate_enabled is False
+    assert WelcomePolicy(min_account_age_days=7).age_gate_enabled is True
+
+
+def test_greeting_delete_after_property():
+    assert WelcomePolicy(delete_after_seconds=0).greeting_delete_after is None
+    assert WelcomePolicy(delete_after_seconds=30).greeting_delete_after == 30.0
+
+
+def test_policy_defaults_keep_new_options_off():
+    # A fresh policy is byte-identical to v1: no gate, no auto-delete.
+    p = WelcomePolicy()
+    assert p.min_account_age_days == welcome_config.DEFAULT_MIN_ACCOUNT_AGE_DAYS == 0
+    assert p.delete_after_seconds == welcome_config.DEFAULT_DELETE_AFTER_SECONDS == 0
+    assert p.age_gate_enabled is False
+    assert p.greeting_delete_after is None

--- a/tests/unit/services/test_welcome_service.py
+++ b/tests/unit/services/test_welcome_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
@@ -480,3 +481,202 @@ async def test_leave_disabled_is_noop(monkeypatch):
     )
     await welcome_service.handle_member_leave(member)
     channel.send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Join-delay age-gating (anti-raid)
+# ---------------------------------------------------------------------------
+
+
+def _aged_member(days_old: float, guild: MagicMock | None = None) -> MagicMock:
+    """A member whose account was created ``days_old`` days ago (tz-aware UTC)."""
+    member = _member(guild)
+    member.created_at = discord.utils.utcnow() - dt.timedelta(days=days_old)
+    return member
+
+
+@pytest.mark.asyncio
+async def test_join_too_young_account_is_skipped_entirely(monkeypatch):
+    """A below-threshold account gets no greeting, no DM, and no entry role."""
+    channel = _text_channel()
+    member = _aged_member(days_old=1)  # 1 day old, gate is 7 days
+    member.send = AsyncMock()
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                dm_enabled=True,
+                channel_id=100,
+                entry_role_id=500,
+                min_account_age_days=7,
+            ),
+        ),
+    )
+    apply = AsyncMock()
+    monkeypatch.setattr("services.role_automation.apply", apply)
+
+    await welcome_service.handle_member_join(member)
+
+    channel.send.assert_not_called()
+    member.send.assert_not_called()
+    apply.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_join_old_enough_account_is_greeted(monkeypatch):
+    """An account at/above the threshold is greeted normally."""
+    channel = _text_channel()
+    member = _aged_member(days_old=30)  # 30 days old, gate is 7
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                channel_id=100,
+                min_account_age_days=7,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_join(member)
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_join_gate_off_does_not_consult_account_age(monkeypatch):
+    """With the gate at 0 a brand-new account is still greeted (default behaviour)."""
+    channel = _text_channel()
+    member = _aged_member(days_old=0)  # created seconds ago
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                channel_id=100,
+                min_account_age_days=0,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_join(member)
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_join_unknown_account_age_fails_open(monkeypatch):
+    """A missing created_at (unknown age) greets rather than silently dropping."""
+    channel = _text_channel()
+    member = _member()
+    member.created_at = None
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                channel_id=100,
+                min_account_age_days=7,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_join(member)
+    channel.send.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Ping-then-delete (auto-delete the channel greeting/farewell)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_join_greeting_passes_delete_after(monkeypatch):
+    channel = _text_channel()
+    member = _member()
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                channel_id=100,
+                delete_after_seconds=30,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_join(member)
+    channel.send.assert_awaited_once()
+    assert channel.send.await_args.kwargs["delete_after"] == 30.0
+
+
+@pytest.mark.asyncio
+async def test_join_greeting_delete_after_off_is_none(monkeypatch):
+    channel = _text_channel()
+    member = _member()
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                join_enabled=True,
+                channel_id=100,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_join(member)
+    assert channel.send.await_args.kwargs["delete_after"] is None
+
+
+@pytest.mark.asyncio
+async def test_leave_farewell_passes_delete_after(monkeypatch):
+    channel = _text_channel()
+    member = _member()
+    member.guild.get_channel.return_value = channel
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                leave_enabled=True,
+                channel_id=100,
+                delete_after_seconds=45,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_leave(member)
+    assert channel.send.await_args.kwargs["delete_after"] == 45.0
+
+
+@pytest.mark.asyncio
+async def test_dm_greeting_is_never_deleted(monkeypatch):
+    """delete_after applies to the channel post, never to the DM send."""
+    member = _member()
+    member.send = AsyncMock()
+    monkeypatch.setattr(
+        welcome_service.welcome_config,
+        "load_policy",
+        AsyncMock(
+            return_value=WelcomePolicy(
+                enabled=True,
+                dm_enabled=True,
+                delete_after_seconds=30,
+            ),
+        ),
+    )
+    await welcome_service.handle_member_join(member)
+    member.send.assert_awaited_once()
+    assert "delete_after" not in member.send.await_args.kwargs


### PR DESCRIPTION
Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closes the **Welcome** completion cert's punch-list #2 remainder — the last two best-in-class options vs Carl-bot/MEE6/Dyno:

- **Join-delay age-gating** — a `welcome_min_account_age_days` setting (default `0` = off). When set, a joining member whose Discord account is younger than the threshold gets **no greeting, no DM, and no entry role** — anti-raid (fresh throwaway accounts in a raid don't get auto-roled in). Fail-open: an unknown account age greets normally.
- **Ping-then-delete** — a `welcome_delete_after_seconds` setting (default `0` = keep). When set, the **channel** greeting/farewell message is auto-deleted after N seconds (via discord.py's native `delete_after`), keeping the channel uncluttered. The DM greeting is untouched.

Both are additive scalar settings on the existing welcome policy model — **no migration**, default-off, **byte-identical** for every existing config.

Born-red per Q-0133; flips to `complete` as the final step. Self-merge on green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr9WYWDHzrCZjMQRLnbako)_