### PR TITLE
sim(roles): pin Style first-screen in the builder layout sim

### DIFF
--- a/.sessions/2026-07-01-role-menu-layout-sim-pin-style.md
+++ b/.sessions/2026-07-01-role-menu-layout-sim-pin-style.md
@@ -1,6 +1,7 @@
 # 2026-07-01 — Layout sim: pin Style first-screen (owner correction)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Run type: manual · owner-directed.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: manual · owner-directed.
+> Full CI mirror green (**13576 passed**; lint clean; arch 0 new). PR #1613.
 
 **Branch:** `claude/reaction-roles-counter-bgxnyd` (restarted from `main` @ #1612 — the sim merged).
 

--- a/.sessions/2026-07-01-role-menu-layout-sim-pin-style.md
+++ b/.sessions/2026-07-01-role-menu-layout-sim-pin-style.md
@@ -1,0 +1,76 @@
+# 2026-07-01 — Layout sim: pin Style first-screen (owner correction)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Run type: manual · owner-directed.
+
+**Branch:** `claude/reaction-roles-counter-bgxnyd` (restarted from `main` @ #1612 — the sim merged).
+
+## What I'm about to do (intentions)
+
+Owner corrected the layout sim's recommendation: **"the style button should definitely be visible on
+the first screen."** My model had treated Style (dropdown-vs-buttons) as a rarely-tapped knob (because
+the RSVP template sets it) and folded it behind Advanced — but Style is a **primary, up-front choice**
+about the menu's whole shape, so it belongs first-screen. Encode that in the sim:
+
+1. A `PINNED_FIRST_SCREEN = {"style"}` set — pinned buttons are never folded (the fold-builder skips
+   them) and get a row-0 pull via a new `pin_penalty` (LAMBDA_PIN).
+2. Surface Style as a real up-front choice in the colour + game journeys (dropdown-vs-buttons is a
+   genuine early decision there).
+3. Re-run + update the docstring FINDINGS + tests.
+
+## What shipped
+
+Encoded the owner's "Style stays first-screen" directive in the layout sim + re-optimised:
+
+1. **`tools/sim/role_menu_layout_sim.py`** — `PINNED_FIRST_SCREEN = {"style"}` (never folded, `LAMBDA_PIN`
+   row-0 pull via `pin_penalty`); the fold-builder now skips pinned members, so `lean_advanced` folds
+   five knobs (Theme/Card/Counts/Mode/Limit) and **keeps Style visible**. Style added to the colour +
+   game journeys (a real up-front choice there). Docstring FINDINGS refreshed.
+2. **`tests/unit/tools/test_role_menu_layout_sim.py`** — updated the fold test (Style no longer folded)
+   + a new guard that **every** optimised variant places Style on row 0.
+
+**Corrected result (stable across seeds 1/2/7):** current ≈ 40. **lean_advanced (~ −52%)** —
+`row0: Template Packs Roles Style Text · row1: Back Colours Channel Advanced Post` (Advanced hides the
+five knobs; Style stays row 0). **Low-risk re-order (~ −42%)** keeps all 14, Style on row 0. Advisory —
+still doesn't change the builder.
+
+## Context delta
+
+- **Discovered:** the owner's correction is exactly the "verify the model against real knowledge" loop —
+  my journey weights treated Style as template-set/rarely-tapped, but dropdown-vs-buttons is a *primary*
+  choice. The `PINNED_FIRST_SCREEN` mechanism is deliberately general (extensible to Counts/others if the
+  owner wants more pinned) rather than a one-off Style hack.
+- **Decisions made alone (reversible):** pinned Style to **row 0** (not just "not folded") since "first
+  screen" means visible up-front; added it to two journeys to reflect genuine usage.
+- **🛠 Friction → guard:** the new "Style on row 0 in every variant" test locks the directive in — the
+  sim can't silently re-fold Style on a future weight tweak.
+
+## 💡 Session idea (Q-0089)
+
+Contributed in the parent sim session (instrument builder button-presses → data-driven weights). Per
+Q-0089 (one genuine idea per session, not per follow-up commit), no forced second idea here — the
+data-driven-weights idea is the direct answer to "is Style really first-screen-worthy?" and stands.
+
+## ⟲ Previous-session review (Q-0102)
+
+Predecessor is the parent **layout-sim PR (#1612)**. **Did well:** transparent, tunable model with a
+documented cost function + stability check across seeds. **What this correction proves it missed:** it
+shipped a recommendation (fold Style) that contradicted the owner's real UX intent — because the journey
+weights were my estimates, unverified against how the owner actually thinks about the builder. **System
+note:** advisory sims should ideally surface their most load-bearing assumptions for a quick owner
+gut-check *before* the recommendation is presented as "optimal" — the Q-0089 instrumentation idea is the
+durable fix, but even a one-line "key assumptions" callout in the report would have flagged the Style
+weight for correction sooner.
+
+## 📤 Run report
+
+- **Did:** encoded the owner's Style-first-screen correction into the layout sim (pin + re-weight) and
+  re-optimised. · **Outcome:** shipped (advisory tool; no UI change)
+- **Shipped:** PR (this) — sim(roles): pin Style first-screen + re-optimise
+- **Run type:** `manual · owner-directed`
+- **Class:** tooling / analysis (read-only, disposable, test-guarded)
+- **⚑ Owner decisions needed:** still the adopt choice — lean (−52%, Style visible) vs safe re-order
+  (−42%) vs hold.
+- **⚑ Owner manual steps:** none (no runtime change).
+- **⚑ Self-initiated:** no — owner-directed correction.
+- **↪ Next:** adopt the chosen layout in `role_menu_builder.py`; the Q-0089 press-instrumentation for
+  data-driven weights.

--- a/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
+++ b/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
@@ -1,1 +1,0 @@
- - `claude/reaction-roles-counter-bgxnyd` · **layout sim — pin Style first-screen** — owner correction: Style must stay visible (never folded); re-optimise · `tools/sim/role_menu_layout_sim.py` `tests/unit/tools/test_role_menu_layout_sim.py` · 2026-07-01 · in-progress

--- a/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
+++ b/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
@@ -1,0 +1,1 @@
+ - `claude/reaction-roles-counter-bgxnyd` · **layout sim — pin Style first-screen** — owner correction: Style must stay visible (never folded); re-optimise · `tools/sim/role_menu_layout_sim.py` `tests/unit/tools/test_role_menu_layout_sim.py` · 2026-07-01 · in-progress

--- a/tests/unit/tools/test_role_menu_layout_sim.py
+++ b/tests/unit/tools/test_role_menu_layout_sim.py
@@ -80,9 +80,20 @@ def test_cost_model_rewards_hot_buttons_top_left(mod):
 
 def test_lean_advanced_variant_folds_the_rare_knobs(mod):
     lean = next(v for v in mod.VARIANTS if v.name == "lean_advanced")
-    # The six rarely-tapped knobs are hidden behind one grid button.
-    for folded in ("theme", "card", "counts", "style", "mode", "limit"):
+    # The rarely-tapped knobs are hidden behind one grid button …
+    for folded in ("theme", "card", "counts", "mode", "limit"):
         assert lean.grid_key(folded) == "advanced"
-    # …and the hot content buttons stay top-level.
+    # … but Style is pinned first-screen (owner directive) — never folded …
+    assert lean.grid_key("style") == "style"
+    # … and the hot content buttons stay top-level too.
     for hot in ("template", "packs", "roles", "post"):
         assert lean.grid_key(hot) == hot
+
+
+def test_pinned_style_stays_on_the_first_screen(mod):
+    """Every optimised variant must place Style on row 0 (owner directive)."""
+    assert "style" in mod.PINNED_FIRST_SCREEN
+    for v in mod.VARIANTS:
+        layout, _cost = mod.optimise(v, seed=1, iters=1500)
+        pos = mod.positions(layout)
+        assert pos["style"][0] == 0, f"{v.name}: Style not on row 0 ({pos['style']})"

--- a/tools/sim/role_menu_layout_sim.py
+++ b/tools/sim/role_menu_layout_sim.py
@@ -37,24 +37,27 @@ Stdlib only. Read-only. Deterministic (seeded).
 
 FINDINGS (seed 1, stable across seeds 1/2/7; re-run to confirm)
 ---------------------------------------------------------------
-The CURRENT 14-button / 3-row builder scores ~34.1. It leads with rarely-tapped
-knobs (Theme/Mode/Style/Limit on the top two rows) and scatters the hot content
+The CURRENT 14-button / 3-row builder scores ~40. It leads with rarely-tapped
+knobs (Theme/Mode/Limit on the top two rows) and scatters the hot content
 buttons, so the common RSVP/self-role tasks pay for buttons they never press.
 
-Two improvements, both re-order the hot content buttons (Template/Packs/Roles/
-Text/Colours) onto row 0 and drop Post to the bottom-right (submit convention):
+Style is PINNED first-screen (owner directive, 2026-07-01: dropdown-vs-buttons is
+a primary choice), so every recommendation keeps it visible on row 0.
 
-  * LOW-RISK — keep all 14 buttons, only re-order:               ~ -45% cost.
-  * BEST — "lean_advanced": fold the six rarely-tapped knobs
-    (Theme/Card/Counts/Style/Mode/Limit) behind one ⚙️ Advanced
-    button → a 9-button / 2-row builder:                          ~ -55% cost.
-        row 0: [🧩 Template] [📦 Packs] [🏷️ Roles] [📝 Text] [🎨 Colours]
-        row 1: [↩ Back] [📍 Channel] [⚙️ Advanced] [🚀 Post]
+Two improvements, both re-order the hot content buttons onto row 0 with Style, and
+drop Post to the bottom-right (submit convention):
 
-The lean layout is a product call (it hides six functions behind Advanced — the
-RSVP template already sets Style/Counts/Mode, so the common path never needs
-them); the re-order is a safe, mechanical win. Adopting either is a follow-up —
-this file only *finds* the layout; it doesn't change the builder.
+  * LOW-RISK — keep all 14 buttons, only re-order:               ~ -42% cost.
+  * BEST — "lean_advanced": fold the five rarely-tapped knobs
+    (Theme/Card/Counts/Mode/Limit) behind one ⚙️ Advanced button
+    (Style stays visible) → a 10-button / 2-row builder:          ~ -52% cost.
+        row 0: [🧩 Template] [📦 Packs] [🏷️ Roles] [🎚️ Style] [📝 Text]
+        row 1: [↩ Back] [🎨 Colours] [📍 Channel] [⚙️ Advanced] [🚀 Post]
+
+The lean layout is a product call (it hides five functions behind Advanced — the
+RSVP template already sets Counts/Mode, so the common path never needs them); the
+re-order is a safe, mechanical win. Adopting either is a follow-up — this file
+only *finds* the layout; it doesn't change the builder.
 
 Provenance: added 2026-07-01 for the owner-directed builder-layout question
 (follow-on to the reaction-roles counter/roster/preview-fix arc, #1570/#1571/#1608).
@@ -85,6 +88,7 @@ COL_W = 1.0
 OPEN_COST = 6.0  # opening a grouping submenu ~ crossing 6 index units of friction
 LAMBDA_GROUP = 0.6  # keep a function group's buttons contiguous
 LAMBDA_CONV = 1.6  # Post -> bottom-right (submit), Back -> bottom-left (convention)
+LAMBDA_PIN = 3.0  # a first-screen-pinned button (Style) belongs on row 0
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +124,12 @@ BUTTONS: list[Button] = [
 ]
 BY_KEY = {b.key: b for b in BUTTONS}
 
+# Buttons the owner wants VISIBLE ON THE FIRST SCREEN — never folded behind a
+# grouping button, and pulled to row 0. Style (dropdown vs buttons) is a primary,
+# up-front choice about the menu's whole shape, so it stays first-screen even
+# though the RSVP template pre-sets it (owner directive, 2026-07-01).
+PINNED_FIRST_SCREEN: set[str] = {"style"}
+
 # The CURRENT live layout (row-by-row, mirrors the decorators' row= values).
 CURRENT_LAYOUT: list[list[str]] = [
     ["text", "roles", "colours", "packs", "template"],  # row 0
@@ -143,8 +153,10 @@ JOURNEYS: list[Journey] = [
     # style=buttons, mode=unique, counts=on, so those are NOT tapped here.
     Journey("rsvp_event", 0.24, ("template", "packs", "channel", "post")),
     Journey("rsvp_quick", 0.06, ("template", "packs", "post")),
-    Journey("colour_roles", 0.15, ("template", "colours", "post")),
-    Journey("game_roles", 0.14, ("template", "roles", "text", "post")),
+    # Non-RSVP self-role menus: dropdown-vs-buttons is a real up-front choice, so
+    # Style IS tapped here (owner: Style belongs on the first screen, 2026-07-01).
+    Journey("colour_roles", 0.15, ("template", "colours", "style", "post")),
+    Journey("game_roles", 0.14, ("template", "roles", "style", "text", "post")),
     Journey("notification_roles", 0.12, ("template", "packs", "post")),
     Journey("verify_gate", 0.06, ("template", "roles", "post")),
     # The rare power-user path that actually touches every knob.
@@ -200,6 +212,8 @@ def _folded_variant(name: str, folds: dict[str, tuple[str, str, list[str]]]) -> 
     for new_key, (label, _group, members) in folds.items():
         labels[new_key] = label
         for m in members:
+            if m in PINNED_FIRST_SCREEN:
+                continue  # a first-screen-pinned button is never folded
             fold_map[m] = new_key
             folded_members.add(m)
     top = [b.key for b in BUTTONS if b.key not in folded_members]
@@ -227,8 +241,9 @@ VARIANTS: list[Variant] = [
             "rules": ("⚙️ Rules", "behaviour", ["mode", "limit"]),
         },
     ),
-    # Aggressive: one "Advanced" button hides every rarely-tapped knob
-    # (theme/card/counts/style/mode/limit) so the top level is the hot path only.
+    # Aggressive: one "Advanced" button hides the rarely-tapped knobs so the top
+    # level is the hot path only. Style is PINNED first-screen, so it is NOT folded
+    # here even though it is listed (the fold-builder skips pinned members).
     _folded_variant(
         "lean_advanced",
         {
@@ -318,6 +333,11 @@ def group_penalty(variant: Variant, pos: dict[str, tuple[int, int]]) -> float:
     return pen
 
 
+def pin_penalty(pos: dict[str, tuple[int, int]]) -> float:
+    """First-screen-pinned buttons (Style) belong on row 0 (owner directive)."""
+    return float(sum(pos[k][0] for k in PINNED_FIRST_SCREEN if k in pos))
+
+
 def convention_penalty(
     variant: Variant,
     layout: list[list[str]],
@@ -340,6 +360,7 @@ def total_cost(variant: Variant, layout: list[list[str]]) -> float:
     cost = sum(j.weight * journey_cost(j, variant, pos) for j in JOURNEYS)
     cost += LAMBDA_GROUP * group_penalty(variant, pos)
     cost += LAMBDA_CONV * convention_penalty(variant, layout, pos)
+    cost += LAMBDA_PIN * pin_penalty(pos)
     return cost
 
 


### PR DESCRIPTION
## What & why

Owner correction to the just-merged layout sim (#1612): *"the style button should definitely be visible
on the first screen."* My model had treated **Style** (dropdown-vs-buttons) as a rarely-tapped knob —
because the RSVP template pre-sets it — and folded it behind ⚙️ Advanced. But Style is a **primary,
up-front choice** about the menu's whole shape, so it belongs first-screen. This encodes that.

## Changes

- **`PINNED_FIRST_SCREEN = {"style"}`** — pinned buttons are never folded (the fold-builder skips them)
  and get a row-0 pull via a new `pin_penalty` (`LAMBDA_PIN`). The mechanism is general (extensible if
  you want more buttons pinned later).
- Style is now tapped in the **colour** + **game** journeys (dropdown-vs-buttons is a genuine early
  decision for those non-RSVP self-role menus), so the model *values* it, not just places it.
- Docstring FINDINGS + tests updated (the fold test no longer expects Style folded; a new guard asserts
  **every** optimised variant places Style on row 0).

## Corrected result (stable across seeds 1/2/7)

Current ≈ 40. Both options now keep **Style visible on row 0**:

- **Low-risk re-order** (all 14 buttons): ~ **−42%**.
- **Best — "lean_advanced"**: fold the *five* rarely-tapped knobs (Theme/Card/Counts/Mode/Limit) behind
  ⚙️ Advanced — **Style stays visible** → 10 buttons / 2 rows: ~ **−52%**.

  ```
  row 0: [🧩 Template] [📦 Packs] [🏷️ Roles] [🎚️ Style] [📝 Text]
  row 1: [↩ Back] [🎨 Colours] [📍 Channel] [⚙️ Advanced] [🚀 Post]
  ```

Still advisory — this doesn't change the builder. Adopting a layout is the next step once you pick.

## Scope

`tools/sim/` + its `tests/unit/tools/` guard. Read-only, stdlib-only, no runtime change, no migration.
Full CI mirror green (13576 passed).

## Status

Born-red (`in-progress` card) until CI is green, then flipped to `complete` (Q-0133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENiR31Pj63NF8ZmDVVUGTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENiR31Pj63NF8ZmDVVUGTL)_