### PR TITLE
Fishing Tide Pool — coral structure-target sink (5th cast knob)

### DIFF
--- a/.sessions/2026-07-01-fishing-tide-pool-structure.md
+++ b/.sessions/2026-07-01-fishing-tide-pool-structure.md
@@ -1,0 +1,21 @@
+# 2026-07-01 — Fishing Tide Pool structure (coral structure-target sink)
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
+
+**Branch:** `claude/funny-franklin-4n38rf` (restarted from origin/main #1597).
+**Run type:** routine · dispatch
+
+## What this run is doing
+
+Empty scheduled fire → advance the next plan slice. The S1 sector's explicit `[offline]`
+"▶ Next offline successor" for the fishing rare-material arc is *"a second curio tier or a
+**structure-target variant** (a deepwater material that builds a fishing structure rather than a
+collectible)."* Building the **structure-target variant**: the **Tide Pool** — a coral-built
+mining-structure (generic `mining_structures` table, no migration) that gives coral its first
+**functional** sink (complementing the cosmetic curios), granting a small passive rarity-pull
+bonus folded as the fishing cast's 5th knob (default 1.0 when unbuilt ⇒ byte-identical).
+
+Reuses the Forge/Home/Campfire structure pattern end-to-end (registry entry + audited
+`mining_workflow.build_structure` + panel), and the existing `EffectiveStats`-style additive-safety
+property already used by fishing gear.

--- a/.sessions/2026-07-01-fishing-tide-pool-structure.md
+++ b/.sessions/2026-07-01-fishing-tide-pool-structure.md
@@ -1,21 +1,108 @@
 # 2026-07-01 — Fishing Tide Pool structure (coral structure-target sink)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 <!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
 
+**PR:** [#1598](https://github.com/menno420/superbot/pull/1598) — Fishing Tide Pool (5th cast knob).
 **Branch:** `claude/funny-franklin-4n38rf` (restarted from origin/main #1597).
-**Run type:** routine · dispatch
+**Run type:** `routine · dispatch`
 
-## What this run is doing
+## What this run did
 
-Empty scheduled fire → advance the next plan slice. The S1 sector's explicit `[offline]`
-"▶ Next offline successor" for the fishing rare-material arc is *"a second curio tier or a
+Empty scheduled fire → advanced the next plan slice. The S1 sector's explicit `[offline]`
+"▶ Next offline successor" for the fishing rare-material arc was *"a second curio tier or a
 **structure-target variant** (a deepwater material that builds a fishing structure rather than a
-collectible)."* Building the **structure-target variant**: the **Tide Pool** — a coral-built
-mining-structure (generic `mining_structures` table, no migration) that gives coral its first
-**functional** sink (complementing the cosmetic curios), granting a small passive rarity-pull
-bonus folded as the fishing cast's 5th knob (default 1.0 when unbuilt ⇒ byte-identical).
+collectible)."* Built the **structure-target variant**: the **Tide Pool** — coral's first
+*functional* sink (alongside the cosmetic curios shipped the same morning).
 
-Reuses the Forge/Home/Campfire structure pattern end-to-end (registry entry + audited
-`mining_workflow.build_structure` + panel), and the existing `EffectiveStats`-style additive-safety
-property already used by fishing gear.
+## Shipped (PR #1598)
+
+- **`utils/mining/structures.py`** — new `TIDE_POOL` registry entry (3-level coral + coin build
+  ladder) + pure `tide_pool_pull_mult(level)` payoff helper (`1.0 + 0.04·level`, clamped). Reuses the
+  generic Forge/Home/Campfire registry math.
+- **`utils/mining/market.py`** — `TIDE_POOL_BUILD_REASON` economy-audit tag.
+- **`services/mining_workflow.py`** — Tide Pool wired into the audited `build_structure` seam
+  (`_STRUCTURE_BUILD_REASON` + a `+N%` reward suffix); no new mutation path.
+- **`services/fishing_workflow.py`** — `begin_cast` reads the player's tide-pool level and folds its
+  pull multiplier as the **5th "how-well" knob** (rod × bait × weather × gear × **tide pool**);
+  unbuilt (level 0) ⇒ ×1.0 ⇒ byte-identical (the additive-safety property the gear knob uses). A new
+  `CastStart.tide_pool_bonus` flag surfaces a 🪸 cast-footer note.
+- **`views/fishing/tide_pool.py`** + `cogs/fishing_cog.py` `!tidepool` + a 🪸 Tide Pool button on the
+  fishing menu — the build panel (mirrors the Forge/Home panels), reachable + buttonized (0 gaps).
+- Tests: +6 structure-math cases, +2 `begin_cast` fold cases (built raises pull / unbuilt
+  byte-identical), +1 service build case (coral consumed + reward line); regenerated dashboard/site
+  artifacts for the new command; `docs/planning/fishing-tide-pool-numbers-2026-07-01.md` (sim-pinned).
+
+Full CI mirror green (13,423 passed); `check_architecture --mode strict` 0 errors. No migration
+(coral + structures reuse existing stores). Self-merge on green.
+
+## Decisions made alone (owner should be aware)
+
+- **Payoff = rarity-pull, not bite-speed or new fish.** The Tide Pool reweights the *already-unlocked*
+  band toward rarer fish (max +12% at level 3); it never unlocks species (that stays the fishing-level
+  axis) and never changes bite wait. Chosen as the single most intuitive, easily-bounded "my
+  investment gets better fish." Reversible (a number + one multiplier).
+- **Domain placement:** a *fishing* feature stored on the *mining*_structures table + built via
+  `mining_workflow`. Precedent: the Campfire structure already gates "cooking fish," and coral itself
+  already crosses fishing→mining_inventory. The table is explicitly generic `(user, guild, structure, level)`.
+
+## Flagged for maintainer / known limits
+
+- Never played live — the numbers (coral 3/6/10, +4/8/12%) are sim-reasoned, not balance-tested. A
+  live walk may want them re-tuned; all are single-line constants in the numbers doc + test.
+
+## Context delta
+
+- **Needed but not pointed to:** that CI **excludes `tests/`** from black is in CLAUDE.md, but it's
+  easy to trip — a broad `black tests/` reformatted ~120 unrelated test files (see friction below).
+- **Pointed to but didn't need:** nothing notable — the S1 sector file routed straight to the pick.
+- **Discovered by hand:** the structure system is fully registry-driven — a new structure is one
+  `_DEFS` entry + ladder + names + (optional) a reward-suffix + payoff hook; `build_structure`,
+  `_check_materials`, and `describe_materials` are all material-agnostic (coral "just works").
+
+## 🛠 Friction → guard
+
+- **Friction:** `python3.10 -m black tests/…` reformatted ~120 test files CI never formats (`tests/`
+  is a black exclude), creating a huge spurious diff I had to revert file-by-file. **Guard shipped:**
+  none code-level this run (a black-scope guard touching config is owner-gated). **Proposed (DISCUSS):**
+  a tiny pre-commit/checker that warns when a formatter is invoked over a CI-excluded path, or a
+  `scripts/fmt.py` wrapper pinned to CI's exact scope so agents never pass a raw path. Recorded here so
+  the next run reaches for `scripts/check_quality.py` (correct scope) rather than a bare `black <path>`.
+
+## 💡 Session idea
+
+**A "fishing dock" bite-speed structure** as the Tide Pool's sibling — the same coral (or a new
+deepwater material) building a structure whose payoff is a *bite-speed* knob (faster bites) rather than
+rarity-pull, giving the two structures distinct roles. Genuinely worth having: it turns the single
+"tide pool" into a small *choice* of coral investment (rarer fish vs. faster fishing), which is the
+kind of build-order depth the mining structure ladder already rewards. Left as the sharpened ▶ Next in
+the S1 sector file; not built this run (kept scope to one clean slice).
+
+## ⟲ Previous-session review
+
+The prior dispatch run (coral 🪸 / curios, same morning) did the *cosmetic* half of the rare-material
+arc cleanly and, notably, **left the roadmap ▶ Next crisply worded with two concrete options** — which
+is exactly why this run could pick up and ship in one hop with zero re-derivation. That's the
+self-improving loop working: a good handoff line is worth more than a long narrative. One thing it
+*could* have done: it catalogued the previously-uncatalogued pearl as a fix-on-sight, but the coral
+doc's "second curio tier or a structure variant" was slightly under-specified on *which* stores/seams
+a structure variant would reuse — I had to confirm `mining_structures` is generic by reading source. A
+**system improvement** this surfaces: when a roadmap ▶ Next names an option that spans a *different*
+subsystem (here, fishing → mining structures), a one-line "reuses X seam" pointer in the handoff would
+save the next agent the cross-domain source dig. Minor; not worth a guard.
+
+## 📤 Run report
+
+- **Did:** shipped the Tide Pool — coral's functional fishing-structure sink (the roadmap's named
+  structure-target variant) · **Outcome:** shipped
+- **Shipped:** #1598 — Tide Pool structure + the fishing cast's 5th rarity-pull knob (coral sink,
+  no migration, byte-identical when unbuilt).
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none` (merge auto-deploys; no data step — coral/structures reuse
+  existing stores)
+- **⚑ Self-initiated:** `none` (the work was the sector's explicit `[offline]` ▶ Next startable pick,
+  grounded in the shipped coral arc's roadmap successor — not an invented feature)
+- **↪ Next:** S1 fishing — a second Tide Pool-style structure with a *different* payoff (a bite-speed
+  "dock"), or a second curio tier; both pure + sim-pinnable, self-mergeable. (Sharpened in
+  `docs/current-state/S1-bot.md`.)

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T03:20:15Z",
+    "generated_at": "2026-07-01T06:13:15Z",
     "build": {
-      "commit": "a0e4c0c6",
-      "subject": "fishing: open born-red session card for coral/curios slice",
-      "committed_at": "2026-07-01T03:20:15Z"
+      "commit": "a1d868c8",
+      "subject": "chore(session): open born-red card — fishing Tide Pool coral structure sink",
+      "committed_at": "2026-07-01T06:13:15Z"
     }
   },
   "counts": {
-    "commands": 476,
+    "commands": 477,
     "features": 43,
     "games": 12
   },
@@ -9937,6 +9937,31 @@
         },
         {
           "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "tidepool",
+      "aliases": [
+        "reef",
+        "tidepools"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Build a Tide Pool — the deepwater-coral structure that pulls rarer catches.",
+      "description": "Build a Tide Pool — the deepwater-coral structure that pulls rarer catches.",
+      "use_cases": null,
+      "examples": [
+        "!sail",
+        "!curios"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
           "status": "ideas"
         }
       ],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -6342,6 +6342,30 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "tidepool",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Build a Tide Pool — the deepwater-coral structure that pulls rarer catches.",
+    "description": "Build a Tide Pool — the deepwater-coral structure that pulls rarer catches.",
+    "usage": "!tidepool",
+    "aliases": [
+      "reef",
+      "tidepools"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [
+      "!sail",
+      "!curios"
+    ],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
+      }
+    ]
+  },
+  {
     "name": "timedprize",
     "area": "moderation",
     "status": "finished",
@@ -7241,7 +7265,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "a0e4c0c6",
+    "build": "a1d868c8",
     "title": "New public bot website",
     "changes": [
       {
@@ -7253,7 +7277,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "a0e4c0c6",
+    "build": "a1d868c8",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7265,7 +7289,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "a0e4c0c6",
+    "build": "a1d868c8",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T05:51:01Z",
+    "generated_at": "2026-07-01T06:13:15Z",
     "build": {
-      "commit": "bf8d8a31",
-      "subject": "Merge pull request #1596 from menno420/claude/funny-franklin-i3ggz1",
-      "committed_at": "2026-07-01T05:51:01Z"
+      "commit": "a1d868c8",
+      "subject": "chore(session): open born-red card — fishing Tide Pool coral structure sink",
+      "committed_at": "2026-07-01T06:13:15Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 55,
-      "commands": 476,
+      "commands": 477,
       "setting_keys": 115,
       "setting_domains": 17,
       "typed_settings": 95,
@@ -2708,6 +2708,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-07-01-fishing-tide-pool-structure.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Fishing Tide Pool structure (coral structure-target sink)",
+      "status": "in-progress",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-01-fishing-coral-curios.md",
       "date": "2026-07-01",
       "title": "2026-07-01 — Fishing: coral 🪸 deepwater rare-material drop → cosmetic curio collectibles",
@@ -3161,14 +3169,6 @@
       "title": "2026-06-27 — Fishing-gear acquisition depth: fish→charm craft path",
       "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-27-feature-completion-framework.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — Feature-completion certification framework (S1 bot units)",
-      "status": "complete",
-      "run_type": "manual",
       "self_initiated": false
     }
   ],
@@ -7081,6 +7081,20 @@
           "classification": "",
           "has_panel": false,
           "button_backed": false
+        },
+        {
+          "name": "tidepool",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "reef",
+            "tidepools"
+          ],
+          "brief": "Build a Tide Pool — the deepwater-coral structure that pulls rarer catches.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
         },
         {
           "name": "trophies",

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -40,11 +40,13 @@ from views.fishing import (
     BaitShopView,
     FishingMenuView,
     RodShopView,
+    TidePoolView,
     build_bait_embed,
     build_fishlog_embed,
     build_menu_embed,
     build_recipe_panel,
     build_rod_embed,
+    build_tide_pool_embed,
     prepare_cast,
 )
 
@@ -337,6 +339,18 @@ class FishingCog(commands.Cog):
             )
         embed.set_footer(text="Carve with !craftcurio <name>")
         await ctx.send(embed=embed)
+
+    @commands.command(name="tidepool", aliases=["reef", "tidepools"])
+    async def tidepool(self, ctx):
+        """Build a Tide Pool — the deepwater-coral structure that pulls rarer catches.
+
+        Coral drops rarely on a **deepwater** reel (`!sail`). Stock a reef pool with
+        it to bias every cast toward the big end of your unlocked band — coral's
+        *functional* sink alongside the cosmetic curios (`!curios`).
+        """
+        embed = await build_tide_pool_embed(ctx.author.id, ctx.guild.id)
+        view = TidePoolView(ctx.author, ctx.guild.id)
+        view.message = await ctx.send(embed=embed, view=view)
 
     @commands.command(name="craftcurio", aliases=["carve", "curiocraft"])
     async def craftcurio(self, ctx, *, curio: str = ""):

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -46,6 +46,7 @@ from utils.fishing import (
 from utils.fishing import venue as venue_mod
 from utils.fishing import weather as weather_mod
 from utils.mining import character
+from utils.mining import structures as structures_mod
 
 logger = logging.getLogger("bot.fishing_workflow")
 
@@ -299,6 +300,11 @@ class CastStart:
     #: ``effective_bite_speed``) — for the 🎣 cast-panel note. ``False`` when no
     #: fishing gear is equipped, in which case the cast is byte-identical.
     fishing_gear_bonus: bool = False
+    #: Whether a built **Tide Pool** structure biased this cast toward rarer fish
+    #: (its rarity-pull bonus is already folded into the roll pull) — for the 🪸
+    #: cast-panel note. ``False`` when the Tide Pool is unbuilt (level 0), in which
+    #: case that knob is ×1.0 and the cast is byte-identical.
+    tide_pool_bonus: bool = False
 
 
 def _fmt_wait(seconds: int) -> str:
@@ -369,16 +375,24 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
     )
     gear_pull = fishing_gear.fishing_pull_mult(gear_stats)
     gear_bite_speed = fishing_gear.fishing_bite_speed_mult(gear_stats)
-    # Four "how-well" knobs compound: rod × bait × weather × gear. rarity_pull
-    # (all ≥ 1) pulls the catch toward the big end of the SAME unlocked band (never
-    # a new band — that stays the fishing-level axis); bite_speed (rod/bait/gear ≤ 1,
-    # weather either way) scales the bite wait. Weather is the transient, shared,
-    # free knob (a storm makes a rarer catch likelier but the wait longer).
+    # The 5th knob: a built **Tide Pool** structure (coral's functional sink). Its
+    # rarity-pull bonus is another ≥ 1.0 multiplier; unbuilt (level 0) ⇒ ×1.0 ⇒
+    # byte-identical, exactly like the gear knob's additive-safety property.
+    built = await db.get_structures(user_id, guild_id)
+    tide_pool_level = built.get(structures_mod.TIDE_POOL, 0)
+    tide_pool_pull = structures_mod.tide_pool_pull_mult(tide_pool_level)
+    # Five "how-well" knobs compound: rod × bait × weather × gear × tide pool.
+    # rarity_pull (all ≥ 1) pulls the catch toward the big end of the SAME unlocked
+    # band (never a new band — that stays the fishing-level axis); bite_speed
+    # (rod/bait/gear ≤ 1, weather either way) scales the bite wait. Weather is the
+    # transient, shared, free knob (a storm makes a rarer catch likelier but the
+    # wait longer).
     effective_pull = (
         rod.rarity_pull
         * (bait.rarity_pull if bait else 1.0)
         * weather.rarity_mult
         * gear_pull
+        * tide_pool_pull
     )
     effective_bite_speed = (
         rod.bite_speed
@@ -428,6 +442,7 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
         venue_profile=profile,
         weather=weather,
         fishing_gear_bonus=fishing_gear.has_fishing_bonus(gear_stats),
+        tide_pool_bonus=tide_pool_level > 0,
     )
 
 

--- a/disbot/services/mining_workflow.py
+++ b/disbot/services/mining_workflow.py
@@ -678,6 +678,7 @@ _STRUCTURE_BUILD_REASON = {
     structures.FORGE: market.FORGE_BUILD_REASON,
     structures.HOME: market.HOME_BUILD_REASON,
     structures.CAMPFIRE: market.CAMPFIRE_BUILD_REASON,
+    structures.TIDE_POOL: market.TIDE_POOL_BUILD_REASON,
 }
 
 
@@ -692,6 +693,10 @@ def _build_success_suffix(structure: str, new_level: int) -> str:
         return f" Now crafts **{unlocked[-1]}-tier** gear." if unlocked else ""
     if structure == structures.HOME:
         return " It now frames your Character card."
+    if structure == structures.TIDE_POOL:
+        mult = structures.tide_pool_pull_mult(new_level)
+        pct = round((mult - 1.0) * 100)
+        return f" Your casts now pull **+{pct}%** toward rarer fish."
     return ""
 
 

--- a/disbot/utils/mining/market.py
+++ b/disbot/utils/mining/market.py
@@ -23,6 +23,7 @@ VAULT_UPGRADE_REASON = "mining:vault_upgrade"
 FORGE_BUILD_REASON = "mining:forge_build"
 HOME_BUILD_REASON = "mining:home_build"
 CAMPFIRE_BUILD_REASON = "mining:campfire_build"
+TIDE_POOL_BUILD_REASON = "mining:tide_pool_build"
 
 # Gear shop — coins to buy each item (the sink).  Priced ~5-6× the sell value
 # of the materials it would take to craft, so crafting stays the cheaper path
@@ -185,6 +186,7 @@ __all__ = [
     "FORGE_BUILD_REASON",
     "HOME_BUILD_REASON",
     "CAMPFIRE_BUILD_REASON",
+    "TIDE_POOL_BUILD_REASON",
     "sell_price",
     "sellable_inventory",
     "total_sale_value",

--- a/disbot/utils/mining/structures.py
+++ b/disbot/utils/mining/structures.py
@@ -33,6 +33,7 @@ from utils import equipment
 FORGE = "forge"
 HOME = "home"
 CAMPFIRE = "campfire"
+TIDE_POOL = "tide_pool"
 
 #: Gear at or below this tier index needs **no** forge (bronze=1, iron=2,
 #: silver=3 are free; gold=4 → forge 1; diamond=5 → forge 2).  ``forge_level =
@@ -51,6 +52,19 @@ _HOME_LEVEL_NAMES = ("(not built)", "Cozy Cabin", "Stone Keep", "Grand Hall")
 #: **cooking fish into food** (energy refill, see ``services/mining_workflow.cook``).
 #: A small coin + material sink, buildable early — a progression beat, not a wall.
 _CAMPFIRE_LEVEL_NAMES = ("(not built)", "Campfire")
+
+#: Tide Pool (2026-07-01): the deepwater-**coral** structure sink — coral's first
+#: *functional* payoff (the cosmetic curios are its other sink).  A stocked reef
+#: pool nudges the fishing catch toward the big end of the unlocked band: each
+#: level adds a small ``rarity_pull`` bonus folded into ``begin_cast`` as the 5th
+#: "how-well" knob (rod × bait × weather × gear × tide pool).  Unbuilt ⇒ ×1.0 ⇒
+#: byte-identical casts — additive, never a wall.
+_TIDE_POOL_LEVEL_NAMES = ("(not built)", "Reef Pool", "Tidal Basin", "Grand Reef")
+
+#: Per-level rarity-pull bonus (added to the ×1.0 base).  Level 3 ⇒ ×1.12 — a
+#: modest edge (the fishing-level axis still owns which fish are reachable at all;
+#: this only reweights the band).  Tunable — pin in the numbers doc + the test.
+_TIDE_POOL_PULL_STEP = 0.04
 
 
 @dataclass(frozen=True)
@@ -89,6 +103,20 @@ _CAMPFIRE_BUILD_LADDER: tuple[BuildCost, ...] = (
     BuildCost(coins=500, materials={"wood": 20, "stone": 10}),
 )
 
+#: Tide Pool build ladder — a rising coin + **coral** sink for the three levels
+#: (coral is the deepwater-only reel drop, ``utils.fishing.rewards.CORAL_ITEM``;
+#: it reuses the generic ``mining_inventory`` store).  Comparable total-coral cost
+#: to carving the full curio shelf, so coral has two real sinks to choose between.
+#: Pin changes in ``docs/planning/fishing-tide-pool-numbers-2026-07-01.md`` + the test.
+_TIDE_POOL_BUILD_LADDER: tuple[BuildCost, ...] = (
+    # → Reef Pool (×1.04 rarity pull)
+    BuildCost(coins=1_500, materials={"coral": 3}),
+    # → Tidal Basin (×1.08)
+    BuildCost(coins=4_000, materials={"coral": 6}),
+    # → Grand Reef (×1.12)
+    BuildCost(coins=9_000, materials={"coral": 10}),
+)
+
 
 @dataclass(frozen=True)
 class StructureDef:
@@ -112,6 +140,12 @@ _DEFS: dict[str, StructureDef] = {
         _CAMPFIRE_BUILD_LADDER,
         _CAMPFIRE_LEVEL_NAMES,
     ),
+    TIDE_POOL: StructureDef(
+        TIDE_POOL,
+        "Tide Pool",
+        _TIDE_POOL_BUILD_LADDER,
+        _TIDE_POOL_LEVEL_NAMES,
+    ),
 }
 
 STRUCTURES: tuple[str, ...] = tuple(_DEFS)
@@ -126,10 +160,25 @@ MAX_HOME_LEVEL = len(_HOME_BUILD_LADDER)
 #: Highest Campfire level (a single buildable level).
 MAX_CAMPFIRE_LEVEL = len(_CAMPFIRE_BUILD_LADDER)
 
+#: Highest Tide Pool level (the top rarity-pull bonus).
+MAX_TIDE_POOL_LEVEL = len(_TIDE_POOL_BUILD_LADDER)
+
 
 def cooking_unlocked(campfire_level: int) -> bool:
     """True if a campfire at *campfire_level* unlocks cooking (level ≥ 1)."""
     return campfire_level >= 1
+
+
+def tide_pool_pull_mult(level: int) -> float:
+    """The fishing rarity-pull multiplier a Tide Pool at *level* grants (≥ 1.0).
+
+    Folded into ``services.fishing_workflow.begin_cast`` as the 5th "how-well"
+    knob.  Level 0 (unbuilt) ⇒ exactly ``1.0`` so an existing cast is
+    byte-identical — the additive-safety property the fishing gear knob relies on.
+    Clamped to the ladder so an out-of-range level can never over-reward.
+    """
+    level = max(0, min(level, MAX_TIDE_POOL_LEVEL))
+    return round(1.0 + _TIDE_POOL_PULL_STEP * level, 4)
 
 
 def is_structure(name: str) -> bool:
@@ -220,13 +269,16 @@ __all__ = [
     "FORGE",
     "HOME",
     "CAMPFIRE",
+    "TIDE_POOL",
     "STRUCTURES",
     "MAX_FORGE_LEVEL",
     "MAX_CAMPFIRE_LEVEL",
+    "MAX_TIDE_POOL_LEVEL",
     "FREE_TIER_CEILING",
     "BuildCost",
     "is_structure",
     "cooking_unlocked",
+    "tide_pool_pull_mult",
     "forge_level_name",
     "forge_build_cost",
     "forge_level_required",

--- a/disbot/views/fishing/__init__.py
+++ b/disbot/views/fishing/__init__.py
@@ -17,6 +17,7 @@ from views.fishing.menu import (
 )
 from views.fishing.rod_recipe_browser import RodRecipeBrowserView, build_recipe_panel
 from views.fishing.rod_shop import RodShopView, build_rod_embed
+from views.fishing.tide_pool import TidePoolView, build_tide_pool_embed
 
 __all__ = [
     "BaitShopView",
@@ -24,11 +25,13 @@ __all__ = [
     "FishingMenuView",
     "RodRecipeBrowserView",
     "RodShopView",
+    "TidePoolView",
     "active_casts",
     "build_bait_embed",
     "build_fishlog_embed",
     "build_menu_embed",
     "build_recipe_panel",
     "build_rod_embed",
+    "build_tide_pool_embed",
     "prepare_cast",
 ]

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -127,6 +127,10 @@ async def prepare_cast(
         # Equipped fishing gear is biasing this cast (rarer catches + quicker
         # bites) — its stats are already folded into the roll / bite speed.
         footer += " · 🎣 fishing gear"
+    if start.tide_pool_bonus:
+        # A built Tide Pool is nudging this cast toward rarer fish (its pull
+        # bonus is already folded into the roll).
+        footer += " · 🪸 tide pool"
     embed.set_footer(text=footer)
     return embed, view
 

--- a/disbot/views/fishing/menu.py
+++ b/disbot/views/fishing/menu.py
@@ -283,6 +283,24 @@ class FishingMenuView(HubView):
         shop.message = interaction.message
         self.stop()
 
+    @discord.ui.button(
+        label="Tide Pool",
+        emoji="🪸",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def tide_pool_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from views.fishing.tide_pool import TidePoolView, build_tide_pool_embed
+
+        embed = await build_tide_pool_embed(self._author.id, self.guild_id)
+        view = TidePoolView(self._author, self.guild_id)
+        await interaction.response.edit_message(embed=embed, view=view)
+        view.message = interaction.message
+        self.stop()
+
     @discord.ui.button(label="Fishdex", emoji="📖", style=discord.ButtonStyle.secondary)
     async def fishdex_btn(
         self,

--- a/disbot/views/fishing/tide_pool.py
+++ b/disbot/views/fishing/tide_pool.py
@@ -1,0 +1,132 @@
+"""Fishing Tide Pool panel — the coral structure-target sink (2026-07-01).
+
+The Tide Pool is coral's first **functional** sink: a built structure (on the
+generic ``mining_structures`` table, no migration) whose rarity-pull bonus is
+folded into :func:`services.fishing_workflow.begin_cast` as the cast's 5th
+"how-well" knob.  This panel shows the built level, the bonus it grants, and the
+next build cost (coins + coral), with a 🪸 Build button.
+
+Every build runs through :mod:`services.mining_workflow` (one transaction per
+op — coin debit + coral consume + level raise commit together, audited via the
+economy log); this view is only the button that calls it.  Structurally it is a
+sibling of ``views/mining/forge_panel.py`` but themed for — and reachable from —
+the fishing menu.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from services import mining_workflow
+from utils import db
+from utils.mining import structures, workshop
+from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR
+from views.base import HubView
+
+_TIDE_POOL_COLOR = discord.Color.teal()
+
+
+def _bonus_text(level: int) -> str:
+    """The rarity-pull bonus a Tide Pool at *level* grants, as a ``+N%`` label."""
+    pct = round((structures.tide_pool_pull_mult(level) - 1.0) * 100)
+    return f"+{pct}% pull toward rarer fish" if pct else "no bonus yet"
+
+
+async def build_tide_pool_embed(
+    user_id: int,
+    guild_id: int,
+    *,
+    note: str = "",
+) -> discord.Embed:
+    """The Tide Pool embed: built level, current bonus, and the next build cost."""
+    built = await db.get_structures(user_id, guild_id)
+    level = built.get(structures.TIDE_POOL, 0)
+
+    embed = discord.Embed(title="🪸 Tide Pool", color=_TIDE_POOL_COLOR)
+    embed.description = note or (
+        "Stock a reef pool with **coral** to nudge your casts toward rarer "
+        "fish. Coral drops on a **deepwater** reel (`!sail`) — the same coral "
+        "you can carve into curios, now with a second, *useful* home."
+    )
+    embed.add_field(
+        name="Level",
+        value=(
+            f"**{structures.level_name(structures.TIDE_POOL, level)}** "
+            f"({level}/{structures.MAX_TIDE_POOL_LEVEL})"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Current bonus",
+        value=_bonus_text(level),
+        inline=False,
+    )
+    cost = structures.build_cost(structures.TIDE_POOL, level)
+    if cost is None:
+        embed.add_field(
+            name="Maxed",
+            value="Your Tide Pool is at its highest level — casts pull their best.",
+            inline=False,
+        )
+        embed.set_footer(text="↩ Fishing menu")
+    else:
+        nxt = structures.level_name(structures.TIDE_POOL, level + 1)
+        embed.add_field(
+            name=f"Next: {nxt} → {_bonus_text(level + 1)}",
+            value=f"{workshop.describe_materials(cost.materials)} + **{cost.coins}** 🪙",
+            inline=False,
+        )
+        embed.set_footer(text="🪸 Build  •  ↩ Fishing menu")
+    return embed
+
+
+class TidePoolView(HubView):
+    """Build/upgrade-the-Tide-Pool panel; a child of the fishing menu."""
+
+    SUBSYSTEM = "fishing"
+
+    def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    @discord.ui.button(label="🪸 Build", style=discord.ButtonStyle.success, row=0)
+    async def build_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        result = await mining_workflow.build_structure(
+            self._author.id,
+            self.guild_id,
+            structures.TIDE_POOL,
+        )
+        embed = await build_tide_pool_embed(
+            self._author.id,
+            self.guild_id,
+            note=("✅ " if result.ok else "❌ ") + result.message,
+        )
+        embed.color = SUCCESS_COLOR if result.ok else ERROR_COLOR
+        await safe_edit(interaction, embed=embed, view=self)
+
+    @discord.ui.button(
+        label="↩ Fishing menu",
+        style=discord.ButtonStyle.secondary,
+        row=0,
+    )
+    async def back_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # The menu self.stop()s when it opens this panel, so rebuild the fully-
+        # navigable menu in place. Lazy import to respect menu→child direction.
+        from views.fishing.menu import open_fishing_menu
+
+        self.stop()
+        await open_fishing_menu(interaction, self._author, self.guild_id)
+
+
+__all__ = ["TidePoolView", "build_tide_pool_embed"]

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -331,8 +331,15 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   by the existing inventory browser; `!curios` / `!craftcurio`). Mirrors the pearl pattern; no
   migration, no minigame mechanic wiring; also catalogued the previously-uncatalogued pearl for clean
   display (fix-on-sight). Sim-pinned ([coral numbers](../planning/fishing-coral-numbers-2026-07-01.md)).
-  ▶ **Next offline successor:** a *second* curio tier or a **structure**-target variant (a deepwater
-  material that builds a fishing structure rather than a collectible) — pure + sim-pinnable, self-mergeable.
+  **The structure-target variant SHIPPED 2026-07-01 (dispatch run, PR #1598):** the **Tide Pool** 🪸 —
+  coral's first *functional* sink (alongside the cosmetic curios). A coral-built structure on the
+  generic `mining_structures` table (no migration) whose rarity-pull bonus folds into `begin_cast` as
+  the cast's **5th "how-well" knob** (rod × bait × weather × gear × **tide pool**), default ×1.0 when
+  unbuilt ⇒ byte-identical. Reuses the Forge/Home/Campfire pattern end-to-end (registry entry + audited
+  `mining_workflow.build_structure` + `views/fishing/tide_pool.py` panel + `!tidepool` + a menu button).
+  Sim-pinned ([tide-pool numbers](../planning/fishing-tide-pool-numbers-2026-07-01.md)).
+  ▶ **Next offline successor:** a *second* curio tier, or a **second** Tide Pool-style structure with a
+  different fishing payoff (e.g. a bite-speed "dock") — pure + sim-pinnable, self-mergeable.
 - `[needs-live-bot]` **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
   (owner-directed, 2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow
   (**7 steps**: what kind of server is this · greet · moderators · block spam · choose a log channel ·

--- a/docs/owner/claims/claude-funny-franklin-4n38rf.md
+++ b/docs/owner/claims/claude-funny-franklin-4n38rf.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-4n38rf · fishing Tide Pool coral structure-target sink · disbot/utils/mining/structures.py + market.py + services/{mining_workflow,fishing_workflow}.py + views/fishing/ + cogs/fishing_cog.py + tests · 2026-07-01

--- a/docs/owner/claims/claude-funny-franklin-4n38rf.md
+++ b/docs/owner/claims/claude-funny-franklin-4n38rf.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-4n38rf · fishing Tide Pool coral structure-target sink · disbot/utils/mining/structures.py + market.py + services/{mining_workflow,fishing_workflow}.py + views/fishing/ + cogs/fishing_cog.py + tests · 2026-07-01

--- a/docs/planning/fishing-tide-pool-numbers-2026-07-01.md
+++ b/docs/planning/fishing-tide-pool-numbers-2026-07-01.md
@@ -1,0 +1,56 @@
+# Fishing Tide Pool — pinned numbers (2026-07-01)
+
+> **Status:** `living-ledger` — the tunable constants behind the **Tide Pool**, coral's
+> first *functional* sink. Change a number here **and** in
+> `tests/unit/utils/test_mining_structures.py` (the build ladder + pull multiplier are
+> pinned there) in the same commit, like the coral / pearl / gear number docs before it.
+
+## What this is
+
+The fishing rare-material arc's **structure-target** successor (S1 "▶ next offline
+successor"): coral now has two sinks to choose between —
+
+- **curios** (`utils.fishing.curios`) — the *cosmetic* sink (a completionist shelf), and
+- the **Tide Pool** (`utils.mining.structures.TIDE_POOL`) — the *functional* sink: a built
+  structure whose rarity-pull bonus is folded into
+  `services.fishing_workflow.begin_cast` as the cast's **5th "how-well" knob**
+  (rod × bait × weather × gear × **tide pool**).
+
+It reuses the generic `mining_structures` table (no migration), the audited
+`services.mining_workflow.build_structure` seam, and the same additive-safety property the
+fishing gear knob relies on: **unbuilt (level 0) ⇒ ×1.0 ⇒ every existing cast is
+byte-identical.**
+
+## Build ladder (`utils/mining/structures.py` — `_TIDE_POOL_BUILD_LADDER`)
+
+| Level | Name | Coral | Coins | Rarity-pull bonus |
+|---|---|---|---|---|
+| 1 | Reef Pool | 3 | 1,500 | ×1.04 (+4%) |
+| 2 | Tidal Basin | 6 | 4,000 | ×1.08 (+8%) |
+| 3 | Grand Reef | 10 | 9,000 | ×1.12 (+12%) |
+
+- **`tide_pool_pull_mult(level) = 1.0 + 0.04 · level`** (`_TIDE_POOL_PULL_STEP = 0.04`),
+  clamped to the ladder. Level 0 ⇒ exactly `1.0`.
+- **Coral cost** (3 + 6 + 10 = **19** for the full build) is comparable to carving the
+  whole curio shelf (~14 coral), so the two sinks are a genuine choice rather than one
+  dominating — a dedicated deep-sea fisher can eventually do both.
+- **Coins** (1.5k / 4k / 9k) sit between the Campfire (500) and Forge (3k / 8k) ladders —
+  a mid-weight coin sink, never a wall (fishing works fully without it).
+
+## Why rarity-pull (not bite-speed / new fish)
+
+The Tide Pool reweights the player's **already-unlocked** band toward the bigger, rarer
+fish — it never unlocks new species (that stays the fishing-**level** axis) and never
+changes the bite wait. So the bonus is meaningful (better trophies / dex fills) but small
+and bounded (max +12%), and it composes cleanly with the four existing knobs as a plain
+multiplier.
+
+## Invariants the tests pin
+
+- `tide_pool_pull_mult(0) == 1.0` (byte-identical cast when unbuilt) and it rises
+  `1.04 / 1.08 / 1.12` across the three levels, clamped above `MAX_TIDE_POOL_LEVEL`.
+- `build_cost(TIDE_POOL, level)` returns the ladder rows above and `None` past the top.
+- `begin_cast` folds the tide-pool multiplier into `effective_pull` (a built pool raises
+  the pull vs. an unbuilt one; an unbuilt pool leaves the pre-existing value unchanged).
+- Building routes through the audited `mining_workflow.build_structure` seam (coin debit +
+  coral consume + level raise in one transaction) — no new mutation path.

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -567,6 +567,7 @@ async def test_buy_rod_debits_coins_and_raises_the_tier():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf.db, "transaction", _ctx),
         patch.object(
             wf.economy_service,
@@ -599,6 +600,7 @@ async def test_buy_rod_with_insufficient_funds_writes_nothing():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf.db, "transaction", _ctx),
         patch.object(
             wf.economy_service,
@@ -650,6 +652,7 @@ async def test_begin_cast_spends_energy_and_rolls_when_charged():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
@@ -692,6 +695,7 @@ async def test_begin_cast_does_not_charge_on_an_empty_catalog():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
@@ -778,6 +782,7 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf, "roll_catch", recording_roll_catch(rec)),
@@ -815,6 +820,7 @@ async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf, "roll_catch", recording_roll_catch(rec)),
@@ -863,6 +869,7 @@ async def test_begin_cast_folds_equipped_fishing_gear_into_the_knobs():
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_equipment", AsyncMock(return_value=equipped)),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
     ):
@@ -902,6 +909,7 @@ async def test_begin_cast_with_no_fishing_gear_is_byte_identical():
             AsyncMock(return_value={"tool": "diamond pickaxe"}),
         ),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
         patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
     ):
@@ -910,6 +918,79 @@ async def test_begin_cast_with_no_fishing_gear_is_byte_identical():
     assert rec["rarity_pull"] == pytest.approx(starter.rarity_pull)
     assert start.effective_bite_speed == pytest.approx(starter.bite_speed)
     assert start.fishing_gear_bonus is False
+
+
+# ---------------------------------------------------------------------------
+# Tide Pool — the 5th cast knob (2026-07-01): rod × bait × weather × gear × pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_folds_a_built_tide_pool_into_the_pull():
+    """A built Tide Pool raises the roll's rarity pull and flags ``tide_pool_bonus``
+    — the 5th how-well knob."""
+    from utils.fishing import rods
+    from utils.mining import structures
+
+    rec: dict = {}
+    starter = rods.rod_for_tier(0)
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(
+            wf.db,
+            "get_structures",
+            AsyncMock(return_value={structures.TIDE_POOL: 3}),
+        ),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert rec["rarity_pull"] == pytest.approx(
+        starter.rarity_pull * structures.tide_pool_pull_mult(3),
+    )
+    assert rec["rarity_pull"] > starter.rarity_pull  # the pool actually pulled
+    assert start.tide_pool_bonus is True
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_with_no_tide_pool_is_byte_identical():
+    """An unbuilt Tide Pool ⇒ ×1.0 ⇒ the pull is unchanged + ``tide_pool_bonus``
+    False (the additive-safety property)."""
+    from utils.fishing import rods
+
+    rec: dict = {}
+    starter = rods.rod_for_tier(0)
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert rec["rarity_pull"] == pytest.approx(starter.rarity_pull)
+    assert start.tide_pool_bonus is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_fishing_workflow_bait.py
+++ b/tests/unit/services/test_fishing_workflow_bait.py
@@ -32,12 +32,13 @@ _FEAST_PEARLS = bait_mod.pearl_recipe("feast")  # pearls per Royal Feast pack
 
 @pytest.fixture(autouse=True)
 def _no_fishing_gear():
-    """Default the cast's gear reads (Q-0175 4th knob) to empty so the bait-layer
-    assertions stay rod×bait-only — fishing gear is exercised in
+    """Default the cast's gear + structure reads (the 4th/5th knobs) to empty so the
+    bait-layer assertions stay rod×bait-only — fishing gear is exercised in
     ``test_fishing_workflow.py``. Tests that need gear can re-patch these."""
     with (
         patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
         patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
     ):
         yield
 

--- a/tests/unit/services/test_mining_forge.py
+++ b/tests/unit/services/test_mining_forge.py
@@ -187,3 +187,32 @@ async def test_build_unknown_structure():
     result = await mining_workflow.build_structure(1, 99, "spaceport")
     assert result.ok is False
     assert "isn't a buildable structure" in result.message
+
+
+@pytest.mark.asyncio
+async def test_build_tide_pool_consumes_coral_and_reports_the_bonus(_null_txn):
+    """The Tide Pool routes through the same audited build seam: coral consumed
+    as a negative delta + level raised, with the fishing-bonus reward line."""
+    with (
+        patch(f"{_WF}.db.get_structures", new_callable=AsyncMock, return_value={}),
+        patch(
+            f"{_WF}.db.get_mining_inventory",
+            new_callable=AsyncMock,
+            return_value={"coral": 20},
+        ),
+        patch(
+            f"{_WF}.economy_service.debit_in_txn",
+            new_callable=AsyncMock,
+            return_value=8_500,
+        ),
+        patch(f"{_WF}.db.apply_inventory_deltas", new_callable=AsyncMock) as deltas,
+        patch(f"{_WF}.db.set_structure_level", new_callable=AsyncMock) as lvl,
+        patch(f"{_WF}._emit_balance", new_callable=AsyncMock),
+    ):
+        result = await mining_workflow.build_structure(1, 99, "tide_pool")
+    assert result.ok is True
+    assert "Reef Pool" in result.message
+    assert "+4%" in result.message  # the level-1 rarity-pull bonus reward line
+    # Coral consumed as a negative delta; level raised 0 → 1.
+    assert deltas.await_args.args[2] == {"coral": -3}
+    assert lvl.await_args.args[:4] == (1, 99, "tide_pool", 1)

--- a/tests/unit/utils/test_mining_structures.py
+++ b/tests/unit/utils/test_mining_structures.py
@@ -113,6 +113,8 @@ def test_is_structure() -> None:
     assert structures.is_structure("  Forge ") is True
     assert structures.is_structure("home") is True  # Slice C added Home
     assert structures.is_structure("  Home ") is True
+    assert structures.is_structure("tide_pool") is True  # 2026-07-01 Tide Pool
+    assert structures.is_structure("  Tide_Pool ") is True
     assert structures.is_structure("castle") is False
     assert structures.is_structure("") is False
 
@@ -175,3 +177,69 @@ def test_home_does_not_gate_crafting() -> None:
     """Home is cosmetic — it never appears in the gear-craft forge gate."""
     # forge_level_required only ever consults the gear ladder, never Home.
     assert structures.forge_level_required("home") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Tide Pool (2026-07-01) — coral's functional sink; the fishing cast's 5th knob.
+# Numbers pinned to docs/planning/fishing-tide-pool-numbers-2026-07-01.md.
+# --------------------------------------------------------------------------- #
+
+
+def test_tide_pool_registered_and_named() -> None:
+    assert structures.TIDE_POOL in structures.STRUCTURES
+    assert structures.display_name(structures.TIDE_POOL) == "Tide Pool"
+    assert (
+        structures.max_level(structures.TIDE_POOL)
+        == structures.MAX_TIDE_POOL_LEVEL
+        == 3
+    )
+
+
+def test_tide_pool_level_names() -> None:
+    assert structures.level_name(structures.TIDE_POOL, 0) == "(not built)"
+    assert structures.level_name(structures.TIDE_POOL, 1) == "Reef Pool"
+    assert structures.level_name(structures.TIDE_POOL, 2) == "Tidal Basin"
+    assert structures.level_name(structures.TIDE_POOL, 3) == "Grand Reef"
+    # Clamped above the ladder.
+    assert structures.level_name(structures.TIDE_POOL, 99) == "Grand Reef"
+
+
+def test_tide_pool_build_cost_ladder_is_a_rising_coral_sink() -> None:
+    costs = [structures.build_cost(structures.TIDE_POOL, lvl) for lvl in range(3)]
+    assert [c.coins for c in costs] == [1_500, 4_000, 9_000]
+    assert [c.materials["coral"] for c in costs] == [3, 6, 10]
+    # Strictly rising coin + coral sink.
+    assert costs[0].coins < costs[1].coins < costs[2].coins
+    assert (
+        costs[0].materials["coral"]
+        < costs[1].materials["coral"]
+        < costs[2].materials["coral"]
+    )
+
+
+def test_tide_pool_build_cost_maxed_returns_none() -> None:
+    assert (
+        structures.build_cost(structures.TIDE_POOL, structures.MAX_TIDE_POOL_LEVEL)
+        is None
+    )
+    assert structures.build_cost(structures.TIDE_POOL, -1) is None
+
+
+def test_tide_pool_pull_mult_ladder_and_additive_safety() -> None:
+    # Unbuilt ⇒ exactly 1.0 (byte-identical cast — the additive-safety property).
+    assert structures.tide_pool_pull_mult(0) == 1.0
+    assert structures.tide_pool_pull_mult(1) == 1.04
+    assert structures.tide_pool_pull_mult(2) == 1.08
+    assert structures.tide_pool_pull_mult(3) == 1.12
+    # Clamped: an out-of-range level can never over-reward.
+    assert structures.tide_pool_pull_mult(99) == 1.12
+    assert structures.tide_pool_pull_mult(-5) == 1.0
+    # Strictly rising bonus across the ladder.
+    mults = [structures.tide_pool_pull_mult(lvl) for lvl in range(4)]
+    assert mults == sorted(mults)
+    assert mults[0] < mults[-1]
+
+
+def test_tide_pool_does_not_gate_crafting() -> None:
+    """The Tide Pool is a fishing bonus — never a gear-craft forge gate."""
+    assert structures.forge_level_required("tide_pool") == 0


### PR DESCRIPTION
## What & why

Empty scheduled dispatch fire → advance the next plan slice. The S1 sector's explicit `[offline]`
**▶ Next offline successor** for the fishing rare-material arc is *"a second curio tier or a
**structure-target variant** (a deepwater material that builds a fishing structure rather than a
collectible)."*

This builds the **structure-target variant**: the **Tide Pool** — a coral-built structure on the
generic `mining_structures` table that gives coral its first **functional** sink (complementing the
cosmetic curios shipped this morning). Building it grants a small passive rarity-pull bonus, folded
as the fishing cast's **5th "how-well" knob** (rod × bait × weather × gear × **tide pool**), default
`1.0` when unbuilt ⇒ **byte-identical** to current casts (the same additive-safety property fishing
gear uses).

## Shipped

- **`utils/mining/structures.py`** — new `TIDE_POOL` registry entry (coral + coin build ladder,
  3 levels) + pure `tide_pool_pull_mult(level)` payoff helper; reuses the generic build math.
- **`utils/mining/market.py`** — `TIDE_POOL_BUILD_REASON` economy-audit tag.
- **`services/mining_workflow.py`** — Tide Pool wired into the audited `build_structure` seam
  (`_STRUCTURE_BUILD_REASON` + reward suffix); no new mutation path.
- **`services/fishing_workflow.py`** — `begin_cast` reads the player's tide-pool level and folds
  its pull multiplier as the 5th knob; unbuilt ⇒ 1.0 (byte-identical).
- **`views/fishing/tide_pool.py`** + `cogs/fishing_cog.py` `!tidepool` + a Tide Pool button on the
  fishing menu — the build panel (mirrors the Forge/Home panels), reachable + buttonized.
- Tests + `docs/planning/fishing-tide-pool-numbers-2026-07-01.md` (sim-pinned numbers).

No migration (coral + structures both reuse existing stores). Self-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zuHU8PNt46RnH5MXZMadn)_