### PR TITLE
feat(roles): slim (lean) menu-builder layout

### DIFF
--- a/.sessions/2026-07-01-role-menu-builder-lean-layout.md
+++ b/.sessions/2026-07-01-role-menu-builder-lean-layout.md
@@ -1,0 +1,86 @@
+# 2026-07-01 — Role-menu builder "slim" lean layout
+
+> **Status:** `in-progress` — born-red card (Q-0133). Run type: manual · owner-directed.
+
+**Branch:** `claude/reaction-roles-counter-bgxnyd` (restarted from `main` @ #1613 — the sim merged).
+
+## What I'm about to do (intentions)
+
+Owner: "Build the slim version now." Adopt the layout the sim (#1612/#1613) recommended into the actual
+builder — the lean 2-row layout with the five rarely-tapped knobs folded behind a new ⚙️ Advanced
+sub-panel, Style kept first-screen.
+
+## What shipped
+
+The reaction-role menu builder went from **14 buttons / 3 rows** to a **lean 2-row** layout:
+
+- **`disbot/views/roles/role_menu_builder.py`:**
+  - **Row 0** (hot content): 🧩 Template · 📦 Packs · 🏷️ Roles · 🎚️ Style · 📝 Text.
+  - **Row 1**: 🎨 Colours · 📍 Channel · ⚙️ Advanced · 🚀 Post · ↩ Back (Back moved row 2→1).
+  - New **`_AdvancedView`** sub-panel (opened by ⚙️ Advanced) holds the five folded controls —
+    🎭 Theme · ⚙️ Mode · 🔢 Limit · 🖼️ Card · 📊 Counts — reusing the existing pickers/modals. Their
+    current values still show on the **main preview** (the builder's Settings field), which updates live.
+  - **Style stays top-level** (owner directive — dropdown-vs-buttons is a primary choice).
+  - Fixed `_LimitModal.on_submit` + the folded Counts toggle to refresh the **main** preview via the
+    builder's stored panel interaction (`_rerender`), since they're now opened from the sub-panel (their
+    own interaction is on the sub-panel message, not the main one).
+- **`architecture_rules/consistency_exceptions.yml`:** repointed the `edit_in_place` allowlist entries
+  for the folded controls to `_AdvancedView`, added `RoleMenuBuilder.advanced_btn` (all open genuine
+  ephemeral sub-flows, the same idiom as the other allowlisted pickers).
+- **Tests (+3):** top-level buttons are the lean set (Style present, the five knobs absent); `_AdvancedView`
+  holds exactly the five folded controls; the Advanced Counts toggle flips the builder flag. The existing
+  row-cap guard confirms both rows ≤ 5.
+
+No change to what gets **posted** — only the builder's button surface. No migration, no new commands.
+
+## Why this is contained / safe
+
+Pure UI-surface reorganisation of the builder; all the underlying flows (pickers, modals, commit,
+`_rerender`) are reused unchanged. The row-cap test + consistency allowlist guard the structural risks.
+Needs a live re-test (open `!roles` → Reaction Roles → Role Menus → New Menu; confirm the two rows render
+and ⚙️ Advanced opens the five controls). Full CI mirror green (13598 passed).
+
+## Context delta
+
+- **Discovered:** the `edit_in_place` consistency rule flags every "open a sub-picker via send_message"
+  handler — the existing builder pickers were already allowlisted, so the new `advanced_btn` +
+  `_AdvancedView` pickers needed the same treatment (moving the folded ones' entries to the new class).
+  A good guard: it forced me to consciously mark each new ephemeral-sub-flow as intentional.
+- **Decisions made alone (reversible):** kept Back on the action row after Post (matching the builder's
+  existing Post-then-Back convention) rather than the sim's Back-left nicety; the folded Counts toggle
+  refreshes its own sub-panel in place (immediate feedback) *and* the main preview.
+- **🛠 Friction → guard:** none new — the row-cap test + the `edit_in_place` consistency rule already
+  cover the two ways this change could go wrong (a 6th button on a row; an un-allowlisted new-message flow).
+
+## 💡 Session idea (Q-0089)
+
+The builder-press instrumentation idea (data-driven journey weights) from the parent sim sessions stands
+and is now *more* valuable — with the lean layout live, real press counts would confirm whether the
+Advanced fold matches actual usage (e.g. is Counts really rare now that RSVP templates set it?). Per
+Q-0089 (one genuine idea per session, no filler), no second idea here.
+
+## ⟲ Previous-session review (Q-0102)
+
+Predecessor is the **pin-Style sim update (#1613)**. **Did well:** it took the owner's correction and
+encoded it as a *general* mechanism (`PINNED_FIRST_SCREEN`), not a one-off Style hack, so the next pinned
+button is one line. **What this session confirms it set up well:** because the sim already produced the
+exact lean grid (with Style row-0), building it was a mechanical translation — the sim doubled as the
+spec. **System note:** the sim→build handoff worked, but there's no automated check that the *built*
+layout matches the sim's `CURRENT_LAYOUT` constant — a future drift (someone re-orders a button) would
+silently diverge the sim's "current" baseline from reality. A tiny guard asserting the builder's actual
+top-level button set matches the sim's inventory would close that loop (a lean extension of the existing
+drift-guard test).
+
+## 📤 Run report
+
+- **Did:** adopted the sim's lean 2-row builder layout (five knobs folded behind ⚙️ Advanced, Style
+  first-screen). · **Outcome:** shipped (pending live re-test)
+- **Shipped:** PR (this) — the "slim" builder layout
+- **Run type:** `manual · owner-directed`
+- **Class:** UX / feature (builder surface reorganisation; reuses all underlying flows)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** a quick **live re-test** of the builder (two rows render; ⚙️ Advanced opens
+  Theme/Card/Counts/Mode/Limit; each still updates the preview). Merge auto-deploys.
+- **⚑ Self-initiated:** no — owner-directed ("build the slim version now").
+- **↪ Next:** the sim↔builder layout-parity guard noted above; builder-press instrumentation for
+  data-driven weights; the deferred `ReactionRolesPanel._rerender` ephemeral-edit fix.

--- a/.sessions/2026-07-01-role-menu-builder-lean-layout.md
+++ b/.sessions/2026-07-01-role-menu-builder-lean-layout.md
@@ -1,6 +1,7 @@
 # 2026-07-01 — Role-menu builder "slim" lean layout
 
-> **Status:** `in-progress` — born-red card (Q-0133). Run type: manual · owner-directed.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: manual · owner-directed.
+> Full CI mirror green (**13598 passed**; lint/mypy/consistency clean; arch 0 new). PR #1615.
 
 **Branch:** `claude/reaction-roles-counter-bgxnyd` (restarted from `main` @ #1613 — the sim merged).
 

--- a/architecture_rules/consistency_exceptions.yml
+++ b/architecture_rules/consistency_exceptions.yml
@@ -59,12 +59,14 @@ edit_in_place:
       reason: "Opens RolePackView(on_created=_add_pack_roles); the created pack roles fold into the draft via _rerender."
     - pattern: views/roles/role_menu_builder.py::RoleMenuBuilder.template_btn
       reason: "Opens a PaginatedSelectView template picker; _apply_template folds the template into the draft via _rerender."
-    - pattern: views/roles/role_menu_builder.py::RoleMenuBuilder.card_btn
-      reason: "Opens the _CardPickView banner picker; the chosen card applies to the draft via _rerender."
-    - pattern: views/roles/role_menu_builder.py::RoleMenuBuilder.theme_btn
-      reason: "Opens a PaginatedSelectView theme picker; _apply_theme folds the theme into the draft via _rerender."
-    - pattern: views/roles/role_menu_builder.py::RoleMenuBuilder.mode_btn
-      reason: "Opens a PaginatedSelectView mode picker; _apply_mode folds the mode into the draft via _rerender."
+    - pattern: views/roles/role_menu_builder.py::RoleMenuBuilder.advanced_btn
+      reason: "Opens the _AdvancedView sub-panel (the folded Theme/Card/Counts/Mode/Limit controls); its controls fold into the draft via _rerender (lean layout, tools/sim/role_menu_layout_sim.py)."
+    - pattern: views/roles/role_menu_builder.py::_AdvancedView.theme_btn
+      reason: "Opens a PaginatedSelectView theme picker; _apply_theme folds the theme into the draft via the builder's _rerender."
+    - pattern: views/roles/role_menu_builder.py::_AdvancedView.mode_btn
+      reason: "Opens a PaginatedSelectView mode picker; _apply_mode folds the mode into the draft via the builder's _rerender."
+    - pattern: views/roles/role_menu_builder.py::_AdvancedView.card_btn
+      reason: "Opens the _CardPickView banner picker; the chosen card applies to the draft via the builder's _rerender."
     - pattern: views/roles/role_menu_builder.py::RoleMenuBuilder.channel_btn
       reason: "Opens the _ChannelPickView channel picker; the chosen channel applies to the draft via _rerender."
     - pattern: views/server_management/hub.py::ServerManagementHubView.help_editor_btn

--- a/disbot/views/roles/role_menu_builder.py
+++ b/disbot/views/roles/role_menu_builder.py
@@ -494,7 +494,7 @@ class RoleMenuBuilder(BaseView):
                 label="↩ Back",
                 custom_id="role:builder:back",
                 parent_builder=_build_parent,
-                row=2,
+                row=1,
             )
 
     @classmethod
@@ -628,56 +628,32 @@ class RoleMenuBuilder(BaseView):
             await self.message.edit(embed=embed, view=self.parent)
 
     # -- field editors ------------------------------------------------------
+    # Lean layout (owner-approved, tools/sim/role_menu_layout_sim.py, 2026-07-01):
+    #   row 0 = the hot content path (Template · Packs · Roles · Style · Text)
+    #   row 1 = Colours · Channel · ⚙️ Advanced (Theme/Card/Counts/Mode/Limit) ·
+    #           🚀 Post · ↩ Back
+    # Style stays first-screen (a primary dropdown-vs-buttons choice); the
+    # rarely-tapped knobs fold behind ⚙️ Advanced. Method definition order sets
+    # the left-to-right order within each row.
 
-    @discord.ui.button(label="📝 Text", style=discord.ButtonStyle.grey, row=0)
-    async def text_btn(
+    @discord.ui.button(label="🧩 Template", style=discord.ButtonStyle.grey, row=0)
+    async def template_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await interaction.response.send_modal(_TextModal(self))
-
-    @discord.ui.button(label="🏷️ Roles", style=discord.ButtonStyle.grey, row=0)
-    async def roles_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        manageable, _excluded = role_feasibility.manageable_roles(
-            self.guild.roles,
-            bot_member=self.guild.me,
-            actor=(
-                interaction.user
-                if isinstance(interaction.user, discord.Member)
-                else None
+        options = [
+            discord.SelectOption(label=t.label[:100], value=t.key)
+            for t in presentation.templates()
+        ]
+        await interaction.response.send_message(
+            "Start from a template (you can still tweak everything):",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                self._apply_template,
+                placeholder="Pick a starter template…",
             ),
-        )
-        if not manageable:
-            await interaction.response.send_message(
-                "I can't manage any of this server's roles (they're all above my "
-                "highest role). Move my role up, then try again.",
-                ephemeral=True,
-            )
-            return
-        await interaction.response.send_message(
-            "Pick the roles this menu offers (up to 25):",
-            view=_RolePickView(self, manageable),
-            ephemeral=True,
-        )
-
-    @discord.ui.button(label="🎨 Colours", style=discord.ButtonStyle.grey, row=0)
-    async def colours_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if not _can_manage(interaction):
-            await _deny(interaction)
-            return
-        await interaction.response.send_message(
-            "Pick preset colours to auto-create as roles, or **✏️ Custom** for a "
-            "custom colour or gradient — each becomes a role added to this menu:",
-            view=_ColourRolesView(self),
             ephemeral=True,
         )
 
@@ -715,117 +691,68 @@ class RoleMenuBuilder(BaseView):
                 self.role_ids.append(role_id)
         await self._rerender()
 
-    @discord.ui.button(label="🧩 Template", style=discord.ButtonStyle.grey, row=0)
-    async def template_btn(
+    @discord.ui.button(label="🏷️ Roles", style=discord.ButtonStyle.grey, row=0)
+    async def roles_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        options = [
-            discord.SelectOption(label=t.label[:100], value=t.key)
-            for t in presentation.templates()
-        ]
-        await interaction.response.send_message(
-            "Start from a template (you can still tweak everything):",
-            view=PaginatedSelectView(
-                interaction.user,
-                options,
-                self._apply_template,
-                placeholder="Pick a starter template…",
+        manageable, _excluded = role_feasibility.manageable_roles(
+            self.guild.roles,
+            bot_member=self.guild.me,
+            actor=(
+                interaction.user
+                if isinstance(interaction.user, discord.Member)
+                else None
             ),
-            ephemeral=True,
         )
-
-    # Row 2 (the action row, with 🚀 Post + ↩ Back): row 0 filled to Discord's
-    # 5-button cap once the 📦 Packs button landed, so the banner-card toggle sits
-    # next to Post — the last thing you set before posting.
-    @discord.ui.button(label="🖼️ Card", style=discord.ButtonStyle.grey, row=2)
-    async def card_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await interaction.response.send_message(
-            "Add an optional **banner image** above the menu, or set its overlay "
-            "text. Pick **✖️ None** to remove the card:",
-            view=_CardPickView(self),
-            ephemeral=True,
-        )
-
-    @discord.ui.button(label="📊 Counts", style=discord.ButtonStyle.grey, row=2)
-    async def counts_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        """Toggle the live sign-up counter (current holders shown on the menu)."""
-        self.show_counts = not self.show_counts
-        self._panel_interaction = interaction
-        await safe_edit(interaction, embed=self.build_embed(), view=self)
-
-    @discord.ui.button(label="🎭 Theme", style=discord.ButtonStyle.grey, row=1)
-    async def theme_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        options = [
-            discord.SelectOption(
-                label=t.label,
-                value=t.key,
-                default=t.key == self.theme,
+        if not manageable:
+            await interaction.response.send_message(
+                "I can't manage any of this server's roles (they're all above my "
+                "highest role). Move my role up, then try again.",
+                ephemeral=True,
             )
-            for t in presentation.themes()
-        ]
+            return
         await interaction.response.send_message(
-            "Pick an embed theme:",
-            view=PaginatedSelectView(
-                interaction.user,
-                options,
-                self._apply_theme,
-                placeholder="Theme…",
-            ),
+            "Pick the roles this menu offers (up to 25):",
+            view=_RolePickView(self, manageable),
             ephemeral=True,
         )
 
-    @discord.ui.button(label="⚙️ Mode", style=discord.ButtonStyle.grey, row=1)
-    async def mode_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        options = [
-            discord.SelectOption(label=_MODE_LABEL[m], value=m, default=m == self.mode)
-            for m in ("normal", "unique", "verify")
-        ]
-        await interaction.response.send_message(
-            "How should members pick from this menu?",
-            view=PaginatedSelectView(
-                interaction.user,
-                options,
-                self._apply_mode,
-                placeholder="Mode…",
-            ),
-            ephemeral=True,
-        )
-
-    @discord.ui.button(label="🎚️ Style", style=discord.ButtonStyle.grey, row=1)
+    @discord.ui.button(label="🎚️ Style", style=discord.ButtonStyle.grey, row=0)
     async def style_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
+        """Toggle dropdown vs buttons — a first-screen choice (owner directive)."""
         self.style = "button" if self.style == "dropdown" else "dropdown"
         self._panel_interaction = interaction
         await safe_edit(interaction, embed=self.build_embed(), view=self)
 
-    @discord.ui.button(label="🔢 Limit", style=discord.ButtonStyle.grey, row=1)
-    async def limit_btn(
+    @discord.ui.button(label="📝 Text", style=discord.ButtonStyle.grey, row=0)
+    async def text_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await interaction.response.send_modal(_LimitModal(self))
+        await interaction.response.send_modal(_TextModal(self))
+
+    @discord.ui.button(label="🎨 Colours", style=discord.ButtonStyle.grey, row=1)
+    async def colours_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        await interaction.response.send_message(
+            "Pick preset colours to auto-create as roles, or **✏️ Custom** for a "
+            "custom colour or gradient — each becomes a role added to this menu:",
+            view=_ColourRolesView(self),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="📍 Channel", style=discord.ButtonStyle.grey, row=1)
     async def channel_btn(
@@ -848,7 +775,24 @@ class RoleMenuBuilder(BaseView):
             ephemeral=True,
         )
 
-    @discord.ui.button(label="🚀 Post", style=discord.ButtonStyle.green, row=2)
+    @discord.ui.button(label="⚙️ Advanced", style=discord.ButtonStyle.grey, row=1)
+    async def advanced_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Open the folded less-common options (Theme / Card / Counts / Mode / Limit).
+
+        Their current values stay visible on the main preview above; this sub-panel
+        is just the controls, so the top-level builder stays lean.
+        """
+        await interaction.response.send_message(
+            "Fine-tune the less-common options — the menu preview above updates live:",
+            view=_AdvancedView(self),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="🚀 Post", style=discord.ButtonStyle.green, row=1)
     async def post_btn(
         self,
         interaction: discord.Interaction,
@@ -1023,6 +967,119 @@ class RoleMenuBuilder(BaseView):
 # ---------------------------------------------------------------------------
 
 
+class _AdvancedView(BaseView):
+    """The ⚙️ Advanced sub-panel — the less-common menu options folded off the
+    lean two-row builder (Theme / Card / Counts / Mode / Limit).
+
+    Each control edits the builder draft and refreshes the **main preview** via
+    the builder's stored panel interaction (``_rerender``), so the current values
+    stay visible on that preview while the top-level builder stays clean. The
+    pickers/modals reused here are exactly the ones the builder opened when these
+    were top-level buttons.
+    """
+
+    def __init__(self, builder: RoleMenuBuilder) -> None:
+        super().__init__(builder._author, timeout=300)
+        self.builder = builder
+
+    def build_embed(self) -> discord.Embed:
+        counts = "on" if self.builder.show_counts else "off"
+        return discord.Embed(
+            title="⚙️ Advanced options",
+            description=(
+                "Fine-tune the less-common menu options below. Every current value "
+                "is shown on the **menu preview above**, which updates live as you "
+                "change it here.\n\n"
+                f"📊 Sign-up counts: **{counts}** — tap 📊 Counts to toggle."
+            ),
+            color=presentation.theme_color(self.builder.theme),
+        )
+
+    @discord.ui.button(label="🎭 Theme", style=discord.ButtonStyle.grey, row=0)
+    async def theme_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        options = [
+            discord.SelectOption(
+                label=t.label,
+                value=t.key,
+                default=t.key == self.builder.theme,
+            )
+            for t in presentation.themes()
+        ]
+        await interaction.response.send_message(
+            "Pick an embed theme:",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                self.builder._apply_theme,
+                placeholder="Theme…",
+            ),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="⚙️ Mode", style=discord.ButtonStyle.grey, row=0)
+    async def mode_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        options = [
+            discord.SelectOption(
+                label=_MODE_LABEL[m],
+                value=m,
+                default=m == self.builder.mode,
+            )
+            for m in ("normal", "unique", "verify")
+        ]
+        await interaction.response.send_message(
+            "How should members pick from this menu?",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                self.builder._apply_mode,
+                placeholder="Mode…",
+            ),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="🔢 Limit", style=discord.ButtonStyle.grey, row=0)
+    async def limit_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(_LimitModal(self.builder))
+
+    @discord.ui.button(label="🖼️ Card", style=discord.ButtonStyle.grey, row=1)
+    async def card_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_message(
+            "Add an optional **banner image** above the menu, or set its overlay "
+            "text. Pick **✖️ None** to remove the card:",
+            view=_CardPickView(self.builder),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="📊 Counts", style=discord.ButtonStyle.grey, row=1)
+    async def counts_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Toggle the live sign-up counter (current holders shown on the menu)."""
+        self.builder.show_counts = not self.builder.show_counts
+        # Refresh this sub-panel in place (shows the new state) …
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+        # … then the main builder preview via its stored panel interaction.
+        await self.builder._rerender()
+
+
 class _RolePickView(BaseView):
     """Ephemeral windowed multi-role picker feeding the builder draft."""
 
@@ -1102,8 +1159,11 @@ class _LimitModal(discord.ui.Modal, title="Per-member limit"):  # type: ignore[c
             )
             return
         self.builder.max_roles = value
-        self.builder._panel_interaction = interaction
-        await safe_edit(interaction, embed=self.builder.build_embed(), view=self.builder)
+        # Opened from the ⚙️ Advanced sub-panel, so this interaction is NOT the main
+        # panel's — refresh the main preview through the builder's stored token.
+        if not await safe_defer(interaction):
+            return
+        await self.builder._rerender()
 
 
 class _CardPickView(BaseView):

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,14 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Reaction-roles builder — "slim" lean layout** (owner-directed, from the layout sim #1612/#1613) —
+  the role-menu builder went from **14 buttons / 3 rows** (felt dense in a live test) to a **lean 2-row**
+  layout the optimizer recommended: row 0 = Template · Packs · Roles · **Style** · Text; row 1 = Colours ·
+  Channel · **⚙️ Advanced** · Post · Back. The five rarely-tapped knobs (Theme/Card/Counts/Mode/Limit)
+  fold into a new `_AdvancedView` sub-panel (values still shown live on the main preview). Style stays
+  first-screen per owner directive. Reuses the existing pickers; the folded Limit modal + Counts toggle
+  refresh the **main** preview via the stored panel interaction. No change to what posts; +3 tests,
+  consistency allowlist updated.
 - **Utility — user-tier `!ping` + `!botinfo`/`!membercount` + first command/authority tests** (PR #1609,
   completion-first deepening, Utility cert punch #1/#2/#3 CLOSED + #4 advanced) — resolved the
   declared-but-unimplemented `utility.tool.ping` capability by adding a real **user-tier `!ping`** (gateway

--- a/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
+++ b/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
@@ -1,1 +1,0 @@
- - `claude/reaction-roles-counter-bgxnyd` · **role-menu builder lean layout** — adopt the sim's "slim" 2-row layout: fold rare knobs behind ⚙️ Advanced, keep Style first-screen · `disbot/views/roles/role_menu_builder.py` `architecture_rules/consistency_exceptions.yml` · 2026-07-01 · in-progress

--- a/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
+++ b/docs/owner/claims/claude__reaction-roles-counter-bgxnyd.md
@@ -1,0 +1,1 @@
+ - `claude/reaction-roles-counter-bgxnyd` · **role-menu builder lean layout** — adopt the sim's "slim" 2-row layout: fold rare knobs behind ⚙️ Advanced, keep Style first-screen · `disbot/views/roles/role_menu_builder.py` `architecture_rules/consistency_exceptions.yml` · 2026-07-01 · in-progress

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -139,6 +139,17 @@
 > `RoleMenuListView._rerender` got the same one-liner (stale list after delete/repost). Lesson for any
 > ephemeral multi-step panel: **never refresh via `Message.edit()` — use the interaction token.**
 >
+> **▶ Refinement (2026-07-01, owner-directed — the "slim" builder, sim #1612/#1613 → PR):** the builder
+> was **14 buttons over 3 rows** and felt dense in a live test. A layout optimizer
+> (`tools/sim/role_menu_layout_sim.py`) modelled the buttons + weighted operator journeys + a UX cost
+> model and recommended a **lean two-row layout** — adopted here: **row 0** = Template · Packs · Roles ·
+> **Style** · Text (the hot content path; Style stays first-screen per owner directive — dropdown-vs-
+> buttons is a primary choice); **row 1** = Colours · Channel · **⚙️ Advanced** · Post · Back. The five
+> rarely-tapped knobs (Theme / Card / Counts / Mode / Limit) fold into a new **`_AdvancedView`** sub-panel
+> (their current values still show on the main preview, which updates live). Reuses the existing pickers/
+> modals; `_LimitModal` + the folded Counts toggle refresh the **main** preview via the builder's stored
+> panel interaction (`_rerender`), not their own sub-panel interaction. No behaviour change to what posts.
+>
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
 > add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,

--- a/tests/unit/views/test_reaction_roles_refinement.py
+++ b/tests/unit/views/test_reaction_roles_refinement.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import discord
 import pytest
 
 from views.roles import reaction_panel
-from views.roles.role_menu_builder import RoleMenuBuilder
+from views.roles.role_menu_builder import _AdvancedView, RoleMenuBuilder
 
 
 class _FakeRole:
@@ -217,6 +218,51 @@ async def test_apply_template_sets_mode_and_counts_from_template() -> None:
     assert builder.style == "button"
     assert builder.mode == "unique"
     assert builder.show_counts is True
+
+
+def _button_labels(view) -> list[str]:
+    return [c.label for c in view.children if isinstance(c, discord.ui.Button)]
+
+
+def test_lean_builder_keeps_hot_buttons_and_style_first_screen() -> None:
+    """The lean layout keeps content + Style top-level and folds the rare knobs."""
+    builder = _counter_builder()
+    labels = _button_labels(builder)
+    for present in (
+        "🧩 Template",
+        "📦 Packs",
+        "🏷️ Roles",
+        "🎚️ Style",  # Style stays first-screen (owner directive)
+        "📝 Text",
+        "🎨 Colours",
+        "📍 Channel",
+        "⚙️ Advanced",
+        "🚀 Post",
+    ):
+        assert present in labels, present
+    # The five rarely-tapped knobs are no longer top-level (folded into Advanced).
+    for folded in ("🎭 Theme", "⚙️ Mode", "🔢 Limit", "🖼️ Card", "📊 Counts"):
+        assert folded not in labels, folded
+
+
+def test_advanced_view_holds_exactly_the_folded_controls() -> None:
+    builder = _counter_builder()
+    labels = set(_button_labels(_AdvancedView(builder)))
+    assert labels == {"🎭 Theme", "⚙️ Mode", "🔢 Limit", "🖼️ Card", "📊 Counts"}
+
+
+@pytest.mark.asyncio
+async def test_advanced_counts_toggle_flips_builder_flag() -> None:
+    builder = _counter_builder()
+    builder.show_counts = False
+    adv = _AdvancedView(builder)
+    counts = next(c for c in adv.children if getattr(c, "label", None) == "📊 Counts")
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(edit_message=AsyncMock()),
+    )
+    await counts.callback(interaction)
+    assert builder.show_counts is True
+    interaction.response.edit_message.assert_awaited_once()
 
 
 def test_builder_keeps_every_action_row_within_discords_five_button_cap() -> None:


### PR DESCRIPTION
## What & why

Owner: *"build the slim version now."* Adopts the layout the optimizer (#1612/#1613) recommended into
the actual reaction-role **menu builder**, which was 14 buttons over 3 rows and felt dense in a live
test.

## The lean layout

```
row 0: [🧩 Template] [📦 Packs] [🏷️ Roles] [🎚️ Style] [📝 Text]
row 1: [🎨 Colours] [📍 Channel] [⚙️ Advanced] [🚀 Post] [↩ Back]
```

- **Row 0 = the hot content path.** **Style stays first-screen** (your directive — dropdown-vs-buttons
  is a primary choice).
- The **five rarely-tapped knobs** (Theme / Card / Counts / Mode / Limit) fold into a new
  **⚙️ Advanced** sub-panel. Their current values still show on the **main preview** (the Settings
  field), which updates live as you change them.

## How it works

- New **`_AdvancedView`** holds the five folded controls, reusing the exact pickers/modals they used as
  top-level buttons.
- Because those controls now open from the sub-panel, `_LimitModal.on_submit` and the folded Counts
  toggle refresh the **main** preview via the builder's stored panel interaction (`_rerender`) rather
  than their own sub-panel interaction (the ephemeral-edit fix from #1608 generalised).
- `architecture_rules/consistency_exceptions.yml`: the `edit_in_place` allowlist entries for the folded
  controls were repointed to `_AdvancedView`, and `advanced_btn` added — all open genuine ephemeral
  sub-flows, the same idiom as the other allowlisted pickers.

**No change to what gets posted** — only the builder's button surface. No migration, no new commands.

## Tests

+3: the top-level buttons are the lean set (Style present; the five knobs absent); `_AdvancedView` holds
exactly the five folded controls; the Advanced Counts toggle flips the builder flag. The existing
row-cap guard confirms both rows ≤ 5. Full CI mirror green (13598 passed).

Worth a quick live re-test: `!roles` → Reaction Roles → Role Menus → New Menu → confirm the two rows and
that ⚙️ Advanced opens the five controls (each still updates the preview).

## Status

Born-red (`in-progress` card) until CI is green, then flipped to `complete` (Q-0133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENiR31Pj63NF8ZmDVVUGTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENiR31Pj63NF8ZmDVVUGTL)_