### PR TITLE
fix(fishing): resolve !dock/!sail token collision crashing boot

### DIFF
--- a/.sessions/2026-07-01-fishing-dock-sail-alias-crash.md
+++ b/.sessions/2026-07-01-fishing-dock-sail-alias-crash.md
@@ -1,6 +1,6 @@
 # 2026-07-01 — PROD hotfix: fishing `dock` command collided with `sail`'s `dock` alias (crash loop)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Incident:** Railway `worker` in a boot crash loop (restart every ~30s, never reaching the
 gateway). Reported via attached deploy logs. Owner-directed live session. ⚑ **Self-initiated:**
@@ -52,17 +52,88 @@ a collision prevents.
 - **`tests/unit/invariants/test_extension_integrity.py`** — broadened the guard (enforce, don't
   exhort — Q-0194/Q-0132): `_top_level_command_tokens` → `_top_level_command_claims`, now counting
   distinct **commands** per token (identity-deduped, so a command's own name+aliases is one claim
-  but two commands are two). Renamed the test `…_across_cogs` → `test_no_duplicate_top_level_command_tokens`
-  — it now catches **same-cog and cross-cog** token collisions uniformly. Regression-proven: with the
-  alias re-added it fails `!dock: FishingCog.dock, FishingCog.sail`; removed, it's green. A full scan
-  found **no other** same-cog collisions in the bot.
+  but two commands are two). Renamed `…_across_cogs` → `test_no_duplicate_top_level_command_tokens`
+  — it now catches **same-cog and cross-cog** token collisions uniformly. Regression-proven: with
+  the alias re-added it fails `!dock: FishingCog.dock, FishingCog.sail`; removed, it's green. A full
+  scan found **no other** same-cog collisions in the bot.
+- **`docs/owner/maintainer-question-router.md`** — updated the Q-0211 enforcement reference to the
+  renamed/broadened guard (drift-on-sight, Q-0166).
 - **Generated data** — regenerated `dashboard/data/dashboard.json`, `botsite/data/site.json`,
   `botsite/site/data.js` so the displayed alias lists no longer show `!dock` under `sail` (command
   *names* unchanged, so no structural-drift surface moved; timestamp/changelog churn is volatile).
 
 ## Verification
 
-_(pending final run — see close-out)_
+- `python3.10 scripts/check_quality.py --full` → **green**: `All checks passed ✓`
+  (black + isort + ruff + mypy + **13433 passed, 48 skipped, 2 xfailed**; artifacts fresh).
+- `python3.10 scripts/check_architecture.py --mode strict` → **exit 0** (only pre-existing `[known]`
+  warnings; `fishing_cog` / the guard test unmentioned — no new violations).
+- `python3.10 scripts/check_current_state_ledger.py --strict` → in sync.
+- Guard regression: re-adding the alias ⇒ test fails `!dock: FishingCog.dock, FishingCog.sail`;
+  removing ⇒ 60/60 green. Full-bot scan: no other same-cog token collisions.
+- CI `code-quality` green except the intentional born-red session gate (this card), flipped to
+  `complete` as the deliberate final step.
 
 **Recovery:** merge → Railway auto-redeploys `worker` → bot back within minutes (the merge IS the
-deploy; no manual restart — Q-0193).
+deploy; no manual restart — Q-0193). **Live-verify** the worker reaches the gateway post-merge (the
+one step CI can't prove — no Discord runtime in CI).
+
+## 💡 Session idea (Q-0089)
+
+**CI "boot smoke test": construct a real `commands.Bot` and `await load_extension` for every
+`config.INITIAL_EXTENSIONS`, asserting all load.** `test_extension_integrity` covers this class
+*statically* (importable + coroutine `setup` + token-collision scan), but a real `load_extension`
+would catch the *whole* `add_cog` failure surface end-to-end — token collisions, a raising
+`cog_load`, duplicate view `custom_id`s, a bad `app_commands` tree — not just the subset a static
+walk can model. This is now the **second** boot-crash collision in ~2 days (give cross-cog, dock
+same-cog); each was a shape the static guards had to be *extended* to cover after the fact. A live
+boot test would front-run the next unknown shape. (Idea only — needs a no-DB `setup_hook` path and a
+fake token; gate behind a marker if slow. Worth a `docs/ideas/` file if it survives review.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous session (`2026-07-01-fishing-dock-structure`, PR #1599) shipped the Dock feature
+well — clean structure math, audited build seam, byte-identical unbuilt-cast path, thorough tests.
+But it introduced the boot-crash: it registered a top-level command **named** `dock` without
+grepping the existing token surface for `dock` (present as `!sail`'s alias since 2026-06-29). Its
+own tests (`test_dock_registered_and_named`, the begin_cast fold) exercised the *structure logic*
+but **never actually loaded the cog**, so the collision was invisible to them. **System improvement
+(shipped this session):** the same-cog token guard now closes the exact hole, so this fails at CI
+instead of at boot. **Deeper, recurring lesson:** *nothing verifies a merge actually stayed up in
+prod* — same as the 2026-06-29 `give` review. Two boot-crashes in two days is a strong signal to
+prioritize both a **live boot smoke test** (the idea above) and a **post-merge prod-health check**
+(the 2026-06-29 degrade-don't-die territory).
+
+## 📋 Doc audit (Q-0104)
+
+- Ledger in sync at start and end (`check_current_state_ledger --strict` exit 0); PR #1600 will be
+  recorded by the next reconciliation pass (#1620) — no self-referential placeholder (the pattern
+  the early-PR-open rule removed).
+- Owner router: no new *decision* (mechanical bug fix + test-guard extension, not product intent).
+  Updated the existing **Q-0211** reference to the renamed guard for accuracy.
+- New/changed docs reachable; no chat-only knowledge left un-homed (the guard-gap analysis lives in
+  the test docstring + this card).
+
+## Context delta (reflection interview)
+
+- **Needed but not pointed to:** the three-layer collision-guard model (Q-0200 same-*module* `def`
+  names · cross-cog token guard · runtime ledger) and the **gap between them** — reconstructed from
+  the 2026-06-29 session log + guard source. Now captured in the guard's own docstring.
+- **Pointed to but didn't need:** CodeGraph / broad orientation — this was a tight, log-driven
+  root-cause fix; `grep` + reading two files carried it.
+- **Discovered by hand:** the dashboard/site **freshness structural surface excludes aliases**
+  (`_STRUCTURAL_SURFACES.commands` keys on `(cog, name)`), so an alias-only change causes no gated
+  drift — reverse-engineered from `check_dashboard_data.py`.
+- **Decisions made alone:** (a) remove `sail`'s vestigial alias rather than rename the `dock`
+  *command* (the feature owns the name; renaming would ripple through `structures.DOCK`, tests,
+  docs, artifacts). (b) broaden **+ rename** the existing guard rather than add a parallel same-cog
+  test (one uniform guard > two). (c) regenerate artifacts despite the alias-only change (the public
+  site/dashboard *display* alias lists). All reversible, none product-intent.
+- **Flagged for maintainer / known limit:** the fix is static- and regression-test-proven but **not
+  boot-tested in CI** (no Discord runtime) — the real end-to-end proof is the Railway redeploy;
+  please confirm the worker reaches the gateway after merge.
+- **🛠 Friction → guard:** *Friction* — a same-cog name-vs-alias command-token collision crash-looped
+  prod and **no existing guard caught it** (it fell between the same-module and cross-cog guards).
+  *Guard shipped (enforcing, free-to-ship test — Q-0194/Q-0132):* broadened
+  `test_no_duplicate_top_level_command_tokens` to count distinct commands per token, so the same-cog
+  shape now fails at CI. Regression-proven. No hook / settings / CLAUDE.md change needed.

--- a/.sessions/2026-07-01-fishing-dock-sail-alias-crash.md
+++ b/.sessions/2026-07-01-fishing-dock-sail-alias-crash.md
@@ -1,0 +1,68 @@
+# 2026-07-01 — PROD hotfix: fishing `dock` command collided with `sail`'s `dock` alias (crash loop)
+
+> **Status:** `in-progress`
+
+**Incident:** Railway `worker` in a boot crash loop (restart every ~30s, never reaching the
+gateway). Reported via attached deploy logs. Owner-directed live session. ⚑ **Self-initiated:**
+the guard-generalization below (broadening the duplicate-token CI check to catch *same-cog*
+collisions) goes beyond the literal one-line alias fix — added as root-cause prevention for the
+whole same-cog collision shape.
+
+## Root cause (confirmed from the deploy logs)
+
+```
+❌ Failed to load cogs.fishing_cog: CommandRegistrationError:
+   The command dock is already an existing command or alias.
+→ Subsystem 'fishing' has no loaded commands — marking INTERNAL
+→ entry_point 'fish'/'fishlog' declared by 'fishing' is not a loaded command
+→ Identity-contract findings | total=2 | fatal=2 | STRICT=on | abort=yes
+→ Identity-contract: STRICT mode aborting startup.
+```
+
+A **same-cog** top-level token collision inside `FishingCog`:
+
+- `!sail` (`disbot/cogs/fishing_cog.py:112`) has carried `dock` as an **alias** since `98a692d`
+  (2026-06-29) — "dock back on shore", the venue toggle.
+- **PR #1599 / commit `8744a7b`** (`feat(fishing): Dock — bite-speed coral structure`) added a
+  first-class command literally **named** `dock` (the Tide Pool's sibling: view + embed + audited
+  build seam + tests, all keyed to `structures.DOCK = "dock"`).
+
+At `add_cog`, `sail` registers first (claiming alias `dock`); the new `dock` command's name then
+collides → `CommandRegistrationError` → the whole cog fails to load → its declared entry points
+(`fish`, `fishlog`) vanish → STRICT identity-contract aborts boot. Crash loop, never reaches the
+gateway → offline.
+
+## Why CI didn't catch it (the guard gap)
+
+The `give` crash (2026-06-29) added `test_no_duplicate_top_level_command_names_across_cogs`, but it
+de-duplicated claimants **by cog** (`len(set(cogs)) > 1`) — so a single cog claiming a token twice
+(here `dock` = `sail`'s alias **and** the `dock` command's name, both in `FishingCog`) looked like
+*one* claimant and slipped through. This fell in the gap **between** the two existing guards:
+Q-0200's exact-name guard is same-*module* but matches `def` names (sees `def sail` ≠ `def dock`),
+and the cross-cog guard dedupes by cog. Neither models a same-cog **name-vs-alias** clash. The
+runtime `command_surface_ledger` can't help either — it only sees commands *after* they load, which
+a collision prevents.
+
+## What changed
+
+- **`disbot/cogs/fishing_cog.py`** — dropped the vestigial `dock` alias from `!sail`
+  (`aliases=["setsail", "dock"]` → `["setsail"]`); the new `!dock` structure command owns the name
+  (its natural, discoverable entry point). `!sail` + `!setsail` still fully cover the venue toggle;
+  docstring reworded ("dock back on shore" → "return to shore") so nothing implies `!dock` toggles.
+- **`tests/unit/invariants/test_extension_integrity.py`** — broadened the guard (enforce, don't
+  exhort — Q-0194/Q-0132): `_top_level_command_tokens` → `_top_level_command_claims`, now counting
+  distinct **commands** per token (identity-deduped, so a command's own name+aliases is one claim
+  but two commands are two). Renamed the test `…_across_cogs` → `test_no_duplicate_top_level_command_tokens`
+  — it now catches **same-cog and cross-cog** token collisions uniformly. Regression-proven: with the
+  alias re-added it fails `!dock: FishingCog.dock, FishingCog.sail`; removed, it's green. A full scan
+  found **no other** same-cog collisions in the bot.
+- **Generated data** — regenerated `dashboard/data/dashboard.json`, `botsite/data/site.json`,
+  `botsite/site/data.js` so the displayed alias lists no longer show `!dock` under `sail` (command
+  *names* unchanged, so no structural-drift surface moved; timestamp/changelog churn is volatile).
+
+## Verification
+
+_(pending final run — see close-out)_
+
+**Recovery:** merge → Railway auto-redeploys `worker` → bot back within minutes (the merge IS the
+deploy; no manual restart — Q-0193).

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T06:42:29Z",
+    "generated_at": "2026-07-01T08:58:08Z",
     "build": {
-      "commit": "8f679dba",
-      "subject": "chore(session): open born-red card — fishing Dock bite-speed structure",
-      "committed_at": "2026-07-01T06:42:29Z"
+      "commit": "07c881a",
+      "subject": "Merge pull request #1599 from menno420/claude/funny-franklin-4n38rf",
+      "committed_at": "2026-07-01T08:58:08Z"
     }
   },
   "counts": {
@@ -8414,14 +8414,13 @@
     {
       "name": "sail",
       "aliases": [
-        "setsail",
-        "dock"
+        "setsail"
       ],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
-      "usage": "Set sail for deepwater (or dock back on shore) — toggles your fishing venue.",
-      "description": "Set sail for deepwater (or dock back on shore) — toggles your fishing venue.",
+      "usage": "Set sail for deepwater (or return to shore) — toggles your fishing venue.",
+      "description": "Set sail for deepwater (or return to shore) — toggles your fishing venue.",
       "use_cases": null,
       "examples": [
         "!fish"

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -5010,12 +5010,11 @@ const COMMANDS = [
     "name": "sail",
     "area": "games",
     "status": "in-progress",
-    "summary": "Set sail for deepwater (or dock back on shore) — toggles your fishing venue.",
-    "description": "Set sail for deepwater (or dock back on shore) — toggles your fishing venue.",
+    "summary": "Set sail for deepwater (or return to shore) — toggles your fishing venue.",
+    "description": "Set sail for deepwater (or return to shore) — toggles your fishing venue.",
     "usage": "!sail",
     "aliases": [
-      "setsail",
-      "dock"
+      "setsail"
     ],
     "permissions": "anyone",
     "cooldown": null,
@@ -7289,7 +7288,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "8f679dba",
+    "build": "07c881a",
     "title": "New public bot website",
     "changes": [
       {
@@ -7301,7 +7300,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "8f679dba",
+    "build": "07c881a",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7313,7 +7312,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "8f679dba",
+    "build": "07c881a",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T06:42:29Z",
+    "generated_at": "2026-07-01T08:58:08Z",
     "build": {
-      "commit": "8f679dba",
-      "subject": "chore(session): open born-red card — fishing Dock bite-speed structure",
-      "committed_at": "2026-07-01T06:42:29Z"
+      "commit": "07c881a",
+      "subject": "Merge pull request #1599 from menno420/claude/funny-franklin-4n38rf",
+      "committed_at": "2026-07-01T08:58:08Z"
     },
     "counts": {
       "functions": 43,
@@ -2719,9 +2719,9 @@
       "file": "2026-07-01-fishing-dock-structure.md",
       "date": "2026-07-01",
       "title": "2026-07-01 — Fishing Dock structure (bite-speed coral sink, Tide Pool sibling)",
-      "status": "in-progress",
+      "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
+      "self_initiated": true
     },
     {
       "file": "2026-07-01-fishing-coral-curios.md",
@@ -7088,10 +7088,9 @@
           "is_group": false,
           "parent": null,
           "aliases": [
-            "setsail",
-            "dock"
+            "setsail"
           ],
-          "brief": "Set sail for deepwater (or dock back on shore) — toggles your fishing venue.",
+          "brief": "Set sail for deepwater (or return to shore) — toggles your fishing venue.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -109,9 +109,9 @@ class FishingCog(commands.Cog):
         embed.set_footer(text="Same for everyone today · 🎣 !fish to cast")
         await ctx.send(embed=embed)
 
-    @commands.command(name="sail", aliases=["setsail", "dock"])
+    @commands.command(name="sail", aliases=["setsail"])
     async def sail(self, ctx):
-        """Set sail for deepwater (or dock back on shore) — toggles your fishing venue.
+        """Set sail for deepwater (or return to shore) — toggles your fishing venue.
 
         Deepwater holds rare boat-only fish that bite slower and fight harder;
         shore is the relaxed everyday catch. Your choice persists, so ``!fish``

--- a/docs/owner/claims/claude__new-session-4nyrrq.md
+++ b/docs/owner/claims/claude__new-session-4nyrrq.md
@@ -1,0 +1,1 @@
+- `claude/new-session-4nyrrq` · **PROD crash-loop hotfix** — fishing `dock`/`sail` command-token collision (same-cog) + broaden the duplicate-token guard to catch it · `disbot/cogs/fishing_cog.py` `tests/unit/invariants/test_extension_integrity.py` · 2026-07-01 · PR pending

--- a/docs/owner/claims/claude__new-session-4nyrrq.md
+++ b/docs/owner/claims/claude__new-session-4nyrrq.md
@@ -1,1 +1,0 @@
-- `claude/new-session-4nyrrq` · **PROD crash-loop hotfix** — fishing `dock`/`sail` command-token collision (same-cog) + broaden the duplicate-token guard to catch it · `disbot/cogs/fishing_cog.py` `tests/unit/invariants/test_extension_integrity.py` · 2026-07-01 · PR pending

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7772,10 +7772,12 @@ distinct command, untouched.
 `tests/unit/invariants/test_extension_integrity.py`:
 - `test_no_banned_command_tokens_anywhere` — fails the build if any command/alias named `give` is ever
   re-added (`BANNED_COMMAND_TOKENS = {"give"}`; recurses into group subcommands).
-- `test_no_duplicate_top_level_command_names_across_cogs` — the broader root-cause guard: catches **any**
-  duplicate top-level command name/alias across cogs at CI time. The runtime `command_surface_ledger`
-  only sees duplicates *after* every cog loads — which a collision prevents — so it could never catch
-  this class; the static check can.
+- `test_no_duplicate_top_level_command_tokens` — the broader root-cause guard: catches **any**
+  top-level command name/alias claimed by two distinct commands at CI time, **same-cog or cross-cog**
+  (broadened + renamed from `…_across_cogs` on 2026-07-01 after the fishing `dock`/`sail` *same-cog*
+  collision crash-looped boot — PR #1600 — which the original, de-duplicating claimants by cog, missed).
+  The runtime `command_surface_ledger` only sees duplicates *after* every cog loads — which a collision
+  prevents — so it could never catch this class; the static check can.
 
 **Home:** this Q-block (canonical) + `tests/unit/invariants/test_extension_integrity.py` (enforcement) +
 `.claude/CLAUDE.md` § Helpers "Exact-name guard (Q-0200)" (the sibling same-module guard this extends

--- a/tests/unit/invariants/test_extension_integrity.py
+++ b/tests/unit/invariants/test_extension_integrity.py
@@ -44,21 +44,30 @@ def test_extension_is_importable_with_coroutine_setup(extension: str) -> None:
     )
 
 
-def _top_level_command_tokens() -> dict[str, list[str]]:
-    """Map every top-level prefix-command token -> the cogs that declare it.
+def _top_level_command_claims() -> dict[str, list[str]]:
+    """Map every top-level prefix-command token -> the *commands* that claim it.
 
     A "token" is a command's ``name`` or one of its ``aliases``. discord.py's
     ``Bot`` keeps a single global namespace for top-level prefix commands
-    (``Bot.all_commands`` is keyed by name *and* every alias), so two cogs that
-    each claim the same token collide. Group **subcommands** live in their
-    group's own namespace (e.g. ``!karma add`` is scoped to the ``karma`` group,
-    not the global table), so only commands with no parent are global and are
-    counted here.
+    (``Bot.all_commands`` is keyed by name *and* every alias), so two *distinct
+    commands* that each claim the same token collide at ``add_cog`` — whether
+    they live in the same cog or in two different cogs. Group **subcommands**
+    live in their group's own namespace (e.g. ``!karma add`` is scoped to the
+    ``karma`` group, not the global table), so only commands with no parent are
+    global and are counted here.
+
+    Each claimant is labelled ``"<CogName>.<command>"`` and de-duplicated by
+    command **identity** (``id``), so a single command claiming a token through
+    both its name and one of its own aliases counts once (no false
+    self-collision), while two *different* commands claiming the same token —
+    the crash class — surface as two labels.
 
     Read from each cog's class-level ``__cog_commands__`` via ``importlib`` —
     no Discord runtime, no DB, no cog instantiation.
     """
-    tokens: dict[str, list[str]] = defaultdict(list)
+    # token -> {id(command): "<CogName>.<command>"} — identity-deduped claimants,
+    # so name+alias on one command is a single claim but two commands are two.
+    claims: dict[str, dict[int, str]] = defaultdict(dict)
     for extension in config.INITIAL_EXTENSIONS:
         module = importlib.import_module(extension)
         for _name, obj in inspect.getmembers(module, inspect.isclass):
@@ -71,36 +80,51 @@ def _top_level_command_tokens() -> dict[str, list[str]]:
             for cmd in getattr(obj, "__cog_commands__", ()):
                 if getattr(cmd, "parent", None) is not None:
                     continue  # subcommand — namespaced under its group
+                label = f"{obj.__name__}.{cmd.name}"
                 for token in (cmd.name, *(cmd.aliases or ())):
-                    tokens[token].append(obj.__name__)
-    return tokens
+                    claims[token][id(cmd)] = label
+    return {token: sorted(labels.values()) for token, labels in claims.items()}
 
 
-def test_no_duplicate_top_level_command_names_across_cogs() -> None:
-    """No two cogs may claim the same top-level prefix command name/alias.
+def test_no_duplicate_top_level_command_tokens() -> None:
+    """No two distinct commands may claim the same top-level prefix token.
 
-    The "bot offline" class (2026-06-29): two cogs each declared a top-level
-    ``give`` (economy's peer-transfer vs mining's admin grant). At boot the
-    second ``add_cog`` raised ``CommandRegistrationError: The command give is
-    already an existing command or alias``, so the whole cog failed to load,
-    its declared entry points went missing, and the STRICT identity-contract
-    check aborted startup — a crash loop, never reaching the gateway.
+    (Formerly ``test_no_duplicate_top_level_command_names_across_cogs``;
+    broadened 2026-07-01 to also catch *same-cog* collisions — the fishing
+    ``dock`` incident below.)
+
+    The "bot offline" class has two shapes, both of which crash
+    ``bot.load_extension`` at boot with the *same*
+    ``CommandRegistrationError: The command <x> is already an existing command
+    or alias`` → the cog's declared entry points go missing → STRICT
+    identity-contract aborts startup → crash loop, never reaching the gateway:
+
+    * **cross-cog** (2026-06-29): two cogs each declared a top-level ``give``
+      (economy peer-transfer vs mining admin grant).
+    * **same-cog** (2026-07-01): inside ``FishingCog`` the new ``!dock``
+      structure command's *name* collided with the pre-existing ``dock``
+      *alias* of ``!sail``. The first guard version de-duplicated claimants by
+      **cog**, so one cog claiming a token twice looked like a single claimant
+      and slipped through — the exact hole this version closes by counting
+      distinct **commands**. (Q-0200's exact-name guard is same-*module* only
+      and matches ``def`` names, so it too missed a name-vs-alias clash.)
 
     The runtime ``command_surface_ledger`` only sees duplicates *after* every
     cog has loaded, which is exactly what a collision prevents — so it cannot
-    catch this. This static check does, pre-merge. A failure here means the
-    bot would crash on boot: rename or remove one side of each listed clash.
+    catch either shape. This static check does, pre-merge. A failure here means
+    the bot would crash on boot: rename or remove one side of each listed clash.
     """
     collisions = {
-        token: sorted(set(cogs))
-        for token, cogs in _top_level_command_tokens().items()
-        if len(set(cogs)) > 1
+        token: claimants
+        for token, claimants in _top_level_command_claims().items()
+        if len(claimants) > 1
     }
     assert not collisions, (
-        "Top-level prefix command name/alias claimed by more than one cog — "
+        "Top-level prefix command token claimed by more than one command — "
         "this crashes bot.load_extension at boot (CommandRegistrationError):\n"
         + "\n".join(
-            f"  !{token}: {', '.join(cogs)}" for token, cogs in sorted(collisions.items())
+            f"  !{token}: {', '.join(claimants)}"
+            for token, claimants in sorted(collisions.items())
         )
     )
 
@@ -119,7 +143,7 @@ def _walk_cog_commands(cog_cls: type) -> list[object]:
 
     ``__cog_commands__`` holds the cog's top-level commands; a group's children
     are reached via the group's ``commands`` attribute. Unlike
-    :func:`_top_level_command_tokens` (global-namespace collisions only), the ban
+    :func:`_top_level_command_claims` (global-namespace collisions only), the ban
     applies to **every** command including subcommands like ``!karma give``.
     """
     out: list[object] = []


### PR DESCRIPTION
## Summary

**PROD hotfix — the `worker` was in a boot crash loop** (restart every ~30s, never reaching the gateway). `cogs.fishing_cog` failed to load with `CommandRegistrationError: The command dock is already an existing command or alias`, so the `fishing` subsystem had no loaded commands, its declared entry points (`fish`/`fishlog`) went missing, and STRICT identity-contract aborted startup.

**Root cause — a *same-cog* top-level token collision inside `FishingCog`:**
- `!sail` has carried `dock` as an **alias** since `98a692d` (2026-06-29) — the "return to shore" venue toggle.
- PR #1599 (`8744a7b`, `feat(fishing): Dock`) added a first-class command literally **named** `dock` (the Dock structure). At `add_cog`, the new command's name collides with `sail`'s alias.

**Fix:** drop the vestigial `dock` alias from `!sail` — the new `!dock` structure command owns the name (its natural entry point; `!sail`/`!setsail` still fully cover the venue toggle).

**Guard (root-cause prevention):** the `give`-collision guard (`test_no_duplicate_top_level_command_names_across_cogs`, 2026-06-29) de-duplicated claimants **by cog**, so a single cog claiming a token twice slipped through — the exact same-cog shape here. Broadened it to count distinct **commands** per token so it catches same-cog *and* cross-cog collisions uniformly. Regression-proven: re-adding the alias makes it fail `!dock: FishingCog.dock, FishingCog.sail`; a full scan found no other same-cog collisions.

## Linked issue / plan

Follow-up hotfix to PR #1599 (fishing Dock structure).

## Type of change

- [x] Bug fix
- [x] Tooling / CI (broadened duplicate-token guard)

## Checks

- [x] `python3.10 scripts/check_quality.py --full` passes (black + isort + ruff + mypy + pytest)
- [x] `python3.10 scripts/check_architecture.py --mode strict` passes (exit 0)
- [x] Docs / ledger updated if behavior or project state changed (regenerated dashboard/site artifacts; session card)
- [x] No secrets, tokens, or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012qtu2QGrPCtyGXnVB3aq7g)_