### PR TITLE
sim(roles): optimizer for the menu-builder button layout

### DIFF
--- a/.sessions/2026-07-01-role-menu-layout-sim.md
+++ b/.sessions/2026-07-01-role-menu-layout-sim.md
@@ -1,22 +1,98 @@
 # 2026-07-01 — Role-menu builder button-layout simulation
 
-> **Status:** `in-progress` — born-red card (Q-0133). Run type: manual · owner-directed.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: manual · owner-directed.
+> Full CI mirror green (**13550 passed**, 48 skipped; lint/mypy clean; arch strict 0 new). PR #1612.
 
 **Branch:** `claude/reaction-roles-counter-bgxnyd` (restarted from `main` @ #1608 — prior PR merged).
 
 ## What I'm about to do (intentions)
 
 Owner asked (after the builder preview-fix): "create a simulation to find out the most optimal button
-placements and functions." Build a real optimizer (in the `tools/sim/` precedent — `help_menu_grouping_sim`,
-`setup_wizard_sim`) that models the builder's buttons + weighted operator journeys + a transparent UX
-cost model, and searches (seeded simulated annealing) for the layout — and function set — that minimises
-interaction cost. Deliver the tool + its findings; adopting a layout is a separate, owner-gated follow-up
-(it changes their tested UI).
+placements and functions." Build a real optimizer (in the `tools/sim/` precedent) that models the
+builder's buttons + weighted operator journeys + a transparent UX cost model, and searches for the
+best layout + function set. Deliver the tool + findings; adopting a layout is an owner-gated follow-up.
 
 ## What shipped
 
-_(filled in at close)_
+1. **`tools/sim/role_menu_layout_sim.py`** — a seeded (deterministic) simulated-annealing optimizer over
+   the builder's button layout AND function-set variants. Models: the **14 live buttons** (drift-guarded
+   against `role_menu_builder.py`), **8 weighted operator journeys** (RSVP / colour / game / notification
+   / verify / custom / edit — RSVP-led, templates short-circuiting config), and a **transparent cost
+   model** (prominence by top-left reading index; travel with row jumps costlier than column steps;
+   submenu-open penalty for folded functions; layout terms for group contiguity + Post/Back submit/back
+   corners). Ranks variants, prints the winning grid + per-journey tap cost vs. the current layout.
+   Findings are baked into the module docstring.
+2. **`tests/unit/tools/test_role_menu_layout_sim.py`** — +7 guards: inventory drift-guard (every sim
+   button still exists in the live builder), current-layout integrity, weights-sum-to-1, determinism
+   (same seed → same cost), optimiser-beats-current, cost-model-orientation sanity (hot button top-left
+   < bottom-right), and the lean_advanced fold shape.
+
+**Findings (stable across seeds 1/2/7):** current 14-button/3-row builder ≈ 34.1 cost (it leads with
+rarely-tapped knobs). Two improvements: **low-risk re-order** (all 14, content on row 0, Post
+bottom-right) ≈ **−45%**; **best = "lean_advanced"** — fold the six rarely-tapped knobs
+(Theme/Card/Counts/Style/Mode/Limit) behind one **⚙️ Advanced** button → a 9-button/2-row builder ≈
+**−55%** (`row0: Template Packs Roles Text Colours · row1: Back Channel Advanced Post`).
+
+**Recommendation is advisory — this PR does not touch the builder.** The lean fold is a product call
+(hides six functions behind Advanced; the RSVP template already sets Style/Counts/Mode, so the common
+path never needs them); the re-order is a safe mechanical win. Adoption is the owner's pick, done next.
+
+## Why this is contained / safe
+
+Read-only, stdlib-only, disposable advisory tool in `tools/sim/` (established precedent —
+`help_menu_grouping_sim`, `setup_wizard_sim`). No runtime code, no migration, no builder change. The
+drift-guard keeps the sim honest against the live builder.
 
 ## Context delta
 
-_(filled in at close)_
+- **Discovered:** my first cost model put **Post on the top row** — because it charged
+  find-from-scratch prominence to Post even though Post is a colour-coded anchor (green = submit) users
+  learn once. Fixed the model (action buttons pay no prominence; the convention penalty places them),
+  and the winner became sensible (Post bottom-right). A good reminder that a sim's output is only as
+  trustworthy as its cost model — so the model is fully documented + the weights tunable, and I checked
+  the winner is stable across seeds before trusting it (the Q-0120 "verify the tool" instinct).
+- **Decisions made alone (reversible):** modeled the journey weights from the owner's RSVP-first
+  priority + general self-role usage (documented as judgment); scoped the deliverable to the **tool +
+  findings** and left **adopting** a layout as an owner pick (the lean fold changes the feature surface
+  — a product call, not a mechanical edit).
+- **🛠 Friction → guard:** ruff's `S101` (no-assert) fired on the sim's asserts (the `tools/**/*.py`
+  ignore covers S603/S607 but not S101) — converted them to explicit `raise`s rather than widen the
+  lint ignore. The inventory drift-guard test is itself the friction→guard for "the sim silently
+  drifting from the real builder."
+
+## 💡 Session idea (Q-0089)
+
+**Instrument the builder's button presses → feed the sim real weights.** The sim's journey weights are
+my best-judgment guesses; the honest next step is to close the model→measure loop: log an **aggregate**
+per-button press counter for the builder (the exact privacy-safe pattern `role_menu_pickup_stats`
+already uses — counts only, no per-user history), then add a `--weights <file>` input so the sim
+re-optimises against *real* usage instead of assumptions. That turns "optimal per my model" into
+"optimal per what operators actually do", and would either confirm or correct the −55% recommendation
+before anyone commits to a UI change.
+
+## ⟲ Previous-session review (Q-0102)
+
+Predecessor is **#1608 (the builder preview-fix)**. **Did well:** root-caused a real bug straight from
+the owner's screen recording (ephemeral `Message.edit()` no-op), fixed the whole class (builder +
+manager, not just the one symptom), and added routing tests that pin the fix. **Missed / system note:**
+it knowingly **scoped out `ReactionRolesPanel._rerender`** (the emoji panel — same latent bug) to keep
+the PR verifiable. That's a reasonable call, but a "same bug, deferred" instance can rot silently; it's
+tracked only in the ↪ Next line. The Q-0089 static guard I proposed last session (flag `self.message
+.edit(` in `views/`) is exactly what would keep such deferrals honest — worth actually building it as a
+small checker so "deferred = tracked by CI", not "deferred = hope someone remembers".
+
+## 📤 Run report
+
+- **Did:** built + ran a deterministic optimizer for the reaction-role builder's button layout +
+  function set; produced a stable, documented recommendation (−45% re-order / −55% lean fold).
+  · **Outcome:** shipped (advisory tool; no UI change)
+- **Shipped:** PR #1612 — sim(roles): optimizer for the menu-builder button layout
+- **Run type:** `manual · owner-directed`
+- **Class:** tooling / analysis (read-only, disposable, test-guarded)
+- **⚑ Owner decisions needed:** **which layout to adopt** — (a) low-risk re-order (−45%), (b) lean
+  Advanced-fold (−55%, hides six knobs behind ⚙️ Advanced), or (c) leave as-is / tune the weights.
+- **⚑ Owner manual steps:** none (no runtime change; merge just adds the tool).
+- **⚑ Self-initiated:** no — owner-directed ("create a simulation to find…").
+- **↪ Next:** adopt the chosen layout in `role_menu_builder.py` (guarded by the existing row-cap test);
+  the Q-0089 builder-press instrumentation → data-driven weights; the deferred `ReactionRolesPanel`
+  re-render fix + the `self.message.edit` static guard.

--- a/.sessions/2026-07-01-role-menu-layout-sim.md
+++ b/.sessions/2026-07-01-role-menu-layout-sim.md
@@ -1,0 +1,22 @@
+# 2026-07-01 — Role-menu builder button-layout simulation
+
+> **Status:** `in-progress` — born-red card (Q-0133). Run type: manual · owner-directed.
+
+**Branch:** `claude/reaction-roles-counter-bgxnyd` (restarted from `main` @ #1608 — prior PR merged).
+
+## What I'm about to do (intentions)
+
+Owner asked (after the builder preview-fix): "create a simulation to find out the most optimal button
+placements and functions." Build a real optimizer (in the `tools/sim/` precedent — `help_menu_grouping_sim`,
+`setup_wizard_sim`) that models the builder's buttons + weighted operator journeys + a transparent UX
+cost model, and searches (seeded simulated annealing) for the layout — and function set — that minimises
+interaction cost. Deliver the tool + its findings; adopting a layout is a separate, owner-gated follow-up
+(it changes their tested UI).
+
+## What shipped
+
+_(filled in at close)_
+
+## Context delta
+
+_(filled in at close)_

--- a/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
+++ b/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
@@ -1,0 +1,1 @@
+ - `claude/reaction-roles-counter-bgxnyd` · **role-menu builder layout simulation** — optimizer for the builder's button placement + function set (finds the layout, advisory) · `tools/sim/role_menu_layout_sim.py` `tests/unit/tools/test_role_menu_layout_sim.py` · 2026-07-01 · in-progress

--- a/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
+++ b/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
@@ -1,1 +1,0 @@
- - `claude/reaction-roles-counter-bgxnyd` · **role-menu builder layout simulation** — optimizer for the builder's button placement + function set (finds the layout, advisory) · `tools/sim/role_menu_layout_sim.py` `tests/unit/tools/test_role_menu_layout_sim.py` · 2026-07-01 · in-progress

--- a/tests/unit/tools/test_role_menu_layout_sim.py
+++ b/tests/unit/tools/test_role_menu_layout_sim.py
@@ -1,0 +1,88 @@
+"""Guards for the role-menu builder layout sim (`tools/sim/role_menu_layout_sim.py`).
+
+A disposable advisory tool, so the guard is light: keep it runnable + deterministic,
+keep its cost model oriented the right way, and — the important half — **pin its
+button inventory to the live builder** so the recommendation can't silently drift
+from the real ``RoleMenuBuilder`` surface. Loaded via importlib (repo convention
+for non-package tool scripts).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO / "tools" / "sim" / "role_menu_layout_sim.py"
+_BUILDER = _REPO / "disbot" / "views" / "roles" / "role_menu_builder.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("role_menu_layout_sim_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inventory_matches_the_live_builder(mod):
+    """Every button the sim models must still exist in RoleMenuBuilder — if a
+    button is renamed/removed, this flags the sim as stale (update or delete it).
+    """
+    source = _BUILDER.read_text(encoding="utf-8")
+    for btn in mod.BUTTONS:
+        word = btn.label.split()[-1]  # emoji-tolerant: match the text token
+        assert word in source, f"sim button {btn.key!r} ({word!r}) not in the builder"
+    # 14 is the count the layout question was asked about; a drift here is a signal.
+    assert len(mod.BUTTONS) == 14
+
+
+def test_current_layout_is_well_formed(mod):
+    flat = [k for row in mod.CURRENT_LAYOUT for k in row]
+    assert set(flat) == {b.key for b in mod.BUTTONS}  # covers exactly the inventory
+    assert len(flat) == len(set(flat))  # no duplicates
+    assert mod.valid(mod.CURRENT_LAYOUT)  # <=5/row, <=5 rows
+
+
+def test_journey_weights_sum_to_one(mod):
+    assert abs(sum(j.weight for j in mod.JOURNEYS) - 1.0) < 1e-9
+
+
+def test_optimiser_is_deterministic(mod):
+    base = mod.VARIANTS[0]
+    a = mod.optimise(base, seed=3, iters=800)
+    b = mod.optimise(base, seed=3, iters=800)
+    assert a[1] == pytest.approx(b[1])  # same seed -> same best cost
+
+
+def test_optimiser_beats_the_current_layout(mod):
+    base = mod.VARIANTS[0]
+    _layout, best = mod.optimise(base, seed=1, iters=2000)
+    current = mod.total_cost(base, mod.CURRENT_LAYOUT)
+    assert best < current  # the search actually finds something better
+
+
+def test_cost_model_rewards_hot_buttons_top_left(mod):
+    """Sanity: putting a frequently-pressed button (Template) top-left costs less
+    than burying it bottom-right — i.e. the cost model points the right way.
+    """
+    base = mod.VARIANTS[0]
+    others = [b.key for b in mod.BUTTONS if b.key != "template"]
+    top_left = [["template"] + others[:4], others[4:9], others[9:]]
+    bottom_right = [others[:5], others[5:10], others[10:] + ["template"]]
+    assert mod.total_cost(base, top_left) < mod.total_cost(base, bottom_right)
+
+
+def test_lean_advanced_variant_folds_the_rare_knobs(mod):
+    lean = next(v for v in mod.VARIANTS if v.name == "lean_advanced")
+    # The six rarely-tapped knobs are hidden behind one grid button.
+    for folded in ("theme", "card", "counts", "style", "mode", "limit"):
+        assert lean.grid_key(folded) == "advanced"
+    # …and the hot content buttons stay top-level.
+    for hot in ("template", "packs", "roles", "post"):
+        assert lean.grid_key(hot) == hot

--- a/tools/sim/role_menu_layout_sim.py
+++ b/tools/sim/role_menu_layout_sim.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""
+Role-menu builder button-layout simulation.
+
+Finds the button arrangement (and function set) for the reaction-role **menu
+builder** (``disbot/views/roles/role_menu_builder.py`` ``RoleMenuBuilder``) that
+minimises real interaction cost across the tasks operators actually do — the
+owner asked "find the most optimal button placements and functions" after a live
+test where the 14-button, 3-row builder felt dense and a couple of taps deep.
+
+It is a model, not a sketch, but "optimal" is only as good as the model, so every
+assumption is spelled out and tunable:
+
+  * INVENTORY — the 14 builder buttons + their groups are the live set (kept in
+    sync with the button decorators in role_menu_builder.py; a drift guard in
+    tests/unit/tools/test_role_menu_layout_sim.py pins the names).
+  * JOURNEYS — weighted operator tasks (build an RSVP, colour roles, game roles,
+    notifications, verify gate, a fully-custom menu, edit-a-field). Weights lead
+    with the RSVP/self-role cases the owner cares about; templates short-circuit
+    config, so most journeys start at "Template" and never touch Mode/Limit/etc.
+  * COST — for a layout, each journey pays: prominence (a button's top-left
+    reading index — top-left is found fastest), travel (eye/thumb move between
+    consecutive taps, row jumps costlier than column), and a submenu-open penalty
+    when a pressed function is folded behind a grouping button. Layout-level terms
+    reward keeping a group's buttons contiguous and putting Post/Back in their
+    conventional submit/back corners.
+  * SEARCH — seeded simulated annealing with restarts (deterministic; no live
+    RNG), over both the arrangement AND a few function-set variants (fold rarely
+    used cosmetic/rule buttons behind one grouping button).
+
+The output ranks the variants, prints the winning grid, and lists the per-journey
+tap cost vs. the CURRENT layout so the recommendation is concrete and auditable.
+
+Stdlib only. Read-only. Deterministic (seeded).
+  Report:  python3.10 tools/sim/role_menu_layout_sim.py
+           python3.10 tools/sim/role_menu_layout_sim.py --seed 7 --iters 40000
+
+FINDINGS (seed 1, stable across seeds 1/2/7; re-run to confirm)
+---------------------------------------------------------------
+The CURRENT 14-button / 3-row builder scores ~34.1. It leads with rarely-tapped
+knobs (Theme/Mode/Style/Limit on the top two rows) and scatters the hot content
+buttons, so the common RSVP/self-role tasks pay for buttons they never press.
+
+Two improvements, both re-order the hot content buttons (Template/Packs/Roles/
+Text/Colours) onto row 0 and drop Post to the bottom-right (submit convention):
+
+  * LOW-RISK — keep all 14 buttons, only re-order:               ~ -45% cost.
+  * BEST — "lean_advanced": fold the six rarely-tapped knobs
+    (Theme/Card/Counts/Style/Mode/Limit) behind one ⚙️ Advanced
+    button → a 9-button / 2-row builder:                          ~ -55% cost.
+        row 0: [🧩 Template] [📦 Packs] [🏷️ Roles] [📝 Text] [🎨 Colours]
+        row 1: [↩ Back] [📍 Channel] [⚙️ Advanced] [🚀 Post]
+
+The lean layout is a product call (it hides six functions behind Advanced — the
+RSVP template already sets Style/Counts/Mode, so the common path never needs
+them); the re-order is a safe, mechanical win. Adopting either is a follow-up —
+this file only *finds* the layout; it doesn't change the builder.
+
+Provenance: added 2026-07-01 for the owner-directed builder-layout question
+(follow-on to the reaction-roles counter/roster/preview-fix arc, #1570/#1571/#1608).
+Verifiable: the inventory mirrors the live button decorators (drift-guarded) and
+the cost model is transparent + tunable — re-run after any builder button change.
+Disposable: advisory tooling; if the builder's surface changes shape, delete this
+rather than work around it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Grid + tuning constants (Discord: <=5 buttons per row, <=5 rows)
+# ---------------------------------------------------------------------------
+COLS = 5
+MAX_ROWS = 5
+
+# Cost weights — documented judgment, tunable. See module docstring.
+P_W = 1.0  # prominence per reading-index unit (top-left = cheapest to find)
+T_W = 1.0  # travel weight
+ROW_W = 3.0  # a row jump is a bigger eye/thumb move than a column step
+COL_W = 1.0
+OPEN_COST = 6.0  # opening a grouping submenu ~ crossing 6 index units of friction
+LAMBDA_GROUP = 0.6  # keep a function group's buttons contiguous
+LAMBDA_CONV = 1.6  # Post -> bottom-right (submit), Back -> bottom-left (convention)
+
+
+# ---------------------------------------------------------------------------
+# Inventory — the live builder buttons (grounded in role_menu_builder.py)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Button:
+    key: str
+    label: str
+    group: str
+
+
+BUTTONS: list[Button] = [
+    # content — what the menu offers / says
+    Button("template", "🧩 Template", "content"),
+    Button("roles", "🏷️ Roles", "content"),
+    Button("packs", "📦 Packs", "content"),
+    Button("colours", "🎨 Colours", "content"),
+    Button("text", "📝 Text", "content"),
+    # appearance — how it looks
+    Button("theme", "🎭 Theme", "appearance"),
+    Button("style", "🎚️ Style", "appearance"),
+    Button("card", "🖼️ Card", "appearance"),
+    Button("counts", "📊 Counts", "appearance"),
+    # behaviour — assignment rules
+    Button("mode", "⚙️ Mode", "behaviour"),
+    Button("limit", "🔢 Limit", "behaviour"),
+    # placement
+    Button("channel", "📍 Channel", "placement"),
+    # actions
+    Button("post", "🚀 Post", "action"),
+    Button("back", "↩ Back", "action"),
+]
+BY_KEY = {b.key: b for b in BUTTONS}
+
+# The CURRENT live layout (row-by-row, mirrors the decorators' row= values).
+CURRENT_LAYOUT: list[list[str]] = [
+    ["text", "roles", "colours", "packs", "template"],  # row 0
+    ["theme", "mode", "style", "limit", "channel"],  # row 1
+    ["card", "counts", "post", "back"],  # row 2
+]
+
+
+# ---------------------------------------------------------------------------
+# Journeys — weighted operator tasks (ordered fine-grained button presses)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Journey:
+    name: str
+    weight: float
+    presses: tuple[str, ...]
+
+
+JOURNEYS: list[Journey] = [
+    # The owner's headline case: an RSVP poll. The Event RSVP template pre-sets
+    # style=buttons, mode=unique, counts=on, so those are NOT tapped here.
+    Journey("rsvp_event", 0.24, ("template", "packs", "channel", "post")),
+    Journey("rsvp_quick", 0.06, ("template", "packs", "post")),
+    Journey("colour_roles", 0.15, ("template", "colours", "post")),
+    Journey("game_roles", 0.14, ("template", "roles", "text", "post")),
+    Journey("notification_roles", 0.12, ("template", "packs", "post")),
+    Journey("verify_gate", 0.06, ("template", "roles", "post")),
+    # The rare power-user path that actually touches every knob.
+    Journey(
+        "custom_advanced",
+        0.09,
+        ("text", "roles", "style", "mode", "limit", "theme", "channel", "post"),
+    ),
+    # Edit an existing menu: reopen, tweak the roles (the common edit), Save(=post).
+    Journey("edit_tweak", 0.14, ("roles", "post")),
+]
+if abs(sum(j.weight for j in JOURNEYS) - 1.0) >= 1e-9:  # pragma: no cover - guard
+    raise ValueError("journey weights must sum to 1")
+
+
+# ---------------------------------------------------------------------------
+# Function-set variants — fold rarely-used buttons behind one grouping button.
+# fold maps a fine-grained key -> the top-level button actually on the grid.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Variant:
+    name: str
+    buttons: tuple[str, ...]  # top-level keys placed on the grid
+    fold: dict[str, str] = field(default_factory=dict)  # pressed key -> grid key
+    labels: dict[str, str] = field(default_factory=dict)  # grid key -> label
+
+    def grid_key(self, pressed: str) -> str:
+        return self.fold.get(pressed, pressed)
+
+    def label_of(self, key: str) -> str:
+        if key in self.labels:
+            return self.labels[key]
+        return BY_KEY[key].label
+
+    def group_of(self, key: str) -> str:
+        if key in BY_KEY:
+            return BY_KEY[key].group
+        return "grouped"
+
+
+def _base_variant() -> Variant:
+    return Variant("base(14)", tuple(b.key for b in BUTTONS))
+
+
+def _folded_variant(name: str, folds: dict[str, tuple[str, str, list[str]]]) -> Variant:
+    """Build a variant that folds groups of fine buttons behind grouping buttons.
+
+    folds: new_key -> (label, group, [member fine keys folded into it]).
+    """
+    fold_map: dict[str, str] = {}
+    labels: dict[str, str] = {}
+    folded_members = set()
+    for new_key, (label, _group, members) in folds.items():
+        labels[new_key] = label
+        for m in members:
+            fold_map[m] = new_key
+            folded_members.add(m)
+    top = [b.key for b in BUTTONS if b.key not in folded_members]
+    top += list(folds.keys())
+    return Variant(name, tuple(top), fold_map, labels)
+
+
+VARIANTS: list[Variant] = [
+    _base_variant(),
+    # Fold the two cosmetic buttons hardly anyone taps (Card, Theme) behind "Look".
+    _folded_variant(
+        "fold_look",
+        {"look": ("🎨 Look", "appearance", ["theme", "card"])},
+    ),
+    # Fold the two assignment-rule buttons behind "Rules".
+    _folded_variant(
+        "fold_rules",
+        {"rules": ("⚙️ Rules", "behaviour", ["mode", "limit"])},
+    ),
+    # Both of the above.
+    _folded_variant(
+        "fold_look_rules",
+        {
+            "look": ("🎨 Look", "appearance", ["theme", "card"]),
+            "rules": ("⚙️ Rules", "behaviour", ["mode", "limit"]),
+        },
+    ),
+    # Aggressive: one "Advanced" button hides every rarely-tapped knob
+    # (theme/card/counts/style/mode/limit) so the top level is the hot path only.
+    _folded_variant(
+        "lean_advanced",
+        {
+            "advanced": (
+                "⚙️ Advanced",
+                "appearance",
+                ["theme", "card", "counts", "style", "mode", "limit"],
+            ),
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Layout helpers
+# ---------------------------------------------------------------------------
+def positions(layout: list[list[str]]) -> dict[str, tuple[int, int]]:
+    pos: dict[str, tuple[int, int]] = {}
+    for r, row in enumerate(layout):
+        for c, key in enumerate(row):
+            pos[key] = (r, c)
+    return pos
+
+
+def reading_index(pos: tuple[int, int]) -> int:
+    return pos[0] * COLS + pos[1]
+
+
+def valid(layout: list[list[str]]) -> bool:
+    return len(layout) <= MAX_ROWS and all(len(r) <= COLS for r in layout)
+
+
+def _submenu_grid_sequence(
+    journey: Journey,
+    variant: Variant,
+) -> list[tuple[str, bool]]:
+    """Collapse a journey to the sequence of GRID taps, marking submenu opens.
+
+    A pressed key folded behind a grouping button becomes a tap on that grouping
+    button (is_submenu=True); consecutive presses that stay inside the same
+    submenu don't re-open it.
+    """
+    seq: list[tuple[str, bool]] = []
+    for pressed in journey.presses:
+        gk = variant.grid_key(pressed)
+        is_sub = gk != pressed
+        if is_sub and seq and seq[-1][0] == gk:
+            continue  # already inside that submenu
+        seq.append((gk, is_sub))
+    return seq
+
+
+def journey_cost(
+    journey: Journey,
+    variant: Variant,
+    pos: dict[str, tuple[int, int]],
+) -> float:
+    seq = _submenu_grid_sequence(journey, variant)
+    cost = 0.0
+    prev = (0, 0)  # eye starts at the top-left of the button block
+    for gk, is_sub in seq:
+        p = pos[gk]
+        # Post/Back are colour-coded anchors (green = submit) the operator learns
+        # once, so they don't pay find-from-scratch prominence — the convention
+        # penalty places them in their submit/back corners instead. Everything
+        # else pays prominence by reading index (top-left = found fastest).
+        if variant.group_of(gk) != "action":
+            cost += P_W * reading_index(p)
+        cost += T_W * (ROW_W * abs(p[0] - prev[0]) + COL_W * abs(p[1] - prev[1]))
+        if is_sub:
+            cost += OPEN_COST
+        prev = p
+    return cost
+
+
+def group_penalty(variant: Variant, pos: dict[str, tuple[int, int]]) -> float:
+    """Penalise a function group whose buttons are scattered (non-contiguous)."""
+    groups: dict[str, list[int]] = {}
+    for key in variant.buttons:
+        groups.setdefault(variant.group_of(key), []).append(reading_index(pos[key]))
+    pen = 0.0
+    for _g, idxs in groups.items():
+        if len(idxs) <= 1:
+            continue
+        span = max(idxs) - min(idxs)
+        pen += span - (len(idxs) - 1)  # 0 when perfectly contiguous
+    return pen
+
+
+def convention_penalty(
+    variant: Variant,
+    layout: list[list[str]],
+    pos: dict[str, tuple[int, int]],
+) -> float:
+    """Post belongs bottom-right (submit); Back bottom-left (convention)."""
+    pen = 0.0
+    last_row = len(layout) - 1
+    if "post" in pos:
+        r, c = pos["post"]
+        pen += (last_row - r) + (COLS - 1 - c)
+    if "back" in pos:
+        r, c = pos["back"]
+        pen += (last_row - r) + c
+    return pen
+
+
+def total_cost(variant: Variant, layout: list[list[str]]) -> float:
+    pos = positions(layout)
+    cost = sum(j.weight * journey_cost(j, variant, pos) for j in JOURNEYS)
+    cost += LAMBDA_GROUP * group_penalty(variant, pos)
+    cost += LAMBDA_CONV * convention_penalty(variant, layout, pos)
+    return cost
+
+
+def mean_taps(variant: Variant) -> float:
+    """Weighted mean number of GRID taps per journey (a plain, model-free stat)."""
+    return sum(j.weight * len(_submenu_grid_sequence(j, variant)) for j in JOURNEYS)
+
+
+# ---------------------------------------------------------------------------
+# Search — seeded simulated annealing over row layouts
+# ---------------------------------------------------------------------------
+def _rows_for(n: int) -> int:
+    return min(MAX_ROWS, math.ceil(n / COLS))
+
+
+def _random_layout(keys: list[str], rng: random.Random) -> list[list[str]]:
+    ks = keys[:]
+    rng.shuffle(ks)
+    rows = _rows_for(len(ks))
+    layout: list[list[str]] = [[] for _ in range(rows)]
+    for i, k in enumerate(ks):
+        layout[i % rows].append(k)  # round-robin keeps rows balanced + <=COLS
+    return [r for r in layout if r]
+
+
+def _neighbour(layout: list[list[str]], rng: random.Random) -> list[list[str]]:
+    new = [row[:] for row in layout]
+    flat = [(r, c) for r, row in enumerate(new) for c in range(len(row))]
+    move = rng.random()
+    if move < 0.6 and len(flat) >= 2:
+        (r1, c1), (r2, c2) = rng.sample(flat, 2)
+        new[r1][c1], new[r2][c2] = new[r2][c2], new[r1][c1]
+    else:
+        r1, c1 = rng.choice(flat)
+        key = new[r1].pop(c1)
+        tgt = rng.randrange(len(new))
+        if len(new[tgt]) >= COLS:
+            tgt = r1
+        new[tgt].insert(rng.randint(0, len(new[tgt])), key)
+        new = [r for r in new if r]
+    return new if valid(new) else layout
+
+
+def optimise(variant: Variant, seed: int, iters: int) -> tuple[list[list[str]], float]:
+    rng = random.Random(seed)
+    best_layout: list[list[str]] | None = None
+    best_cost = math.inf
+    keys = list(variant.buttons)
+    for restart in range(4):
+        cur = _random_layout(keys, random.Random(seed + restart * 101))
+        cur_cost = total_cost(variant, cur)
+        t = 3.0
+        for i in range(iters):
+            t = 3.0 * (1.0 - i / iters) + 0.01
+            cand = _neighbour(cur, rng)
+            cc = total_cost(variant, cand)
+            if cc < cur_cost or rng.random() < math.exp((cur_cost - cc) / max(t, 1e-6)):
+                cur, cur_cost = cand, cc
+            if cur_cost < best_cost:
+                best_layout, best_cost = [r[:] for r in cur], cur_cost
+    if best_layout is None:  # pragma: no cover - always set on the first iteration
+        raise RuntimeError("optimise: no layout found")
+    return best_layout, best_cost
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+def render(variant: Variant, layout: list[list[str]]) -> str:
+    lines = []
+    for r, row in enumerate(layout):
+        cells = " ".join(f"[{variant.label_of(k)}]" for k in row)
+        lines.append(f"    row {r}: {cells}")
+    return "\n".join(lines)
+
+
+def journey_table(
+    variant: Variant,
+    layout: list[list[str]],
+) -> list[tuple[str, float, int, float]]:
+    pos = positions(layout)
+    rows = []
+    for j in JOURNEYS:
+        rows.append(
+            (
+                j.name,
+                j.weight,
+                len(_submenu_grid_sequence(j, variant)),
+                journey_cost(j, variant, pos),
+            ),
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Role-menu builder layout simulation.")
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--iters", type=int, default=12000)
+    args = parser.parse_args()
+
+    print("=" * 78)
+    print("ROLE-MENU BUILDER — BUTTON-LAYOUT SIMULATION")
+    print(f"inventory: {len(BUTTONS)} buttons · {len(JOURNEYS)} weighted journeys")
+    print(
+        f"grid: <={COLS}/row, <={MAX_ROWS} rows · seed={args.seed} iters={args.iters}",
+    )
+    print("=" * 78)
+
+    base = VARIANTS[0]
+    cur_cost = total_cost(base, CURRENT_LAYOUT)
+    print("\nCURRENT live layout:")
+    print(render(base, CURRENT_LAYOUT))
+    print(f"    cost = {cur_cost:.2f}   mean grid-taps/journey = {mean_taps(base):.2f}")
+
+    print("\nOptimising each function-set variant (lower cost = better):\n")
+    print(
+        f"  {'variant':<16} {'top-btns':<9} {'best cost':<11} {'vs current':<11} mean-taps",
+    )
+    results = []
+    for v in VARIANTS:
+        layout, cost = optimise(v, args.seed, args.iters)
+        results.append((v, layout, cost))
+        delta = (cost - cur_cost) / cur_cost * 100.0
+        print(
+            f"  {v.name:<16} {len(v.buttons):<9} {cost:<11.2f} "
+            f"{delta:+6.1f}%     {mean_taps(v):.2f}",
+        )
+
+    results.sort(key=lambda t: t[2])
+    win_v, win_layout, win_cost = results[0]
+
+    print("\n" + "=" * 78)
+    print("RECOMMENDATION")
+    print("=" * 78)
+    improve = (cur_cost - win_cost) / cur_cost * 100.0
+    print(
+        f"\n  Best: '{win_v.name}'  —  cost {win_cost:.2f} "
+        f"({improve:+.1f}% vs current {cur_cost:.2f})\n",
+    )
+    print(render(win_v, win_layout))
+    print("\n  per-journey cost (winner vs current base layout):\n")
+    print(f"    {'journey':<20} {'weight':<7} {'taps':<5} {'winner':<9} current")
+    cur_pos_v = base
+    cur_rows = journey_table(cur_pos_v, CURRENT_LAYOUT)
+    win_rows = journey_table(win_v, win_layout)
+    cur_by = {r[0]: r for r in cur_rows}
+    for name, w, taps, wc in win_rows:
+        cc = cur_by.get(name, (name, w, taps, float("nan")))[3]
+        print(f"    {name:<20} {w:<7.2f} {taps:<5} {wc:<9.2f} {cc:.2f}")
+
+    # Also surface the best pure-placement result (base function set) — the
+    # low-risk change (just reorder), separate from any function folding.
+    base_layout, base_cost = optimise(base, args.seed, args.iters)
+    print("\n  Low-risk option (keep all 14 buttons, only re-order):")
+    print(
+        f"    cost {base_cost:.2f} ({(cur_cost - base_cost) / cur_cost * 100:+.1f}% vs current)",
+    )
+    print(render(base, base_layout))
+
+    print(
+        "\n  NOTE: 'optimal' reflects the journey weights + cost model above "
+        "(documented,\n  tunable). Re-run with --seed/--iters to confirm the "
+        "winner is stable.",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

The owner asked, after the builder preview-fix: *"create a simulation to find out the most optimal
button placements and functions."* This adds a real optimizer for the reaction-role **menu builder's**
button layout — objective analysis instead of gut feel — in the existing `tools/sim/` precedent
(`help_menu_grouping_sim`, `setup_wizard_sim`).

## The simulation (`tools/sim/role_menu_layout_sim.py`)

Models three things, all transparent + tunable:
- **Inventory** — the 14 live builder buttons + their groups (drift-guarded against
  `role_menu_builder.py`).
- **Journeys** — weighted operator tasks (RSVP, colour roles, game roles, notifications, verify gate, a
  fully-custom build, edit-a-field), leading with the RSVP/self-role cases; templates short-circuit
  config, so most journeys start at Template and never touch Mode/Limit/Style/Counts.
- **Cost** — per journey: prominence (top-left is found fastest), travel (row jumps cost more than
  column steps), and a submenu-open penalty when a function is folded behind a grouping button. Plus
  layout terms that keep a group's buttons contiguous and put Post/Back in their submit/back corners.

It runs seeded simulated annealing (deterministic — no live RNG) over both the **arrangement** and a few
**function-set variants** (fold rarely-tapped knobs behind one grouping button), ranks them, prints the
winning grid, and lists the per-journey tap cost vs. the current layout.

## Findings (stable across seeds)

- **Current** 14-button / 3-row builder: cost ~34. It leads with rarely-tapped knobs
  (Theme/Mode/Style/Limit) and scatters the hot content buttons.
- **Low-risk** — keep all 14, only re-order (content on row 0, Post bottom-right): **~ −45%**.
- **Best — "lean_advanced"**: fold the six rarely-tapped knobs (Theme/Card/Counts/Style/Mode/Limit)
  behind one **⚙️ Advanced** button → a clean **9-button / 2-row** builder: **~ −55%**.

  ```
  row 0: [🧩 Template] [📦 Packs] [🏷️ Roles] [📝 Text] [🎨 Colours]
  row 1: [↩ Back] [📍 Channel] [⚙️ Advanced] [🚀 Post]
  ```

The lean layout is a **product call** (it hides six functions behind Advanced — the RSVP template
already sets Style/Counts/Mode, so the common path never needs them); the re-order is a safe mechanical
win. **This PR only *finds* the layout — it doesn't change the builder.** Adopting either is a
follow-up I'll do once you pick.

## Scope

`tools/sim/` + a `tests/unit/tools/` guard (inventory drift-guard against the live builder, determinism,
"optimiser beats current", model-orientation sanity). Read-only, stdlib-only, disposable advisory tool.
No runtime change, no migration. Full CI mirror green (13550 passed).

## Status

Born-red (`in-progress` card) until CI is green, then flipped to `complete` (Q-0133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENiR31Pj63NF8ZmDVVUGTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENiR31Pj63NF8ZmDVVUGTL)_