### PR TITLE
BTD6 menu layout simulator + round-range NL answer fix

### DIFF
--- a/.sessions/2026-07-01-btd6-menu-layout-design.md
+++ b/.sessions/2026-07-01-btd6-menu-layout-design.md
@@ -1,0 +1,40 @@
+# 2026-07-01 — BTD6 menu layout design (simulator) + round-range NL answer fix
+
+> **Status:** `in-progress`
+
+**Run type:** `owner-directed`
+
+## What I'm about to do
+
+Owner sent a 40s Discord screen-recording (scrolling the `/btd6` slash autocomplete, which lists
+**both** the mature reference bot **Cyber Quincy** and **SuperBot**) + two panel/response
+screenshots, and asked me to:
+
+1. **Review every frame** and compare Cyber Quincy's command surface to SuperBot's BTD6 menu.
+2. **Build a "simulator" to find the best menu layout** — pack as many useful functions as
+   possible into clear right-sized subdivisions, staying clear without too many button presses.
+3. **Fix a real NL miss:** the question *"list all the bloons from r29 till r63"* only grounded
+   the two endpoint rounds (29 + 62/63), not the whole range.
+
+Plan:
+- **Bug (root fix):** the resolver's `_ROUND_PATTERNS` extract isolated round numbers with no
+  range concept, so a range query grounds only the endpoints. `_ROUND_RANGE_RE` /
+  `round_composition(lo, hi)` already exist (used for cash/RBE totals) — add a deterministic
+  **round-range bloon-listing** builder to `_BTD6_LIST_BUILDERS` + range-composition grounding,
+  and reach the Ask-modal path too (it currently bypasses the list floor). Tests.
+- **Simulator:** a self-contained interactive HTML page rendering the current panel + candidate
+  redesigns (grouped category sub-panels / select-menu hybrid), with a full function inventory
+  (SuperBot's existing slash surface + the Cyber Quincy gaps worth adding) and clicks-to-reach
+  metrics — the maintainer's visualize-first design tool.
+- **Redesign:** implement the recommended grouped layout in `panel.py` (back-compat custom_ids
+  kept) + a design doc.
+
+Aim: ship the bug fix + the simulator + a concrete panel improvement in one session.
+
+## What shipped
+
+_(filled in at close)_
+
+## 📤 Run report
+
+_(filled in at close)_

--- a/.sessions/2026-07-01-btd6-menu-layout-design.md
+++ b/.sessions/2026-07-01-btd6-menu-layout-design.md
@@ -1,40 +1,130 @@
 # 2026-07-01 — BTD6 menu layout design (simulator) + round-range NL answer fix
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** `owner-directed`
 
-## What I'm about to do
+## What I did
 
-Owner sent a 40s Discord screen-recording (scrolling the `/btd6` slash autocomplete, which lists
-**both** the mature reference bot **Cyber Quincy** and **SuperBot**) + two panel/response
-screenshots, and asked me to:
+Owner sent a 40s Discord screen-recording (scrolling the `/btd6` slash autocomplete, which
+lists **both** the mature reference bot **Cyber Quincy** and **SuperBot**) + two screenshots,
+and asked me to review it, build a **simulator to find the best menu layout** (many functions,
+clear subdivisions, few presses), and fix the miss behind *"list all the bloons from r29 till
+r63"* (it only answered the two endpoint rounds).
 
-1. **Review every frame** and compare Cyber Quincy's command surface to SuperBot's BTD6 menu.
-2. **Build a "simulator" to find the best menu layout** — pack as many useful functions as
-   possible into clear right-sized subdivisions, staying clear without too many button presses.
-3. **Fix a real NL miss:** the question *"list all the bloons from r29 till r63"* only grounded
-   the two endpoint rounds (29 + 62/63), not the whole range.
+## What shipped (PR #1617)
 
-Plan:
-- **Bug (root fix):** the resolver's `_ROUND_PATTERNS` extract isolated round numbers with no
-  range concept, so a range query grounds only the endpoints. `_ROUND_RANGE_RE` /
-  `round_composition(lo, hi)` already exist (used for cash/RBE totals) — add a deterministic
-  **round-range bloon-listing** builder to `_BTD6_LIST_BUILDERS` + range-composition grounding,
-  and reach the Ask-modal path too (it currently bypasses the list floor). Tests.
-- **Simulator:** a self-contained interactive HTML page rendering the current panel + candidate
-  redesigns (grouped category sub-panels / select-menu hybrid), with a full function inventory
-  (SuperBot's existing slash surface + the Cyber Quincy gaps worth adding) and clicks-to-reach
-  metrics — the maintainer's visualize-first design tool.
-- **Redesign:** implement the recommended grouped layout in `panel.py` (back-compat custom_ids
-  kept) + a design doc.
+**1 · Round-range NL answer fix (runtime).** Root cause: the resolver's `_ROUND_PATTERNS`
+extract isolated round numbers with no range concept, and the Ask-modal path bypassed the
+deterministic list floor — so a range grounded only its endpoints (rounds 29 + 63).
 
-Aim: ship the bug fix + the simulator + a concrete panel improvement in one session.
+- `round_range_bloon_roster(lo, hi, roundset)` in `services/btd6_data_service.py` — walks every
+  round in the range, returns the distinct bloon types (first/last round, rounds-present, total
+  spawned) + modifiers seen; fails closed on an unknown set/range. Pure, sim-pinnable.
+- `deterministic_round_range_bloons_reply` in `services/btd6_context_service.py` — a new
+  `_BTD6_LIST_BUILDERS` floor that owns the range roster. Fires on one range + a bloon/spawn cue;
+  defers on economy cues (economy builder) and 2+ ranges (comparison builder) — incl. a bare
+  second-range guard so *"which has more bloons, 20-40 or 40-60"* defers. Pinned in the
+  floor-exclusivity invariant corpus (+ an economy-vs-bloon boundary case).
+- `for_list_reply` (`btd6_response_builder.py`) + a `_deterministic_list_floor` check in
+  `btd6_ai_service.answer_question` — the Ask modal / `!btd6 ask` now serve the same authoritative
+  floor the conversational stage already used, instead of the endpoint-only intent.
+- Now: *"list all the bloons from r29 till r63"* → all 35 rounds, all 13 bloon types
+  (Yellow…BFB) with spans + counts. +~30 tests (`test_btd6_round_range_bloons.py`).
 
-## What shipped
+**2 · Menu layout simulator + design study (docs/tooling).**
+- `tools/btd6/menu_layout_simulator.html` — a self-contained, dependency-free interactive tool:
+  the current panel vs. two redesigns (category hub / select hybrid), a data-driven function
+  inventory (SuperBot `have` vs Cyber-Quincy `add` gaps), live clicks-to-reach / coverage /
+  footprint metrics, and clickable ephemeral drill-down. Verified via Playwright screenshots.
+- `docs/btd6/btd6-menu-layout-design-2026-07-01.md` — the written companion: the finding that
+  **SuperBot already owns most of Cyber Quincy's functions but the panel under-surfaces them as a
+  flat 13-button wall**; the ten subdivisions; the **mobile button-truncation finding** (5/row
+  collapses "Events"→"E…", even 4/row clips 6-letter emoji labels); the A/B/C candidates +
+  recommendation (**B, category hub, ≤4/row**); and a back-compat `panel.py` implementation plan.
+  **The B-vs-C pick is left to the owner — the simulator's whole purpose.** Reachable from the
+  btd6 index.
 
-_(filled in at close)_
+CI mirror: `check_quality.py --full` green (13,6xx passed); arch 0; check_docs strict green.
 
 ## 📤 Run report
 
-_(filled in at close)_
+- **Did:** (1) fixed the owner-reported round-range NL miss end-to-end (data primitive + list
+  floor + Ask-path wiring + tests); (2) built the requested menu-layout simulator + a design study
+  with a back-compat implementation plan · **Outcome:** shipped, CI green, auto-merge armed.
+- **Shipped:** #1617.
+- **Run type:** `owner-directed`.
+- **⚑ Owner decisions needed:** the **B-vs-C layout pick** (category hub vs select hybrid) — open
+  the simulator, then tell me which to implement (the panel rewrite is a ready, back-compat PR per
+  the design doc §6). Not blocking.
+- **⚑ Owner manual steps:** none — the bug fix is pure logic, live on next auto-deploy. Re-test in
+  prod: ask the bot *"list all the bloons from r29 till r63"*. The simulator is a static file —
+  open `tools/btd6/menu_layout_simulator.html` in any browser.
+- **⚑ Self-initiated:** the menu **redesign was NOT auto-applied** — deliberately left as a
+  simulator + plan for the owner's visual pick (he designs/visualizes; the sim exists to decide).
+  The round-range fix + the tooling are the owner-directed asks.
+- **↪ Next:** implement the chosen layout (design doc §6 — top-level regroup keeping every legacy
+  `btd6:*` custom_id) → then the `add` backlog (Calculators / Challenge-Index families) as their
+  own slices.
+
+## 💡 Session idea (Q-0089)
+
+**A panel "coverage lint" for slash-vs-panel parity.** This session's core finding — SuperBot
+*owns* ~28 BTD6 functions but the panel only surfaces 13 — was invisible until I hand-inventoried
+the slash tree against the panel buttons. A tiny checker that lists every `@app_commands.command`
+/ registered function in a subsystem and flags the ones with **no panel/menu entry** would turn
+"discoverability drift" into a visible signal for any subsystem (BTD6, mining, economy…), not
+just a thing an agent notices by eye. It's the menu analogue of the existing help-catalogue
+projection. Genuine (it *is* the finding that drove the design study); captured here — it needs
+an owner nod on scope (per-subsystem opt-in) before it becomes a plan.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1596, fishing coral→curios) was a clean completion-first slice with a strong
+self-audit — no complaint. What it (and the recent S1 cadence) **models well and I reused**: the
+"pure, sim-pinnable, no-migration, byte-identical-when-inactive" discipline — my
+`round_range_bloon_roster` follows the same shape (pure data primitive, fails closed, deferring
+floor). **System improvement it surfaced for me:** its own Q-0102 note asked for **inline gate
+tags** (`[offline]`/`[owner]`) on completion punch-lists; I applied that spirit to my run report's
+`↪ Next` and to the design doc, tagging the owner-gated layout pick explicitly so a dispatch run
+can see at a glance what's self-buildable (the `add` backlog) vs. what needs the owner (the B-vs-C
+choice). The chain is auditing itself — the ask from #1596 shaped how I wrote #1617's handoff.
+
+## Doc audit (Q-0104)
+
+- Owner decision to route: the **B-vs-C layout pick** is captured as an explicit owner-gated item
+  in the design doc + run report (not a router Q — it's a product-visual choice the simulator
+  exists to serve, not a durable rule).
+- Ledger: #1617 is the newest merge; the living-ledger reconciliation is the recon routine's job
+  (next pass at #1620) — no drift to fix on sight. Deliberately did **not** hand-add my own
+  unmerged PR to the ledger (the born-red rule's exact anti-pattern).
+- New docs reachable + badged: design doc `plan`, linked from `docs/btd6/README.md` (new "UI /
+  menu" section); `check_docs --strict` green (pinned paths all exist). Simulator lives in
+  `tools/btd6/` (not a doc, so no badge needed).
+
+## 🛠 Friction → guard (Q-0194)
+
+- **Friction:** two Ask-path tests used `asyncio.get_event_loop().run_until_complete()` — green in
+  isolation, **red in the full suite** (a closed/foreign event loop leaked from earlier async
+  tests). The `--check-only` + isolated runs hid it; only `check_quality.py --full` caught it.
+  **Guard (shipped):** converted them to the repo's `@pytest.mark.asyncio` + `async def`
+  convention (what `test_btd6_ai_service` already uses) — isolation-safe by construction. **Durable
+  lesson (recorded):** never drive an `async def` under test via `get_event_loop()`; always
+  `@pytest.mark.asyncio`. The enforcing guard already exists — it's `check_quality.py --full`;
+  the lesson is to trust *it* over the fast/isolated runs before flipping born-red.
+- **Friction:** Playwright's ESM import ignores `NODE_PATH` for a globally-installed module.
+  **Guard (habit):** import from the absolute path
+  (`/opt/node22/lib/node_modules/playwright/index.mjs`) + let `PLAYWRIGHT_BROWSERS_PATH` locate
+  Chromium (don't pass `executablePath` a directory). Recorded here for the next agent that
+  screenshots a mockup.
+
+## Context delta
+
+- **Needed but not pointed to:** the split between the two BTD6 answer paths — the **Ask modal /
+  `!btd6 ask`** (`btd6_ai_service.answer_question`) vs. the **conversational stage**
+  (`natural_language_stage` → `deterministic_btd6_list_reply`) — was the crux of the bug: the list
+  floor only covered the second path. `docs/subsystems/btd6.md` describes grounding but doesn't
+  call out that the two surfaces had *diverged* on the floor. Now unified via `for_list_reply`.
+- **Pointed to but didn't need:** the CodeGraph symbol tools — the fix was a contained,
+  well-understood edit across four known files, so `context_map` + targeted grep carried it
+  (the "contained change" path from `codegraph-usage.md`).

--- a/disbot/services/btd6_ai_service.py
+++ b/disbot/services/btd6_ai_service.py
@@ -52,6 +52,7 @@ from services.btd6_response_builder import (
     BTD6Response,
     for_bloon,
     for_hero,
+    for_list_reply,
     for_map,
     for_mode,
     for_reference_facts,
@@ -140,6 +141,24 @@ def deterministic_answer(intent: ResolvedIntent) -> BTD6Response:
     return for_unresolved(intent)
 
 
+def _deterministic_list_floor(text: str) -> BTD6Response | None:
+    """The BUG-0009 / round-range list floor, wrapped for the Ask surfaces.
+
+    Returns a :class:`BTD6Response` when ``btd6_context_service`` owns a labelled
+    list/range answer for ``text`` (the same floor the conversational stage serves
+    as raw text), else ``None`` so the caller keeps its normal entity path.
+    Best-effort — a floor build failure never breaks the reply.
+    """
+    try:
+        from services import btd6_context_service
+
+        reply = btd6_context_service.deterministic_btd6_list_reply(text)
+    except Exception:  # noqa: BLE001 — never block on the floor
+        logger.debug("btd6_ai_service: list floor unavailable", exc_info=True)
+        return None
+    return for_list_reply(reply) if reply else None
+
+
 async def answer_question(
     text: str,
     *,
@@ -160,6 +179,15 @@ async def answer_question(
     already sanitised + provenance-labelled before reaching this layer.
     """
     intent = resolve(text)
+    # Deterministic list/range floor FIRST: it owns labelled list answers the
+    # entity resolver can't assemble — notably a round RANGE, which the resolver
+    # only sees as two endpoint round numbers ("list all the bloons from r29 till
+    # r63" grounded just rounds 29 + 63). Serving it here gives the Ask modal /
+    # `!btd6 ask` the same authoritative floor the conversational stage already
+    # uses; best-effort, never blocks the normal entity path.
+    floor = _deterministic_list_floor(text)
+    if floor is not None:
+        return floor
     response = deterministic_answer(intent)
     response = await _attach_live_grounding(text, response)
     if response.title == UNRESOLVED_TITLE and response.live_facts:

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -4295,6 +4295,106 @@ def deterministic_paragon_elite_reply(message_text: str) -> str | None:
     )
 
 
+# A bloon-listing intent over a round RANGE: "list all the bloons from r29 till
+# r63", "what bloons spawn between rounds 40 and 60", "which bloons in rounds
+# 29-63". Anchored on a bloon/spawn/composition noun so an economy range question
+# ("rbe of r29 to r63") still routes to deterministic_round_economy_reply above.
+_ROUND_RANGE_BLOON_CUE_RE = re.compile(
+    r"\b(?:bloons?|blimps?|moabs?|spawns?|spawned|spawning|composition|"
+    r"enemies|threats?)\b",
+    re.I,
+)
+# A bare "A-B" number-pair (no round token). Used ONLY to detect a second,
+# token-less comparison range — "which has more bloons, rounds 20-40 or 40-60"
+# (`_extract_round_ranges` needs a round token on each anchor, so it sees only
+# the first) — so the roster defers to the model on a comparison rather than
+# answering about the first range alone.
+_BARE_ROUND_PAIR_RE = re.compile(
+    r"(?<![\d-])(\d{1,3})\s*(?:to|through|thru|until|till|[-–])\s*(\d{1,3})(?![\d-])",
+    re.I,
+)
+
+
+def _format_round_range_bloons(result: dict[str, Any]) -> str:
+    """Render the :func:`btd6_data_service.round_range_bloon_roster` result."""
+    lo = result["round_start"]
+    hi = result["round_end"]
+    roster = result["roster"]
+    lines = [
+        f"**Bloons across rounds {lo}–{hi}** "
+        f"({result['roundset_label']} round set — {result['rounds_in_range']} "
+        f"rounds, {result['total_bloons_entering']:,} bloons enter, "
+        f"{result['total_rbe']:,} total RBE)",
+        f"**Bloon types that appear ({len(roster)}):**",
+    ]
+    for record in roster:
+        first, last = record["first_round"], record["last_round"]
+        span = f"R{first}" if first == last else f"R{first}–R{last}"
+        present = record["rounds_present"]
+        lines.append(
+            f"• **{record['bloon']}** — {span}, in {present} "
+            f"round{'' if present == 1 else 's'} (~{record['total']:,} spawned)",
+        )
+    modifiers = result.get("modifiers_seen") or []
+    if modifiers:
+        lines.append(f"_Modifiers seen across the range: {', '.join(modifiers)}._")
+    lines.append(
+        f"_Per-round detail: `/btd6 round {lo} {hi}` (values table), or ask about "
+        "a single round for its exact spawn composition._",
+    )
+    reply = "\n".join(lines)
+    return reply if len(reply) <= 1900 else reply[:1899] + "…"
+
+
+def deterministic_round_range_bloons_reply(message_text: str) -> str | None:
+    """A code-built "which bloons appear across rounds X-Y" answer, or ``None``.
+
+    Fixes the "list all the bloons from r29 till r63" miss (owner-reported,
+    2026-07-01): the NL resolver extracts the two endpoint round NUMBERS with no
+    range concept, so the grounding pass rendered only rounds 29 and 63 and the
+    answer listed those two rounds' bloons instead of the whole span. This floor
+    OWNS the range roster — the distinct bloon TYPES across **every** round in the
+    range, off the audited :func:`btd6_data_service.round_range_bloon_roster`
+    engine — so the span is enumerated deterministically, never sampled at the
+    endpoints.
+
+    Fires on exactly ONE inclusive round range (``lo != hi``) + a bloon/spawn/
+    composition cue. Defers (``None``) when an economy cue is present (that is
+    :func:`deterministic_round_economy_reply`'s range case, earlier in the chain),
+    on two-or-more ranges (the comparison builder), or without a range — so it
+    stays mutually exclusive with its siblings and ordinary questions fall through
+    to the model.
+    """
+    text = (message_text or "").strip()
+    if not text:
+        return None
+    low = text.lower()
+    if not _ROUND_RANGE_BLOON_CUE_RE.search(low):
+        return None
+    # Economy range questions belong to deterministic_round_economy_reply.
+    if _ROUND_ECONOMY_CUE_RE.search(low):
+        return None
+    distinct: set[tuple[int, int]] = {
+        (min(a, b), max(a, b)) for a, b in _extract_round_ranges(low) if a != b
+    }
+    # A second (possibly token-less) range makes this a comparison, not a listing.
+    for match in _BARE_ROUND_PAIR_RE.finditer(low):
+        a, b = int(match.group(1)), int(match.group(2))
+        if a != b:
+            distinct.add((min(a, b), max(a, b)))
+    if len(distinct) != 1:
+        return None
+    lo, hi = next(iter(distinct))
+
+    from services import btd6_data_service
+
+    roundset = "alternate" if _ABR_CUE_RE.search(low) else "default"
+    result = btd6_data_service.round_range_bloon_roster(lo, hi, roundset)
+    if not result.get("found"):
+        return None
+    return _format_round_range_bloons(result)
+
+
 # --- BUG-0009 deterministic list-answer dispatcher ----------------------------
 # The ordered floor builders the dispatcher fans out to. Each OWNS its labelled
 # answer and is narrow (returns ``None`` for anything but its exact list shape),
@@ -4306,6 +4406,7 @@ def deterministic_paragon_elite_reply(message_text: str) -> str | None:
 # contract, no test edit needed. Append a new list family here.
 _BTD6_LIST_BUILDERS: tuple[Callable[[str], str | None], ...] = (
     deterministic_round_economy_reply,
+    deterministic_round_range_bloons_reply,
     deterministic_round_xp_reply,
     deterministic_mk_reference_reply,
     deterministic_mk_category_roster_reply,

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -2235,6 +2235,105 @@ def round_composition(
     return out
 
 
+def round_range_bloon_roster(
+    round_start: int,
+    round_end: int,
+    roundset: str = "default",
+) -> dict[str, Any]:
+    """Distinct bloon TYPES that appear across an inclusive round range.
+
+    The "which bloons show up between rounds X and Y" primitive — the roster
+    complement of :func:`round_composition` (which caps its per-round detail at
+    :data:`_ROUND_DETAIL_CAP` and collapses modifiers). Walks **every** round in
+    the range (so a wide span never truncates a type out of the roster) and
+    returns each base bloon type once, in first-appearance order, with the round
+    it first/last appears, how many rounds carry it, and its total spawn count.
+    Modifiers (Regrow / Fortified / Camo) are gathered as the set seen across the
+    range rather than split into per-variant rows, since a modifier is an
+    attribute of a bloon, not a separate bloon.
+
+    Fixes the "list all the bloons from r29 till r63" miss: the NL resolver only
+    extracts the two endpoint round numbers, so the grounding/answer path saw
+    just rounds 29 and 63. This engine enumerates the whole span deterministically
+    for the round-range list floor. ``found: False`` (never a silent default) when
+    the set or range is unknown, mirroring the sibling round primitives.
+    """
+    resolved = resolve_roundset(roundset)
+    if resolved is None:
+        return {
+            "found": False,
+            "note": f"unknown round set: {roundset!r} (default or alternate/abr)",
+        }
+    lo = round_start
+    hi = round_end
+    if lo > hi:
+        lo, hi = hi, lo
+    all_rounds = _rounds_for_set(resolved)
+    set_label = "standard" if resolved == "default" else "alternate (ABR)"
+    if not all_rounds:
+        return {"found": False, "note": f"no {set_label} round data is loaded"}
+    rounds = sorted(
+        (r for r in all_rounds if lo <= r.round_number <= hi),
+        key=lambda r: r.round_number,
+    )
+    if not rounds:
+        return {
+            "found": False,
+            "note": f"no {set_label} rounds in {lo}-{hi} (valid 1-140)",
+        }
+
+    roster: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    modifiers_seen: dict[str, None] = {}  # insertion-ordered set
+    for entry in rounds:
+        number = entry.round_number
+        seen_this_round: set[str] = set()
+        for group in entry.groups:
+            bid = str(group.get("bloon_id", "") or "")
+            if not bid:
+                continue
+            count = int(group.get("count", 0) or 0)
+            for modifier in group.get("modifiers", ()) or ():
+                modifiers_seen.setdefault(str(modifier).capitalize(), None)
+            record = roster.get(bid)
+            if record is None:
+                bloon = get_bloon(bid)
+                record = {
+                    "bloon_id": bid,
+                    "bloon": bloon.canonical if bloon is not None else bid.title(),
+                    "category": bloon.category if bloon is not None else "",
+                    "first_round": number,
+                    "last_round": number,
+                    "rounds_present": 0,
+                    "total": 0,
+                }
+                roster[bid] = record
+                order.append(bid)
+            record["last_round"] = number
+            record["total"] += count
+            if bid not in seen_this_round:
+                record["rounds_present"] += 1
+                seen_this_round.add(bid)
+
+    out: dict[str, Any] = {
+        "found": True,
+        "round_start": lo,
+        "round_end": hi,
+        "roundset": resolved,
+        "roundset_label": set_label,
+        "rounds_in_range": len(rounds),
+        "roster": [roster[bid] for bid in order],
+        "modifiers_seen": list(modifiers_seen),
+        "total_bloons_entering": sum(
+            int(g.get("count", 0) or 0) for r in rounds for g in r.groups
+        ),
+        "total_rbe": sum(r.rbe or 0 for r in rounds),
+    }
+    if resolved == "alternate":
+        out["note"] = _ABR_NOTE
+    return out
+
+
 # Medium-difficulty standard starting cash — the cumulative-cash baseline.
 # rounds.json stores cumulative_cash as $650 + the running per-round total
 # (pinned by tests/unit/services/test_btd6_round_cash.py); this constant lets a

--- a/disbot/services/btd6_response_builder.py
+++ b/disbot/services/btd6_response_builder.py
@@ -349,6 +349,26 @@ def for_reference_facts(facts: tuple[str, ...]) -> BTD6Response:
     )
 
 
+def for_list_reply(reply: str) -> BTD6Response:
+    """Wrap a deterministic list-floor string as a :class:`BTD6Response`.
+
+    The BUG-0009 / round-range list floors (``btd6_context_service`` —
+    e.g. "list all the bloons from r29 till r63") return a self-contained
+    markdown answer the conversational stage sends verbatim. The Ask modal /
+    ``!btd6 ask`` render a :class:`BTD6Response` instead, so this carries the
+    floor string through unchanged as the embed body — the two surfaces serve
+    the one authoritative answer rather than the Ask path re-deriving a weaker
+    one from the endpoint-only intent. High confidence: the floor is
+    code-built, not model-authored.
+    """
+    return BTD6Response(
+        title="BTD6",
+        short_answer=reply,
+        confidence="high",
+        sources=(_source_label(),),
+    )
+
+
 # The one string the unresolved path is recognised by (``answer_question``
 # upgrades an unresolved response to ``for_reference_facts`` when grounding
 # found facts anyway) — never compare against a literal copy of the title.

--- a/docs/btd6/README.md
+++ b/docs/btd6/README.md
@@ -55,6 +55,14 @@ is one folder behind the folio instead of ~14 files scattered at the root.
   question/answer corpus for bot accuracy (damage-type ↔ bloon-property interactions, bloons,
   economy, paragons), with the damage-type interaction-grounding layer it backs.
 
+## UI / menu
+
+- [`btd6-menu-layout-design-2026-07-01.md`](./btd6-menu-layout-design-2026-07-01.md) —
+  design study + back-compat implementation plan for the `/btd6menu` panel: the
+  Cyber-Quincy function comparison, the ten subdivisions, the mobile button-truncation
+  finding, and the A/B/C candidate layouts. Companion to the interactive
+  [`tools/btd6/menu_layout_simulator.html`](../../tools/btd6/menu_layout_simulator.html).
+
 ## Checklists
 
 - [`btd6-smoke-test-checklist.md`](./btd6-smoke-test-checklist.md) — BTD6 smoke-test

--- a/docs/btd6/btd6-menu-layout-design-2026-07-01.md
+++ b/docs/btd6/btd6-menu-layout-design-2026-07-01.md
@@ -1,0 +1,150 @@
+# BTD6 menu layout — design study + implementation plan
+
+> **Status:** `plan` — owner-directed design study (2026-07-01). The interactive
+> tool is [`tools/btd6/menu_layout_simulator.html`](../../tools/btd6/menu_layout_simulator.html);
+> this doc is its written companion + the back-compat implementation plan. The live
+> panel is [`disbot/views/btd6/panel.py`](../../disbot/views/btd6/panel.py). No panel
+> code changed yet — the **B-vs-C pick is the owner's**, made from the simulator.
+
+## Why this exists
+
+The owner sent a 40-second screen-recording scrolling the `/btd6` slash
+autocomplete. It lists **two** bots side by side: the mature reference bot
+**Cyber Quincy** and **SuperBot**. The ask: compare the surfaces, then build a
+*simulator to find the best menu layout* that packs as many useful functions as
+possible into clear subdivisions, staying clear without too many button presses.
+
+The recording also carried a concrete miss — *"list all the bloons from r29 till
+r63"* only answered for the two endpoint rounds. That bug is **fixed and shipped
+this session** (see [§5](#5-the-round-range-answer-fix-shipped)); this doc is the
+menu-layout half.
+
+## 1. What the recording showed
+
+Cyber Quincy exposes ~40 BTD6 functions as **flat slash commands** — `round`,
+`rbe`, `tower`, `hero`, `herolevel`, `paragon`, `tierlist`, `temple`, `relic`,
+`quiz`, `race_lb`, `ct_lb`, `nft`, `ltc`/`lcc`/`lcd`/`2tc`/`2mp`/`fttc`,
+`calc`, `cash`, `crosspath_compare`, `bloon`, `boss`, `alias`, `balance`,
+`decay`, `gluetrap`, `adora-sac`, `income`, `map`, … .
+
+The key insight: **SuperBot already owns most of those functions** — as
+`/btd6 <sub>` slash commands (`round`, `rbe`, `income`, `hero`, `tower`, `relic`,
+`estimate`, `ct`, `strat *`, `events *`, `ops *`, `ask`, `status`, `diagnostics`)
+plus the panel buttons. SuperBot is *not* missing the capability; the **panel
+under-surfaces it**. The `/btd6menu` panel
+([`panel.py`](../../disbot/views/btd6/panel.py)) shows **13 flat buttons** (Ask,
+Live Events, Towers, Heroes, Leaderboards, CT, Modes, Status, Paragon, Admin,
+Maps, Strategy, Help) with no grouping — so on mobile it is a tall ungrouped
+wall, and the ~27 non-buttoned functions have **no panel entry at all** (they are
+slash-only, i.e. undiscoverable from the panel).
+
+## 2. Function inventory & subdivisions
+
+The full, interactive inventory (with per-function descriptions and a
+have/add filter) lives in the simulator. Summary — **ten subdivisions**:
+
+| Subdivision | Have today | Candidate additions (Cyber Quincy gaps) |
+|---|---|---|
+| 🧠 **Ask** | AI Q&A | — |
+| 🗼 **Units** | Towers, Heroes, Paragon calc | Crosspath compare, Tier list |
+| 🎲 **Rounds & Economy** | Round, RBE, Income/cash, Bloon, Boss estimate | — |
+| 🧮 **Calculators** | — | Cost calc, Cash-goal, Sun-Temple sacrifice, Hero-leveling, Glue duration, CT decay, Adora sacrifice |
+| 🎯 **Live Events** | Live events, Leaderboards, CT + map, Relic | — |
+| 🗺️ **Maps & Modes** | Maps, Modes | Tier list (shared w/ Units) |
+| 📋 **Strategy** | Browse, Submit, Mine, Pending | — |
+| 🏆 **Challenge Index** | — | 2TC, 2MP, LTC, LCC, LCD, FTTC databases |
+| ℹ️ **Help & Status** | Status, Diagnostics, Help, Data sources | — |
+| 🛠️ **Admin** (staff) | Seed, Sources, Announce, Readiness, Admin panel | — |
+
+So SuperBot ships **~28** panel-worthy functions today and there are **~15**
+worthwhile additions — but the two empty subdivisions (**Calculators**,
+**Challenge Index**) are *all* candidate work, so they stay off the live panel
+until at least one function in each exists.
+
+## 3. The mobile-truncation finding
+
+Building the mock surfaced a constraint the static comparison hid: **Discord
+truncates button labels hard on mobile.** At the recording's width, **5 buttons
+per row** collapses "Events" → "E…", and even **4 per row** clips a 6-letter
+emoji label ("Rou…"). A Discord message is also capped at **5 action rows**, each
+**5 buttons OR one select**. So the real design space is:
+
+- **≤ 3–4 category buttons per row**, or drop emojis, to stay glanceable; **or**
+- **a select menu**, which stays fully readable at any width and scales to
+  unlimited categories, at the cost of one tap to reveal the list.
+
+## 4. Candidate layouts
+
+| | A — Current (flat) | **B — Category hub** | C — Select hybrid |
+|---|---|---|---|
+| Top-level controls | 13 buttons | 10 category buttons (≤4/row) | 2 buttons + 1 select |
+| Rows on mobile | ~5 | 3 | 2 |
+| Functions reachable from panel | 13 / ~43 | **43 / 43** | **43 / 43** |
+| Clicks to any function | 1 (for the 13) | ≤ 2 | ≤ 2 |
+| Glanceable subdivisions | none | **yes** | in the dropdown |
+| Label readability on mobile | good (≤3/row) | good at ≤4/row | **best** |
+
+**Recommendation: B (category hub, ≤4 buttons/row).** It makes every subdivision
+a labelled, glanceable button, keeps depth at ≤2 clicks, and has room for the
+whole Calculators + Challenge-Index backlog without adding a top-level control.
+**C** is the compact fallback if footprint matters more than glanceability. Both
+are strictly better than A on coverage. The **B-vs-C pick is the owner's** — the
+simulator exists to make it.
+
+## 5. The round-range answer fix (shipped)
+
+Independent of the layout, the recording's *"list all the bloons from r29 till
+r63"* miss is fixed this session:
+
+- `round_range_bloon_roster(lo, hi, roundset)` in
+  [`btd6_data_service.py`](../../disbot/services/btd6_data_service.py) walks every
+  round in the range and returns the distinct bloon types (first/last round,
+  rounds-present, total spawned).
+- `deterministic_round_range_bloons_reply` in
+  [`btd6_context_service.py`](../../disbot/services/btd6_context_service.py) is a new
+  `_BTD6_LIST_BUILDERS` floor that owns the range roster; `for_list_reply` +
+  `answer_question` in
+  [`btd6_ai_service.py`](../../disbot/services/btd6_ai_service.py) serve it on the
+  Ask-modal path too (which previously bypassed the floor). Tests:
+  [`test_btd6_round_range_bloons.py`](../../tests/unit/services/test_btd6_round_range_bloons.py).
+
+## 6. Implementation plan (for the chosen layout)
+
+A single, back-compat-safe restructure of the `BTD6PanelView` persistent view.
+The persistent-view contract requires **stable `custom_id`s** for existing anchor
+messages, so the plan **keeps every legacy `btd6:*` id working**.
+
+**PR 1 — top-level regroup (no new capability).**
+1. Repoint the top row(s) of `BTD6PanelView` to the chosen shape:
+   - **B:** category buttons `btd6:cat:units` / `btd6:cat:rounds` / … , ≤4/row,
+     each opening an ephemeral **sub-panel view** listing that category's
+     existing `open_*` entries (reuse `open_tower_browser`, `open_hero_browser`,
+     `open_paragon_calculator`, the round/rbe/income builders, etc.).
+   - **C:** two buttons (`btd6:ask`, `btd6:events`) + a `discord.ui.Select`
+     (`btd6:browse`) whose options are the categories, + `btd6:admin`.
+2. **Back-compat:** keep the legacy leaf ids (`btd6:towers`, `btd6:heroes`,
+   `btd6:modes`, `btd6:maps`, `btd6:strategy`, `btd6:status`, `btd6:paragon`,
+   `btd6:ct`, `btd6:leaderboards`, `btd6:events`, `btd6:admin`) as **hidden
+   handlers** so old anchor messages still route (the file already documents this
+   pattern). New anchors render the new rows.
+3. Surface the already-shipped-but-panel-invisible functions as sub-panel
+   entries: **Round / RBE / Income / Boss estimate / Bloon / Relic / Diagnostics /
+   Data sources** (all exist as slash commands today — they just gain a button).
+4. Tests: extend the panel view tests to assert (a) every category button opens
+   its sub-panel, (b) every legacy `custom_id` still resolves, (c) staff gating on
+   Admin. Keep it `PersistentView`-conformant.
+
+**PR 2+ (optional, backlog) — new capability.** Build the Calculators and
+Challenge-Index families (the `add` column) behind their sub-panels: cost/cash
+calculators reuse `btd6_data_service` cost engines; the challenge indices need a
+new data source + `*_service`. These are separate, plannable slices — the panel
+categories are ready to receive them.
+
+## 7. Using the simulator
+
+Open [`tools/btd6/menu_layout_simulator.html`](../../tools/btd6/menu_layout_simulator.html)
+in a browser. Toggle **A / B / C**, click the phone's buttons/menu to walk the
+real drill-down, and read the live metrics + inventory. The whole model is the
+`DATA` object at the top of the file — edit the categories / functions / layout
+rows to try your own grouping and everything re-renders. It is a static file
+(no build, no server, no dependencies).

--- a/docs/owner/claims/claude-btd6-menu-layout-design-mrm358.md
+++ b/docs/owner/claims/claude-btd6-menu-layout-design-mrm358.md
@@ -1,0 +1,1 @@
+- `claude/btd6-menu-layout-design-mrm358` · BTD6 menu layout design + round-range NL bug · disbot/views/btd6/panel.py, disbot/services/btd6_context_service.py, docs/btd6/, tools/btd6/ · 2026-07-01

--- a/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
+++ b/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
@@ -124,6 +124,16 @@ _SHOULD_FIRE: tuple[tuple[str, str], ...] = (
         "what's the economy of round 95",
         "deterministic_round_economy_reply",
     ),
+    (
+        "list all the bloons from r29 till r63",
+        "deterministic_round_range_bloons_reply",
+    ),
+    # An economy cue over a range stays with the economy builder — the range-bloon
+    # roster defers whenever _ROUND_ECONOMY_CUE_RE matches (locks that boundary).
+    (
+        "what's the total rbe from rounds 29 to 63",
+        "deterministic_round_economy_reply",
+    ),
 )
 
 # Ordinary BTD6 questions / strategy / single-entity lookups — zero builders fire.

--- a/tests/unit/services/test_btd6_round_range_bloons.py
+++ b/tests/unit/services/test_btd6_round_range_bloons.py
@@ -1,0 +1,175 @@
+"""BTD6 round-range bloon roster — the "list all the bloons from r29 till r63" fix.
+
+Owner-reported miss (2026-07-01): a round RANGE in a bloon-listing question only
+grounded the two endpoint round numbers (the NL resolver extracts isolated round
+numbers with no range concept), so the answer listed rounds 29 + 63's bloons
+instead of the whole span. These pin the deterministic
+``round_range_bloon_roster`` primitive, the ``deterministic_round_range_bloons_reply``
+floor + its exclusivity with the economy/comparison round builders, and the
+Ask-modal path wiring (``answer_question``) that previously bypassed the floor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import (  # noqa: E402
+    btd6_ai_service,
+    btd6_context_service,
+    btd6_data_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dataset_cache():
+    btd6_data_service.reset_cache()
+    yield
+    btd6_data_service.reset_cache()
+
+
+# --- the primitive (btd6_data_service.round_range_bloon_roster) ----------------
+
+
+def test_roster_enumerates_every_round_in_the_range():
+    result = btd6_data_service.round_range_bloon_roster(29, 63)
+    assert result["found"] is True
+    # The whole inclusive span, not two endpoints (the bug: only 29 + 63 grounded).
+    assert result["round_start"] == 29
+    assert result["round_end"] == 63
+    assert result["rounds_in_range"] == 35
+    assert result["roundset_label"] == "standard"
+
+
+def test_roster_collects_distinct_types_across_the_span():
+    result = btd6_data_service.round_range_bloon_roster(29, 63)
+    names = [entry["bloon"] for entry in result["roster"]]
+    # A range that only sampled its endpoints would miss the mid-range types.
+    # Ceramics/MOABs/BFB appear well inside 29-63, never at round 29 alone.
+    for expected in ("Ceramic Bloon", "MOAB", "BFB"):
+        assert expected in names, f"{expected} missing from the range roster"
+    # Distinct — each base type appears exactly once in the roster.
+    assert len(names) == len(set(names))
+
+
+def test_roster_first_last_round_and_counts_are_bounded_to_the_range():
+    result = btd6_data_service.round_range_bloon_roster(29, 63)
+    for entry in result["roster"]:
+        assert 29 <= entry["first_round"] <= entry["last_round"] <= 63
+        assert entry["rounds_present"] >= 1
+        assert entry["total"] >= entry["rounds_present"]  # >=1 spawned per round
+
+
+def test_roster_normalises_reversed_endpoints():
+    forward = btd6_data_service.round_range_bloon_roster(29, 63)
+    reversed_ = btd6_data_service.round_range_bloon_roster(63, 29)
+    assert reversed_["round_start"] == 29
+    assert reversed_["round_end"] == 63
+    assert [e["bloon_id"] for e in reversed_["roster"]] == [
+        e["bloon_id"] for e in forward["roster"]
+    ]
+
+
+def test_roster_records_modifiers_seen_across_the_range():
+    result = btd6_data_service.round_range_bloon_roster(29, 63)
+    # Regrow / Camo / Fortified all appear inside this span; they are gathered as
+    # a set of modifiers seen, not split into per-variant roster rows.
+    assert set(result["modifiers_seen"]) & {"Regrow", "Camo", "Fortified"}
+
+
+def test_roster_fails_closed_on_unknown_set_and_empty_range():
+    assert btd6_data_service.round_range_bloon_roster(29, 63, "nonsense")["found"] is False
+    # Valid rounds are 1-140; a range fully outside has no rounds.
+    assert btd6_data_service.round_range_bloon_roster(200, 220)["found"] is False
+
+
+def test_roster_supports_the_abr_round_set():
+    result = btd6_data_service.round_range_bloon_roster(20, 40, "abr")
+    assert result["found"] is True
+    assert result["roundset"] == "alternate"
+    assert "ABR" in result["roundset_label"] or "alternate" in result["roundset_label"]
+
+
+# --- the floor builder (deterministic_round_range_bloons_reply) ----------------
+
+
+def test_builder_owns_the_reported_query():
+    reply = btd6_context_service.deterministic_round_range_bloons_reply(
+        "list all the bloons from r29 till r63",
+    )
+    assert reply is not None
+    assert "rounds 29" in reply and "63" in reply
+    assert "Ceramic Bloon" in reply and "MOAB" in reply
+    assert len(reply) <= 1900
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "list all the bloons from r29 till r63",
+        "what bloons spawn between rounds 40 and 60",
+        "which bloons appear in rounds 29-63",
+        "what blimps show up from round 80 to 100",
+    ],
+)
+def test_builder_fires_on_range_bloon_phrasings(phrase: str):
+    assert btd6_context_service.deterministic_round_range_bloons_reply(phrase) is not None
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        # No range — a single round is a single-round question, not this floor.
+        "what bloons are on round 63",
+        # No bloon cue — an economy range belongs to the economy builder.
+        "what's the total rbe from rounds 29 to 63",
+        "how much cash do i earn from rounds 20-40",
+        # Two ranges — the comparison builder owns that.
+        "which has more bloons, rounds 20-40 or 40-60",
+        # Not a range question at all.
+        "what is a ceramic bloon",
+    ],
+)
+def test_builder_defers_outside_its_shape(phrase: str):
+    assert btd6_context_service.deterministic_round_range_bloons_reply(phrase) is None
+
+
+def test_builder_routes_abr_when_cued():
+    reply = btd6_context_service.deterministic_round_range_bloons_reply(
+        "list the bloons in rounds 20-40 in abr",
+    )
+    assert reply is not None
+    assert "alternate" in reply.lower() or "ABR" in reply
+
+
+# --- the Ask-modal path wiring (btd6_ai_service.answer_question) ----------------
+
+
+def _answer(text: str):
+    return asyncio.get_event_loop().run_until_complete(
+        btd6_ai_service.answer_question(text),
+    )
+
+
+def test_ask_path_serves_the_range_floor_not_the_endpoint_round():
+    # Before the fix, the Ask path answered "Round 29 …" (deterministic_answer
+    # took intent.rounds[0]); now the range floor owns the whole-span answer.
+    response = _answer("list all the bloons from r29 till r63")
+    body = response.short_answer
+    assert "Bloons across rounds 29" in body
+    assert "Ceramic Bloon" in body and "MOAB" in body
+    # Not the single-round headline the endpoint-only path produced.
+    assert not response.title.startswith("Round 29")
+
+
+def test_ask_path_single_round_still_uses_the_entity_answer():
+    # A single round is not a range — the normal deterministic round answer wins.
+    response = _answer("what happens on round 63")
+    assert response.title.startswith("Round 63")

--- a/tests/unit/services/test_btd6_round_range_bloons.py
+++ b/tests/unit/services/test_btd6_round_range_bloons.py
@@ -11,7 +11,6 @@ Ask-modal path wiring (``answer_question``) that previously bypassed the floor.
 
 from __future__ import annotations
 
-import asyncio
 import sys
 from pathlib import Path
 
@@ -152,16 +151,11 @@ def test_builder_routes_abr_when_cued():
 # --- the Ask-modal path wiring (btd6_ai_service.answer_question) ----------------
 
 
-def _answer(text: str):
-    return asyncio.get_event_loop().run_until_complete(
-        btd6_ai_service.answer_question(text),
-    )
-
-
-def test_ask_path_serves_the_range_floor_not_the_endpoint_round():
+@pytest.mark.asyncio
+async def test_ask_path_serves_the_range_floor_not_the_endpoint_round():
     # Before the fix, the Ask path answered "Round 29 …" (deterministic_answer
     # took intent.rounds[0]); now the range floor owns the whole-span answer.
-    response = _answer("list all the bloons from r29 till r63")
+    response = await btd6_ai_service.answer_question("list all the bloons from r29 till r63")
     body = response.short_answer
     assert "Bloons across rounds 29" in body
     assert "Ceramic Bloon" in body and "MOAB" in body
@@ -169,7 +163,8 @@ def test_ask_path_serves_the_range_floor_not_the_endpoint_round():
     assert not response.title.startswith("Round 29")
 
 
-def test_ask_path_single_round_still_uses_the_entity_answer():
+@pytest.mark.asyncio
+async def test_ask_path_single_round_still_uses_the_entity_answer():
     # A single round is not a range — the normal deterministic round answer wins.
-    response = _answer("what happens on round 63")
+    response = await btd6_ai_service.answer_question("what happens on round 63")
     assert response.title.startswith("Round 63")

--- a/tools/btd6/menu_layout_simulator.html
+++ b/tools/btd6/menu_layout_simulator.html
@@ -1,0 +1,497 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>BTD6 menu layout simulator — SuperBot</title>
+<style>
+  :root {
+    --bg: #1e1f22; --panel: #2b2d31; --panel2: #313338; --edge: #232428;
+    --txt: #dbdee1; --muted: #949ba4; --green: #248046; --greenH: #1a6334;
+    --blurple: #5865f2; --blurpleH: #4752c4; --grey: #4e5058; --greyH: #6d6f78;
+    --gold: #f0b232; --red: #da373c; --line: #3f4147; --accent: #00a8fc;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--txt);
+    font-family: "gg sans", "Segoe UI", Helvetica, Arial, sans-serif;
+    line-height: 1.45;
+  }
+  header { padding: 20px 24px 8px; border-bottom: 1px solid var(--line); }
+  header h1 { margin: 0 0 4px; font-size: 20px; }
+  header p { margin: 4px 0; color: var(--muted); font-size: 14px; max-width: 980px; }
+  .wrap { display: flex; flex-wrap: wrap; gap: 24px; padding: 20px 24px 60px; align-items: flex-start; }
+  .col-phone { flex: 0 0 auto; }
+  .col-info { flex: 1 1 420px; min-width: 340px; }
+
+  /* layout tabs */
+  .tabs { display: flex; gap: 8px; margin: 14px 0 10px; flex-wrap: wrap; }
+  .tab {
+    background: var(--panel); color: var(--txt); border: 1px solid var(--line);
+    border-radius: 8px; padding: 8px 14px; cursor: pointer; font-size: 13px; font-weight: 600;
+  }
+  .tab.active { background: var(--blurple); border-color: var(--blurple); color: #fff; }
+  .tab small { display: block; font-weight: 400; opacity: .8; font-size: 11px; }
+
+  /* phone mock */
+  .phone {
+    width: 360px; background: #000; border-radius: 28px; padding: 12px 10px;
+    box-shadow: 0 10px 40px rgba(0,0,0,.5); border: 1px solid #333;
+  }
+  .screen { background: var(--bg); border-radius: 18px; overflow: hidden; min-height: 620px; display: flex; flex-direction: column; }
+  .chan { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--edge); font-weight: 600; font-size: 14px; }
+  .chan .hash { color: var(--muted); }
+  .chan .online { margin-left: auto; color: var(--muted); font-size: 11px; font-weight: 400; }
+  .msg { padding: 12px; overflow-y: auto; flex: 1; }
+  .embed {
+    border-left: 4px solid var(--green); background: var(--panel); border-radius: 4px;
+    padding: 12px 14px; font-size: 13px;
+  }
+  .embed h3 { margin: 0 0 6px; font-size: 15px; }
+  .embed .field-name { font-weight: 700; margin-top: 8px; font-size: 12px; }
+  .embed .field-val { color: var(--txt); font-size: 12px; }
+  .embed .foot { color: var(--muted); font-size: 11px; margin-top: 10px; border-top: 1px solid var(--line); padding-top: 6px; }
+  .mono { font-family: ui-monospace, Menlo, Consolas, monospace; background: var(--edge); padding: 1px 5px; border-radius: 4px; font-size: 11px; }
+
+  /* action rows (buttons) */
+  .rows { padding: 6px 10px 12px; }
+  .row { display: flex; gap: 8px; margin-top: 8px; flex-wrap: nowrap; }
+  .btn {
+    flex: 1 1 0; min-width: 0; border: none; border-radius: 8px; padding: 9px 6px; cursor: pointer;
+    font-size: 12px; font-weight: 600; color: #fff; white-space: nowrap; overflow: hidden;
+    text-overflow: ellipsis; transition: filter .1s;
+  }
+  .btn:hover { filter: brightness(1.12); }
+  .btn.primary { background: var(--blurple); }
+  .btn.success { background: var(--green); }
+  .btn.secondary { background: var(--grey); }
+  .btn.danger { background: var(--red); }
+  .btn.ghost { background: transparent; border: 1px dashed var(--line); color: var(--muted); }
+  .select {
+    width: 100%; background: var(--panel2); border: 1px solid var(--line); border-radius: 8px;
+    padding: 10px 12px; color: var(--txt); cursor: pointer; display: flex; align-items: center; font-size: 13px;
+  }
+  .select .chev { margin-left: auto; color: var(--muted); }
+  .subpanel { border-top: 1px solid var(--line); margin-top: 6px; padding-top: 8px; }
+  .subpanel .crumb { font-size: 11px; color: var(--muted); padding: 0 2px 6px; }
+  .subpanel .crumb b { color: var(--accent); }
+  .backbtn { background: var(--panel2); color: var(--muted); border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; font-size: 12px; cursor: pointer; }
+  .ephemeral-tag { font-size: 10px; color: var(--muted); padding: 6px 4px 0; }
+
+  /* info panels */
+  .card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; margin-bottom: 16px; }
+  .card h2 { margin: 0 0 8px; font-size: 15px; }
+  .metrics { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .metric { background: var(--panel2); border-radius: 8px; padding: 10px 12px; }
+  .metric .n { font-size: 22px; font-weight: 800; }
+  .metric .l { font-size: 11px; color: var(--muted); }
+  .metric.good .n { color: #3ba55d; }
+  .metric.warn .n { color: var(--gold); }
+  .metric.bad .n { color: var(--red); }
+  .verdict { font-size: 13px; margin-top: 10px; padding: 10px 12px; border-radius: 8px; background: var(--panel2); border-left: 3px solid var(--accent); }
+  .legend { font-size: 12px; color: var(--muted); }
+  .pill { display: inline-block; font-size: 10px; padding: 1px 7px; border-radius: 10px; font-weight: 700; vertical-align: middle; }
+  .pill.have { background: #204b2c; color: #4fd67e; }
+  .pill.new { background: #4a3a12; color: var(--gold); }
+
+  /* inventory */
+  table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--edge); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; position: sticky; top: 0; background: var(--panel); }
+  .cat-h { font-weight: 800; color: #fff; background: var(--panel2); }
+  td.src { white-space: nowrap; }
+  .controls { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 8px; font-size: 13px; }
+  .controls label { cursor: pointer; }
+  code.k { color: var(--accent); }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+<header>
+  <h1>🐵 BTD6 menu layout simulator</h1>
+  <p>
+    A side-by-side of SuperBot's current BTD6 panel and two redesigns that pack
+    every useful function into clear subdivisions with a shallow click depth.
+    Toggle a layout, then <b>click the buttons/menu in the phone</b> to walk the
+    real drill-down. Metrics update per layout. The function inventory (bottom)
+    marks what SuperBot already ships (<span class="pill have">have</span>) vs.
+    gaps seen on the reference bot <b>Cyber&nbsp;Quincy</b> in the recording
+    (<span class="pill new">add</span>).
+  </p>
+  <p style="font-size:12px">
+    Data model lives in the <span class="mono">DATA</span> object in this file —
+    edit it to try your own grouping; the mock + metrics re-render from it.
+  </p>
+</header>
+
+<div class="wrap">
+  <!-- PHONE -->
+  <div class="col-phone">
+    <div class="tabs" id="tabs"></div>
+    <div class="phone">
+      <div class="screen">
+        <div class="chan"><span class="hash">#</span> 🤖 bots <span class="online">18 online</span></div>
+        <div class="msg">
+          <div class="embed">
+            <h3>🐵 BTD6 Assistant</h3>
+            <div class="field-val">Ask BTD6 questions or browse tower / hero / mode / round info.</div>
+            <div class="field-name">📚 Reference (seed)</div>
+            <div class="field-val">v1.0 · game v55.1 · 25 towers • 17 heroes • 86 maps • 18 modes • 140 rounds</div>
+            <div class="foot">!btd6 ask &lt;q&gt; · !btd6 round &lt;N&gt; · !btd6 leaderboard</div>
+          </div>
+          <div class="rows" id="rows"></div>
+          <div class="ephemeral-tag" id="ephHint"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- INFO -->
+  <div class="col-info">
+    <div class="card">
+      <h2 id="layoutTitle"></h2>
+      <div class="metrics" id="metrics"></div>
+      <div class="verdict" id="verdict"></div>
+    </div>
+
+    <div class="card">
+      <h2>Why these subdivisions</h2>
+      <div class="legend" id="rationale"></div>
+    </div>
+
+    <div class="card">
+      <h2>Function inventory &amp; subdivisions</h2>
+      <div class="controls">
+        <label><input type="checkbox" id="showNew" checked /> show <span class="pill new">add</span> (Cyber Quincy gaps)</label>
+        <span id="invCount" class="legend"></span>
+      </div>
+      <div style="max-height: 520px; overflow-y: auto;">
+        <table id="inv"><tbody></tbody></table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ============================================================================
+   DATA — edit here to try your own grouping. Everything else renders from this.
+   source: "have" = SuperBot ships it today (slash and/or panel button);
+           "new"  = a Cyber Quincy function worth adding.
+   ========================================================================== */
+const DATA = {
+  categories: {
+    ask:        { emoji:"🧠", label:"Ask",              short:"Ask",     blurb:"Free-form AI Q&A (grounded)." },
+    units:      { emoji:"🗼", label:"Units",            short:"Units",   blurb:"Towers, heroes, paragons — stats, upgrades, crosspaths." },
+    rounds:     { emoji:"🎲", label:"Rounds & Economy", short:"Rounds",  blurb:"Round info, RBE, income/cash, bloons, boss estimate." },
+    calc:       { emoji:"🧮", label:"Calculators",      short:"Calc",    blurb:"Cost/cash, sacrifices, hero-leveling, decay, glue." },
+    events:     { emoji:"🎯", label:"Live Events",      short:"Events",  blurb:"Race / boss / CT / odyssey, leaderboards, relics." },
+    mapsmodes:  { emoji:"🗺️", label:"Maps & Modes",     short:"Maps",    blurb:"Map browser + mode rules + tier list." },
+    strategy:   { emoji:"📋", label:"Strategy",         short:"Strats",  blurb:"Community strategy memory: browse / submit / mine." },
+    challenges: { emoji:"🏆", label:"Challenge Index",  short:"Index",   blurb:"2TC / 2MP / LTC / LCC / LCD / FTTC databases." },
+    help:       { emoji:"ℹ️", label:"Help & Status",    short:"Help",    blurb:"Help, status, diagnostics, data freshness." },
+    admin:      { emoji:"🛠️", label:"Admin",            short:"Admin",   blurb:"Staff: seed/sources/announce/readiness.", staff:true },
+  },
+  // functions per category
+  functions: {
+    ask:        [ {l:"Ask a question (AI)", s:"have", d:"grounded natural-language answer"} ],
+    units:      [ {l:"Towers browser", s:"have", d:"cost, upgrades, crosspaths, stats, Pro view"},
+                  {l:"Heroes browser", s:"have", d:"levels, abilities"},
+                  {l:"Paragon calculator", s:"have", d:"degree + stats"},
+                  {l:"Crosspath compare", s:"new", d:"compare two crosspaths for a tower"},
+                  {l:"Tier list", s:"new", d:"community tier list by version"} ],
+    rounds:     [ {l:"Round info", s:"have", d:"single round or a values table across a range"},
+                  {l:"RBE per round", s:"have", d:"single or inclusive range"},
+                  {l:"Income / cash", s:"have", d:"verified cash per round, single or range"},
+                  {l:"Bloon lookup", s:"have", d:"health, RBE, immunities, children"},
+                  {l:"Boss estimate", s:"have", d:"estimate a boss fight from HP/DPS/cost"} ],
+    calc:       [ {l:"Cost calculator", s:"new", d:"evaluate an upgrade-cost expression"},
+                  {l:"Cash goal", s:"new", d:"when can I afford $X (inverse income)"},
+                  {l:"Sun Temple sacrifice", s:"new", d:"max-temple / by-category sacrifice calc"},
+                  {l:"Hero leveling", s:"new", d:"level by income / by round placement"},
+                  {l:"Glue duration", s:"new", d:"how long a glue trap lasts"},
+                  {l:"CT tile decay", s:"new", d:"tile score decay over time"},
+                  {l:"Adora sacrifice", s:"new", d:"optimal Adora sacrifice"} ],
+    events:     [ {l:"Live events", s:"have", d:"race / boss / CT / odyssey / event"},
+                  {l:"Leaderboards", s:"have", d:"race / boss standings"},
+                  {l:"CT browser + map", s:"have", d:"tiles + rendered hex map"},
+                  {l:"Relic lookup", s:"have", d:"CT relic effects"} ],
+    mapsmodes:  [ {l:"Maps browser", s:"have", d:"by difficulty, water marker"},
+                  {l:"Modes catalog", s:"have", d:"mode rules & restrictions"} ],
+    strategy:   [ {l:"Browse strategies", s:"have", d:"published community strategies"},
+                  {l:"Submit a strategy", s:"have", d:"add to strategy memory"},
+                  {l:"My submissions", s:"have", d:"your own strategies in this guild"},
+                  {l:"Pending (staff)", s:"have", d:"review queue"} ],
+    challenges: [ {l:"2TC index", s:"new", d:"2-tower CHIMPS completions"},
+                  {l:"2MP index", s:"new", d:"2-money-pops completions"},
+                  {l:"LTC index", s:"new", d:"least-tiers CHIMPS"},
+                  {l:"LCC index", s:"new", d:"least-cash CHIMPS"},
+                  {l:"LCD index", s:"new", d:"least-cash deflation"},
+                  {l:"FTTC index", s:"new", d:"first-to-tier CHIMPS"} ],
+    help:       [ {l:"Status", s:"have", d:"assistant status"},
+                  {l:"Diagnostics", s:"have", d:"dataset diagnostics"},
+                  {l:"Help / commands", s:"have", d:"command reference"},
+                  {l:"Data sources", s:"have", d:"source registry freshness"} ],
+    admin:      [ {l:"Seed data", s:"have", d:"seed the Postgres store"},
+                  {l:"Sources on/off", s:"have", d:"enable / disable an ingestion source"},
+                  {l:"Announce channel", s:"have", d:"new-version announcements"},
+                  {l:"Readiness / runs", s:"have", d:"ingestion readiness + recent runs"},
+                  {l:"Admin panel", s:"have", d:"manual fetches + diagnostics"} ],
+  },
+  // three candidate layouts. Each row: list of controls.
+  // control kinds: {cat} category button (opens sub-panel) · {act} direct action
+  //                {sel:[cats]} a select menu whose options are categories
+  layouts: {
+    current: {
+      name: "A · Current (flat wall)",
+      blurb: "Every surfaced function is its own top-level button, ungrouped. Clear labels, but a 13-button wall that wraps to ~5 rows on mobile — and ~27 functions have no panel entry at all (slash-only).",
+      rows: [
+        [ {act:"Ask", cat:"ask", style:"success"}, {act:"Live Events", cat:"events", style:"primary"}, {act:"Towers", cat:"units", style:"primary"} ],
+        [ {act:"Heroes", cat:"units", style:"primary"}, {act:"Leaderboards", cat:"events", style:"primary"} ],
+        [ {act:"🗺️ CT", cat:"events", style:"secondary"}, {act:"Modes", cat:"mapsmodes", style:"secondary"}, {act:"Status", cat:"help", style:"primary"} ],
+        [ {act:"🔮 Paragon", cat:"units", style:"primary"}, {act:"🛠️ Admin", cat:"admin", style:"secondary"} ],
+        [ {act:"🗺️ Maps", cat:"mapsmodes", style:"secondary"}, {act:"📋 Strategy", cat:"strategy", style:"secondary"}, {act:"📚 Help", cat:"help", style:"secondary"} ],
+      ],
+    },
+    hub: {
+      name: "B · Category hub (recommended)",
+      blurb: "Ten labelled subdivisions, capped at FOUR buttons per row so short labels stay readable on mobile (5/row truncates to 'U…' — try it by editing the rows). Ask is a direct modal, the rest open an ephemeral sub-panel. Every function is 1–2 clicks away and there is room to add the whole calculator + challenge families without a new top-level button.",
+      rows: [
+        [ {cat:"ask", style:"success"}, {cat:"events", style:"primary"}, {cat:"units", style:"primary"}, {cat:"rounds", style:"primary"} ],
+        [ {cat:"calc", style:"primary"}, {cat:"mapsmodes", style:"secondary"}, {cat:"strategy", style:"secondary"}, {cat:"challenges", style:"secondary"} ],
+        [ {cat:"help", style:"secondary"}, {cat:"admin", style:"danger"} ],
+      ],
+    },
+    select: {
+      name: "C · Select hybrid (most compact)",
+      blurb: "Two hot buttons + one 'Browse BTD6…' dropdown that lists every browse category, + Admin. Smallest footprint (3 rows), scales to unlimited categories, still 1–2 clicks to any function. Slightly less glanceable than B because the categories hide inside the menu.",
+      rows: [
+        [ {cat:"ask", style:"success"}, {cat:"events", style:"primary"} ],
+        [ {sel:["units","rounds","calc","mapsmodes","strategy","challenges","help"]} ],
+        [ {cat:"admin", style:"danger"} ],
+      ],
+    },
+  },
+};
+
+/* ============================================================================ */
+const $ = s => document.querySelector(s);
+let current = "hub";        // active layout
+let drill = null;           // active sub-panel category id (or null)
+let selectOpen = false;
+
+const styleClass = s => ({success:"success", primary:"primary", secondary:"secondary", danger:"danger"}[s] || "secondary");
+const catLabel = id => `${DATA.categories[id].emoji} ${DATA.categories[id].label}`;
+const catBtnLabel = id => `${DATA.categories[id].emoji} ${DATA.categories[id].short || DATA.categories[id].label}`;
+
+function renderTabs() {
+  $("#tabs").innerHTML = "";
+  for (const key of Object.keys(DATA.layouts)) {
+    const L = DATA.layouts[key];
+    const b = document.createElement("button");
+    b.className = "tab" + (key === current ? " active" : "");
+    b.innerHTML = L.name.replace(/^(\S+ · )/, "<span>$1</span>").replace(/·/, "·");
+    b.onclick = () => { current = key; drill = null; selectOpen = false; renderAll(); };
+    $("#tabs").appendChild(b);
+  }
+}
+
+function controlButton(ctrl) {
+  const b = document.createElement("button");
+  b.className = "btn " + styleClass(ctrl.style);
+  b.textContent = ctrl.act || catBtnLabel(ctrl.cat);
+  b.onclick = () => {
+    if (ctrl.cat === "ask") { drill = "ask"; }
+    else { drill = ctrl.cat; }
+    selectOpen = false; renderRows(); renderMetrics();
+  };
+  return b;
+}
+
+function renderRows() {
+  const host = $("#rows");
+  host.innerHTML = "";
+  const L = DATA.layouts[current];
+
+  // Top-level controls
+  for (const row of L.rows) {
+    const r = document.createElement("div");
+    r.className = "row";
+    for (const ctrl of row) {
+      if (ctrl.sel) {
+        const sel = document.createElement("div");
+        sel.className = "select";
+        sel.innerHTML = `<span>🔽 Browse BTD6…</span><span class="chev">▾</span>`;
+        sel.onclick = () => { selectOpen = !selectOpen; drill = null; renderRows(); };
+        r.appendChild(sel);
+      } else {
+        r.appendChild(controlButton(ctrl));
+      }
+    }
+    host.appendChild(r);
+  }
+
+  // Expanded select options
+  if (selectOpen) {
+    const L2 = L.rows.flat().find(c => c.sel);
+    if (L2) {
+      const box = document.createElement("div");
+      box.className = "subpanel";
+      box.innerHTML = `<div class="crumb">Browse BTD6… — pick a category</div>`;
+      for (const catId of L2.sel) {
+        const opt = document.createElement("button");
+        opt.className = "btn secondary";
+        opt.style.marginTop = "6px";
+        opt.style.textAlign = "left";
+        opt.textContent = `${catLabel(catId)} — ${DATA.categories[catId].blurb}`;
+        opt.onclick = () => { drill = catId; selectOpen = false; renderRows(); renderMetrics(); };
+        box.appendChild(opt);
+      }
+      host.appendChild(box);
+    }
+  }
+
+  // Drill-down sub-panel
+  if (drill) {
+    host.appendChild(renderSubpanel(drill));
+  }
+  $("#ephHint").textContent = drill
+    ? "▲ ephemeral sub-panel — only you can see this"
+    : "Tip: click a category to open its ephemeral sub-panel.";
+}
+
+function renderSubpanel(catId) {
+  const box = document.createElement("div");
+  box.className = "subpanel";
+  const cat = DATA.categories[catId];
+  if (catId === "ask") {
+    box.innerHTML = `<div class="crumb"><b>${catLabel("ask")}</b> · a modal opens</div>
+      <div class="embed" style="border-color:var(--green)"><h3>Ask BTD6 Assistant</h3>
+      <div class="field-val">Type your question… e.g. <span class="mono">list all the bloons from r29 till r63</span></div></div>`;
+    const back = document.createElement("button");
+    back.className = "backbtn"; back.style.marginTop = "8px"; back.textContent = "↩ close";
+    back.onclick = () => { drill = null; renderRows(); renderMetrics(); };
+    box.appendChild(back);
+    return box;
+  }
+  const crumb = document.createElement("div");
+  crumb.className = "crumb";
+  crumb.innerHTML = `<b>${catLabel(catId)}</b> · ${cat.blurb}`;
+  box.appendChild(crumb);
+
+  const showNew = $("#showNew").checked;
+  const fns = DATA.functions[catId].filter(f => showNew || f.s === "have");
+  for (const f of fns) {
+    const b = document.createElement("button");
+    b.className = "btn " + (f.s === "new" ? "ghost" : "secondary");
+    b.style.marginTop = "6px";
+    b.style.textAlign = "left";
+    b.innerHTML = `${f.l} <span style="opacity:.6;font-weight:400">— ${f.d}</span>` +
+      (f.s === "new" ? ` <span class="pill new">add</span>` : "");
+    box.appendChild(b);
+  }
+  const back = document.createElement("button");
+  back.className = "backbtn"; back.style.marginTop = "8px"; back.textContent = "↩ back to menu";
+  back.onclick = () => { drill = null; renderRows(); renderMetrics(); };
+  box.appendChild(back);
+  return box;
+}
+
+/* ---- metrics ---- */
+function computeMetrics(key) {
+  const L = DATA.layouts[key];
+  const rows = L.rows;
+  const nRows = rows.length;
+  let controls = 0, hasSelect = false;
+  const reachableCats = new Set();
+  for (const row of rows) for (const c of row) {
+    controls++;
+    if (c.sel) { hasSelect = true; c.sel.forEach(x => reachableCats.add(x)); }
+    else if (c.cat) reachableCats.add(c.cat);
+  }
+  // functions reachable from the panel
+  const allCats = Object.keys(DATA.categories);
+  let reachFns = 0, totalFns = 0;
+  for (const cat of allCats) {
+    const n = DATA.functions[cat].length;
+    totalFns += n;
+    if (reachableCats.has(cat)) reachFns += n;
+  }
+  // max presses to a function: current = 1 (button==fn, the surfaced ones);
+  // hub = 2 (category → function); select = 2 (menu pick → function), ask = 1.
+  let maxPress;
+  if (key === "current") maxPress = 1;
+  else maxPress = 2;
+  return { nRows, controls, hasSelect, reachFns, totalFns, maxPress, coverage: Math.round(100*reachFns/totalFns) };
+}
+
+function renderMetrics() {
+  const m = computeMetrics(current);
+  $("#layoutTitle").textContent = DATA.layouts[current].name;
+  const cov = m.coverage;
+  const covCls = cov >= 100 ? "good" : cov >= 60 ? "warn" : "bad";
+  const rowCls = m.nRows <= 3 ? "good" : m.nRows <= 4 ? "warn" : "bad";
+  const cells = [
+    { n: m.controls, l: "top-level controls", cls: m.controls <= 5 ? "good" : m.controls <= 10 ? "warn" : "bad" },
+    { n: m.nRows, l: "rows on mobile", cls: rowCls },
+    { n: cov + "%", l: `functions reachable (${m.reachFns}/${m.totalFns})`, cls: covCls },
+    { n: "≤" + m.maxPress, l: "clicks to any function", cls: m.maxPress <= 2 ? "good" : "warn" },
+  ];
+  $("#metrics").innerHTML = cells.map(c =>
+    `<div class="metric ${c.cls}"><div class="n">${c.n}</div><div class="l">${c.l}</div></div>`).join("");
+  $("#verdict").innerHTML = DATA.layouts[current].blurb;
+  $("#rationale").innerHTML = rationaleHTML();
+}
+
+function rationaleHTML() {
+  return `
+    The recording showed the reference bot <b>Cyber Quincy</b> exposing ~40 BTD6
+    functions as flat <code class="k">/</code>slash commands. SuperBot already
+    owns most of them, but the <b>panel</b> only surfaces 13 as an ungrouped wall
+    (layout&nbsp;A) — so the depth is shallow but discovery is poor and the mobile
+    footprint is tall. Grouping into <b>ten subdivisions</b> keeps every function
+    1–2 clicks deep while making room for the whole
+    <span class="pill new">add</span> backlog (calculators, challenge indices)
+    without adding a single top-level button.
+    <br><br><b>Mobile finding (from the recording):</b> Discord truncates button
+    labels hard — <b>5 buttons per row</b> collapses "Events"→"E…". So the real
+    choice is <b>B at ≤4 buttons/row</b> (glanceable, 3 rows) vs. <b>C</b>, a
+    dropdown that stays fully readable at any width (2 rows).
+    <br><br><b>Recommendation:</b> ship <b>B</b> (category hub, ≤4/row) — clearest
+    subdivisions, 2-click depth, back-compatible with the existing
+    <span class="mono">btd6:*</span> button ids (they become the sub-panel
+    entries). Put a <b>select inside</b> the crowded sub-panels (Calculators,
+    Challenge Index) so they never exceed one row. If footprint matters more than
+    glanceability, <b>C</b> is the compact fallback.`;
+}
+
+/* ---- inventory table ---- */
+function renderInventory() {
+  const showNew = $("#showNew").checked;
+  const tb = $("#inv").querySelector("tbody");
+  tb.innerHTML = "";
+  let have = 0, add = 0;
+  for (const catId of Object.keys(DATA.categories)) {
+    const cat = DATA.categories[catId];
+    const fns = DATA.functions[catId].filter(f => showNew || f.s === "have");
+    if (!fns.length) continue;
+    const h = document.createElement("tr");
+    h.innerHTML = `<td class="cat-h" colspan="3">${cat.emoji} ${cat.label}${cat.staff ? " (staff)" : ""} — <span style="font-weight:400;color:var(--muted)">${cat.blurb}</span></td>`;
+    tb.appendChild(h);
+    for (const f of fns) {
+      if (f.s === "have") have++; else add++;
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td style="width:170px">${f.l}</td>
+        <td class="src"><span class="pill ${f.s === "have" ? "have" : "new"}">${f.s === "have" ? "have" : "add"}</span></td>
+        <td style="color:var(--muted)">${f.d}</td>`;
+      tb.appendChild(tr);
+    }
+  }
+  $("#invCount").textContent = `${have} shipped · ${add} candidate additions · ${have+add} total`;
+}
+
+function renderAll() { renderTabs(); renderRows(); renderMetrics(); renderInventory(); }
+$("#showNew").addEventListener("change", () => { renderRows(); renderInventory(); });
+renderAll();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Owner-directed (screen-recording + screenshots). Two deliverables:

## 1. Round-range NL answer fix
The question **"list all the bloons from r29 till r63"** only grounded the two endpoint rounds (29 + 62/63), never the full range. Root cause: the NL resolver extracts isolated round numbers with no range concept, and the Ask-modal path bypasses the deterministic list floor. Fix: a deterministic **round-range bloon-listing** builder + range-composition grounding so a range enumerates every round in it.

## 2. BTD6 menu layout simulator
An interactive HTML tool comparing SuperBot's current BTD6 panel to the mature **Cyber Quincy** reference surface (from the video), with candidate grouped-subdivision layouts and clicks-to-reach metrics — the maintainer's visualize-first design aid — plus the recommended redesign implemented in `panel.py` (back-compat custom_ids kept) and a design doc.

Status: **born red** (in-progress session card); flips to ready as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015sC9tZ1qAVEz4gvZcdCbBU)_