### PR TITLE
fishing: coral deepwater rare-material drop → cosmetic curio collectibles

### DIFF
--- a/.sessions/2026-07-01-fishing-coral-curios.md
+++ b/.sessions/2026-07-01-fishing-coral-curios.md
@@ -1,0 +1,35 @@
+# 2026-07-01 — Fishing: coral 🪸 deepwater rare-material drop → cosmetic curio collectibles
+
+> **Status:** `in-progress`
+
+**Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+Scheduled dispatch fire, no work order. Both FIX-backlog bugs are gated (BUG-0019 #1 = owner
+design fork; BUG-0009 remainder = data-gated on release-order source), so I take the next real
+plan slice under S1's completion-first posture: the **fishing rare-material successor** — the
+explicit `[offline]` "▶ Next offline successor" in `docs/current-state/S1-bot.md`.
+
+Mirror the pearl pattern (#1518) with a **second** rare reel-drop material feeding a **new,
+non-bait craft target** (the roadmap's "a dedicated craft material that feeds a *new* craft
+target rather than the premium bait — e.g. a cosmetic or a structure"):
+
+- **coral 🪸** — a rare reel-drop material, **deepwater-venue-gated** (thematic reef find; also
+  gives the boat venue #1340 a unique payoff — deepens an existing feature). Mirrors the pearl:
+  stored in the generic `mining_inventory` (no migration), never a dex/trophy row, byte-identical
+  economics when it doesn't drop.
+- **Curios** (`utils/fishing/curios.py`) — cosmetic **carving collectibles** crafted from coral
+  (`ItemKind.TREASURE` → non-sellable, no crafting use), a completionist collection like the
+  Fishdex/trophies. Shown by the **existing** inventory browser (no new panel) + a `!curios`
+  list + `!craftcurio`. Also catalogues coral + the pre-existing (uncatalogued) pearl for clean
+  display — fix-on-sight drift.
+
+No migration, no minigame-view mechanic wiring, pure + sim-pinnable, self-mergeable. Deepens two
+completion units (fishing + inventory).
+
+Aim: 2–3 slices — this material→collection slice first; then a second plan slice if budget allows.
+
+## What shipped
+
+_(to be filled at close)_

--- a/.sessions/2026-07-01-fishing-coral-curios.md
+++ b/.sessions/2026-07-01-fishing-coral-curios.md
@@ -1,6 +1,6 @@
 # 2026-07-01 — Fishing: coral 🪸 deepwater rare-material drop → cosmetic curio collectibles
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** `routine · dispatch`
 
@@ -30,6 +30,113 @@ completion units (fishing + inventory).
 
 Aim: 2–3 slices — this material→collection slice first; then a second plan slice if budget allows.
 
-## What shipped
+## What shipped (PR #1596)
 
-_(to be filled at close)_
+- **`utils/fishing/rewards.py`** — `CORAL_ITEM` + `CORAL_DROP_CHANCE` (0.06) + `coral_drop_chance(venue)`
+  / `roll_coral_drop(venue, rng)`: a flat, **deepwater-only** reel-drop (shore short-circuits to
+  `False` without consuming rng, so shore casts stay byte-identical). Mirrors the pearl roll but
+  venue-gated instead of size-scaled.
+- **`utils/fishing/curios.py`** (new, pure) — the cosmetic curio catalog (Carved Coral Shell 🐚 /
+  Coral Seahorse 🌊 / Coral Idol 🗿, ascending coral cost 2/4/8) + `curio_by_key` / `craftable_key_for`
+  / `cost_text` / `collection_progress` (mirrors the bait recipe helpers).
+- **`services/fishing_workflow.py`** — `commit_catch` rolls + grants coral (deepwater only) in the
+  same atomic transaction (order bonus→pearl→coral), sets `FishResult.coral_found`; new `craft_curio`
+  (debit coral, grant the `TREASURE` curio, one transaction — no coins, never sold) + `CurioCraftResult`.
+- **`utils/mining/items.py`** — the three curios catalogued as `ItemKind.TREASURE` (→ `market.sell_price`
+  returns `None`: non-sellable, no coin faucet). Coral left uncatalogued as a material (mirrors the
+  pearl → unknown → not sellable).
+- **`cogs/fishing_cog.py`** — `!curios` (collection + coral + per-curio ✅/🔨/🔒 progress) and
+  `!craftcurio <name>` (aliases `carve`/`curiocraft`).
+- **`cogs/inventory_cog.py`** — `ITEM_CATALOGUE` gains a **Fishing** category (coral + the
+  previously-uncatalogued **pearl** — fix-on-sight) and a **Collectibles** category (the curios), with
+  category order + meta; so the existing browser shows them cleanly instead of the "Other" catch-all.
+- **`views/fishing/cast_view.py`** — renders the "🪸 A piece of coral!" line on a coral reel.
+- **Tests (+~20):** `test_fishing_rewards.py` (coral roll: deepwater-only, deterministic, ≈rate) ·
+  `test_fishing_curios.py` (catalog/recipes pinned, TREASURE-non-sellable contract, collection tally) ·
+  `test_fishing_workflow_curio.py` (craft debits coral/grants curio/rejects unknown+insufficient) ·
+  `test_fishing_workflow.py` (commit grants coral only in deepwater, never on shore, byte-identical
+  when unlucky).
+- **Docs:** `docs/planning/fishing-coral-numbers-2026-07-01.md` (sim-pinned) + de-staled the S1
+  fishing bullet (marked the successor shipped, linked the numbers doc, pointed at the next successor).
+  Regenerated dashboard/site artifacts (2 new commands → 476 total).
+
+CI mirror green (`check_quality.py --full`: 13,414 passed; arch 0 errors).
+
+## 📤 Run report
+
+- **Did:** shipped the S1 completion-first `[offline]` "▶ next offline successor" — the fishing
+  rare-material variant (coral 🪸 deepwater drop → cosmetic curio collectibles), deepening the fishing
+  + inventory units and giving the boat venue a unique payoff · **Outcome:** shipped (CI green,
+  auto-merge armed).
+- **Shipped:** #1596.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none.
+- **⚑ Owner manual steps:** none (pure logic + additive content; no migration, live on next
+  auto-deploy). To try it: `!sail` to deepwater, `!fish` until coral drops, then `!curios` / `!craftcurio`.
+- **⚑ Self-initiated:** yes — no work order this fire; I took the next plan slice under S1's
+  completion-first posture (the roadmap-named next offline successor). Contained, reversible,
+  test-covered; flagged here per Q-0172 for owner review.
+- **↪ Next:** a *second* curio tier or a **structure**-target variant (a deepwater material that
+  builds a fishing structure rather than a collectible) — pure + sim-pinnable, self-mergeable (see the
+  de-staled S1 bullet). Both FIX-backlog bugs (BUG-0019 #1 owner design fork; BUG-0009 newest-towers
+  data-gated on release-order source) remain owner/data-gated.
+
+## 💡 Session idea (Q-0089)
+
+**A "dead capability declaration" guard.** While scoping Inventory punch #3 I found the
+`@capability(...)` decorator (`core/runtime/subsystem_capabilities.py`) has **zero real usages** in the
+whole codebase (the only match is the docstring example) — so the reverse-map diagnostic
+(`!platform capability-map`) is always empty, and the registry's `capabilities` lists are governance
+declarations enforced elsewhere (ui_permissions / GovernanceMutationPipeline), not via this decorator.
+A tiny checker (or a `!platform` note) that flags a **declared** capability with **no** enforcing use
+would turn "aspirational placeholder vs. real capability" from tribal knowledge into a visible signal —
+exactly the ambiguity that makes Inventory punch #3 an owner call today. Genuine (it directly shaped
+this session's pick), not filler. Captured only here (it needs an owner decision on enforce-vs-remove
+before it becomes a plan — router-worthy, not self-buildable).
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1595, Inventory item-detail per-rarity-tier fields) was a clean, well-tested
+completion-first punch (#4 closed) — no complaint. What it (and the whole recent Inventory cert thread)
+**left implicit** is that the unit's remaining `◐ → ✔` blockers (#1–#3) are *all* owner-gated, which
+isn't obvious until you trace the `@capability` decorator and find it dead (above). **System
+improvement:** a completion cert's punch-list should mark each item's **gate** (`[offline]` /
+`[owner]` / `[needs-live-bot]`) inline, the same tags S1's ▶ Next uses — so a dispatch run can tell at
+a glance which punches are self-buildable vs. which need the owner, without re-deriving it (I spent
+real budget confirming Inventory's punches were all owner-gated before pivoting). The Inventory cert
+does this in prose ("owner, minor") but not with the machine-readable tag.
+
+## Doc audit (Q-0104)
+
+- No owner *decision* to route (self-initiated build under the existing completion-first posture; the
+  standing Q-0172 idea-gate covers it, flagged on the run report).
+- Ledger: this session's PR is the newest merge; the living-ledger reconciliation is the recon
+  routine's job (not due until #1620) — no drift to fix on sight.
+- New doc (`fishing-coral-numbers-2026-07-01.md`) is reachable (linked from S1-bot.md) and badged
+  `living-ledger` (matching the sibling pearl numbers doc; `numbers-pin` is not an allowed badge — a
+  small trap I hit and corrected).
+- Generated artifacts re-exported (dashboard/site) so the new commands aren't stale; `check_quality
+  --full` green confirms `check_docs` / `check_artifacts_fresh` clean.
+
+## 🛠 Friction → guard (Q-0194)
+
+- **Friction:** I badged the new numbers doc `numbers-pin` (it *is* a numbers pin), but that token
+  isn't in `check_docs`'s allowed set → red. **Guard (shipped):** none needed beyond the fix — the
+  `check_docs` badge check already *is* the enforcing guard; it caught the invalid token immediately.
+  The durable lesson (recorded here): copy an existing sibling doc's `Status:` badge rather than
+  inventing a descriptive one.
+- **Friction:** running `isort` over `disbot/ tests/ scripts/` flagged a `tests/` file from an
+  unrelated merged PR — a false alarm, since CI/`check_quality` **exclude `tests/`** from formatters.
+  **Guard (habit):** trust `check_quality.py` (pinned scope) over ad-hoc bare-tool invocations — the
+  exact trap CLAUDE.md §CI-parity already warns about; reconfirmed here.
+
+## Context delta
+
+- **Needed but not pointed to:** that curios/coral are *cosmetic collectibles reusing `mining_inventory`
+  with no migration* is the design insight that made this a tight slice — it's implicit in how the
+  pearl works but nowhere stated. The pearl/coral pattern ("rare reel-drop material → a craft sink,
+  stored in the generic mining inventory, never a dex/trophy row") is now a clear two-instance template
+  for the next successor.
+- **Pointed to but didn't need:** the mining structures panel machinery — I scoped a structure-target
+  variant first, then chose the lighter collectible target (no new panel/effect wiring), which is why
+  the slice stayed tight. The structure variant remains the named next successor for a later run.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T00:11:46Z",
+    "generated_at": "2026-07-01T03:20:15Z",
     "build": {
-      "commit": "4ecf0dac",
-      "subject": "wip(logging): open born-red card — ignored channels/users exclusion lists",
-      "committed_at": "2026-07-01T00:11:46Z"
+      "commit": "a0e4c0c6",
+      "subject": "fishing: open born-red session card for coral/curios slice",
+      "committed_at": "2026-07-01T03:20:15Z"
     }
   },
   "counts": {
-    "commands": 474,
+    "commands": 476,
     "features": 43,
     "games": 12
   },
@@ -5097,6 +5097,32 @@
       "notes": null
     },
     {
+      "name": "craftcurio",
+      "aliases": [
+        "carve",
+        "curiocraft"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Carve a cosmetic curio from coral — the deepwater rare-material sink.",
+      "description": "Carve a cosmetic curio from coral — the deepwater rare-material sink.",
+      "use_cases": null,
+      "examples": [
+        "!sail",
+        "!craftcurio coral idol",
+        "!curios"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "craftpearl",
       "aliases": [
         "pearlcraft"
@@ -5353,6 +5379,31 @@
         },
         {
           "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "curios",
+      "aliases": [
+        "curio",
+        "carvings"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the coral-carving collection + your coral and craft progress.",
+      "description": "Show the coral-carving collection + your coral and craft progress.",
+      "use_cases": null,
+      "examples": [
+        "!sail",
+        "!craftcurio <name>"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
           "status": "ideas"
         }
       ],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -1678,6 +1678,31 @@ const COMMANDS = [
     ]
   },
   {
+    "name": "craftcurio",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Carve a cosmetic curio from coral — the deepwater rare-material sink.",
+    "description": "Carve a cosmetic curio from coral — the deepwater rare-material sink.",
+    "usage": "!craftcurio",
+    "aliases": [
+      "carve",
+      "curiocraft"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [
+      "!sail",
+      "!craftcurio coral idol",
+      "!curios"
+    ],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
+      }
+    ]
+  },
+  {
     "name": "craftpearl",
     "area": "games",
     "status": "in-progress",
@@ -1841,6 +1866,30 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
+      }
+    ]
+  },
+  {
+    "name": "curios",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Show the coral-carving collection + your coral and craft progress.",
+    "description": "Show the coral-carving collection + your coral and craft progress.",
+    "usage": "!curios",
+    "aliases": [
+      "curio",
+      "carvings"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [
+      "!sail",
+      "!craftcurio <name>"
+    ],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
       }
     ]
   },
@@ -7192,7 +7241,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "4ecf0dac",
+    "build": "a0e4c0c6",
     "title": "New public bot website",
     "changes": [
       {
@@ -7204,7 +7253,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "4ecf0dac",
+    "build": "a0e4c0c6",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7216,7 +7265,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "4ecf0dac",
+    "build": "a0e4c0c6",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T00:11:46Z",
+    "generated_at": "2026-07-01T03:20:15Z",
     "build": {
-      "commit": "4ecf0dac",
-      "subject": "wip(logging): open born-red card — ignored channels/users exclusion lists",
-      "committed_at": "2026-07-01T00:11:46Z"
+      "commit": "a0e4c0c6",
+      "subject": "fishing: open born-red session card for coral/curios slice",
+      "committed_at": "2026-07-01T03:20:15Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 55,
-      "commands": 474,
+      "commands": 476,
       "setting_keys": 115,
       "setting_domains": 17,
       "typed_settings": 95,
@@ -2695,6 +2695,22 @@
       "file": "2026-07-01-logging-ignored-lists.md",
       "date": "2026-07-01",
       "title": "2026-07-01 — Logging: ignored channels/users exclusion lists (completion deepening)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-07-01-inventory-density.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Inventory: item-detail density (rarity-tier fields) — completion deepening",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-01-fishing-coral-curios.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Fishing: coral 🪸 deepwater rare-material drop → cosmetic curio collectibles",
       "status": "in-progress",
       "run_type": "routine",
       "self_initiated": false
@@ -3154,22 +3170,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-effectivestats-knob-coverage.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — EffectiveStats knob-coverage guard + dead-stat finding (BUG-00xx)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-27-economy-flow-timeseries.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — Games-economy observability: per-day faucet/sink trend view",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -6923,6 +6923,20 @@
           "button_backed": false
         },
         {
+          "name": "craftcurio",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "carve",
+            "curiocraft"
+          ],
+          "brief": "Carve a cosmetic curio from coral — the deepwater rare-material sink.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "craftpearl",
           "type": "prefix",
           "is_group": false,
@@ -6944,6 +6958,20 @@
             "rodcraft"
           ],
           "brief": "Craft the next rod up the ladder from caught fish — the non-coin path.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "curios",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "curio",
+            "carvings"
+          ],
+          "brief": "Show the coral-carving collection + your coral and craft progress.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -29,8 +29,9 @@ from discord.ext import commands
 from core.runtime import guild_resources as resources
 from services import fishing_workflow, game_xp_service
 from utils import db
-from utils.fishing import PEARL_ITEM
+from utils.fishing import CORAL_ITEM, PEARL_ITEM
 from utils.fishing import bait as bait_mod
+from utils.fishing import curios as curios_mod
 from utils.fishing import gear as fishing_gear
 from utils.fishing import rods as rods_mod
 from utils.fishing import weather as weather_mod
@@ -300,6 +301,60 @@ class FishingCog(commands.Cog):
             )
             return
         result = await fishing_workflow.craft_pearl_bait(
+            ctx.author.id,
+            ctx.guild.id,
+            key,
+        )
+        await ctx.send(result.message)
+
+    @commands.command(name="curios", aliases=["curio", "carvings"])
+    async def curios(self, ctx):
+        """Show the coral-carving collection + your coral and craft progress.
+
+        Coral drops rarely when you reel in a fish out in **deepwater** (`!sail`).
+        Carve it into cosmetic curios with `!craftcurio <name>` — a completionist
+        shelf, purely for show (never sold, no gameplay effect).
+        """
+        inventory = await db.get_mining_inventory(str(ctx.author.id), ctx.guild.id)
+        coral = inventory.get(CORAL_ITEM, 0)
+        owned, total = curios_mod.collection_progress(inventory)
+        embed = discord.Embed(
+            title="🪸 Coral Curios",
+            description=(
+                f"You have **{coral}** 🪸 coral · collection **{owned}/{total}** carved.\n"
+                "Coral drops rarely on a **deepwater** reel (`!sail` to the boat)."
+            ),
+            color=_FISHING_COLOR,
+        )
+        for curio in curios_mod.CURIO_CATALOG:
+            have = inventory.get(curio.item, 0)
+            mark = "✅" if have > 0 else ("🔨" if coral >= curio.coral_cost else "🔒")
+            owned_txt = f" ×{have}" if have > 0 else ""
+            embed.add_field(
+                name=f"{mark} {curio.emoji} {curio.name}{owned_txt}",
+                value=f"{curios_mod.cost_text(curio)} · {curio.rarity}",
+                inline=False,
+            )
+        embed.set_footer(text="Carve with !craftcurio <name>")
+        await ctx.send(embed=embed)
+
+    @commands.command(name="craftcurio", aliases=["carve", "curiocraft"])
+    async def craftcurio(self, ctx, *, curio: str = ""):
+        """Carve a cosmetic curio from coral — the deepwater rare-material sink.
+
+        Coral drops rarely when you reel in a fish out in **deepwater** (`!sail`).
+        Name a curio (e.g. `!craftcurio coral idol`); with no argument it lists the
+        collection. See `!curios` for your coral and progress.
+        """
+        key = curios_mod.craftable_key_for(curio)
+        if key is None:
+            craftable = ", ".join(c.name for c in curios_mod.CURIO_CATALOG)
+            await ctx.send(
+                f"That isn't a carvable curio. Carvable: {craftable}. "
+                "See `!curios` for your collection.",
+            )
+            return
+        result = await fishing_workflow.craft_curio(
             ctx.author.id,
             ctx.guild.id,
             key,

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -98,12 +98,50 @@ ITEM_CATALOGUE: dict[str, dict] = {
         "type": "Job Unlock",
         "rarity": "Rare",
     },
+    # Fishing rare materials (mining_inventory) — the reel-drop crafting materials.
+    # Pearl (any venue, size-scaled) crafts the premium bait; coral (deepwater
+    # only) carves the cosmetic curios below. Catalogued here so the browser shows
+    # them with a proper emoji/rarity instead of the "Other" catch-all.
+    "pearl": {
+        "category": "Fishing",
+        "emoji": "🦪",
+        "type": "Material",
+        "rarity": "Rare",
+    },
+    "coral": {
+        "category": "Fishing",
+        "emoji": "🪸",
+        "type": "Material",
+        "rarity": "Rare",
+    },
+    # Fishing curios (mining_inventory) — cosmetic carvings crafted from coral
+    # (utils/fishing/curios.py). Purely collectible; never sold, no gameplay use.
+    "coral shell": {
+        "category": "Collectibles",
+        "emoji": "🐚",
+        "type": "Curio",
+        "rarity": "Uncommon",
+    },
+    "coral seahorse": {
+        "category": "Collectibles",
+        "emoji": "🌊",
+        "type": "Curio",
+        "rarity": "Rare",
+    },
+    "coral idol": {
+        "category": "Collectibles",
+        "emoji": "🗿",
+        "type": "Curio",
+        "rarity": "Epic",
+    },
 }
 
 _CATEGORY_ORDER: tuple[str, ...] = (
     "Mining Materials",
     "Crafted Items",
     "Tools",
+    "Fishing",
+    "Collectibles",
     "Economy Items",
 )
 
@@ -111,6 +149,8 @@ _CATEGORY_META: dict[str, dict] = {
     "Mining Materials": {"emoji": "⛏️", "color": ECONOMY_COLOR},
     "Crafted Items": {"emoji": "🏗️", "color": WARNING_COLOR},
     "Tools": {"emoji": "🔧", "color": INFO_COLOR},
+    "Fishing": {"emoji": "🎣", "color": INFO_COLOR},
+    "Collectibles": {"emoji": "🏆", "color": WARNING_COLOR},
     "Economy Items": {"emoji": "💼", "color": ECONOMY_COLOR},
     "Other": {"emoji": "📦", "color": MINING_COLOR},
 }

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -25,13 +25,24 @@ from typing import Protocol
 from core.events import bus
 from services import economy_service, game_xp_service
 from utils import db
-from utils.fishing import MAX_LEVEL, PEARL_ITEM, Catch
+from utils.fishing import (
+    CORAL_ITEM,
+    MAX_LEVEL,
+    PEARL_ITEM,
+    Catch,
+)
 from utils.fishing import bait as bait_mod
+from utils.fishing import curios as curios_mod
 from utils.fishing import energy as fish_energy
 from utils.fishing import fish as fish_mod
 from utils.fishing import gear as fishing_gear
 from utils.fishing import rods as rods_mod
-from utils.fishing import roll_bonus_catch, roll_catch, roll_pearl_drop
+from utils.fishing import (
+    roll_bonus_catch,
+    roll_catch,
+    roll_coral_drop,
+    roll_pearl_drop,
+)
 from utils.fishing import venue as venue_mod
 from utils.fishing import weather as weather_mod
 from utils.mining import character
@@ -82,6 +93,12 @@ class FishResult:
     #: Granted into the inventory; never a dex/trophy row. Byte-identical when
     #: ``False``. Bigger fish drop pearls more often (size-scaled roll).
     pearl_found: bool = False
+    #: True when this reel also yielded a **coral** — the second rare crafting
+    #: material (``utils.fishing.CORAL_ITEM``), a **deepwater-only** reef find that
+    #: carves into the cosmetic curio collection (``utils.fishing.curios``).
+    #: Granted into the inventory; never a dex/trophy row. Always ``False`` on a
+    #: shore cast; byte-identical economics when ``False``.
+    coral_found: bool = False
 
 
 @dataclass(frozen=True)
@@ -166,6 +183,7 @@ async def commit_catch(
     bonus = roll_bonus_catch(rng)
     grant = 2 if bonus else 1
     pearl = roll_pearl_drop(catch.species.size_rank, rng)
+    coral = roll_coral_drop(cast.venue, rng)
     async with db.transaction() as conn:
         prev_best = await db.record_catch(
             user_id,
@@ -174,15 +192,27 @@ async def commit_catch(
             catch.weight,
             conn=conn,
         )
-        # A pearl drop (the rare crafting material) is granted before the fish so
-        # the fish grant stays the last write — a stable seam for callers/tests
-        # that read the species-grant call. Inventory-only, same atomic catch
-        # transaction (RS02); never a dex/trophy row.
+        # The rare-material drops (pearl, coral) are granted before the fish so the
+        # fish grant stays the last write — a stable seam for callers/tests that
+        # read the species-grant call. Inventory-only, same atomic catch
+        # transaction (RS02); neither is ever a dex/trophy row. The rolls are
+        # drawn (bonus → pearl → coral) before the transaction so the write set is
+        # deterministic under an injected rng.
         if pearl:
             await db.update_mining_item(
                 str(user_id),
                 guild_id,
                 PEARL_ITEM,
+                1,
+                conn=conn,
+            )
+        # Coral is deepwater-only (roll_coral_drop returns False on shore), the
+        # boat venue's unique reward — it carves into the cosmetic curio set.
+        if coral:
+            await db.update_mining_item(
+                str(user_id),
+                guild_id,
+                CORAL_ITEM,
                 1,
                 conn=conn,
             )
@@ -220,6 +250,7 @@ async def commit_catch(
         new_personal_best=new_best,
         bonus_catch=bonus,
         pearl_found=pearl,
+        coral_found=coral,
     )
 
 
@@ -815,6 +846,85 @@ async def craft_pearl_bait(
         f"**{pearl_cost}** 🦪 pearls — **{new_charges}** casts ready.",
         bait=bait,
         charges=new_charges,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Curio carving — turn the deepwater rare-material (coral) into cosmetic
+# collectibles (the coral sink; S1 "▶ next offline successor"). Coral's analogue
+# of craft_pearl_bait, but the target is a cosmetic TREASURE item (a completionist
+# collection), not a bait. An inventory-only conversion: debit coral, grant the
+# curio, in ONE db.transaction() (Q-0071). Never a coin sink, never sellable.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CurioCraftResult:
+    """The outcome of a ``craft_curio`` attempt — a flag + a player-facing message."""
+
+    success: bool
+    message: str
+    #: The curio carved on success (``None`` on failure).
+    curio: curios_mod.Curio | None = None
+
+
+async def craft_curio(
+    user_id: int,
+    guild_id: int,
+    curio_key: str,
+) -> CurioCraftResult:
+    """Carve one *curio_key* from **coral** — the deepwater rare-material sink.
+
+    Coral drops only on a deepwater (boat) reel; this is its sole home — a
+    cosmetic carving collection (:mod:`utils.fishing.curios`). An inventory-only
+    conversion (no coins, no external call): debit the coral and grant the curio
+    item in ONE ``db.transaction()`` (Q-0071). The curio is a cosmetic
+    :class:`utils.mining.items.ItemKind` ``TREASURE`` — never sellable, no gameplay
+    effect; the reward is the collection. Crafting a curio you already own simply
+    adds another copy (harmless; the collection tally counts distinct curios).
+    """
+    curio = curios_mod.curio_by_key(curio_key)
+    if curio is None:
+        return CurioCraftResult(
+            False,
+            "That isn't a carvable curio — see `!curios` for the collection.",
+        )
+
+    inventory = await db.get_mining_inventory(str(user_id), guild_id)
+    have = inventory.get(CORAL_ITEM, 0)
+    if have < curio.coral_cost:
+        return CurioCraftResult(
+            False,
+            f"You need **{curio.coral_cost}** 🪸 coral to carve **{curio.name}** "
+            f"{curio.emoji} — you have **{have}**. Coral drops rarely when you reel "
+            "in a fish out in **deepwater** (`!sail` to the boat first).",
+        )
+
+    async with db.transaction() as conn:
+        await db.update_mining_item(
+            str(user_id),
+            guild_id,
+            CORAL_ITEM,
+            -curio.coral_cost,
+            conn=conn,
+        )
+        await db.update_mining_item(
+            str(user_id),
+            guild_id,
+            curio.item,
+            1,
+            conn=conn,
+        )
+
+    owned, total = curios_mod.collection_progress(
+        {**inventory, curio.item: inventory.get(curio.item, 0) + 1},
+    )
+    return CurioCraftResult(
+        True,
+        f"Carved **{curio.name}** {curio.emoji} from **{curio.coral_cost}** 🪸 "
+        f"coral — a cosmetic collectible for your shelf. "
+        f"Collection: **{owned}/{total}** curios.",
+        curio=curio,
     )
 
 

--- a/disbot/utils/fishing/__init__.py
+++ b/disbot/utils/fishing/__init__.py
@@ -14,6 +14,14 @@ are independently unit-testable; the audited writes live in
 
 from __future__ import annotations
 
+from utils.fishing.curios import (
+    CURIO_CATALOG,
+    CURIO_ITEMS,
+    CURIO_KEYS,
+    Curio,
+    collection_progress,
+    curio_by_key,
+)
 from utils.fishing.fish import (
     FISH_PER_LEVEL,
     MAX_LEVEL,
@@ -30,10 +38,14 @@ from utils.fishing.fish import (
 )
 from utils.fishing.rewards import (
     BONUS_CATCH_CHANCE,
+    CORAL_DROP_CHANCE,
+    CORAL_ITEM,
     PEARL_ITEM,
+    coral_drop_chance,
     pearl_drop_chance,
     roll_bonus_catch,
     roll_catch,
+    roll_coral_drop,
     roll_pearl_drop,
 )
 from utils.fishing.venue import (
@@ -54,6 +66,11 @@ from utils.fishing.weight import nominal_weight, roll_weight
 __all__ = [
     "BONUS_CATCH_CHANCE",
     "CONDITIONS",
+    "CORAL_DROP_CHANCE",
+    "CORAL_ITEM",
+    "CURIO_CATALOG",
+    "CURIO_ITEMS",
+    "CURIO_KEYS",
     "DEEPWATER",
     "FISH_PER_LEVEL",
     "MAX_LEVEL",
@@ -62,9 +79,13 @@ __all__ = [
     "SHORE_VENUE",
     "SPECIES",
     "Catch",
+    "Curio",
     "FishSpecies",
     "VenueProfile",
     "Weather",
+    "collection_progress",
+    "coral_drop_chance",
+    "curio_by_key",
     "current_weather",
     "fish_names",
     "max_size_rank_for_level",
@@ -73,6 +94,7 @@ __all__ = [
     "profile_for",
     "roll_bonus_catch",
     "roll_catch",
+    "roll_coral_drop",
     "roll_pearl_drop",
     "roll_weight",
     "species_by_name",

--- a/disbot/utils/fishing/curios.py
+++ b/disbot/utils/fishing/curios.py
@@ -1,0 +1,129 @@
+"""Fishing curios — cosmetic carvings crafted from coral (the second rare drop).
+
+The fishing rare-material pattern's *second* instance (the roadmap's "▶ next
+offline successor" — a dedicated craft material that feeds a **new** craft target
+rather than the premium bait). The **pearl** (:data:`utils.fishing.rewards.PEARL_ITEM`)
+sinks into a *bait*; **coral** (:data:`utils.fishing.rewards.CORAL_ITEM`, a
+deepwater-only reef drop) sinks into a *cosmetic collection* — carved "curios".
+
+A curio is a purely-cosmetic collectible: an :class:`utils.mining.items.ItemKind`
+``TREASURE`` item (non-sellable, no crafting use) stored in the shared
+``mining_inventory``, so it needs **no migration** and is shown by the existing
+inventory browser. The value is the *collection* — a completionist goal like the
+Fishdex or the trophy board — and a perpetual home for coral: a lucky deep-sea
+fisher can carve the whole shelf.
+
+Pure + stdlib-only (no Discord, no DB): :mod:`services.fishing_workflow` owns the
+craft write (debit coral, grant the curio in one transaction); the cog reads this
+catalog. Mirrors :mod:`utils.fishing.bait`'s recipe helpers exactly. Numbers
+sim-pinned in ``docs/planning/fishing-coral-numbers-2026-07-01.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Curio:
+    """One carved curio — a cosmetic collectible crafted from coral.
+
+    ``item`` is the stable ``mining_inventory`` key (also the display name, kept
+    lower-cased to match how inventory keys are stored); ``coral_cost`` coral are
+    consumed to carve one. Rarer curios cost more coral — the collection's
+    long-tail. Purely cosmetic: no gameplay effect, never sold.
+    """
+
+    key: str  # stable lookup key (also the inventory item key)
+    item: str  # the mining_inventory item name (== key; explicit for clarity)
+    name: str  # display name
+    emoji: str
+    coral_cost: int
+    rarity: str  # display rarity (Uncommon / Rare / Epic) — cosmetic only
+
+
+#: The curio shelf, cheapest first. Each entry is one carving craftable from coral;
+#: the ascending coral cost makes the top curio a genuine deep-sea trophy. Tunable
+#: constants — pin changes in the numbers doc + the test.
+CURIO_CATALOG: tuple[Curio, ...] = (
+    Curio(
+        "coral shell",
+        "coral shell",
+        "Carved Coral Shell",
+        "🐚",
+        coral_cost=2,
+        rarity="Uncommon",
+    ),
+    Curio(
+        "coral seahorse",
+        "coral seahorse",
+        "Coral Seahorse",
+        "🌊",
+        coral_cost=4,
+        rarity="Rare",
+    ),
+    Curio("coral idol", "coral idol", "Coral Idol", "🗿", coral_cost=8, rarity="Epic"),
+)
+
+_BY_KEY: dict[str, Curio] = {c.key: c for c in CURIO_CATALOG}
+
+#: The stable keys, in shelf order (for selects / validation).
+CURIO_KEYS: tuple[str, ...] = tuple(c.key for c in CURIO_CATALOG)
+
+#: The inventory item names every curio occupies — used to tally a player's
+#: collection ("2 of 3 curios carved") without re-deriving it at each call site.
+CURIO_ITEMS: tuple[str, ...] = tuple(c.item for c in CURIO_CATALOG)
+
+
+def curio_by_key(key: str | None) -> Curio | None:
+    """The :class:`Curio` for *key*, or ``None`` for an unknown / empty key."""
+    if not key:
+        return None
+    return _BY_KEY.get(key)
+
+
+def cost_text(curio: Curio) -> str:
+    """A short human label of a curio's cost, e.g. ``4 🪸 coral``."""
+    return f"{curio.coral_cost} 🪸 coral"
+
+
+def craftable_key_for(text: str | None) -> str | None:
+    """Resolve typed *text* (a key or a display name) to a curio key.
+
+    Case-insensitive; matches either the stable key (``coral idol``) or the
+    display name (``Coral Idol``). Returns ``None`` for empty input or an
+    unrecognised curio — so ``!craftcurio "coral idol"`` and ``!craftcurio idol``…
+    (the latter is *not* a full key, so it does not resolve) behave predictably.
+    """
+    if not text:
+        return None
+    needle = text.strip().lower()
+    for key in CURIO_KEYS:
+        curio = _BY_KEY.get(key)
+        if curio is None:
+            continue
+        if needle in (key.lower(), curio.name.lower()):
+            return key
+    return None
+
+
+def collection_progress(inventory: dict[str, int]) -> tuple[int, int]:
+    """``(owned, total)`` — how many distinct curios *inventory* holds vs. the set.
+
+    A curio is "owned" when its item key is present with a positive quantity.
+    Pure over an ``{item: qty}`` map; the cog renders the count.
+    """
+    owned = sum(1 for item in CURIO_ITEMS if inventory.get(item, 0) > 0)
+    return owned, len(CURIO_ITEMS)
+
+
+__all__ = [
+    "Curio",
+    "CURIO_CATALOG",
+    "CURIO_KEYS",
+    "CURIO_ITEMS",
+    "curio_by_key",
+    "cost_text",
+    "craftable_key_for",
+    "collection_progress",
+]

--- a/disbot/utils/fishing/rewards.py
+++ b/disbot/utils/fishing/rewards.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import random
 
 from utils.fishing.fish import SHORE_VENUE, Catch, FishSpecies, unlocked_species
+from utils.fishing.venue import DEEPWATER, normalize
 from utils.fishing.weight import roll_weight
 
 
@@ -109,3 +110,45 @@ def roll_pearl_drop(size_rank: int, rng: random.Random | None = None) -> bool:
     """
     r = rng or random.Random()
     return r.random() < pearl_drop_chance(size_rank)
+
+
+#: A **second** dedicated rare crafting material — "coral" — a reel byproduct like
+#: the pearl, but **deepwater-only**: coral is a reef find, so only a cast made in
+#: the boat/deepwater venue (``utils.fishing.venue.DEEPWATER``) can yield it.  This
+#: gives the deepwater venue (the boat, #1340) a *unique* reward the shore can't
+#: earn — a reason to sail beyond the tougher minigame.  Coral's sole sink is the
+#: cosmetic **curio** collection (``utils.fishing.curios``): a completionist set of
+#: carvings you craft from coral, never a bait (that is the pearl's lane).  Stored
+#: in the shared ``mining_inventory``; never a catch-log / dex / trophy row.
+#: Byte-identical economics when no coral drops.  Numbers sim-pinned in
+#: ``docs/planning/fishing-coral-numbers-2026-07-01.md``.
+CORAL_ITEM = "coral"
+
+#: Per-reel coral-drop chance in the **deepwater** venue (flat — coral is a reef
+#: find, not size-scaled like the pearl).  A shore cast never drops coral.
+CORAL_DROP_CHANCE = 0.06
+
+
+def coral_drop_chance(venue: str) -> float:
+    """The coral-drop probability for a landed catch made in *venue*.
+
+    :data:`CORAL_DROP_CHANCE` in the deepwater venue, ``0.0`` everywhere else —
+    coral is a reef find, exclusive to the boat/deepwater venue.
+    """
+    return CORAL_DROP_CHANCE if normalize(venue) == DEEPWATER else 0.0
+
+
+def roll_coral_drop(venue: str, rng: random.Random | None = None) -> bool:
+    """Roll a coral drop for a landed catch made in *venue* — ``True`` ≈ its chance.
+
+    Rolled at commit time (only a *landed* catch can drop coral), separate from
+    the species / bonus-catch / pearl rolls so the material is a clean,
+    independently-tunable knob.  Always ``False`` outside the deepwater venue.
+    State-in (an explicit ``random.Random`` for seed-determinism in tests),
+    return-out.
+    """
+    chance = coral_drop_chance(venue)
+    if chance <= 0.0:
+        return False
+    r = rng or random.Random()
+    return r.random() < chance

--- a/disbot/utils/mining/items.py
+++ b/disbot/utils/mining/items.py
@@ -87,6 +87,29 @@ _CATALOG: dict[str, ItemDef] = {
         value=20,
         tags=frozenset({"luck"}),
     ),
+    # Fishing curios (2026-07-01) — cosmetic carvings crafted from coral (the
+    # deepwater rare drop, utils/fishing/curios.py). TREASURE = high-value find
+    # with no crafting use → never sellable (sell_price only sells RESOURCE), no
+    # gameplay effect; the reward is the collection. Values are for inventory
+    # net-worth display only.
+    "coral shell": ItemDef(
+        "coral shell",
+        ItemKind.TREASURE,
+        value=30,
+        tags=frozenset({"curio"}),
+    ),
+    "coral seahorse": ItemDef(
+        "coral seahorse",
+        ItemKind.TREASURE,
+        value=60,
+        tags=frozenset({"curio"}),
+    ),
+    "coral idol": ItemDef(
+        "coral idol",
+        ItemKind.TREASURE,
+        value=120,
+        tags=frozenset({"curio"}),
+    ),
     # Food / boosters — eaten via mining_workflow.use_item to refill mining
     # energy (utils/mining/energy.py RESTORE_VALUES). Buyable from the market
     # (a coin sink that lets active players keep digging past the passive regen).

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -423,6 +423,11 @@ class FishingCastView(discord.ui.View):
                 "\n🦪 **A pearl!** A rare crafting material — save them up to "
                 "craft the premium **Royal Feast** bait (`!craftpearl`)."
             )
+        if result.coral_found:
+            desc += (
+                "\n🪸 **A piece of coral!** A rare deepwater find — carve it into "
+                "cosmetic curios for your collection (`!curios`)."
+            )
         if result.unlocked_bigger:
             cap = max_size_rank_for_level(result.fishing_level, species.venue)
             desc += (

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -324,9 +324,15 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   ([pearl numbers](../planning/fishing-pearl-numbers-2026-06-28.md)). **The rod-ladder recipe browser
   UI SHIPPED 2026-06-30 (PR #1585):** a 📋 Recipes panel (rod shop button + `!rodrecipes`) shows every
   craftable tier with the player's live eligible-fish progress, not just the bare requirement — see
-  Recently shipped above. ▶ **Next offline successor:** the remaining **fish-loot rare *material*-drop
-  variant** (a dedicated craft material that feeds a *new* craft target rather than the premium bait —
-  e.g. a "kelp"/"driftwood" that crafts a cosmetic or a structure). Pure + sim-pinnable, self-mergeable.
+  Recently shipped above. **The fish-loot rare *material*-drop variant SHIPPED 2026-07-01 (dispatch
+  run):** **coral 🪸** — a **deepwater-only** rare reel-drop (gives the boat venue #1340 a unique
+  payoff) whose sink is a *new, non-bait* craft target: cosmetic **curios** (`utils/fishing/curios.py`
+  — carvings crafted from coral, `ItemKind.TREASURE` → non-sellable, a completionist collection shown
+  by the existing inventory browser; `!curios` / `!craftcurio`). Mirrors the pearl pattern; no
+  migration, no minigame mechanic wiring; also catalogued the previously-uncatalogued pearl for clean
+  display (fix-on-sight). Sim-pinned ([coral numbers](../planning/fishing-coral-numbers-2026-07-01.md)).
+  ▶ **Next offline successor:** a *second* curio tier or a **structure**-target variant (a deepwater
+  material that builds a fishing structure rather than a collectible) — pure + sim-pinnable, self-mergeable.
 - `[needs-live-bot]` **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
   (owner-directed, 2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow
   (**7 steps**: what kind of server is this · greet · moderators · block spam · choose a log channel ·

--- a/docs/owner/claims/claude-funny-franklin-i3ggz1.md
+++ b/docs/owner/claims/claude-funny-franklin-i3ggz1.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-i3ggz1` · scope: fishing rare-material successor (coral 🪸 deepwater drop → cosmetic curio collectibles) · area: `utils/fishing/`, `services/fishing_workflow.py`, `utils/mining/items.py`, `cogs/fishing_cog.py`, `cogs/inventory_cog.py`, `views/fishing/cast_view.py` · 2026-07-01

--- a/docs/owner/claims/claude-funny-franklin-i3ggz1.md
+++ b/docs/owner/claims/claude-funny-franklin-i3ggz1.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-i3ggz1` · scope: fishing rare-material successor (coral 🪸 deepwater drop → cosmetic curio collectibles) · area: `utils/fishing/`, `services/fishing_workflow.py`, `utils/mining/items.py`, `cogs/fishing_cog.py`, `cogs/inventory_cog.py`, `views/fishing/cast_view.py` · 2026-07-01

--- a/docs/planning/fishing-coral-numbers-2026-07-01.md
+++ b/docs/planning/fishing-coral-numbers-2026-07-01.md
@@ -1,0 +1,57 @@
+# Fishing coral + curios — pinned numbers (2026-07-01)
+
+> **Status:** `living-ledger` — the tunable constants behind the coral rare-material
+> drop and the cosmetic curio collection, with the rationale. Change a number here
+> **and** in `tests/unit/utils/test_fishing_curios.py` in the same commit (the test
+> pins these values), like the pearl/bonus-catch/gear number docs before it.
+
+## What this is
+
+The fishing rare-material pattern's **second** instance (S1 "▶ next offline
+successor"). Mirrors the pearl (`docs/planning/fishing-pearl-numbers-2026-06-28.md`)
+but the drop is **deepwater-only** and its sink is a **cosmetic collection** rather
+than a bait.
+
+- **coral** (`utils.fishing.rewards.CORAL_ITEM`) — a rare reel byproduct that only
+  drops on a **deepwater** (boat) cast, giving that venue (#1340) a unique reward.
+- **curios** (`utils.fishing.curios`) — cosmetic carvings crafted from coral
+  (`ItemKind.TREASURE`: non-sellable, no gameplay effect). The reward is the
+  *collection* — a completionist shelf like the Fishdex / trophy board.
+
+## Drop chance (`utils/fishing/rewards.py`)
+
+| Constant | Value | Rationale |
+|---|---|---|
+| `CORAL_DROP_CHANCE` | `0.06` | Per-reel chance in **deepwater**. Flat (coral is a reef find, not size-scaled like the pearl). Shore always `0.0`. |
+
+Sizing: the pearl is `0.02`–`0.15` size-scaled (all venues). Coral at a flat `0.06`
+is a little more generous per-reel *but only in deepwater*, where reels are slower
+and riskier (22% base escape, 6–12 s bites) — so the effective coral-per-hour rate
+is comparable to pearls, and it rewards the harder venue. Every carve costs
+multiple coral, so the collection is a genuine long-tail.
+
+## Curio recipes (`utils/fishing/curios.py`)
+
+| Curio | Emoji | Coral cost | Rarity (cosmetic) | Net-worth value |
+|---|---|---|---|---|
+| Carved Coral Shell | 🐚 | 2 | Uncommon | 30 |
+| Coral Seahorse | 🌊 | 4 | Rare | 60 |
+| Coral Idol | 🗿 | 8 | Epic | 120 |
+
+- **Ascending coral cost** (2 → 4 → 8) makes the Idol a genuine deep-sea trophy:
+  ~14 coral for the full set, i.e. ~230 successful deepwater reels at 6% before
+  the average player completes it — deliberately long-tail, since it is pure
+  cosmetic completion with no power attached.
+- **`value`** is inventory net-worth display only (curios are `TREASURE`, so
+  `market.sell_price` returns `None` — never sellable, no coin faucet).
+
+## Invariants the tests pin
+
+- Coral never drops on a **shore** cast (`roll_coral_drop(SHORE, …) is False`),
+  drops at ≈ `CORAL_DROP_CHANCE` in **deepwater**.
+- `commit_catch` grants coral only on a deepwater cast, in the same atomic
+  transaction, and never writes a dex/trophy row for it.
+- Curios are `ItemKind.TREASURE` and therefore **not** sellable
+  (`market.sell_price("coral idol") is None`).
+- `craft_curio` debits exactly `coral_cost` coral and grants exactly one curio;
+  it refuses when the player lacks the coral.

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -456,6 +456,70 @@ async def test_commit_catch_no_pearl_on_an_unlucky_reel_is_byte_identical():
 
 
 # ---------------------------------------------------------------------------
+# commit_catch — the coral rare-material drop (deepwater-only, this PR)
+# ---------------------------------------------------------------------------
+
+
+async def _commit_venue(rng, venue):
+    """Commit a fixed cast made in *venue* under a forced *rng*."""
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _ctx():
+        yield sentinel_conn
+
+    cast = wf.Cast(catch=_CATCH, level_before=1, venue=venue)
+    with (
+        patch.object(wf.db, "transaction", _ctx),
+        patch.object(wf.db, "record_catch", AsyncMock(return_value=None)),
+        patch.object(wf.db, "update_mining_item", AsyncMock()) as grant,
+        patch.object(
+            wf.game_xp_service,
+            "award",
+            AsyncMock(return_value=_award(game_total=10)),
+        ),
+        patch.object(wf.game_xp_service, "emit_award_events", AsyncMock()),
+    ):
+        result = await wf.commit_catch(99, 1, cast, rng=rng)
+    return result, grant
+
+
+@pytest.mark.asyncio
+async def test_commit_catch_grants_coral_on_a_lucky_deepwater_reel():
+    forced = MagicMock()
+    forced.random.return_value = 0.0  # every roll fires
+    result, grant = await _commit_venue(forced, wf.venue_mod.DEEPWATER)
+
+    assert result.coral_found is True
+    items = [call.args[2] for call in grant.await_args_list]
+    assert wf.CORAL_ITEM in items
+    assert grant.await_args_list[-1].args[2] == _CATCH.species.name  # fish stays last
+
+
+@pytest.mark.asyncio
+async def test_commit_catch_never_grants_coral_on_shore_even_when_lucky():
+    forced = MagicMock()
+    forced.random.return_value = 0.0
+    result, grant = await _commit_venue(forced, wf.venue_mod.SHORE)
+
+    assert result.coral_found is False
+    items = [call.args[2] for call in grant.await_args_list]
+    assert wf.CORAL_ITEM not in items
+
+
+@pytest.mark.asyncio
+async def test_commit_catch_no_coral_on_an_unlucky_deepwater_reel():
+    forced = MagicMock()
+    forced.random.return_value = 0.99  # nothing fires
+    result, grant = await _commit_venue(forced, wf.venue_mod.DEEPWATER)
+
+    assert result.coral_found is False
+    items = [call.args[2] for call in grant.await_args_list]
+    assert wf.CORAL_ITEM not in items
+    assert items == [_CATCH.species.name]  # only the fish, byte-identical
+
+
+# ---------------------------------------------------------------------------
 # roll_cast — the rod's rarity_pull reaches the roll
 # ---------------------------------------------------------------------------
 
@@ -589,7 +653,9 @@ async def test_begin_cast_spends_energy_and_rolls_when_charged():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
-        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
         patch.object(wf, "roll_catch", fake_roll_catch()),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()) as set_energy,
     ):
@@ -629,7 +695,9 @@ async def test_begin_cast_does_not_charge_on_an_empty_catalog():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
-        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
         patch.object(wf, "roll_catch", fake_roll_catch(None)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()) as set_energy,
     ):
@@ -685,7 +753,9 @@ async def test_set_venue_deepwater_message_names_the_tradeoff():
 async def test_toggle_venue_flips_from_the_stored_value():
     with (
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
-        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
         patch.object(wf.db, "set_fishing_venue", AsyncMock()) as set_v,
     ):
         change = await wf.toggle_venue(99, 1)
@@ -702,7 +772,9 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="deepwater")),
-        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
@@ -715,7 +787,9 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
 
     assert start.ok is True
     assert rec["venue"] == "deepwater"  # the stored venue gated the roll
-    assert start.venue_profile is venue_mod.DEEPWATER_PROFILE  # ...and the view's tuning
+    assert (
+        start.venue_profile is venue_mod.DEEPWATER_PROFILE
+    )  # ...and the view's tuning
     assert start.cast.venue == "deepwater"
 
 
@@ -754,7 +828,9 @@ async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
     assert start.effective_bite_speed == pytest.approx(
         gold.bite_speed * storm.bite_speed_mult,
     )
-    assert start.effective_bite_speed != pytest.approx(gold.bite_speed)  # weather moved it
+    assert start.effective_bite_speed != pytest.approx(
+        gold.bite_speed
+    )  # weather moved it
 
 
 # ---------------------------------------------------------------------------
@@ -779,7 +855,9 @@ async def test_begin_cast_folds_equipped_fishing_gear_into_the_knobs():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
-        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
@@ -812,7 +890,9 @@ async def test_begin_cast_with_no_fishing_gear_is_byte_identical():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
-        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),

--- a/tests/unit/services/test_fishing_workflow_curio.py
+++ b/tests/unit/services/test_fishing_workflow_curio.py
@@ -1,0 +1,77 @@
+"""fishing_workflow curio layer — the coral → cosmetic-carving conversion.
+
+Coral is the deepwater-only rare drop; ``craft_curio`` is its sole sink (a cosmetic
+collection, never a bait, never sold). Mirrors the pearl-craft tests.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import fishing_workflow as wf
+from utils.fishing import curios as curios_mod
+
+_IDOL = curios_mod.curio_by_key("coral idol")
+_IDOL_CORAL = _IDOL.coral_cost
+
+
+@pytest.mark.asyncio
+async def test_craft_curio_debits_coral_and_grants_the_carving():
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _ctx():
+        yield sentinel_conn
+
+    with (
+        patch.object(
+            wf.db,
+            "get_mining_inventory",
+            AsyncMock(return_value={wf.CORAL_ITEM: _IDOL_CORAL + 1}),
+        ),
+        patch.object(wf.db, "transaction", _ctx),
+        patch.object(wf.db, "update_mining_item", AsyncMock()) as write,
+        patch.object(wf.economy_service, "debit_in_txn", AsyncMock()) as debit,
+    ):
+        result = await wf.craft_curio(99, 1, "coral idol")
+
+    assert result.success is True
+    assert result.curio is _IDOL
+    # exactly the recipe's coral debited + exactly one curio granted, no coins
+    write.assert_any_await("99", 1, wf.CORAL_ITEM, -_IDOL_CORAL, conn=sentinel_conn)
+    write.assert_any_await("99", 1, _IDOL.item, 1, conn=sentinel_conn)
+    assert write.await_count == 2
+    debit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_craft_curio_without_enough_coral_writes_nothing():
+    with (
+        patch.object(
+            wf.db,
+            "get_mining_inventory",
+            AsyncMock(return_value={wf.CORAL_ITEM: _IDOL_CORAL - 1}),
+        ),
+        patch.object(wf.db, "update_mining_item", AsyncMock()) as write,
+    ):
+        result = await wf.craft_curio(99, 1, "coral idol")
+
+    assert result.success is False
+    assert result.curio is None
+    write.assert_not_awaited()  # no coral, no write
+
+
+@pytest.mark.asyncio
+async def test_craft_curio_rejects_an_unknown_curio_without_reading_inventory():
+    with (
+        patch.object(wf.db, "get_mining_inventory", AsyncMock()) as inv,
+        patch.object(wf.db, "update_mining_item", AsyncMock()) as write,
+    ):
+        result = await wf.craft_curio(99, 1, "driftwood")
+
+    assert result.success is False
+    inv.assert_not_awaited()
+    write.assert_not_awaited()

--- a/tests/unit/utils/test_fishing_curios.py
+++ b/tests/unit/utils/test_fishing_curios.py
@@ -1,0 +1,64 @@
+"""Curios — the cosmetic coral-carving collection (pure).
+
+Pins the catalog/recipe numbers (docs/planning/fishing-coral-numbers-2026-07-01.md)
+and the non-sellable TREASURE contract that keeps curios cosmetic (no coin faucet).
+"""
+
+from __future__ import annotations
+
+from utils.fishing import curios
+from utils.mining import items, market
+
+
+def test_catalog_shape_and_ascending_coral_cost():
+    keys = curios.CURIO_KEYS
+    assert keys == ("coral shell", "coral seahorse", "coral idol")
+    costs = [c.coral_cost for c in curios.CURIO_CATALOG]
+    assert costs == sorted(costs)  # ascending — the Idol is the trophy
+    assert costs == [2, 4, 8]  # pinned (numbers doc)
+
+
+def test_curio_by_key_resolves_and_rejects_unknown():
+    assert curios.curio_by_key("coral idol").name == "Coral Idol"
+    assert curios.curio_by_key("nope") is None
+    assert curios.curio_by_key(None) is None
+    assert curios.curio_by_key("") is None
+
+
+def test_craftable_key_for_matches_key_or_display_name_case_insensitively():
+    assert curios.craftable_key_for("coral idol") == "coral idol"
+    assert curios.craftable_key_for("Coral Idol") == "coral idol"
+    assert curios.craftable_key_for("CORAL SHELL") == "coral shell"
+    assert curios.craftable_key_for("driftwood") is None
+    assert curios.craftable_key_for("") is None
+
+
+def test_collection_progress_counts_distinct_owned_curios():
+    assert curios.collection_progress({}) == (0, 3)
+    assert curios.collection_progress({"coral shell": 5}) == (1, 3)
+    # a zero/negative qty is not "owned"
+    assert curios.collection_progress({"coral shell": 0, "coral idol": 2}) == (1, 3)
+    full = {item: 1 for item in curios.CURIO_ITEMS}
+    assert curios.collection_progress(full) == (3, 3)
+
+
+def test_every_curio_is_a_non_sellable_treasure_item():
+    # Curios must be catalogued as TREASURE so the browser sorts them and — the
+    # key contract — market.sell_price returns None (no coin faucet from a rare
+    # cosmetic). This fails if a curio is ever miscatalogued as a RESOURCE.
+    for curio in curios.CURIO_CATALOG:
+        item = items.lookup(curio.item)
+        assert item is not None, f"{curio.item} missing from items catalog"
+        assert item.kind is items.ItemKind.TREASURE
+        assert market.sell_price(curio.item) is None
+
+
+def test_coral_material_is_not_sellable():
+    # Coral is a crafting material, never a coin source (uncatalogued as a
+    # sellable RESOURCE, mirroring the pearl).
+    assert market.sell_price("coral") is None
+
+
+def test_cost_text_is_human_readable():
+    curio = curios.curio_by_key("coral seahorse")
+    assert curios.cost_text(curio) == "4 🪸 coral"

--- a/tests/unit/utils/test_fishing_rewards.py
+++ b/tests/unit/utils/test_fishing_rewards.py
@@ -50,7 +50,9 @@ def test_smaller_fish_are_more_common_than_bigger_ones():
     rng = random.Random(99)
     from collections import Counter
 
-    counts = Counter(roll_catch(fish.MAX_LEVEL, rng).species.size_rank for _ in range(8000))
+    counts = Counter(
+        roll_catch(fish.MAX_LEVEL, rng).species.size_rank for _ in range(8000)
+    )
     # The smallest fish should out-appear the largest (inverse-size weighting).
     assert counts[1] > counts[len(fish.SPECIES)]
 
@@ -124,8 +126,13 @@ def test_roll_yields_only_the_requested_venues_fish():
 
 def test_shore_and_deepwater_rolls_draw_from_disjoint_pools():
     rng = random.Random(11)
-    shore = {roll_catch(fish.MAX_LEVEL, rng, venue="shore").species.name for _ in range(400)}
-    deep = {roll_catch(fish.MAX_LEVEL, rng, venue="deepwater").species.name for _ in range(400)}
+    shore = {
+        roll_catch(fish.MAX_LEVEL, rng, venue="shore").species.name for _ in range(400)
+    }
+    deep = {
+        roll_catch(fish.MAX_LEVEL, rng, venue="deepwater").species.name
+        for _ in range(400)
+    }
     assert shore.isdisjoint(deep)
 
 
@@ -187,7 +194,9 @@ def test_pearl_drop_stays_rare_not_the_norm():
 
 
 def test_roll_pearl_drop_is_deterministic_for_a_fixed_seed():
-    assert roll_pearl_drop(10, random.Random(7)) == roll_pearl_drop(10, random.Random(7))
+    assert roll_pearl_drop(10, random.Random(7)) == roll_pearl_drop(
+        10, random.Random(7)
+    )
 
 
 def test_roll_pearl_drop_fires_about_at_the_size_scaled_rate():
@@ -204,3 +213,44 @@ def test_bigger_fish_drop_pearls_more_often():
         return sum(roll_pearl_drop(rank, rng) for _ in range(20_000)) / 20_000
 
     assert rate(21) > rate(1)
+
+
+# ---------------------------------------------------------------------------
+# the coral rare-material drop (deepwater-only, flat — this PR)
+# ---------------------------------------------------------------------------
+from utils.fishing.rewards import (  # noqa: E402
+    CORAL_DROP_CHANCE,
+    coral_drop_chance,
+    roll_coral_drop,
+)
+from utils.fishing.venue import DEEPWATER, SHORE  # noqa: E402
+
+
+def test_coral_only_drops_in_deepwater():
+    assert coral_drop_chance(DEEPWATER) == CORAL_DROP_CHANCE
+    assert coral_drop_chance(SHORE) == 0.0
+    # unknown / empty venue normalizes to shore → no coral
+    assert coral_drop_chance("") == 0.0
+
+
+def test_roll_coral_drop_never_fires_on_shore():
+    rng = random.Random(3)
+    assert all(not roll_coral_drop(SHORE, rng) for _ in range(5_000))
+
+
+def test_roll_coral_drop_is_deterministic_for_a_fixed_seed():
+    assert roll_coral_drop(DEEPWATER, random.Random(7)) == roll_coral_drop(
+        DEEPWATER,
+        random.Random(7),
+    )
+
+
+def test_roll_coral_drop_fires_about_at_the_configured_rate():
+    rng = random.Random(123)
+    hits = sum(roll_coral_drop(DEEPWATER, rng) for _ in range(20_000))
+    rate = hits / 20_000
+    assert abs(rate - CORAL_DROP_CHANCE) < 0.02
+
+
+def test_coral_stays_rare_not_the_norm():
+    assert 0.0 < CORAL_DROP_CHANCE <= 0.15


### PR DESCRIPTION
Scheduled dispatch fire (no work order). Both FIX-backlog bugs are gated (BUG-0019 #1 owner design fork; BUG-0009 remainder data-gated), so this takes S1's completion-first `[offline]` **▶ Next offline successor**: the fishing rare-material successor.

Mirrors the pearl pattern (#1518) with a **second** rare reel-drop feeding a **new, non-bait craft target**:

- **coral 🪸** — a rare reel-drop material, **deepwater-venue-gated** (reef find; gives the boat venue #1340 a unique payoff). Stored in the generic `mining_inventory` (no migration), never a dex/trophy row, byte-identical economics when it doesn't drop.
- **Curios** — cosmetic carving collectibles crafted from coral (`ItemKind.TREASURE` → non-sellable, no crafting use), a completionist collection. Shown by the existing inventory browser + `!curios` / `!craftcurio`. Also catalogues coral + the pre-existing uncatalogued pearl for clean display (fix-on-sight).

No migration, no minigame mechanic wiring, pure + sim-pinnable. Deepens two completion units (fishing + inventory).

**Status:** born-red (session card `in-progress`) — flips to `complete` as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyVVXDqZMs7oTfXXpJDHd6)_