### PR TITLE
Fishing Dock — bite-speed coral structure (Tide Pool sibling)

### DIFF
--- a/.sessions/2026-07-01-fishing-dock-structure.md
+++ b/.sessions/2026-07-01-fishing-dock-structure.md
@@ -1,0 +1,19 @@
+# 2026-07-01 — Fishing Dock structure (bite-speed coral sink, Tide Pool sibling)
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
+
+**Branch:** `claude/funny-franklin-4n38rf` (restarted from origin/main after #1598 merged).
+**Run type:** `routine · dispatch`
+
+## What this run is doing
+
+Second slice of the same dispatch run (#1598 Tide Pool merged + deployed). Building the
+**Fishing Dock** — the Tide Pool's sibling I flagged as the sharpened ▶ Next: a coral-built
+structure whose payoff is a **bite-speed** knob (faster bites) rather than rarity-pull, and whose
+cost is cheaper + adds a common material (coral + wood), so the two structures are a genuine
+build-order *choice* (faster fishing vs. rarer fish; entry vs. premium).
+
+**Self-initiated** (Q-0172): this is my own session idea, not a dispatched order — flagged on the
+run-report ⚑ Self-initiated line. Reuses the exact Tide Pool pattern (registry entry + audited
+`build_structure` + a 5th/6th-knob fold, byte-identical when unbuilt).

--- a/.sessions/2026-07-01-fishing-dock-structure.md
+++ b/.sessions/2026-07-01-fishing-dock-structure.md
@@ -1,19 +1,105 @@
 # 2026-07-01 — Fishing Dock structure (bite-speed coral sink, Tide Pool sibling)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 <!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
 
+**PR:** [#1599](https://github.com/menno420/superbot/pull/1599) — Fishing Dock (bite-speed structure).
 **Branch:** `claude/funny-franklin-4n38rf` (restarted from origin/main after #1598 merged).
 **Run type:** `routine · dispatch`
 
-## What this run is doing
+## What this run did
 
-Second slice of the same dispatch run (#1598 Tide Pool merged + deployed). Building the
-**Fishing Dock** — the Tide Pool's sibling I flagged as the sharpened ▶ Next: a coral-built
-structure whose payoff is a **bite-speed** knob (faster bites) rather than rarity-pull, and whose
-cost is cheaper + adds a common material (coral + wood), so the two structures are a genuine
-build-order *choice* (faster fishing vs. rarer fish; entry vs. premium).
+**Second slice** of the same dispatch run (after #1598 shipped + auto-deployed the **Tide Pool**).
+Built its **sibling**, the **Fishing Dock** — the ▶ Next I sharpened at the end of slice 1: a second
+coral structure, but the *entry* one (cheaper, coral + wood) with a **bite-speed** payoff (faster
+bites) rather than rarity-pull. The two now form a genuine build-order **choice** — faster fishing
+(Dock) vs. rarer fish (Tide Pool) — and coral has **three** distinct sinks (cosmetic curios ·
+rarity Tide Pool · speed Dock).
 
-**Self-initiated** (Q-0172): this is my own session idea, not a dispatched order — flagged on the
-run-report ⚑ Self-initiated line. Reuses the exact Tide Pool pattern (registry entry + audited
-`build_structure` + a 5th/6th-knob fold, byte-identical when unbuilt).
+## Shipped (PR #1599)
+
+- **`utils/mining/structures.py`** — `DOCK` registry entry (2-level coral + wood ladder) + pure
+  `dock_bite_speed_mult(level)` payoff helper (`1.0 − 0.06·level`, ≤ 1.0, clamped; unbuilt ⇒ 1.0).
+- **`utils/mining/market.py`** — `DOCK_BUILD_REASON` economy-audit tag.
+- **`services/mining_workflow.py`** — Dock through the audited `build_structure` seam + a bite-speed
+  reward suffix; no new mutation path. One `db.get_structures` read now serves both structures.
+- **`services/fishing_workflow.py`** — `begin_cast` folds the dock's bite-speed multiplier into
+  `effective_bite_speed`; unbuilt ⇒ ×1.0 ⇒ byte-identical. New `CastStart.dock_bonus` flag + ⚓ footer.
+- **`views/fishing/dock.py`** + `!dock` + a ⚓ fishing-menu button (reachable, 0 gaps).
+- Tests: +7 structure-math cases (incl. a "Dock is cheaper on coral than the Tide Pool" invariant),
+  +2 `begin_cast` fold cases, +1 service build case (coral + wood consumed + reward line);
+  regenerated dashboard/site artifacts (477→478 commands); `docs/planning/fishing-dock-numbers-2026-07-01.md`.
+
+Full CI mirror green (13,433 passed); `check_architecture --mode strict` 0 errors. No migration
+(coral + structures reuse existing stores). Self-merge on green.
+
+## Decisions made alone (owner should be aware)
+
+- **Payoff = bite-speed, deliberately a *different axis* than the Tide Pool's rarity-pull.** Speed is
+  throughput (more casts/session → more of everything) without changing *what* you catch; pull is
+  quality without changing the rate. So the two structures don't overlap. Both bounded ≤ 12%.
+- **Cost shape differentiates them:** Dock = coral + **wood** (a common mined material) + lower coins,
+  positioning it as the affordable *entry* structure vs. the Tide Pool's coral + coins premium. All
+  single-line constants in the numbers doc + test.
+
+## Flagged for maintainer / known limits
+
+- Never played live — the numbers are sim-reasoned, not balance-tested; a live walk may retune.
+- The fishing menu now carries **two** structure buttons (Tide Pool + Dock). It's within Discord's
+  component budget, but the ▶ Next I left suggests folding them into a single "🏗 Structures" sub-hub
+  before a third structure lands, to keep the menu lean.
+
+## Context delta
+
+- **Needed but not pointed to:** nothing new — I had the full structure pattern loaded from slice 1
+  (#1598), so this slice was a near-mechanical application of it. That *reuse* is the point: the
+  registry-driven structure system makes a new structure genuinely one entry + a payoff hook.
+- **Pointed to but didn't need:** n/a (same-run continuation, no re-orientation).
+- **Discovered by hand:** confirmed `build_structure`'s material check + `describe_materials` handle a
+  *multi*-material cost (coral + wood) generically — no per-material wiring needed.
+
+## 🛠 Friction → guard
+
+- **Friction (same class as slice 1):** isort flagged the new `dock` import placed out of order in
+  `views/fishing/__init__.py` — caught only by the full mirror, not the PostToolUse auto-fix (which
+  fires per-edit but the manual `__all__`/import edit wasn't a formatter-triggering change it re-sorted).
+  **Guard:** already covered by `scripts/check_quality.py --full` (the CI mirror) catching it pre-push;
+  the durable lesson (carried from slice 1) is **run `check_quality`, never a bare formatter over a
+  path** — I avoided the `black tests/` footgun this time. No new guard warranted (the mirror already
+  enforces it); the slice-1 proposal (a formatter-scope wrapper) still stands in that log.
+
+## 💡 Session idea
+
+**A "🏗 Structures" fishing sub-hub** — fold the Tide Pool + Dock (and future fishing structures) menu
+buttons into one child panel that lists all buildable fishing structures with their current level +
+next cost, so the top-level fishing menu stays lean as the structure set grows. Genuinely worth having
+now that there are two; it's the natural scaling seam and mirrors the mining Workshop hub. Left as the
+sharpened ▶ Next in the S1 sector file; not built this run (kept scope to the one structure).
+
+## ⟲ Previous-session review
+
+The previous slice (#1598 Tide Pool, this same run) did exactly what a good first slice should: it
+built a *reusable* pattern (the registry-driven structure + additive-safety knob fold) and **left a
+crisp, specific ▶ Next** ("a bite-speed dock"), which is precisely why this slice shipped in a near-
+mechanical pass with zero re-derivation. The one thing it could have done better — and which this slice
+corrects — is that adding a second menu button revealed the fishing menu will get crowded; slice 1
+could have anticipated the sub-hub seam. A **system observation**: the born-red + auto-merge flow made
+the two-slice run clean, but there's an inherent serialization cost — slice 2 can't cleanly start until
+slice 1 *merges* (else it stacks into the same PR), and webhooks don't signal merge-success, so I had
+to rely on the merge webhook arriving. Worth noting for the routine: multi-slice runs are gated on
+merge latency, not just token budget.
+
+## 📤 Run report
+
+- **Did:** shipped the Fishing Dock — a bite-speed coral structure completing the Tide Pool build-
+  choice (faster fishing vs. rarer fish) · **Outcome:** shipped
+- **Shipped:** #1599 — Dock structure + a bite-speed cast-knob fold (coral + wood sink, no migration,
+  byte-identical when unbuilt). *(Same run also shipped #1598 Tide Pool, already merged + deployed.)*
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none` (merge auto-deploys; no data step)
+- **⚑ Self-initiated:** **yes** — the Dock was my own slice-1 session idea, not a dispatched order
+  (Q-0172). It's a contained, reversible deepening that completes the coral structure-choice; flagged
+  here for owner review/revert. (The Tide Pool #1598 was the roadmap's explicit pick — not self-initiated.)
+- **↪ Next:** S1 fishing — a "🏗 Structures" sub-hub folding the two structure buttons, or a second
+  curio tier; both pure + self-mergeable. (Sharpened in `docs/current-state/S1-bot.md`.)

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T06:13:15Z",
+    "generated_at": "2026-07-01T06:42:29Z",
     "build": {
-      "commit": "a1d868c8",
-      "subject": "chore(session): open born-red card — fishing Tide Pool coral structure sink",
-      "committed_at": "2026-07-01T06:13:15Z"
+      "commit": "8f679dba",
+      "subject": "chore(session): open born-red card — fishing Dock bite-speed structure",
+      "committed_at": "2026-07-01T06:42:29Z"
     }
   },
   "counts": {
-    "commands": 477,
+    "commands": 478,
     "features": 43,
     "games": 12
   },
@@ -5614,6 +5614,31 @@
       "examples": [],
       "status": "finished",
       "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "dock",
+      "aliases": [
+        "pier",
+        "fishingdock"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Build a Dock — the cheap coral+wood structure that makes fish bite faster.",
+      "description": "Build a Dock — the cheap coral+wood structure that makes fish bite faster.",
+      "use_cases": null,
+      "examples": [
+        "!sail",
+        "!tidepool"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
+          "status": "ideas"
+        }
+      ],
       "notes": null
     },
     {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -2173,6 +2173,30 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "dock",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Build a Dock — the cheap coral+wood structure that makes fish bite faster.",
+    "description": "Build a Dock — the cheap coral+wood structure that makes fish bite faster.",
+    "usage": "!dock",
+    "aliases": [
+      "pier",
+      "fishingdock"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [
+      "!sail",
+      "!tidepool"
+    ],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
+      }
+    ]
+  },
+  {
     "name": "economy",
     "area": "economy",
     "status": "in-progress",
@@ -7265,7 +7289,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "a1d868c8",
+    "build": "8f679dba",
     "title": "New public bot website",
     "changes": [
       {
@@ -7277,7 +7301,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "a1d868c8",
+    "build": "8f679dba",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7289,7 +7313,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "a1d868c8",
+    "build": "8f679dba",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T06:13:15Z",
+    "generated_at": "2026-07-01T06:42:29Z",
     "build": {
-      "commit": "a1d868c8",
-      "subject": "chore(session): open born-red card — fishing Tide Pool coral structure sink",
-      "committed_at": "2026-07-01T06:13:15Z"
+      "commit": "8f679dba",
+      "subject": "chore(session): open born-red card — fishing Dock bite-speed structure",
+      "committed_at": "2026-07-01T06:42:29Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 55,
-      "commands": 477,
+      "commands": 478,
       "setting_keys": 115,
       "setting_domains": 17,
       "typed_settings": 95,
@@ -2711,6 +2711,14 @@
       "file": "2026-07-01-fishing-tide-pool-structure.md",
       "date": "2026-07-01",
       "title": "2026-07-01 — Fishing Tide Pool structure (coral structure-target sink)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-01-fishing-dock-structure.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Fishing Dock structure (bite-speed coral sink, Tide Pool sibling)",
       "status": "in-progress",
       "run_type": "routine",
       "self_initiated": false
@@ -3162,14 +3170,6 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-27-fishing-charm-craft.md",
-      "date": "2026-06-27",
-      "title": "2026-06-27 — Fishing-gear acquisition depth: fish→charm craft path",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -6975,6 +6975,20 @@
           "classification": "",
           "has_panel": false,
           "button_backed": false
+        },
+        {
+          "name": "dock",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "pier",
+            "fishingdock"
+          ],
+          "brief": "Build a Dock — the cheap coral+wood structure that makes fish bite faster.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
         },
         {
           "name": "fish",

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -38,10 +38,12 @@ from utils.fishing import weather as weather_mod
 from utils.fishing.fish import SPECIES, fish_names, species_by_name
 from views.fishing import (
     BaitShopView,
+    DockView,
     FishingMenuView,
     RodShopView,
     TidePoolView,
     build_bait_embed,
+    build_dock_embed,
     build_fishlog_embed,
     build_menu_embed,
     build_recipe_panel,
@@ -350,6 +352,18 @@ class FishingCog(commands.Cog):
         """
         embed = await build_tide_pool_embed(ctx.author.id, ctx.guild.id)
         view = TidePoolView(ctx.author, ctx.guild.id)
+        view.message = await ctx.send(embed=embed, view=view)
+
+    @commands.command(name="dock", aliases=["pier", "fishingdock"])
+    async def dock(self, ctx):
+        """Build a Dock — the cheap coral+wood structure that makes fish bite faster.
+
+        The Tide Pool's sibling: coral drops on a **deepwater** reel (`!sail`) and
+        wood you already mine. Faster bites (Dock) vs. rarer fish (`!tidepool`) —
+        spend your coral where you like.
+        """
+        embed = await build_dock_embed(ctx.author.id, ctx.guild.id)
+        view = DockView(ctx.author, ctx.guild.id)
         view.message = await ctx.send(embed=embed, view=view)
 
     @commands.command(name="craftcurio", aliases=["carve", "curiocraft"])

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -305,6 +305,10 @@ class CastStart:
     #: cast-panel note. ``False`` when the Tide Pool is unbuilt (level 0), in which
     #: case that knob is ×1.0 and the cast is byte-identical.
     tide_pool_bonus: bool = False
+    #: Whether a built **Dock** structure sped up this cast's bite (its bite-speed
+    #: multiplier is already folded into ``effective_bite_speed``) — for the ⚓
+    #: cast-panel note. ``False`` when the Dock is unbuilt (level 0).
+    dock_bonus: bool = False
 
 
 def _fmt_wait(seconds: int) -> str:
@@ -375,18 +379,21 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
     )
     gear_pull = fishing_gear.fishing_pull_mult(gear_stats)
     gear_bite_speed = fishing_gear.fishing_bite_speed_mult(gear_stats)
-    # The 5th knob: a built **Tide Pool** structure (coral's functional sink). Its
-    # rarity-pull bonus is another ≥ 1.0 multiplier; unbuilt (level 0) ⇒ ×1.0 ⇒
-    # byte-identical, exactly like the gear knob's additive-safety property.
+    # The structure knobs: the built **Tide Pool** (rarity-pull, coral's functional
+    # sink) and its sibling the **Dock** (bite-speed). Both default to their neutral
+    # multiplier when unbuilt (level 0) ⇒ ×1.0 ⇒ byte-identical, exactly like the
+    # gear knob's additive-safety property. One structures read serves both.
     built = await db.get_structures(user_id, guild_id)
     tide_pool_level = built.get(structures_mod.TIDE_POOL, 0)
     tide_pool_pull = structures_mod.tide_pool_pull_mult(tide_pool_level)
-    # Five "how-well" knobs compound: rod × bait × weather × gear × tide pool.
-    # rarity_pull (all ≥ 1) pulls the catch toward the big end of the SAME unlocked
-    # band (never a new band — that stays the fishing-level axis); bite_speed
-    # (rod/bait/gear ≤ 1, weather either way) scales the bite wait. Weather is the
-    # transient, shared, free knob (a storm makes a rarer catch likelier but the
-    # wait longer).
+    dock_level = built.get(structures_mod.DOCK, 0)
+    dock_bite_speed = structures_mod.dock_bite_speed_mult(dock_level)
+    # The "how-well" knobs compound: rod × bait × weather × gear × tide pool (pull),
+    # and rod × bait × weather × gear × dock (bite speed). rarity_pull (all ≥ 1)
+    # pulls the catch toward the big end of the SAME unlocked band (never a new band
+    # — that stays the fishing-level axis); bite_speed (rod/bait/gear/dock ≤ 1,
+    # weather either way) scales the bite wait. Weather is the transient, shared,
+    # free knob (a storm makes a rarer catch likelier but the wait longer).
     effective_pull = (
         rod.rarity_pull
         * (bait.rarity_pull if bait else 1.0)
@@ -399,6 +406,7 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
         * (bait.bite_speed if bait else 1.0)
         * weather.bite_speed_mult
         * gear_bite_speed
+        * dock_bite_speed
     )
     cast = await roll_cast(
         user_id,
@@ -443,6 +451,7 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
         weather=weather,
         fishing_gear_bonus=fishing_gear.has_fishing_bonus(gear_stats),
         tide_pool_bonus=tide_pool_level > 0,
+        dock_bonus=dock_level > 0,
     )
 
 

--- a/disbot/services/mining_workflow.py
+++ b/disbot/services/mining_workflow.py
@@ -679,6 +679,7 @@ _STRUCTURE_BUILD_REASON = {
     structures.HOME: market.HOME_BUILD_REASON,
     structures.CAMPFIRE: market.CAMPFIRE_BUILD_REASON,
     structures.TIDE_POOL: market.TIDE_POOL_BUILD_REASON,
+    structures.DOCK: market.DOCK_BUILD_REASON,
 }
 
 
@@ -697,6 +698,10 @@ def _build_success_suffix(structure: str, new_level: int) -> str:
         mult = structures.tide_pool_pull_mult(new_level)
         pct = round((mult - 1.0) * 100)
         return f" Your casts now pull **+{pct}%** toward rarer fish."
+    if structure == structures.DOCK:
+        mult = structures.dock_bite_speed_mult(new_level)
+        pct = round((1.0 - mult) * 100)
+        return f" Fish now bite **{pct}%** faster."
     return ""
 
 

--- a/disbot/utils/mining/market.py
+++ b/disbot/utils/mining/market.py
@@ -24,6 +24,7 @@ FORGE_BUILD_REASON = "mining:forge_build"
 HOME_BUILD_REASON = "mining:home_build"
 CAMPFIRE_BUILD_REASON = "mining:campfire_build"
 TIDE_POOL_BUILD_REASON = "mining:tide_pool_build"
+DOCK_BUILD_REASON = "mining:dock_build"
 
 # Gear shop — coins to buy each item (the sink).  Priced ~5-6× the sell value
 # of the materials it would take to craft, so crafting stays the cheaper path
@@ -187,6 +188,7 @@ __all__ = [
     "HOME_BUILD_REASON",
     "CAMPFIRE_BUILD_REASON",
     "TIDE_POOL_BUILD_REASON",
+    "DOCK_BUILD_REASON",
     "sell_price",
     "sellable_inventory",
     "total_sale_value",

--- a/disbot/utils/mining/structures.py
+++ b/disbot/utils/mining/structures.py
@@ -34,6 +34,7 @@ FORGE = "forge"
 HOME = "home"
 CAMPFIRE = "campfire"
 TIDE_POOL = "tide_pool"
+DOCK = "dock"
 
 #: Gear at or below this tier index needs **no** forge (bronze=1, iron=2,
 #: silver=3 are free; gold=4 → forge 1; diamond=5 → forge 2).  ``forge_level =
@@ -65,6 +66,18 @@ _TIDE_POOL_LEVEL_NAMES = ("(not built)", "Reef Pool", "Tidal Basin", "Grand Reef
 #: modest edge (the fishing-level axis still owns which fish are reachable at all;
 #: this only reweights the band).  Tunable — pin in the numbers doc + the test.
 _TIDE_POOL_PULL_STEP = 0.04
+
+#: Dock (2026-07-01): the Tide Pool's **sibling** — a second coral structure, but
+#: the *entry* one (cheaper, adds a common material) with a different payoff: it
+#: speeds up the bite rather than pulling rarer fish.  Each level shortens the bite
+#: wait via a ``bite_speed`` multiplier ≤ 1.0 folded into ``begin_cast`` (the same
+#: knob rod/bait use).  Unbuilt ⇒ ×1.0 ⇒ byte-identical.  Together with the Tide
+#: Pool it makes coral a real *choice* — faster fishing vs. rarer fish.
+_DOCK_LEVEL_NAMES = ("(not built)", "Fishing Dock", "Deepwater Pier")
+
+#: Per-level bite-speed reduction (subtracted from the ×1.0 base — lower = faster
+#: bite).  Level 2 ⇒ ×0.88.  Tunable — pin in the numbers doc + the test.
+_DOCK_BITE_STEP = 0.06
 
 
 @dataclass(frozen=True)
@@ -117,6 +130,17 @@ _TIDE_POOL_BUILD_LADDER: tuple[BuildCost, ...] = (
     BuildCost(coins=9_000, materials={"coral": 10}),
 )
 
+#: Dock build ladder — the *entry* coral structure: cheaper than the Tide Pool and
+#: it adds a common material (wood) so a shore-heavy player can afford it early with
+#: only a little coral.  Pin changes in ``docs/planning/fishing-dock-numbers-2026-07-01.md``
+#: + the test.
+_DOCK_BUILD_LADDER: tuple[BuildCost, ...] = (
+    # → Fishing Dock (×0.94 bite wait — 6% faster)
+    BuildCost(coins=1_200, materials={"coral": 2, "wood": 15}),
+    # → Deepwater Pier (×0.88 — 12% faster)
+    BuildCost(coins=3_500, materials={"coral": 5, "wood": 30}),
+)
+
 
 @dataclass(frozen=True)
 class StructureDef:
@@ -140,6 +164,7 @@ _DEFS: dict[str, StructureDef] = {
         _CAMPFIRE_BUILD_LADDER,
         _CAMPFIRE_LEVEL_NAMES,
     ),
+    DOCK: StructureDef(DOCK, "Dock", _DOCK_BUILD_LADDER, _DOCK_LEVEL_NAMES),
     TIDE_POOL: StructureDef(
         TIDE_POOL,
         "Tide Pool",
@@ -163,6 +188,9 @@ MAX_CAMPFIRE_LEVEL = len(_CAMPFIRE_BUILD_LADDER)
 #: Highest Tide Pool level (the top rarity-pull bonus).
 MAX_TIDE_POOL_LEVEL = len(_TIDE_POOL_BUILD_LADDER)
 
+#: Highest Dock level (the top bite-speed bonus).
+MAX_DOCK_LEVEL = len(_DOCK_BUILD_LADDER)
+
 
 def cooking_unlocked(campfire_level: int) -> bool:
     """True if a campfire at *campfire_level* unlocks cooking (level ≥ 1)."""
@@ -179,6 +207,17 @@ def tide_pool_pull_mult(level: int) -> float:
     """
     level = max(0, min(level, MAX_TIDE_POOL_LEVEL))
     return round(1.0 + _TIDE_POOL_PULL_STEP * level, 4)
+
+
+def dock_bite_speed_mult(level: int) -> float:
+    """The bite-speed multiplier a Dock at *level* grants (≤ 1.0 — lower = faster).
+
+    Folded into ``begin_cast``'s ``effective_bite_speed`` (the same knob rod/bait
+    use, where a smaller value means a shorter bite wait).  Level 0 (unbuilt) ⇒
+    exactly ``1.0`` ⇒ byte-identical.  Clamped to the ladder.
+    """
+    level = max(0, min(level, MAX_DOCK_LEVEL))
+    return round(1.0 - _DOCK_BITE_STEP * level, 4)
 
 
 def is_structure(name: str) -> bool:
@@ -270,15 +309,18 @@ __all__ = [
     "HOME",
     "CAMPFIRE",
     "TIDE_POOL",
+    "DOCK",
     "STRUCTURES",
     "MAX_FORGE_LEVEL",
     "MAX_CAMPFIRE_LEVEL",
     "MAX_TIDE_POOL_LEVEL",
+    "MAX_DOCK_LEVEL",
     "FREE_TIER_CEILING",
     "BuildCost",
     "is_structure",
     "cooking_unlocked",
     "tide_pool_pull_mult",
+    "dock_bite_speed_mult",
     "forge_level_name",
     "forge_build_cost",
     "forge_level_required",

--- a/disbot/views/fishing/__init__.py
+++ b/disbot/views/fishing/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from views.fishing.bait_shop import BaitShopView, build_bait_embed
 from views.fishing.cast_view import FishingCastView, active_casts, prepare_cast
+from views.fishing.dock import DockView, build_dock_embed
 from views.fishing.menu import (
     FishingMenuView,
     build_fishlog_embed,
@@ -21,6 +22,7 @@ from views.fishing.tide_pool import TidePoolView, build_tide_pool_embed
 
 __all__ = [
     "BaitShopView",
+    "DockView",
     "FishingCastView",
     "FishingMenuView",
     "RodRecipeBrowserView",
@@ -28,6 +30,7 @@ __all__ = [
     "TidePoolView",
     "active_casts",
     "build_bait_embed",
+    "build_dock_embed",
     "build_fishlog_embed",
     "build_menu_embed",
     "build_recipe_panel",

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -131,6 +131,10 @@ async def prepare_cast(
         # A built Tide Pool is nudging this cast toward rarer fish (its pull
         # bonus is already folded into the roll).
         footer += " · 🪸 tide pool"
+    if start.dock_bonus:
+        # A built Dock is speeding up the bite (its bite-speed bonus is already
+        # folded into effective_bite_speed).
+        footer += " · ⚓ dock"
     embed.set_footer(text=footer)
     return embed, view
 

--- a/disbot/views/fishing/dock.py
+++ b/disbot/views/fishing/dock.py
@@ -1,0 +1,128 @@
+"""Fishing Dock panel — the bite-speed coral structure (Tide Pool's sibling, 2026-07-01).
+
+The Dock is the *entry* coral structure: cheaper than the Tide Pool and it adds a
+common material (wood), with a different payoff — it speeds up the **bite** (a
+``bite_speed`` multiplier ≤ 1.0 folded into
+:func:`services.fishing_workflow.begin_cast`) rather than pulling rarer fish. So a
+coral investment is a real choice: faster fishing (Dock) vs. rarer catches (Tide
+Pool).
+
+Every build runs through :mod:`services.mining_workflow` (one audited transaction —
+coin debit + material consume + level raise); this view is only the button that
+calls it. Structurally a twin of ``views/fishing/tide_pool.py``.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from services import mining_workflow
+from utils import db
+from utils.mining import structures, workshop
+from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR
+from views.base import HubView
+
+_DOCK_COLOR = discord.Color.dark_teal()
+
+
+def _bonus_text(level: int) -> str:
+    """The bite-speed bonus a Dock at *level* grants, as a ``N% faster`` label."""
+    pct = round((1.0 - structures.dock_bite_speed_mult(level)) * 100)
+    return f"{pct}% faster bites" if pct else "no bonus yet"
+
+
+async def build_dock_embed(
+    user_id: int,
+    guild_id: int,
+    *,
+    note: str = "",
+) -> discord.Embed:
+    """The Dock embed: built level, current bite-speed bonus, and the next cost."""
+    built = await db.get_structures(user_id, guild_id)
+    level = built.get(structures.DOCK, 0)
+
+    embed = discord.Embed(title="⚓ Dock", color=_DOCK_COLOR)
+    embed.description = note or (
+        "Build a dock with **coral** and **wood** so the fish bite sooner — the "
+        "cheap, early counterpart to the Tide Pool. Coral drops on a **deepwater** "
+        "reel (`!sail`); wood you already mine. Faster bites vs. the Tide Pool's "
+        "rarer fish — spend your coral where you like."
+    )
+    embed.add_field(
+        name="Level",
+        value=(
+            f"**{structures.level_name(structures.DOCK, level)}** "
+            f"({level}/{structures.MAX_DOCK_LEVEL})"
+        ),
+        inline=False,
+    )
+    embed.add_field(name="Current bonus", value=_bonus_text(level), inline=False)
+    cost = structures.build_cost(structures.DOCK, level)
+    if cost is None:
+        embed.add_field(
+            name="Maxed",
+            value="Your Dock is at its highest level — the bite is as quick as it gets.",
+            inline=False,
+        )
+        embed.set_footer(text="↩ Fishing menu")
+    else:
+        nxt = structures.level_name(structures.DOCK, level + 1)
+        embed.add_field(
+            name=f"Next: {nxt} → {_bonus_text(level + 1)}",
+            value=f"{workshop.describe_materials(cost.materials)} + **{cost.coins}** 🪙",
+            inline=False,
+        )
+        embed.set_footer(text="⚓ Build  •  ↩ Fishing menu")
+    return embed
+
+
+class DockView(HubView):
+    """Build/upgrade-the-Dock panel; a child of the fishing menu."""
+
+    SUBSYSTEM = "fishing"
+
+    def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    @discord.ui.button(label="⚓ Build", style=discord.ButtonStyle.success, row=0)
+    async def build_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        result = await mining_workflow.build_structure(
+            self._author.id,
+            self.guild_id,
+            structures.DOCK,
+        )
+        embed = await build_dock_embed(
+            self._author.id,
+            self.guild_id,
+            note=("✅ " if result.ok else "❌ ") + result.message,
+        )
+        embed.color = SUCCESS_COLOR if result.ok else ERROR_COLOR
+        await safe_edit(interaction, embed=embed, view=self)
+
+    @discord.ui.button(
+        label="↩ Fishing menu",
+        style=discord.ButtonStyle.secondary,
+        row=0,
+    )
+    async def back_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # The menu self.stop()s when it opens this panel, so rebuild the fully-
+        # navigable menu in place. Lazy import to respect menu→child direction.
+        from views.fishing.menu import open_fishing_menu
+
+        self.stop()
+        await open_fishing_menu(interaction, self._author, self.guild_id)
+
+
+__all__ = ["DockView", "build_dock_embed"]

--- a/disbot/views/fishing/menu.py
+++ b/disbot/views/fishing/menu.py
@@ -301,6 +301,20 @@ class FishingMenuView(HubView):
         view.message = interaction.message
         self.stop()
 
+    @discord.ui.button(label="Dock", emoji="⚓", style=discord.ButtonStyle.secondary)
+    async def dock_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from views.fishing.dock import DockView, build_dock_embed
+
+        embed = await build_dock_embed(self._author.id, self.guild_id)
+        view = DockView(self._author, self.guild_id)
+        await interaction.response.edit_message(embed=embed, view=view)
+        view.message = interaction.message
+        self.stop()
+
     @discord.ui.button(label="Fishdex", emoji="📖", style=discord.ButtonStyle.secondary)
     async def fishdex_btn(
         self,

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -338,8 +338,16 @@ creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`]
   unbuilt ⇒ byte-identical. Reuses the Forge/Home/Campfire pattern end-to-end (registry entry + audited
   `mining_workflow.build_structure` + `views/fishing/tide_pool.py` panel + `!tidepool` + a menu button).
   Sim-pinned ([tide-pool numbers](../planning/fishing-tide-pool-numbers-2026-07-01.md)).
-  ▶ **Next offline successor:** a *second* curio tier, or a **second** Tide Pool-style structure with a
-  different fishing payoff (e.g. a bite-speed "dock") — pure + sim-pinnable, self-mergeable.
+  **Its sibling the Dock SHIPPED 2026-07-01 (dispatch run, PR #1599):** the **Dock** ⚓ — a second,
+  *entry* coral structure (cheaper, coral + **wood**) whose payoff is **bite-speed** (faster bites)
+  rather than rarity-pull, so a coral investment is a genuine *choice* — faster fishing vs. rarer
+  fish — and coral now has **three** distinct sinks (cosmetic curios · rarity Tide Pool · speed
+  Dock). Same pattern (registry entry + audited `build_structure` + a bite-speed knob fold +
+  `views/fishing/dock.py` + `!dock` + a menu button); byte-identical when unbuilt. Sim-pinned
+  ([dock numbers](../planning/fishing-dock-numbers-2026-07-01.md)).
+  ▶ **Next offline successor:** a *second* curio tier, or a **structures sub-hub** that folds the
+  now-two fishing-structure menu buttons (Tide Pool + Dock) into one "🏗 Structures" child so the
+  fishing menu stays lean as more structures land — pure + self-mergeable.
 - `[needs-live-bot]` **Essential Setup spine — PR 1 COMPLETE + polished, incl. step 0, + CUT OVER as the primary `!setup`
   (owner-directed, 2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow
   (**7 steps**: what kind of server is this · greet · moderators · block spam · choose a log channel ·

--- a/docs/owner/claims/claude-funny-franklin-4n38rf.md
+++ b/docs/owner/claims/claude-funny-franklin-4n38rf.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-4n38rf · fishing Dock bite-speed coral structure (Tide Pool sibling) · disbot/utils/mining/structures.py + market.py + services/{mining_workflow,fishing_workflow}.py + views/fishing/ + cogs/fishing_cog.py + tests · 2026-07-01

--- a/docs/owner/claims/claude-funny-franklin-4n38rf.md
+++ b/docs/owner/claims/claude-funny-franklin-4n38rf.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-4n38rf · fishing Dock bite-speed coral structure (Tide Pool sibling) · disbot/utils/mining/structures.py + market.py + services/{mining_workflow,fishing_workflow}.py + views/fishing/ + cogs/fishing_cog.py + tests · 2026-07-01

--- a/docs/planning/fishing-dock-numbers-2026-07-01.md
+++ b/docs/planning/fishing-dock-numbers-2026-07-01.md
@@ -1,0 +1,58 @@
+# Fishing Dock — pinned numbers (2026-07-01)
+
+> **Status:** `living-ledger` — the tunable constants behind the **Dock**, the Tide Pool's
+> bite-speed sibling. Change a number here **and** in
+> `tests/unit/utils/test_mining_structures.py` (the build ladder + bite-speed multiplier are
+> pinned there) in the same commit, like the tide-pool / coral / pearl number docs before it.
+
+## What this is
+
+The Dock is the **second** coral structure (sibling to the Tide Pool,
+`docs/planning/fishing-tide-pool-numbers-2026-07-01.md`). It exists to make a coral investment a
+real **choice** rather than a single upgrade path:
+
+| Structure | Payoff | Cost shape | Role |
+|---|---|---|---|
+| **Tide Pool** | rarity-pull (rarer fish) | coral + coins | premium |
+| **Dock** | bite-speed (faster bites) | coral + **wood** | entry (cheaper) |
+
+Coral now has three meaningfully-different sinks — cosmetic **curios**, the rarity **Tide Pool**,
+and the speed **Dock** — so a lucky deep-sea fisher decides *what* their coral buys.
+
+It reuses the generic `mining_structures` table (no migration), the audited
+`services.mining_workflow.build_structure` seam, and the **additive-safety property**: unbuilt
+(level 0) ⇒ the bite-speed multiplier is exactly `1.0` ⇒ every existing cast is byte-identical.
+
+## Build ladder (`utils/mining/structures.py` — `_DOCK_BUILD_LADDER`)
+
+| Level | Name | Coral | Wood | Coins | Bite-speed |
+|---|---|---|---|---|---|
+| 1 | Fishing Dock | 2 | 15 | 1,200 | ×0.94 (6% faster) |
+| 2 | Deepwater Pier | 5 | 30 | 3,500 | ×0.88 (12% faster) |
+
+- **`dock_bite_speed_mult(level) = 1.0 − 0.06·level`** (`_DOCK_BITE_STEP = 0.06`), clamped to the
+  ladder. Level 0 ⇒ exactly `1.0`. The multiplier is folded into `begin_cast`'s
+  `effective_bite_speed`, where **lower = a shorter bite wait** (the same convention rod/bait use).
+- **Coral cost** (2 + 5 = **7** for the full build) is deliberately *cheaper* than the Tide Pool
+  (19 coral) — the Dock is the entry structure — but it also spends **wood** (a common mined
+  material, like the Campfire) so it isn't purely coral-gated.
+- **Coins** (1.2k / 3.5k) sit just below the Tide Pool's ladder — the cheaper of the two coral
+  structures, so an early fisher can afford *faster* fishing before *rarer* fishing.
+
+## Why bite-speed (a distinct axis from the Tide Pool)
+
+Bite-speed shortens the wait between casts — it makes fishing *faster*, compounding everything
+(more catches, more coral, more XP per session) without changing *what* you catch. That is a
+genuinely different lever from the Tide Pool's rarity-pull (which changes *what* you catch without
+changing the rate), so the two structures don't overlap: one is throughput, the other is quality.
+Both bounded and small (max 12%), both plain multipliers composing with the four base knobs.
+
+## Invariants the tests pin
+
+- `dock_bite_speed_mult(0) == 1.0` (byte-identical when unbuilt) and it falls `0.94 / 0.88` across
+  the two levels, clamped below `MAX_DOCK_LEVEL` and never negative.
+- `build_cost(DOCK, level)` returns the ladder rows above and `None` past the top.
+- `begin_cast` folds the dock multiplier into `effective_bite_speed` (a built dock lowers it vs. an
+  unbuilt one; an unbuilt dock leaves the pre-existing value unchanged) and sets `dock_bonus`.
+- Building routes through the audited `mining_workflow.build_structure` seam (coin debit + coral +
+  wood consume + level raise in one transaction) — no new mutation path.

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -993,6 +993,76 @@ async def test_begin_cast_with_no_tide_pool_is_byte_identical():
     assert start.tide_pool_bonus is False
 
 
+# ---------------------------------------------------------------------------
+# Dock — the bite-speed structure knob (2026-07-01): the Tide Pool's sibling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_folds_a_built_dock_into_the_bite_speed():
+    """A built Dock lowers ``effective_bite_speed`` (faster bite) and flags
+    ``dock_bonus`` — without touching the rarity pull."""
+    from utils.fishing import rods
+    from utils.mining import structures
+
+    starter = rods.rod_for_tier(0)
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(
+            wf.db,
+            "get_structures",
+            AsyncMock(return_value={structures.DOCK: 2}),
+        ),
+        patch.object(wf, "roll_catch", fake_roll_catch()),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert start.effective_bite_speed == pytest.approx(
+        starter.bite_speed * structures.dock_bite_speed_mult(2),
+    )
+    assert start.effective_bite_speed < starter.bite_speed  # the dock sped the bite
+    assert start.dock_bonus is True
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_with_no_dock_is_byte_identical():
+    """An unbuilt Dock ⇒ ×1.0 ⇒ the bite speed is unchanged + ``dock_bonus`` False."""
+    from utils.fishing import rods
+
+    starter = rods.rod_for_tier(0)
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(
+            wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]
+        ),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
+        patch.object(wf.db, "get_equipment", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_skills", AsyncMock(return_value={})),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(wf.db, "get_structures", AsyncMock(return_value={})),
+        patch.object(wf, "roll_catch", fake_roll_catch()),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert start.effective_bite_speed == pytest.approx(starter.bite_speed)
+    assert start.dock_bonus is False
+
+
 @pytest.mark.asyncio
 async def test_get_forecast_returns_todays_weather():
     from utils.fishing import weather as weather_mod

--- a/tests/unit/services/test_mining_forge.py
+++ b/tests/unit/services/test_mining_forge.py
@@ -216,3 +216,32 @@ async def test_build_tide_pool_consumes_coral_and_reports_the_bonus(_null_txn):
     # Coral consumed as a negative delta; level raised 0 → 1.
     assert deltas.await_args.args[2] == {"coral": -3}
     assert lvl.await_args.args[:4] == (1, 99, "tide_pool", 1)
+
+
+@pytest.mark.asyncio
+async def test_build_dock_consumes_coral_and_wood_and_reports_the_bonus(_null_txn):
+    """The Dock routes through the same audited build seam: coral + wood consumed
+    as negative deltas + level raised, with the bite-speed reward line."""
+    with (
+        patch(f"{_WF}.db.get_structures", new_callable=AsyncMock, return_value={}),
+        patch(
+            f"{_WF}.db.get_mining_inventory",
+            new_callable=AsyncMock,
+            return_value={"coral": 10, "wood": 40},
+        ),
+        patch(
+            f"{_WF}.economy_service.debit_in_txn",
+            new_callable=AsyncMock,
+            return_value=6_000,
+        ),
+        patch(f"{_WF}.db.apply_inventory_deltas", new_callable=AsyncMock) as deltas,
+        patch(f"{_WF}.db.set_structure_level", new_callable=AsyncMock) as lvl,
+        patch(f"{_WF}._emit_balance", new_callable=AsyncMock),
+    ):
+        result = await mining_workflow.build_structure(1, 99, "dock")
+    assert result.ok is True
+    assert "Fishing Dock" in result.message
+    assert "6%" in result.message  # the level-1 bite-speed reward line
+    # Both materials consumed as negative deltas; level raised 0 → 1.
+    assert deltas.await_args.args[2] == {"coral": -2, "wood": -15}
+    assert lvl.await_args.args[:4] == (1, 99, "dock", 1)

--- a/tests/unit/utils/test_mining_structures.py
+++ b/tests/unit/utils/test_mining_structures.py
@@ -115,6 +115,8 @@ def test_is_structure() -> None:
     assert structures.is_structure("  Home ") is True
     assert structures.is_structure("tide_pool") is True  # 2026-07-01 Tide Pool
     assert structures.is_structure("  Tide_Pool ") is True
+    assert structures.is_structure("dock") is True  # 2026-07-01 Dock
+    assert structures.is_structure("  Dock ") is True
     assert structures.is_structure("castle") is False
     assert structures.is_structure("") is False
 
@@ -243,3 +245,71 @@ def test_tide_pool_pull_mult_ladder_and_additive_safety() -> None:
 def test_tide_pool_does_not_gate_crafting() -> None:
     """The Tide Pool is a fishing bonus — never a gear-craft forge gate."""
     assert structures.forge_level_required("tide_pool") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Dock (2026-07-01) — the Tide Pool's bite-speed sibling; the entry coral sink.
+# Numbers pinned to docs/planning/fishing-dock-numbers-2026-07-01.md.
+# --------------------------------------------------------------------------- #
+
+
+def test_dock_registered_and_named() -> None:
+    assert structures.DOCK in structures.STRUCTURES
+    assert structures.display_name(structures.DOCK) == "Dock"
+    assert structures.max_level(structures.DOCK) == structures.MAX_DOCK_LEVEL == 2
+
+
+def test_dock_level_names() -> None:
+    assert structures.level_name(structures.DOCK, 0) == "(not built)"
+    assert structures.level_name(structures.DOCK, 1) == "Fishing Dock"
+    assert structures.level_name(structures.DOCK, 2) == "Deepwater Pier"
+    # Clamped above the ladder.
+    assert structures.level_name(structures.DOCK, 99) == "Deepwater Pier"
+
+
+def test_dock_build_cost_ladder_is_a_rising_coral_and_wood_sink() -> None:
+    costs = [structures.build_cost(structures.DOCK, lvl) for lvl in range(2)]
+    assert [c.coins for c in costs] == [1_200, 3_500]
+    assert [c.materials["coral"] for c in costs] == [2, 5]
+    assert [c.materials["wood"] for c in costs] == [15, 30]
+    # Strictly rising coin + material sink.
+    assert costs[0].coins < costs[1].coins
+    assert costs[0].materials["coral"] < costs[1].materials["coral"]
+
+
+def test_dock_build_cost_maxed_returns_none() -> None:
+    assert structures.build_cost(structures.DOCK, structures.MAX_DOCK_LEVEL) is None
+    assert structures.build_cost(structures.DOCK, -1) is None
+
+
+def test_dock_bite_speed_mult_ladder_and_additive_safety() -> None:
+    # Unbuilt ⇒ exactly 1.0 (byte-identical cast — the additive-safety property).
+    assert structures.dock_bite_speed_mult(0) == 1.0
+    assert structures.dock_bite_speed_mult(1) == 0.94
+    assert structures.dock_bite_speed_mult(2) == 0.88
+    # Clamped: an out-of-range level can never over-reward (nor go negative).
+    assert structures.dock_bite_speed_mult(99) == 0.88
+    assert structures.dock_bite_speed_mult(-5) == 1.0
+    # Strictly falling (faster) across the ladder, always positive.
+    mults = [structures.dock_bite_speed_mult(lvl) for lvl in range(3)]
+    assert mults == sorted(mults, reverse=True)
+    assert mults[-1] > 0
+
+
+def test_dock_is_cheaper_on_coral_than_the_tide_pool() -> None:
+    """The Dock is the *entry* coral structure — a smaller total-coral commitment
+    than the full Tide Pool, so a player can afford faster fishing before rarer."""
+    dock_coral = sum(
+        structures.build_cost(structures.DOCK, lvl).materials["coral"]
+        for lvl in range(structures.MAX_DOCK_LEVEL)
+    )
+    pool_coral = sum(
+        structures.build_cost(structures.TIDE_POOL, lvl).materials["coral"]
+        for lvl in range(structures.MAX_TIDE_POOL_LEVEL)
+    )
+    assert dock_coral < pool_coral
+
+
+def test_dock_does_not_gate_crafting() -> None:
+    """The Dock is a fishing bonus — never a gear-craft forge gate."""
+    assert structures.forge_level_required("dock") == 0


### PR DESCRIPTION
## What & why

Second slice of this dispatch run (after #1598 shipped the **Tide Pool**). This is its **sibling**:
the **Fishing Dock** — a coral-built structure whose payoff is a **bite-speed** knob (faster bites)
rather than the Tide Pool's rarity-pull, and whose cost is cheaper + adds a common material
(coral + wood, vs. the Tide Pool's coral + coins). So the two structures are a genuine build-order
**choice** — *faster fishing* vs. *rarer fish*, *entry* vs. *premium* — and coral now has three
meaningfully-different sinks (cosmetic curios · rarity Tide Pool · speed Dock).

It folds into the fishing cast as another "how-well" knob, default `×1.0` when unbuilt ⇒
**byte-identical** casts (the same additive-safety property the gear and Tide Pool knobs use).

**⚑ Self-initiated (Q-0172):** my own session idea (flagged in the log), not a dispatched order —
built because it's a contained, reversible deepening that completes the structure choice.

## Shipped

- **`utils/mining/structures.py`** — `DOCK` registry entry (2-level coral + wood ladder) + pure
  `dock_bite_speed_mult(level)` payoff helper (`≤ 1.0`; unbuilt ⇒ `1.0`).
- **`utils/mining/market.py`** — `DOCK_BUILD_REASON` economy-audit tag.
- **`services/mining_workflow.py`** — Dock wired into the audited `build_structure` seam + reward suffix.
- **`services/fishing_workflow.py`** — `begin_cast` folds the dock's bite-speed multiplier into
  `effective_bite_speed`; unbuilt ⇒ ×1.0 (byte-identical). New `CastStart.dock_bonus` flag + footer note.
- **`views/fishing/dock.py`** + `!dock` + a fishing-menu button (reachable/buttonized).
- Tests + `docs/planning/fishing-dock-numbers-2026-07-01.md` (sim-pinned). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zuHU8PNt46RnH5MXZMadn)_