### PR TITLE
Inventory: item-detail density — rarity-tier fields (completion cert punch #4)

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -627,6 +627,18 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   same push as code**, or run the doc-freshness + session-log step *before* the first
   push. (Successor to the Q-0093 "merge in-turn" lesson, which predates native
   auto-merge.)
+- **★ PR stalls `blocked` with NO `code-quality` run on the head → GitHub dropped the
+  `pull_request:synchronize` event; recover by CLOSE+REOPEN, not just a dispatch re-kick
+  (2026-07-01, #1594).** Under the born-red rapid burst (open → push → push in ~2 min) GitHub
+  sometimes never fires the synchronize event for a `git push`, so the head gets no
+  `code-quality` run and auto-merge waits forever (`mergeable_state: blocked`). Recovery order:
+  **(1)** `actions_run_trigger run_workflow code-quality.yml --ref <branch>` (the
+  `ci-rerun-watchdog` remedy) — BUT a `workflow_dispatch` run's check does **not** satisfy the
+  *required* `code-quality` **context** (a hand `merge_pull_request` then 405s with *"Required
+  status check 'code-quality' is expected"*). **(2)** The reliable fix: **close then reopen the
+  PR** via `update_pull_request` (state closed → open) — `pull_request: reopened` fires a
+  PR-context run that DOES satisfy the required check; auto-merge (re-armed on reopen) then lands
+  it. Verify CI green locally first (`check_quality --full`) so the re-triggered run is trusted.
 - **Never stamp a PR number you haven't created (3 mis-stamps on 2026-06-10:**
   **#673→ok, #677→#678, #680→#682).** Parallel sessions consume numbers, so a
   guessed "next" number is wrong whenever anyone else ships. Order: push →

--- a/.sessions/2026-07-01-inventory-density.md
+++ b/.sessions/2026-07-01-inventory-density.md
@@ -1,6 +1,6 @@
 # 2026-07-01 — Inventory: item-detail density (rarity-tier fields) — completion deepening
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** `routine · dispatch`
 
@@ -20,3 +20,80 @@ Unknown), each field listing that tier's items — readable, dedicated fields pe
 matching the active rarity ordering. In the explicit **quantity / name sorts** keep the flat single
 description (so the field grouping never fights the chosen sort). Single-page/empty output stays
 correct. Extend `test_inventory_display_logic.py`; no migration; self-merge on green.
+
+## What shipped (PR #1595)
+
+Inventory completion cert **punch #4 CLOSED**. Pure display logic, no migration.
+
+- **`disbot/cogs/inventory_cog.py`** — two pure helpers `_item_line(item_key, qty, meta)` and
+  `_group_page_by_rarity(page_items) -> [(tier_label, lines)]` (rarest-first via `_RARITY_TIERS`,
+  `Unknown` catch-all). `_CategoryView.build_embed`: in the default **rarity** sort the page renders
+  one embed field per rarity tier present; explicit **quantity/name** sorts keep the flat ordered
+  description (rarity shown inline); empty stays "Nothing here.".
+- **Tests (+4):** `test_inventory_display_logic.py` — helper order/bucketing, per-tier fields in
+  rarity sort, flat-description in explicit sort, empty-page no-fields (29 on the unit).
+- **Full CI mirror GREEN** (13,396 passed); arch strict clean; black-formatted.
+
+## 📤 Run report
+
+- **Did:** Inventory cert punch #4 — item-detail density: per-rarity-tier embed fields in the default
+  sort so large inventories read cleanly · **Outcome:** shipped (CI green, auto-merge armed)
+- **Shipped:** #1595 — `disbot/cogs/inventory_cog.py` · `tests/unit/cogs/test_inventory_display_logic.py`
+  · docs (`feature-completion/units/inventory.md`, `current-state/S1-bot.md`).
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none.
+- **⚑ Owner manual steps:** none (pure display logic; live on next auto-deploy).
+- **⚑ Self-initiated:** none — this is the named S1 offline deepening ▶ Next (punch #4).
+- **↪ Next:** Inventory's remaining gaps are **owner-gated** (#1 item actions · #2 item-grant audit
+  granularity · #3 capability cleanup · #6 per-guild config) + the live walkthrough (#8/#9). Other
+  offline picks: Logging punch #3 (in-panel event presets) · Proof-channel binding-write UI.
+
+## ⟲ Previous-session review (Q-0102)
+
+The immediately-previous slice this run (#1594, logging ignored-lists) is the neighbour. It went
+well — complete, tested, one-source-reuse of `parse_id_csv` — but it surfaced a **real infra snag
+worth flagging system-wide:** GitHub dropped the `pull_request:synchronize` event for the second
+push, so no `code-quality` run ran on the head and auto-merge stalled with `mergeable_state: blocked`.
+The documented remedy is `ci-rerun-watchdog.yml` (workflow_dispatch re-kick), but (a) a manual
+`workflow_dispatch` run's check did **not** satisfy the *required* `code-quality` context — the merge
+API rejected with "Required status check 'code-quality' is expected" — and (b) what finally worked was
+**close+reopen the PR** (fires `pull_request: reopened` → a PR-context run). **System improvement:** the
+watchdog should verify the *required-context* check is present, not just that "a run happened"; and the
+close/reopen recovery belongs in the journal's CI-recovery runbook as the reliable fallback.
+
+## Doc audit (Q-0104)
+
+`check_current_state_ledger --strict` clean (marker lag only). Punch #4 marked done in the inventory
+cert; S1-bot recently-shipped updated. No new settings keys/commands → no generated-artifact change
+(freshness check green). No chat-only owner decisions. `check_quality --full` green.
+
+## 🛠 Friction → guard (Q-0194)
+
+- **Friction:** the second push's `code-quality` run was dropped by GitHub (known born-red rapid-push
+  race), and a manual `workflow_dispatch` re-kick's check did **not** satisfy the *required* check
+  context — only close+reopen did. **Guard (candidate, owner-gated):** teach `ci-rerun-watchdog.yml`
+  to detect "head has no *required-context* `code-quality` check" and, if a dispatch doesn't produce
+  one within N minutes, close+reopen the PR. Recorded as a candidate, not wired — it changes CI
+  automation.
+- **Friction:** black reformatted `inventory_cog.py` only at the full-mirror stage (the PostToolUse
+  auto-fix hook didn't fire on the MCP-edit path). **Guard (exists):** the mirror's black step *is*
+  the enforcing guard; ran `python3.10 -m black` to fix.
+
+## Context delta
+
+- **Needed but not pointed to (CI recovery):** the journal's CI section should carry the concrete
+  recovery order when a PR stalls on a dropped `code-quality` run: (1) `workflow_dispatch` re-kick →
+  if the merge still reports "Required status check 'code-quality' is expected", (2) **close+reopen
+  the PR** to fire a `pull_request: reopened` run in-context. Learned the hard way this run; the
+  single most useful undocumented operational fact surfaced today.
+- **Pointed to but didn't need:** CodeGraph — localized single-file display change.
+- **Decisions made alone:** grouped fields apply **only in the default rarity sort**; quantity/name
+  sorts keep the flat list so the grouping never fights the chosen sort.
+
+## 💡 Session idea (Q-0089)
+
+**Codify the "dropped code-quality run → close+reopen" recovery** — a journal/runbook line (free to
+ship, adding below) plus a candidate `scripts/ci_recover_pr.py` helper. Two PRs in a row this run hit
+auto-merge stalls from dropped synchronize events; the recovery is non-obvious (dispatch re-kick
+failed the required-context check first). Codifying turns a 15-minute rediscovery into a one-liner.
+Genuine — it cost real wall-clock today.

--- a/.sessions/2026-07-01-inventory-density.md
+++ b/.sessions/2026-07-01-inventory-density.md
@@ -1,0 +1,22 @@
+# 2026-07-01 — Inventory: item-detail density (rarity-tier fields) — completion deepening
+
+> **Status:** `in-progress`
+
+**Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+Second slice of this dispatch run (first: logging ignored-lists #1594, merged). Advancing the S1
+completion-deepening ▶ Next — **Inventory completion cert punch #4** (`item-detail density`,
+`[offline, minor]`, `docs/planning/feature-completion/units/inventory.md`).
+
+**Problem:** the `_CategoryView` detail page renders every item as one dense line
+(`emoji **name** × qty ` + rarity + type`) in a single embed description — a wall of text for large
+inventories.
+
+**Scope (pure display logic, offline-testable):** in the **default rarity sort** (the dominant case),
+render the page grouped into **per-rarity-tier embed fields** (Epic / Rare / Uncommon / Common /
+Unknown), each field listing that tier's items — readable, dedicated fields per the punch, and
+matching the active rarity ordering. In the explicit **quantity / name sorts** keep the flat single
+description (so the field grouping never fights the chosen sort). Single-page/empty output stays
+correct. Extend `test_inventory_display_logic.py`; no migration; self-merge on green.

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -122,6 +122,42 @@ _RARITY_ORDER: dict[str, int] = {
     "Common": 3,
 }
 
+# Display order for the per-rarity-tier fields (punch #4). Rarest-first, with an
+# ``Unknown`` catch-all for items whose meta carries no recognised rarity.
+_RARITY_TIERS: tuple[str, ...] = ("Epic", "Rare", "Uncommon", "Common", "Unknown")
+
+
+def _item_line(item_key: str, qty: int, meta: dict) -> str:
+    """Render one inventory item as a single display line (name · qty · type).
+
+    Rarity is *not* repeated here — the per-rarity-tier field header already
+    names the tier (punch #4). Used by the grouped-fields renderer.
+    """
+    emoji = meta.get("emoji", "📦")
+    itype = meta.get("type", "Item")
+    display_name = item_key.replace("_", " ").title()
+    return f"{emoji} **{display_name}** × {qty} · {itype}"
+
+
+def _group_page_by_rarity(
+    page_items: list[tuple[str, int, dict]],
+) -> list[tuple[str, list[str]]]:
+    """Group one page's items into ``(tier_label, lines)`` pairs, rarest-first.
+
+    Pure display helper for the rarity-sorted detail view (punch #4): a large
+    inventory renders as a dedicated field per rarity tier present on the page
+    instead of one dense description block. Only tiers with at least one item
+    on the page are returned, in :data:`_RARITY_TIERS` order; an unrecognised
+    rarity falls into the ``Unknown`` bucket.
+    """
+    buckets: dict[str, list[str]] = {}
+    for item_key, qty, meta in page_items:
+        rarity = meta.get("rarity", "Unknown")
+        tier = rarity if rarity in _RARITY_ORDER else "Unknown"
+        buckets.setdefault(tier, []).append(_item_line(item_key, qty, meta))
+    return [(tier, buckets[tier]) for tier in _RARITY_TIERS if tier in buckets]
+
+
 # Sort modes for the category detail view (punch #5). "rarity" is the default and
 # matches the rarest-first grouping order; the others let a large inventory be
 # re-ordered by quantity or name. Each is a stable total order (name tiebreak).
@@ -316,15 +352,26 @@ class _CategoryView(BaseView):
         start = self._page * self._PER_PAGE
         page_items = self._shown[start : start + self._PER_PAGE]
 
-        lines = []
-        for item_key, qty, meta in page_items:
-            emoji = meta.get("emoji", "📦")
-            rarity = meta.get("rarity", "Unknown")
-            itype = meta.get("type", "Item")
-            display_name = item_key.replace("_", " ").title()
-            lines.append(f"{emoji} **{display_name}** × {qty}  `{rarity}` · {itype}")
-
-        embed.description = "\n".join(lines) if lines else "Nothing here."
+        if not page_items:
+            embed.description = "Nothing here."
+        elif self._sort == "rarity":
+            # Punch #4: in the default rarity sort, render the page as a
+            # dedicated field per rarity tier so a large inventory reads
+            # cleanly instead of one dense description block. (For the
+            # explicit quantity/name sorts we keep the flat list below so
+            # the grouping never fights the chosen order.)
+            for tier, tier_lines in _group_page_by_rarity(page_items):
+                embed.add_field(
+                    name=f"{tier} ({len(tier_lines)})",
+                    value="\n".join(tier_lines),
+                    inline=False,
+                )
+        else:
+            lines = [
+                f"{_item_line(item_key, qty, meta)}  `{meta.get('rarity', 'Unknown')}`"
+                for item_key, qty, meta in page_items
+            ]
+            embed.description = "\n".join(lines)
         filter_note = (
             "" if self._type_filter is None else f"{self._type_filter} only  •  "
         )

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,12 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Inventory — item-detail density (per-rarity-tier fields)** (PR #1595, completion-first deepening,
+  Inventory cert **punch #4 CLOSED**) — the category detail page's dense single-line item list became,
+  in the default rarity sort, a **dedicated embed field per rarity tier** (Epic/Rare/Uncommon/Common)
+  via pure `_group_page_by_rarity` + `_item_line` helpers, so a large inventory reads cleanly; the
+  explicit quantity/name sorts keep the flat ordered list so grouping never fights the chosen sort.
+  Pure display logic, no migration; +4 tests (29 on the unit). Self-merge on green.
 - **Logging — ignored channels/users exclusion lists** (PR #1594, completion-first deepening, Logging
   cert **punch #1 CLOSED**) — the named best-in-class gap vs Carl-bot/Dyno. Two per-guild scalar
   settings (`logging_ignored_channels` / `logging_ignored_users`, comma-separated id CSV, default

--- a/docs/planning/feature-completion/units/inventory.md
+++ b/docs/planning/feature-completion/units/inventory.md
@@ -43,8 +43,9 @@
 - [x] **Sort/filter** — ✅ **DONE 2026-06-29:** the category detail view has a `🔀 Sort:` cycle
       (Rarity / Quantity / Name, footer shows the active mode) **and** a `Filter by type…` select
       (shown only when the category mixes >1 type; "All types" restores). → punch #5 cleared.
-- [x] **Clear feedback** — empty state + page footer; ⚠ item-detail line is dense (emoji·name·qty·rarity·
-      type on one line) — readability degrades for large inventories. → punch #4.
+- [x] **Clear feedback** — empty state + page footer; item-detail density addressed (✅ punch #4,
+      2026-07-01): in the default rarity sort the page renders as a dedicated field per rarity tier
+      (Epic/Rare/Uncommon/Common), so a large inventory reads cleanly instead of one dense block.
 
 ### D. Authority & safety
 - [x] **Authority re-checked at callback** — view ownership enforced by `BaseView.interaction_check`
@@ -95,7 +96,11 @@
    *role* grants legitimately belong on the audited role seam — they are operator-visible, low-frequency.)
 3. **Capability enforcement** *(owner, minor)* — either enforce the declared `inventory.*` capabilities or
    remove the aspirational ones from the registry until their features exist.
-4. **Item-detail density** *(offline, minor)* — multi-line / dedicated fields for large inventories.
+4. ~~**Item-detail density**~~ ✅ **DONE 2026-07-01 (#1595, dispatch run)** — in the default rarity
+   sort the category detail page renders a **dedicated embed field per rarity tier**
+   (`_group_page_by_rarity` + `_item_line`, pure helpers) instead of one dense description block, so
+   a large inventory reads cleanly; the explicit quantity/name sorts keep the flat ordered list so the
+   grouping never fights the chosen order. +4 tests.
 5. ~~**Sort / filter UI**~~ ✅ **DONE 2026-06-29 (dispatch run)** — `🔀 Sort:` cycle (Rarity /
    Quantity / Name, pure `_sort_items`) **and** a `Filter by type…` select (`_apply` recomputes the
    shown slice + pages, page-clamped) on the category view; +15 tests. (Sort + filter both shipped.)
@@ -109,8 +114,8 @@
 
 ## Evidence
 - **Tests:** `tests/unit/views/test_economy_inventory_edit.py` (navigation lifecycle) ·
-  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 25 cases: punch #7 merge/sort/
-  group/pagination + punch #5 sort cycle + type filter) ·
+  `tests/unit/cogs/test_inventory_display_logic.py` (display logic — 29 cases: punch #7 merge/sort/
+  group/pagination + punch #5 sort cycle + type filter + punch #4 per-rarity-tier fields) ·
   `tests/unit/invariants/test_no_view_level_purchase_writes.py`
 - **Walkthrough:** pending (punch #8)
 - **Owner sign-off:** pending (punch #9)

--- a/tests/unit/cogs/test_inventory_display_logic.py
+++ b/tests/unit/cogs/test_inventory_display_logic.py
@@ -20,6 +20,7 @@ from cogs.inventory_cog import (
     UnifiedInventoryView,
     _build_combined_inventory,
     _CategoryView,
+    _group_page_by_rarity,
     _sort_items,
 )
 
@@ -240,6 +241,67 @@ async def test_cycle_sort_wraps_back_to_rarity():
     for _ in range(len(_SORT_MODES)):
         await view._cycle_sort(interaction)
     assert view._sort == "rarity"  # full cycle returns to the default
+
+
+# ---------------------------------------------------------------------------
+# Item-detail density — per-rarity-tier fields (completion-cert punch #4)
+# ---------------------------------------------------------------------------
+
+
+def test_group_page_by_rarity_orders_rarest_first_and_buckets_unknown():
+    page = [
+        ("gold", 1, {"rarity": "Rare"}),
+        ("mystery", 2, {}),  # no rarity → Unknown bucket
+        ("diamond", 1, {"rarity": "Epic"}),
+        ("ruby", 1, {"rarity": "Rare"}),
+    ]
+    groups = _group_page_by_rarity(page)
+    # Rarest-first, Unknown last; only tiers present appear.
+    assert [name for name, _ in groups] == ["Epic", "Rare", "Unknown"]
+    by_tier = dict(groups)
+    assert len(by_tier["Rare"]) == 2  # gold + ruby share the tier
+    assert len(by_tier["Epic"]) == 1
+    # The per-item line names qty + type but NOT the rarity (the field header does).
+    assert "× 1" in by_tier["Epic"][0]
+    assert "`" not in by_tier["Epic"][0]
+
+
+def test_rarity_sort_renders_one_field_per_tier():
+    view = _CategoryView(_member(), "Mining Materials", _mixed(), hub=_hub())
+    embed = view.build_embed()
+    # Default rarity sort → dedicated fields per tier, rarest-first; no dense block.
+    assert embed.description is None
+    assert [f.name for f in embed.fields] == [
+        "Epic (1)",
+        "Rare (1)",
+        "Uncommon (1)",
+        "Common (1)",
+    ]
+    epic = next(f for f in embed.fields if f.name.startswith("Epic"))
+    assert "Diamond" in epic.value
+
+
+@pytest.mark.asyncio
+async def test_explicit_sort_keeps_flat_description_not_tier_fields():
+    view = _CategoryView(_member(), "Mining Materials", _mixed(), hub=_hub())
+    interaction = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view._cycle_sort(interaction)  # rarity → quantity
+    embed = view.build_embed()
+    # An explicit sort keeps the flat ordered list so grouping never fights it.
+    assert not embed.fields
+    assert embed.description
+    # Highest quantity first (iron=9), with the rarity shown inline in this mode.
+    assert "Iron" in embed.description
+    assert "`Uncommon`" in embed.description
+
+
+def test_empty_page_has_no_tier_fields():
+    view = _CategoryView(_member(), "Tools", [], hub=_hub())
+    embed = view.build_embed()
+    assert embed.description == "Nothing here."
+    assert not embed.fields
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Inventory completion deepening — punch #4 (item-detail density)

Second slice of this dispatch run (first: logging ignored-lists #1594, merged). Clears **Inventory
completion cert punch #4** (`docs/planning/feature-completion/units/inventory.md`) — the dense
single-line item list that degrades for large inventories.

### What ships
- In the **default rarity sort**, the `_CategoryView` detail page renders the page grouped into
  **per-rarity-tier embed fields** (Epic / Rare / Uncommon / Common / Unknown), each field listing
  that tier's items — readable, dedicated fields per the punch, matching the active rarity ordering.
- In the explicit **quantity / name sorts**, the flat single-description list is preserved (the
  field grouping never fights the chosen sort).
- Pure display logic; single-page / empty output unchanged. No migration.

Extends `test_inventory_display_logic.py`. Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiNEsHkHcEc1gWk35gVo2u)_