### PR TITLE
Cleanup: spam-duplicate window → real per-guild setting (cert punch #4)

### DIFF
--- a/.sessions/2026-06-30-cleanup-spam-window-setting.md
+++ b/.sessions/2026-06-30-cleanup-spam-window-setting.md
@@ -1,0 +1,13 @@
+# 2026-06-30 — Cleanup spam-window per-guild setting (completion-first deepening)
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+
+## What this run is about to do
+Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closing **Cleanup completion
+cert punch #4** — surface the hardcoded `!cleanuphistory` spam-duplicate window
+(`SPAM_DUPLICATE_WINDOW_SECONDS = 15`) as a **real per-guild scalar setting with a config-input
+widget** (the `numeric_presets` Settings widget, mirroring automod's `spam_window_seconds`), read at
+command time via `settings_resolution.resolve_value`. Default-off / byte-identical (default stays 15),
+no migration (scalar KV). Then groom one more turn-key completion-first slice if budget allows.

--- a/.sessions/2026-06-30-cleanup-spam-window-setting.md
+++ b/.sessions/2026-06-30-cleanup-spam-window-setting.md
@@ -1,13 +1,89 @@
 # 2026-06-30 — Cleanup spam-window per-guild setting (completion-first deepening)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
 
-## What this run is about to do
-Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closing **Cleanup completion
-cert punch #4** — surface the hardcoded `!cleanuphistory` spam-duplicate window
-(`SPAM_DUPLICATE_WINDOW_SECONDS = 15`) as a **real per-guild scalar setting with a config-input
-widget** (the `numeric_presets` Settings widget, mirroring automod's `spam_window_seconds`), read at
-command time via `settings_resolution.resolve_value`. Default-off / byte-identical (default stays 15),
-no migration (scalar KV). Then groom one more turn-key completion-first slice if budget allows.
+## What this run did
+Empty-fire dispatch advancing the S1 completion-first arc (Q-0209). Closed **Cleanup completion
+cert punch #4** — the last *offline* gap on the Cleanup unit — in one focused PR (#1588).
+**Cleanup's offline punch-list is now CLOSED** (only the owner live walk #5/#6 remains).
+
+### The change
+The `!cleanuphistory` spam-duplicate detection window was a hardcoded module constant
+(`SPAM_DUPLICATE_WINDOW_SECONDS = 15` in `cleanup_cog.py`) that no operator could change. It is now a
+**real per-guild scalar setting with a config-input widget**, mirroring automod's `spam_window_seconds`:
+
+- **New settings key** `CLEANUP_SPAM_WINDOW_SECONDS` (`disbot/utils/settings_keys/cleanup.py`, new
+  submodule) wired into the package `__init__` import + `__all__`. Scalar legacy-KV — **no migration**.
+- **New `SettingSpec`** on `CLEANUP_CONFIG_SCHEMA` (`cogs/cleanup/schemas.py`): name
+  `spam_window_seconds`, int, default 15, `input_hint="numeric_presets"`, presets (10, 15, 30), bounded
+  validator (1..300), capability `cleanup.policy.configure` (a *registered* cap — the identity-contract
+  registry check validates `SettingSpec.capability_required`, unlike the informational DomainPanelSpec).
+  Default + bounds live in the schema module as the single source of truth shared with the consumer.
+- **Runtime read:** `cleanup_cog._resolve_spam_window(guild_id)` resolves via the canonical
+  `settings_resolution.resolve_value`, falling back to the declared default when unset/malformed/out-of
+  -range. `cleanuphistory_command` now passes the resolved window. **Byte-identical** (default stays 15).
+- Cleanup is now a **scalar + domain-panel** Settings group (was panel-only), so it surfaces an editable
+  page through the existing `!settings` widget + the `numeric_presets` widget (`edit_number_presets.py`).
+
+### Tests (+13) / docs
+- `tests/unit/cogs/test_cleanup_schemas.py` (new) — register/idempotent, domain-panel retained, spec
+  shape (default==constant / value_type / settings_key / widget / presets), default-is-historical-15,
+  registered-capability, validator bounds (lower/upper/default ok; below/above/bool/str rejected).
+- `tests/unit/cogs/test_cleanup_spam_window.py` (new) — per-guild resolution returns a set value;
+  falls back to default when unset / malformed (`"abc"`) / out-of-range (`"99999"`) — never raises.
+- `tests/unit/views/test_settings_hub_view.py` — updated the 3 cleanup assertions for the new reality
+  (cleanup `surfaces == ("settings", "panel")`, `editable_setting_count == 1`, inventory `settings: 3`).
+- De-staled the settings command-map doc (cleanup §9/§10), the Cleanup completion cert (punch #4 ✅,
+  verdict, evidence, header note), S1 current-state (recently-shipped + 3 stale Cleanup-#4 pointers),
+  and regenerated the 4 generated artifacts (`setting_keys` 112 → 113, `typed_settings` 93).
+
+## Verification
+- `python3.10 scripts/check_quality.py --full` GREEN — the only 3 failures were captured by a run that
+  started *before* the doc + artifact fixes (the expected `test_existing_settings_keys_constants_referenced`
+  + two artifact-freshness checks); re-ran them after the fixes → all 14 pass. Lint/format/docs/
+  consistency/artifacts all green on `--check-only`.
+- `python3.10 scripts/check_architecture.py --mode strict` — 0 errors (warnings all pre-existing).
+
+## Handoff — next ▶
+**Cleanup unit: offline punch-list CLOSED** — only the owner live walk + sign-off (#5/#6) remain.
+**Diagnostics** + **Welcome** offline punch-lists are also closed (#1584 / #1581). The next turn-key
+**offline** completion-first picks are the named weak spots from the #1545 assessment sweep:
+- **Inventory** — item grants are unaudited + capabilities unenforced (route grants through a
+  `*_mutation.py` seam + `emit_audit_action`; enforce the declared capabilities). *Bugs-first material*
+  (an unaudited mutation seam), but touches economy/inventory writes → keep it a small focused PR.
+- **Proof-channel** modal authority re-check was already addressed by #1550/#1551 — verify before
+  picking it (don't re-do shipped work).
+See `docs/planning/feature-completion/units/` for each cert's punch-list.
+
+## 💡 Session idea
+**A "scalar-setting half-ship" guard.** This run (and the welcome run before it) both turned a
+hardcoded constant into a `SettingSpec`. The recurring half-ship class is the *reverse*: a `SettingSpec`
+declared but the consumer still reads the old constant / hardcoded value, so the operator's setting does
+nothing (the dead-stat class BUG-0026 caught for gear). A cheap AST checker could flag a module that
+declares a `SettingSpec(settings_key=X)` whose `settings_key` constant is **not** read by any
+`resolve_value`/`resolve_setting` call anywhere in `disbot/` — i.e. a setting nobody consumes. Mirrors
+the existing `test_effective_stats_consumed.py` invariant, applied to scalar settings. Dedup-checked
+`docs/ideas/` — not present; worth an idea file if a later run agrees.
+
+## ⟲ Previous-session review
+The previous run (#1581, Welcome age-gating + ping-then-delete) was a clean completion-first slice and
+left a *correct, specific* handoff naming Cleanup #4 as a turn-key pick with the right caveat ("heavier,
+needs a widget not a constant rename") — that pointer is exactly what let this run start in one hop. One
+thing it (and the runs before it) repeatedly hit: the **full suite was launched before the doc/artifact
+de-stale**, so it always reports the same 3 expected red checks (settings-doc + artifact freshness). A
+small workflow improvement: when a change adds a settings key/spec, regenerate artifacts + update the
+command-map doc **first**, then run `--full` once — saves a guaranteed-red full run (~2.5 min each). I
+followed the same out-of-order pattern this run; the fix is to make "new settings key ⇒ regen + doc"
+a pre-`--full` checklist step (candidate for the journal Quick reference).
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PR:** #1588 (Cleanup spam-window per-guild setting, punch #4) — self-merge on green (small/contained).
+- **⚑ Self-initiated:** none (completion-first arc is the standing S1 dispatch lane; this is the named
+  Cleanup cert punch #4, not an unprompted idea→plan promotion).
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (no migration, scalar KV setting; merge auto-deploys).
+- **Bugs:** none opened; none fixed (a latent "operator can't change the spam window" UX gap closed, not
+  a runtime bug).

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T19:09:17Z",
+    "generated_at": "2026-06-30T21:11:58Z",
     "build": {
-      "commit": "8252a5d",
-      "subject": "Add fishing rod-recipe browser with live craft progress",
-      "committed_at": "2026-06-30T19:09:17Z"
+      "commit": "d9f571b1",
+      "subject": "chore: born-red session card — cleanup spam-window setting (punch #4)",
+      "committed_at": "2026-06-30T21:11:58Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7192,7 +7192,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "8252a5d",
+    "build": "d9f571b1",
     "title": "New public bot website",
     "changes": [
       {
@@ -7204,7 +7204,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "8252a5d",
+    "build": "d9f571b1",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7216,7 +7216,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "8252a5d",
+    "build": "d9f571b1",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-30T22:10:17Z",
+    "generated_at": "2026-06-30T21:11:58Z",
     "build": {
-      "commit": "73b272b4",
-      "subject": "Merge pull request #1586 from menno420/claude/claude-md-conciseness-plan",
-      "committed_at": "2026-06-30T22:10:17Z"
+      "commit": "d9f571b1",
+      "subject": "chore: born-red session card — cleanup spam-window setting (punch #4)",
+      "committed_at": "2026-06-30T21:11:58Z"
     },
     "counts": {
       "functions": 43,
@@ -16,9 +16,9 @@
       "env_vars": 39,
       "cogs": 55,
       "commands": 474,
-      "setting_keys": 112,
-      "setting_domains": 16,
-      "typed_settings": 92,
+      "setting_keys": 113,
+      "setting_domains": 17,
+      "typed_settings": 93,
       "visible_subsystems": 43,
       "synonyms": 87,
       "bot_changelog": 3
@@ -2748,6 +2748,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-30-cleanup-spam-window-setting.md",
+      "date": "2026-06-30",
+      "title": "2026-06-30 — Cleanup spam-window per-guild setting (completion-first deepening)",
+      "status": "in-progress",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-30-cleanup-history-filters.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — Cleanup history filters + age gate (completion-first deepening)",
@@ -3143,14 +3151,6 @@
       "file": "2026-06-27-btd6-revert-counter-list.md",
       "date": "2026-06-27",
       "title": "2026-06-27 — BTD6: revert the auto-derived DDT counter list (it grounded wrong towers)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-btd6-qa-accuracy.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — BTD6 QA accuracy: damage-type/status-effect interaction grounding + verified Q&A corpus",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -10023,6 +10023,20 @@
         {
           "constant": "BTD6_CACHE_FRESHNESS_WARNING_HOURS",
           "key": "btd6_cache_freshness_warning_hours"
+        }
+      ]
+    },
+    {
+      "domain": "cleanup",
+      "purpose": "Settings keys owned by the Cleanup subsystem (cogs.cleanup_cog).",
+      "keys": [
+        {
+          "constant": "CLEANUP_SPAM_WINDOW_SECONDS",
+          "key": "cleanup_spam_window_seconds",
+          "type": "int",
+          "hint": "Window (seconds) the `!cleanuphistory` spam sweep treats two near-identical messages from one author as duplicates.",
+          "allowed_values": [],
+          "default": 15
         }
       ]
     },

--- a/disbot/cogs/cleanup/schemas.py
+++ b/disbot/cogs/cleanup/schemas.py
@@ -4,20 +4,79 @@ Cleanup's real configuration is **domain config**, not scalar settings:
 prohibited-word policy + cleanup behavior live in the governance
 ``cleanup_policies`` tables (written only by
 :class:`~governance.writes.GovernanceMutationPipeline`) and are operated
-through the dedicated cleanup panel.  This schema declares exactly that —
-a :class:`~core.runtime.subsystem_schema.DomainPanelSpec` and no scalar
-settings — so the Settings hub discovers cleanup as a *domain
-configuration group* through the real declaration mechanism instead of
-the retired Phase 1 ``DOMAIN_CONFIG_SUBSYSTEMS`` curated table
-(settings audit §10.2 step 4; consolidated plan Batch 4).
+through the dedicated cleanup panel.  This schema declares that
+destination as a :class:`~core.runtime.subsystem_schema.DomainPanelSpec`
+so the Settings hub discovers cleanup as a *domain configuration group*
+through the real declaration mechanism instead of the retired Phase 1
+``DOMAIN_CONFIG_SUBSYSTEMS`` curated table (settings audit §10.2 step 4;
+consolidated plan Batch 4).
+
+It **also** declares the one genuine *scalar* cleanup behaviour — the
+``!cleanuphistory`` spam-duplicate detection window — as a
+:class:`~core.runtime.subsystem_schema.SettingSpec` with a
+``numeric_presets`` config-input widget (completion-cert punch #4).  This
+is an operational knob, not policy, so it is a legacy-KV scalar setting
+(no migration) rather than a governance ``cleanup_policies`` row, mirroring
+automod's ``spam_window_seconds``.  The default + bounds below are the
+single source of truth shared with the consumer in ``cogs.cleanup_cog``
+(pinned by ``test_cleanup_schemas``), so a spec default and the runtime
+fallback can never silently drift.
 """
 
 from __future__ import annotations
 
-from core.runtime.subsystem_schema import DomainPanelSpec, SubsystemSchema
+from core.runtime.subsystem_schema import (
+    DomainPanelSpec,
+    SettingSpec,
+    SubsystemSchema,
+)
+from utils.settings_keys import CLEANUP_SPAM_WINDOW_SECONDS
+
+# Spam-duplicate detection window (seconds) for the ``!cleanuphistory`` spam
+# sweep.  Default is the historical hardcoded constant so every existing guild
+# behaves byte-identically; bounds keep the window sane (1s..5min).
+DEFAULT_SPAM_WINDOW_SECONDS = 15
+MIN_SPAM_WINDOW_SECONDS = 1
+MAX_SPAM_WINDOW_SECONDS = 300
+
+# Edit authority borrows the cleanup *policy* configure capability: the spam
+# window is cleanup behaviour, configured by the same staff who set cleanup
+# policy.  (``cleanup.settings.configure`` is not a registered capability;
+# ``cleanup.policy.configure`` is — see ``utils.subsystem_registry``.)
+_CLEANUP_CAPABILITY = "cleanup.policy.configure"
+
+
+def _validate_spam_window(value: object) -> None:
+    # ``isinstance(True, int)`` is True, so guard the bool type explicitly.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"expected int, got {value!r}")
+    if not (MIN_SPAM_WINDOW_SECONDS <= value <= MAX_SPAM_WINDOW_SECONDS):
+        raise ValueError(
+            f"must be between {MIN_SPAM_WINDOW_SECONDS} and {MAX_SPAM_WINDOW_SECONDS}",
+        )
+
+
+CLEANUP_SETTINGS: tuple[SettingSpec, ...] = (
+    SettingSpec(
+        name="spam_window_seconds",
+        value_type=int,
+        default=DEFAULT_SPAM_WINDOW_SECONDS,
+        settings_key=CLEANUP_SPAM_WINDOW_SECONDS,
+        capability_required=_CLEANUP_CAPABILITY,
+        hint=(
+            "Window (seconds) the `!cleanuphistory` spam sweep treats two "
+            "near-identical messages from one author as duplicates."
+        ),
+        validator=_validate_spam_window,
+        input_hint="numeric_presets",
+        presets=(10, 15, 30),
+    ),
+)
+
 
 CLEANUP_CONFIG_SCHEMA = SubsystemSchema(
     subsystem="cleanup",
+    settings=CLEANUP_SETTINGS,
     domain_panels=(
         DomainPanelSpec(
             name="Cleanup policies",
@@ -40,4 +99,11 @@ def register_schemas() -> None:
     subsystem_schema.register(CLEANUP_CONFIG_SCHEMA)
 
 
-__all__ = ["CLEANUP_CONFIG_SCHEMA", "register_schemas"]
+__all__ = [
+    "CLEANUP_CONFIG_SCHEMA",
+    "CLEANUP_SETTINGS",
+    "DEFAULT_SPAM_WINDOW_SECONDS",
+    "MAX_SPAM_WINDOW_SECONDS",
+    "MIN_SPAM_WINDOW_SECONDS",
+    "register_schemas",
+]

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -32,7 +32,6 @@ CLEANUP_STAGE_NAME = "cleanup"
 # stage-order table in core/runtime/message_pipeline.py.
 CLEANUP_STAGE_ORDER = 10
 MAX_CLEANUP_HISTORY_LIMIT = 1000
-SPAM_DUPLICATE_WINDOW_SECONDS = 15
 HELPER_DELETE_DELAY_SECONDS = 3
 # How long the "commands aren't allowed here" notice stays before self-deleting.
 _BLOCKED_COMMAND_NOTICE_SECONDS = 8
@@ -74,6 +73,25 @@ def _parse_duration_seconds(raw: str) -> int | None:
     if value <= 0:
         return None
     return value * unit_seconds
+
+
+async def _resolve_spam_window(guild_id: int) -> int:
+    """Resolve the per-guild ``!cleanuphistory`` spam-duplicate window (seconds).
+
+    Reads the ``cleanup_spam_window_seconds`` scalar setting via the canonical
+    :func:`services.settings_resolution.resolve_value`, which falls back to the
+    declared :class:`SettingSpec` default (15s) when unset or malformed — so a
+    fresh guild behaves byte-identically to the old hardcoded constant.
+    """
+    from cogs.cleanup.schemas import DEFAULT_SPAM_WINDOW_SECONDS
+    from services.settings_resolution import resolve_value
+
+    return await resolve_value(
+        guild_id,
+        "cleanup",
+        "spam_window_seconds",
+        DEFAULT_SPAM_WINDOW_SECONDS,
+    )
 
 
 class CleanupStage:
@@ -375,6 +393,7 @@ class Cleanup(commands.Cog):
             return
 
         prohibited_words = await db.get_prohibited_words(ctx.guild.id)
+        spam_window = await _resolve_spam_window(ctx.guild.id)
         plan = await build_history_cleanup_plan(
             ctx.channel,
             limit=effective_limit,
@@ -383,7 +402,7 @@ class Cleanup(commands.Cog):
             command_prefixes=self.command_prefixes,
             prohibited_words=prohibited_words,
             exclude_message_ids={ctx.message.id},
-            spam_duplicate_window_seconds=SPAM_DUPLICATE_WINDOW_SECONDS,
+            spam_duplicate_window_seconds=spam_window,
             older_than=older_than,
         )
         final_msg = None

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -49,6 +49,9 @@ from utils.settings_keys.btd6_cache import (
     BTD6_CACHE_DEFAULT_INTERVAL_SECONDS,
     BTD6_CACHE_FRESHNESS_WARNING_HOURS,
 )
+from utils.settings_keys.cleanup import (
+    CLEANUP_SPAM_WINDOW_SECONDS,
+)
 from utils.settings_keys.counters import (
     COUNTERS_BOTS_CHANNEL,
     COUNTERS_BOTS_TEMPLATE,
@@ -187,6 +190,7 @@ __all__ = [
     "BTD6_CT_GROUP_ID",
     "BTD6_STRATEGY_SUBMISSION_CHANNEL",
     "BTD6_VERSION_ANNOUNCEMENT_CHANNEL",
+    "CLEANUP_SPAM_WINDOW_SECONDS",
     "COUNTERS_BOTS_CHANNEL",
     "COUNTERS_BOTS_TEMPLATE",
     "COUNTERS_ENABLED",

--- a/disbot/utils/settings_keys/cleanup.py
+++ b/disbot/utils/settings_keys/cleanup.py
@@ -1,0 +1,20 @@
+"""Settings keys owned by the Cleanup subsystem (cogs.cleanup_cog).
+
+Cleanup's *real* configuration is domain config — prohibited-word policy and the
+per-scope cleanup-level hierarchy live in the governance ``cleanup_policies``
+tables (written only through ``governance.writes.GovernanceMutationPipeline``).
+This module holds the handful of cleanup behaviours that are genuine **scalar**
+guild settings (the legacy KV ``guild_settings`` table) — there is **no
+migration**.  Prefixed ``cleanup_*`` to keep the shared KV namespace
+collision-free, matching the per-subsystem naming convention.
+
+The default is the safe minimal shape so a fresh guild behaves exactly as it
+does today; an operator opts into a different window.  See
+``cogs.cleanup.schemas`` for the default + bounds (the single source of truth
+shared with the ``CLEANUP_CONFIG_SCHEMA`` spec).
+"""
+
+# Duplicate-message detection window (seconds) for the ``!cleanuphistory`` spam
+# sweep — two near-identical messages from the same author within this window
+# count as a duplicate.  Default 15 (the historical constant); operator-tunable.
+CLEANUP_SPAM_WINDOW_SECONDS = "cleanup_spam_window_seconds"

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,14 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Cleanup — spam-duplicate window → real per-guild setting** (PR #1588, completion-first deepening,
+  Cleanup cert punch #4 — **Cleanup's offline punch-list now CLOSED**) — the hardcoded
+  `SPAM_DUPLICATE_WINDOW_SECONDS = 15` constant (used by the `!cleanuphistory` spam sweep) became the
+  `cleanup.spam_window_seconds` scalar `SettingSpec` (settings key `CLEANUP_SPAM_WINDOW_SECONDS`, no
+  migration) with a `numeric_presets` config-input widget (presets 10/15/30, bounds 1..300, capability
+  `cleanup.policy.configure`). `!cleanuphistory` resolves it per-guild via
+  `settings_resolution.resolve_value`, falling back to the declared default — **byte-identical** for
+  every existing guild. +13 tests; cleanup is now a scalar+panel Settings group. Self-merge on green.
 - **Fishing — rod-recipe browser with live craft progress** (PR #1585, the named "next offline
   successor" on the fish→rod craft seam) — the rod shop already advertised a recipe's bare
   requirement ("10 fish, size ≤ 6") but never showed how close the player already was. A new
@@ -214,8 +222,8 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   content-type sweep modes (`embeds`/`links`/`attachments`, Carl-bot/MEE6/Dyno parity) + an
   `older:<duration>` age gate composable with every mode (`HISTORY_CLEANUP_MODES` + `older_than`
   cutoff in the pure `services/history_cleanup.py`; +12 tests). Punch #1 (panel authority re-check)
-  found **already covered** (stale cert note corrected). Cleanup's remaining gaps: #4 spam-window
-  setting (needs a config-input widget — deferred) + the owner walkthrough/sign-off (#5/#6).
+  found **already covered** (stale cert note corrected). Cleanup #4 (spam-window setting) **✅ DONE
+  2026-06-30 (#1588)** — see below; Cleanup's only remaining gaps are now the owner walkthrough/sign-off (#5/#6).
   **✅ DONE 2026-06-30 (#1575): Diagnostics punch #1 + Counters punch #3.** Diagnostics #1 (hub
   completeness) — `startup` + `findings` (read-only health reports) grouped into the `!platform` hub's
   Runtime/status select (audience-preserving `_dispatch`; the `finding` mutation stays out of the
@@ -223,8 +231,9 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   backoff, capped) wired into the rename loop so a persistently-failing guild is skipped for a growing
   number of ticks but never dropped forever. **▶ Next turn-key picks:** ~~Diagnostics list pagination
   (punch #2) + #5 (health-metrics reconcile)~~ **✅ DONE 2026-06-30 (#1584)** — Diagnostics' offline
-  punch-list is now closed (only the owner live walk #3/#4 remains) · Cleanup #4 (spam-window setting
-  *with* a Settings widget). *(Counters punch
+  punch-list is now closed (only the owner live walk #3/#4 remains) · ~~Cleanup #4 (spam-window setting
+  *with* a Settings widget)~~ **✅ DONE 2026-06-30 (#1588)** — `cleanup.spam_window_seconds` scalar with
+  a `numeric_presets` config-input widget; **Cleanup's offline punch-list is now CLOSED**. *(Counters punch
   #1/#2/#4/#5 ✅ #1568; #3 ✅ #1575.)*
   **✅ DONE 2026-06-30 (#1579 + #1581): Welcome punch #2 (best-in-class options) — ALL 4 CLOSED.**
   **Multiple/random messages** + **opt-in DM greeting** (#1579), then **join-delay age-gating**
@@ -235,9 +244,10 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   settings (`numeric_presets` hints), migration-free, byte-identical for existing configs; +18 tests.
   **Welcome punch-list #2 is now CLOSED** — every named best-in-class option exists. Remaining Welcome
   gaps: #1 bespoke panel (or owner waiver) · #3 binding-seam · #4 cog-tests · #5/#6 owner walkthrough.
-  **▶ Next turn-key picks (other units):** Diagnostics list pagination (punch #2 — apply `_PaginatorView`
-  to long findings/consistency output) + #5 (health-metrics reconcile) · Cleanup #4 (spam-window
-  setting *with* a Settings widget).
+  **▶ Next turn-key picks (other units):** ~~Diagnostics list pagination (#2) + #5 (health-metrics
+  reconcile)~~ **✅ #1584** · ~~Cleanup #4 (spam-window setting *with* a Settings widget)~~ **✅ #1588**.
+  Both units' offline punch-lists are now CLOSED. Next offline deepening: Inventory item-grant audit +
+  capability cleanup · Proof-channel lock/unlock audit + modal authority re-check (the named weak spots).
 - `[owner]` **Feature-completion assessments — ALL 36 UNITS ◐ ASSESSED (100%; 0 certified).** The
   completion-first arc (Q-0209). The `▢ → ◐` assessment sweep is **COMPLETE** — every game + server-fn
   now has a rubric-filled, source-grounded certificate under

--- a/docs/owner/claims/funny-franklin-hhpsgs.md
+++ b/docs/owner/claims/funny-franklin-hhpsgs.md
@@ -1,6 +1,0 @@
-# Claim
-
-- branch · `claude/funny-franklin-hhpsgs`
-- scope · Cleanup completion-cert punch #4 — make the `!cleanuphistory` spam-duplicate window a real per-guild setting (config-input widget)
-- expected files/area · `disbot/utils/settings_keys/cleanup.py` (new) + `__init__`, `disbot/cogs/cleanup/schemas.py`, `disbot/cogs/cleanup_cog.py`, tests, settings command-map doc, cert
-- date · 2026-06-30

--- a/docs/owner/claims/funny-franklin-hhpsgs.md
+++ b/docs/owner/claims/funny-franklin-hhpsgs.md
@@ -1,0 +1,6 @@
+# Claim
+
+- branch · `claude/funny-franklin-hhpsgs`
+- scope · Cleanup completion-cert punch #4 — make the `!cleanuphistory` spam-duplicate window a real per-guild setting (config-input widget)
+- expected files/area · `disbot/utils/settings_keys/cleanup.py` (new) + `__init__`, `disbot/cogs/cleanup/schemas.py`, `disbot/cogs/cleanup_cog.py`, tests, settings command-map doc, cert
+- date · 2026-06-30

--- a/docs/planning/feature-completion/units/cleanup.md
+++ b/docs/planning/feature-completion/units/cleanup.md
@@ -19,8 +19,9 @@
 > per-scope cleanup-level hierarchy (Off/Light/Standard/Strict + custom) resolved guild→category→channel.
 > Every write routes through the audited `GovernanceMutationPipeline`
 > (DB + `governance_audit_log` + `audit.action_recorded` in one transaction) and every auto-delete
-> through `moderation_service.auto_delete`. The remaining honest gaps are a hardcoded spam window
-> (needs a config-input widget to be a real setting) and the live walkthrough/owner ✔.
+> through `moderation_service.auto_delete`. The offline punch-list is now CLOSED (the spam-duplicate
+> window became a real per-guild setting with a config-input widget); the only remaining gaps are the
+> live walkthrough/owner ✔.
 
 ## Rubric (server function)
 
@@ -72,10 +73,11 @@
 - [x] **Pipeline contract** — no scalar settings; configuration is **domain config** (the
       `cleanup_policies` governance table) written only through the audited pipeline; no raw DB writes.
 - [x] **config-input widgets** — scope + level + custom-tuning selects (delete-after 0–300s, bool flags);
-      no free-text that could break parsing.
+      the `!cleanuphistory` spam-duplicate window is a scalar `SettingSpec` with a `numeric_presets`
+      config-input widget (✅ #4 this run); no free-text that could break parsing.
 - [x] **Everything configurable that should be** — words add/remove/list, anti-evasion toggle, per-scope
-      levels + custom, history filters (content-type + age); intentionally fixed: pipeline order; the
-      spam window stays a constant pending a config-input widget (→ punch #4).
+      levels + custom, history filters (content-type + age), and the **spam-duplicate window** (✅ #4 —
+      a real per-guild setting now); intentionally fixed: pipeline order.
 
 ### F. Wiring & discoverability
 - [x] **Registry** — key `cleanup`, `category: moderation`, `visibility_tier: administrator`,
@@ -104,10 +106,13 @@
    modes added to `build_history_cleanup_plan` + `!cleanuphistory` (Carl-bot/MEE6/Dyno parity).
 3. ✅ **DONE this run — history age filter.** An `older:<duration>` token (e.g. `older:7d`) sets an
    `older_than` cutoff composable with every mode (bounded by Discord's newest-first pagination).
-4. **Configurable spam window** *(offline, minor — deferred)* — surfacing
-   `SPAM_DUPLICATE_WINDOW_SECONDS` as a *real* per-guild setting needs a config-input widget (a
-   constant rename alone is not "configurable" in the rubric sense), so it is left for a follow-up
-   rather than half-shipped.
+4. ✅ **DONE this run — configurable spam window.** The hardcoded
+   `SPAM_DUPLICATE_WINDOW_SECONDS = 15` constant became the `cleanup.spam_window_seconds` scalar
+   `SettingSpec` (settings key `CLEANUP_SPAM_WINDOW_SECONDS`, no migration) with a `numeric_presets`
+   config-input widget (presets 10/15/30, bounds 1..300, capability `cleanup.policy.configure`).
+   `!cleanuphistory` reads it per-guild via `settings_resolution.resolve_value`, falling back to the
+   declared default — **byte-identical** for every existing guild. A real per-guild setting now, not a
+   constant.
 5. **Live walkthrough** *(owner / live-bot)* — `/verify-bot` boot + scripted click-through (panel → word
    add/remove → a per-scope level set → `!cleanuphistory` confirm), with screenshots.
 6. **Owner sign-off** — maintainer confirms "it does its job the most convenient way."
@@ -119,7 +124,10 @@
   raise, age gate incl. spam-mode composition) · `…/test_cleanup_levels.py` · `…/test_cleanup_profiles.py` ·
   `…/test_cleanup_diagnostics.py` · `tests/unit/runtime/test_successful_command_cleanup.py` ·
   `tests/unit/governance/test_cleanup_resolution_behavior.py` ·
-  `tests/unit/views/cleanup/test_policy_panel.py::test_apply_button_requires_admin` (panel authority, #1)
+  `tests/unit/views/cleanup/test_policy_panel.py::test_apply_button_requires_admin` (panel authority, #1) ·
+  `tests/unit/cogs/test_cleanup_schemas.py` (spam-window spec shape / default / bounds / capability, #4) ·
+  `tests/unit/cogs/test_cleanup_spam_window.py` (per-guild resolution + default/malformed/out-of-range
+  fallback, #4) · `tests/unit/views/test_settings_hub_view.py` (cleanup now surfaces `settings`+`panel`)
 - **Walkthrough:** pending (punch #5)
 - **Owner sign-off:** pending (punch #6)
 
@@ -127,7 +135,8 @@
 Cleanup is a **structurally strong, fully-audited** moderation unit — prohibited-word + command-access
 filtering, a **seven-mode** bulk history sweep with an age gate, and a per-scope cleanup-level hierarchy,
 all written through the audited governance pipeline and discoverable via command/hub/Help/Setup. The
-best-in-class history-filter gaps (#2/#3) were **closed this run** (embeds/links/attachments modes +
-`older:<duration>`), the panel-authority test (#1) was found **already present** (stale note corrected),
-so the remaining gaps are the **configurable spam window** (#4 — needs a config-input widget, deferred)
-and the owner walkthrough/sign-off (#5/#6). No safety/audit/dead-end issues found.
+best-in-class history-filter gaps (#2/#3) were closed, the panel-authority test (#1) was found already
+present, and the **configurable spam window (#4) is now DONE** — a real per-guild scalar setting with a
+`numeric_presets` config-input widget. The **entire offline punch-list is now CLOSED**; the only
+remaining gaps are the owner-led live walkthrough + sign-off (#5/#6, `[owner]`/`[live-bot]`). No
+safety/audit/dead-end issues found.

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -868,12 +868,17 @@ chokepoint); actions route through `moderation_service` (no parallel audit path)
 6. **help_menu_discoverable**: Yes.
 7. **dedicated_panel_command**: `none`.
 8. **help_menu_direct_navigation_hook**: `none`.
-9. **existing_SettingSpec_declarations**: none yet (governance owns
-    cleanup_policies; cleanup-level scalars are roadmap work in S8 v2/v3).
-10. **existing_settings_keys**: none — the legacy
-    `CLEANUP_WHITELIST_CHANNELS` env list was removed (channel exemption is
-    now a per-channel cleanup policy set to `Off`); only the ignored-channel
-    CSV in legacy KV remains to be migrated.
+9. **existing_SettingSpec_declarations**: `spam_window_seconds` — the
+    `!cleanuphistory` spam-duplicate detection window, a scalar with a
+    `numeric_presets` config-input widget (completion-cert punch #4,
+    `disbot/cogs/cleanup/schemas.py`; default 15s, bounds 1..300, capability
+    `cleanup.policy.configure`). Governance still owns cleanup_policies; the
+    deeper cleanup-level scalars stay roadmap work in S8 v2/v3.
+10. **existing_settings_keys**: `CLEANUP_SPAM_WINDOW_SECONDS`
+    (`disbot/utils/settings_keys/cleanup.py`) — a scalar guild setting, **no
+    migration**. The legacy `CLEANUP_WHITELIST_CHANNELS` env list was removed
+    (channel exemption is now a per-channel cleanup policy set to `Off`); only
+    the ignored-channel CSV in legacy KV remains to be migrated.
 11. **existing_BindingSpec_entries**: none. **Cleanup must not own a
     duplicate `cleanup_log_channel` binding** — the logging subsystem owns
     `cleanup_channel`; cleanup deep-links to it.

--- a/tests/unit/cogs/test_cleanup_schemas.py
+++ b/tests/unit/cogs/test_cleanup_schemas.py
@@ -1,0 +1,108 @@
+"""Unit tests for the cleanup subsystem schema (cogs.cleanup.schemas).
+
+Cleanup completion-cert punch #4: the ``!cleanuphistory`` spam-duplicate window
+is now a real per-guild scalar setting with a config-input widget.  These tests
+pin the spec shape (default / bounds / capability / widget) and the consumer's
+runtime resolution so the spec default and the cog fallback can never drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import subsystem_schema as schema_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    saved = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved.values():
+        schema_mod.register(schema)
+
+
+def test_register_adds_cleanup_schema():
+    from cogs.cleanup.schemas import register_schemas
+
+    register_schemas()
+    assert "cleanup" in schema_mod.registered_subsystems()
+    schema = schema_mod.get_schema("cleanup")
+    assert schema is not None and schema.subsystem == "cleanup"
+
+
+def test_register_is_idempotent():
+    from cogs.cleanup.schemas import register_schemas
+
+    register_schemas()
+    schema_mod._reset_for_tests()
+    register_schemas()
+    assert schema_mod.get_schema("cleanup") is not None
+
+
+def test_schema_keeps_its_domain_panel():
+    """Punch #4 adds a scalar setting *without* dropping the governance-policy
+    domain panel — cleanup surfaces both.
+    """
+    from cogs.cleanup.schemas import CLEANUP_CONFIG_SCHEMA
+
+    assert CLEANUP_CONFIG_SCHEMA.domain_panels
+    assert CLEANUP_CONFIG_SCHEMA.domain_panels[0].name == "Cleanup policies"
+
+
+def test_spam_window_spec_shape():
+    from cogs.cleanup.schemas import (
+        CLEANUP_SETTINGS,
+        DEFAULT_SPAM_WINDOW_SECONDS,
+    )
+    from utils.settings_keys import CLEANUP_SPAM_WINDOW_SECONDS
+
+    by_name = {s.name: s for s in CLEANUP_SETTINGS}
+    assert set(by_name) == {"spam_window_seconds"}
+    spec = by_name["spam_window_seconds"]
+    # Default equals the canonical constant (the cog fallback shares it).
+    assert spec.default == DEFAULT_SPAM_WINDOW_SECONDS
+    assert spec.value_type is int
+    assert spec.settings_key == CLEANUP_SPAM_WINDOW_SECONDS
+    # Config-input widget: a numeric preset row.
+    assert spec.input_hint == "numeric_presets"
+    assert spec.presets == (10, 15, 30)
+
+
+def test_spam_window_default_is_the_historical_constant():
+    """Byte-identical for existing guilds: the default stays the old 15s."""
+    from cogs.cleanup.schemas import DEFAULT_SPAM_WINDOW_SECONDS
+
+    assert DEFAULT_SPAM_WINDOW_SECONDS == 15
+
+
+def test_spam_window_requires_a_registered_capability():
+    from cogs.cleanup.schemas import CLEANUP_SETTINGS
+
+    for spec in CLEANUP_SETTINGS:
+        # Must be cleanup's registered policy-configure capability (an
+        # unregistered cap would trip the identity-contract registry check).
+        assert spec.capability_required == "cleanup.policy.configure"
+
+
+def test_spam_window_validator_bounds():
+    from cogs.cleanup.schemas import (
+        CLEANUP_SETTINGS,
+        MAX_SPAM_WINDOW_SECONDS,
+        MIN_SPAM_WINDOW_SECONDS,
+    )
+
+    validator = {s.name: s for s in CLEANUP_SETTINGS}["spam_window_seconds"].validator
+    assert validator is not None
+    validator(MIN_SPAM_WINDOW_SECONDS)  # ok — lower bound
+    validator(MAX_SPAM_WINDOW_SECONDS)  # ok — upper bound
+    validator(15)  # ok — the default
+    with pytest.raises(ValueError):
+        validator(MIN_SPAM_WINDOW_SECONDS - 1)  # below MIN
+    with pytest.raises(ValueError):
+        validator(MAX_SPAM_WINDOW_SECONDS + 1)  # above MAX
+    with pytest.raises(ValueError):
+        validator(True)  # bool is not a valid int
+    with pytest.raises(ValueError):
+        validator("15")  # str is not an int

--- a/tests/unit/cogs/test_cleanup_spam_window.py
+++ b/tests/unit/cogs/test_cleanup_spam_window.py
@@ -1,0 +1,65 @@
+"""The `!cleanuphistory` spam-window is resolved per-guild (cert punch #4).
+
+Pins that ``cogs.cleanup_cog._resolve_spam_window`` reads the
+``cleanup_spam_window_seconds`` scalar via the canonical settings resolver and
+falls back to the declared default (15s) when unset or malformed — so an
+existing guild's sweep behaves byte-identically to the old hardcoded constant.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.runtime import subsystem_schema as schema_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    saved = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    from cogs.cleanup.schemas import register_schemas
+
+    register_schemas()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved.values():
+        schema_mod.register(schema)
+
+
+async def test_resolves_a_set_per_guild_value(monkeypatch):
+    import utils.guild_config_accessors as accessors
+    from cogs.cleanup_cog import _resolve_spam_window
+
+    monkeypatch.setattr(accessors, "get_setting_value", AsyncMock(return_value="30"))
+    assert await _resolve_spam_window(42) == 30
+
+
+async def test_falls_back_to_default_when_unset(monkeypatch):
+    import utils.guild_config_accessors as accessors
+    from cogs.cleanup.schemas import DEFAULT_SPAM_WINDOW_SECONDS
+    from cogs.cleanup_cog import _resolve_spam_window
+
+    monkeypatch.setattr(accessors, "get_setting_value", AsyncMock(return_value=""))
+    assert await _resolve_spam_window(42) == DEFAULT_SPAM_WINDOW_SECONDS
+
+
+async def test_falls_back_to_default_on_malformed_value(monkeypatch):
+    import utils.guild_config_accessors as accessors
+    from cogs.cleanup.schemas import DEFAULT_SPAM_WINDOW_SECONDS
+    from cogs.cleanup_cog import _resolve_spam_window
+
+    # A non-int KV row must not raise — the resolver coerces, fails, defaults.
+    monkeypatch.setattr(accessors, "get_setting_value", AsyncMock(return_value="abc"))
+    assert await _resolve_spam_window(42) == DEFAULT_SPAM_WINDOW_SECONDS
+
+
+async def test_out_of_range_value_falls_back_to_default(monkeypatch):
+    """A stored value outside the validator bounds falls back, never crashes."""
+    import utils.guild_config_accessors as accessors
+    from cogs.cleanup.schemas import DEFAULT_SPAM_WINDOW_SECONDS
+    from cogs.cleanup_cog import _resolve_spam_window
+
+    monkeypatch.setattr(accessors, "get_setting_value", AsyncMock(return_value="99999"))
+    assert await _resolve_spam_window(42) == DEFAULT_SPAM_WINDOW_SECONDS

--- a/tests/unit/views/test_settings_hub_view.py
+++ b/tests/unit/views/test_settings_hub_view.py
@@ -135,11 +135,12 @@ def test_groups_include_bindings_only_subsystem():
 
 
 def test_groups_include_declared_domain_config_subsystem():
-    """Cleanup has no scalar/binding/resource declarations — it appears via
-    its schema's ``domain_panels`` declaration (Settings Phase 2; audit §4:
-    domain group linked to its canonical panel, never an empty scalar page).
-    Registers the REAL cleanup schema so the test pins the shipped
-    declaration, not a synthetic one.
+    """Cleanup appears via its schema's ``domain_panels`` declaration (Settings
+    Phase 2; audit §4: domain group linked to its canonical panel).  Since the
+    completion-cert punch #4 it *also* declares one scalar ``SettingSpec`` (the
+    ``!cleanuphistory`` spam-duplicate window) with a config-input widget, so it
+    surfaces **both** a scalar settings page and the domain panel.  Registers
+    the REAL cleanup schema so the test pins the shipped declaration.
     """
     from cogs.cleanup.schemas import CLEANUP_CONFIG_SCHEMA
 
@@ -148,7 +149,8 @@ def test_groups_include_declared_domain_config_subsystem():
     groups = {g.subsystem: g for g in actionable_settings_groups()}
     assert "cleanup" in groups
     assert groups["cleanup"].has_domain_panel is True
-    assert groups["cleanup"].surfaces == ("panel",)
+    assert groups["cleanup"].editable_setting_count == 1
+    assert groups["cleanup"].surfaces == ("settings", "panel")
 
 
 def test_groups_exclude_internal_subsystems(monkeypatch):
@@ -387,8 +389,9 @@ def test_hub_inventory_reflects_registered_settings_and_groups():
     settings_registry.build_registry()
     embed = SettingsHubView.build_embed()
     inventory = next(f.value for f in embed.fields if f.name == "Inventory")
-    assert "`settings`: 2" in inventory
-    # xp (scalar) + cleanup (declared domain group) are the actionable groups.
+    # xp's 2 scalars + cleanup's 1 scalar (spam-window, punch #4) = 3.
+    assert "`settings`: 3" in inventory
+    # xp (scalar) + cleanup (scalar + declared domain group) are the actionable groups.
     assert "`groups`: 2" in inventory
 
 


### PR DESCRIPTION
## What & why

Closes **Cleanup completion-certificate punch #4** (Q-0209 completion-first arc): surface the
hardcoded `!cleanuphistory` spam-duplicate window (`SPAM_DUPLICATE_WINDOW_SECONDS = 15`) as a
**real per-guild scalar setting with a config-input widget**, instead of a constant that no
operator can change.

Mirrors the proven automod `spam_window_seconds` pattern:
- New scalar KV settings key `cleanup_spam_window_seconds` (no migration — legacy KV table).
- New `SettingSpec` on `CLEANUP_CONFIG_SCHEMA` (`numeric_presets` config-input widget, presets
  10/15/30, bounded validator), capability `cleanup.policy.configure` (already registered).
- `!cleanuphistory` reads the value per-guild via `settings_resolution.resolve_value`, falling
  back to the declared default. **Byte-identical** for every existing guild (default stays 15).

## Status

> Born red — session card flips to `complete` as the final step (Q-0133).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhUT9ovcPqFo3a4X2cNw41)_