### PR TITLE
Server-log embeds: a face per entry (subject avatar in every log embed)

### DIFF
--- a/.sessions/2026-07-01-server-log-avatar.md
+++ b/.sessions/2026-07-01-server-log-avatar.md
@@ -1,0 +1,33 @@
+# 2026-07-01 — Server-log embeds: a face per entry (avatar in the author slot)
+
+> **Status:** `in-progress` — born-red (Q-0133). Run type: manual · owner-directed.
+> PR # pending first push.
+
+**Branch:** `claude/visual-comparison-other-bots-89vna4` (restarted from `main` @ #1614 merged).
+
+## What I'm about to do (intentions)
+
+The owner compared our `#server-log` style with **Dyno's** and said ours is already nice — but asked for
+one improvement idea. Ours is genuinely good (colour-coded borders, emoji titles, structured
+Author/Channel/Content/Before/After/Attachments/Jump fields, full IDs). The **one thing Dyno has that we
+don't** is a per-entry **avatar** — a small round face beside the name at the top of each log embed, so you
+see *who* at a glance while scanning.
+
+The idea (purely additive — changes no field the owner likes): add the event **subject's** avatar + display
+name to each passive-event log embed's **author slot** (`embed.set_author(name=…, icon_url=…)`). The five
+`format_*_embed` builders in `services/server_logging.py` already hold the `discord.Member`/`User` object
+(`message.author`, `after.author`, `member`) with `.display_avatar.url` + `.display_name` right there, and an
+embed references the CDN url directly — **zero network on our side, no failure path**. The structured fields
+(mention + copyable id) stay exactly as they are.
+
+Scope: the 5 passive builders shown in the screenshot (message delete/edit, member join/leave, role change).
+The moderation/audit embeds (`format_log_embed`/`format_audit_embed`) only carry ids, not objects — noted as
+a trivial follow-up (resolve the member from the guild), out of scope here.
+
+## What shipped
+
+_(filled in at close)_
+
+## Context delta
+
+_(filled in at close)_

--- a/.sessions/2026-07-01-server-log-avatar.md
+++ b/.sessions/2026-07-01-server-log-avatar.md
@@ -1,7 +1,7 @@
 # 2026-07-01 — Server-log embeds: a face per entry (avatar in the author slot)
 
-> **Status:** `in-progress` — born-red (Q-0133). Run type: manual · owner-directed.
-> PR # pending first push.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: manual · owner-directed.
+> Full CI mirror green (**13610 passed**; ruff/black/isort/mypy clean; arch 0 new). PR #1618.
 
 **Branch:** `claude/visual-comparison-other-bots-89vna4` (restarted from `main` @ #1614 merged).
 
@@ -26,8 +26,64 @@ a trivial follow-up (resolve the member from the guild), out of scope here.
 
 ## What shipped
 
-_(filled in at close)_
+One small, additive change to `services/server_logging.py`:
+
+1. **`_set_subject_author(embed, user)`** — a defensive helper that puts the subject's `display_name` +
+   `display_avatar.url` in the embed **author slot** (`set_author`). A partial/odd object (no
+   `display_name`/`name`) yields no author line rather than raising into the fail-safe handler. No network
+   on our side — the embed references the CDN url.
+2. Wired into all **five** passive-event builders: `format_message_delete_embed` (author),
+   `format_message_edit_embed` (after.author), `format_member_join_embed` / `format_member_leave_embed` /
+   `format_role_change_embed` (member). Every structured field is untouched — the avatar is strictly extra.
+3. **Tests (+3)** — message embeds set the author avatar, member/role embeds set it, and the helper is
+   defensive on a partial object. Updated the two mock factories (`_message`, `_member`) to carry
+   `display_name` + `display_avatar.url`. Full logging suite green (124 passed); full CI mirror green; arch 0.
+4. **Docs** — `docs/server-logging.md` "Server event logging v1 → Handlers + embeds" notes the author-slot
+   avatar (+ that mod/audit embeds are the follow-up).
+
+Approximate before/after embed mockup shared in chat (embeds can't be rendered to PNG; Discord draws the
+real chrome + the colour emoji).
 
 ## Context delta
 
-_(filled in at close)_
+- **Right altitude for "come up with an idea":** the owner said our style is already nice and asked for *an
+  idea* — so the win had to be **purely additive** (add a face, remove nothing he likes), not a restyle.
+  `set_author` (a small avatar+name header) is exactly that and is the one thing Dyno had that we didn't.
+- **`set_author` over `set_thumbnail`:** the author slot is the compact, top-left "who" indicator (Dyno's
+  look); a thumbnail would be a big right-side image that fights the structured fields.
+- **Scoped to the 5 passive builders** (the screenshot surface). The mod/audit embeds only carry ids, so
+  their avatar needs a guild member-resolve — deliberately deferred as a clean follow-up, not stretched
+  into this PR.
+- **Cheaper than the card avatars:** unlike the rank card (which fetches bytes), an embed references the
+  avatar URL directly — zero network, no fallback path, so this is lower-risk than last session's avatar work.
+- **Verification gap for embeds:** I can render image *cards* to PNG and Read them, but an *embed* can't be
+  screenshotted here — the honest verification is the unit test (author slot asserted) + the owner's live
+  check post-merge. The mockup is an approximation, flagged as such.
+
+## 🛠 Friction → guard
+
+None this session — the change was additive with no footgun, CI was green first try after the local mirror,
+and the born-red/force-with-lease branch restart (last PR merged) went cleanly once the stale remote ref was
+refreshed (already a documented journal Rule: sync/branch-fresh on a resumed session). No new guard warranted.
+
+## 💡 Session idea
+
+**Consolidate bulk deletes into one log embed.** A moderator purge fires `on_bulk_message_delete` (or N
+rapid `on_message_delete`s); if we log each individually the channel floods with dozens of near-identical
+"Message deleted" embeds. Add an `on_bulk_message_delete` listener that posts **one** embed — "N messages
+deleted in #channel" with a small sample — instead of N. Genuinely useful (purges are the common case that
+makes a log channel unreadable) and distinct from today's per-message path. Flagged here per Q-0089; modest
+scope, so a log flag rather than a full idea file.
+
+## ⟲ Previous-session review
+
+Prev: `2026-07-01-visual-comparison-cards.md` (PR #1614 — rank/leaderboard card polish). **Did well:**
+rendered the actual before/after PNGs and *Read* them to verify (the real "visualize, then build" loop),
+fixed emoji tofu at the engine seam (root-cause, one place), and scoped cleanly (deferred `member_display`
++ `/myprofile`). **Could improve:** the leaderboard `_bar_fraction` floor (0.12) left the mid-pack bars a
+bit clustered — I picked a curve and shipped without A/B-rendering two or three alternatives to compare,
+which for a purely-visual choice would have been cheap and more defensible. **Workflow surface:** visual
+work now has *numeric* property guards (the `_bar_fraction` monotonicity test) but no *golden-image*
+regression — a future edit could quietly re-introduce the outlier-squash and no test would catch it.
+Worth considering a lightweight golden-PNG (or perceptual-hash) guard for the card engine, so the visual
+contract is enforced, not just the numeric one. (Captured as a thought — same no-filler bar as Q-0089.)

--- a/.sessions/2026-07-01-server-log-avatar.md
+++ b/.sessions/2026-07-01-server-log-avatar.md
@@ -1,7 +1,8 @@
 # 2026-07-01 — Server-log embeds: a face per entry (avatar in the author slot)
 
 > **Status:** `complete` — ready to merge (Q-0133). Run type: manual · owner-directed.
-> Full CI mirror green (**13610 passed**; ruff/black/isort/mypy clean; arch 0 new). PR #1618.
+> Full CI mirror green (**13618 passed**; ruff/black/isort/mypy clean; arch 0 new). PR #1618.
+> Scope: subject avatar in **every** server-log embed (passive + moderation + audit).
 
 **Branch:** `claude/visual-comparison-other-bots-89vna4` (restarted from `main` @ #1614 merged).
 
@@ -26,23 +27,31 @@ a trivial follow-up (resolve the member from the guild), out of scope here.
 
 ## What shipped
 
-One small, additive change to `services/server_logging.py`:
+A face in the author slot of **every** server-log embed — additive across all surfaces
+(`services/server_logging.py`):
 
-1. **`_set_subject_author(embed, user)`** — a defensive helper that puts the subject's `display_name` +
-   `display_avatar.url` in the embed **author slot** (`set_author`). A partial/odd object (no
-   `display_name`/`name`) yields no author line rather than raising into the fail-safe handler. No network
-   on our side — the embed references the CDN url.
-2. Wired into all **five** passive-event builders: `format_message_delete_embed` (author),
-   `format_message_edit_embed` (after.author), `format_member_join_embed` / `format_member_leave_embed` /
-   `format_role_change_embed` (member). Every structured field is untouched — the avatar is strictly extra.
-3. **Tests (+3)** — message embeds set the author avatar, member/role embeds set it, and the helper is
-   defensive on a partial object. Updated the two mock factories (`_message`, `_member`) to carry
-   `display_name` + `display_avatar.url`. Full logging suite green (124 passed); full CI mirror green; arch 0.
-4. **Docs** — `docs/server-logging.md` "Server event logging v1 → Handlers + embeds" notes the author-slot
-   avatar (+ that mod/audit embeds are the follow-up).
+1. **`_set_subject_author(embed, user)`** — defensive helper that puts the subject's `display_name` +
+   `display_avatar.url` in the embed **author slot** (`set_author`). A partial/odd object or `None` yields
+   no author line rather than raising into the fail-safe handler. No network — the embed references the CDN url.
+2. **Passive-event builders (5)** hold the object they log, so they pass it straight in:
+   `format_message_delete_embed`/`_edit` (author), `format_member_join`/`leave` + `format_role_change` (member).
+3. **Moderation + audit builders (3)** carry only ids, so the *sender* resolves the person via
+   **`_resolve_subject_user`** (guild member cache → the bot's global user cache, so a just-banned/kicked
+   member still gets a face; **cache-only, never a network call**) and passes it into `format_log_embed`
+   (target), `format_public_log_embed` (target — never the moderator, preserving the redaction), and
+   `format_audit_embed` (actor). Every structured field on every embed is untouched.
+4. **Helpers centralised** — `_set_subject_author` moved up beside the new `_resolve_subject_user`, before
+   the first builder, so every call site is a clean backward reference.
+5. **Tests (+11 total)** — passive (message/member/role author-avatar + defensive-on-partial), mod-log +
+   public-log subject avatar + no-subject-no-author, audit actor avatar + no-subject, and the four
+   `_resolve_subject_user` paths (member hit · bot-cache fallback · none-id · unresolvable). Full logging
+   suite green (132 passed).
+6. **Docs** — `docs/server-logging.md` "Handlers + embeds" now documents the face-per-entry across all
+   surfaces (target vs actor vs redacted public) via `_resolve_subject_user`.
 
-Approximate before/after embed mockup shared in chat (embeds can't be rendered to PNG; Discord draws the
-real chrome + the colour emoji).
+Approximate before/after embed mockup (passive "Message deleted") shared in chat — embeds can't be rendered
+to PNG, so it's a sketch; Discord draws the real chrome + emoji. The mod/audit embeds gain the identical
+author-slot avatar.
 
 ## Context delta
 
@@ -59,12 +68,29 @@ real chrome + the colour emoji).
 - **Verification gap for embeds:** I can render image *cards* to PNG and Read them, but an *embed* can't be
   screenshotted here — the honest verification is the unit test (author slot asserted) + the owner's live
   check post-merge. The mockup is an approximation, flagged as such.
+- **Extension (owner: "make everything the same"):** whose face per surface is a real decision — mod-log →
+  the **target** (the person acted on, matching the passive events); audit → the **actor** (there's no
+  person "target", the record is a config change, so the face is *who changed it*); public mod-log → the
+  **target only**, never resolving the moderator, so that surface's deliberate redaction is preserved.
+- **Cache-only resolution, no network in the hot path:** `_resolve_subject_user` tries the guild member
+  cache then the bot's global user cache (`bot.get_user`) — the latter is what lets a just-banned/kicked
+  member (already gone from the guild) still show a face, without a fetch. Unresolvable → no author line,
+  the same graceful degradation as a departed member.
+- **Folded into #1618 rather than a follow-up PR:** the owner asked for it while #1618 was still open
+  (CI blocked, not merged), so I **disabled auto-merge** to hold it, added the extension, and re-armed at
+  the end — one coherent "avatars on every log embed" change instead of two PRs. (If it had already merged,
+  the rule is a fresh branch/PR; it hadn't, verified by fetch.)
 
 ## 🛠 Friction → guard
 
-None this session — the change was additive with no footgun, CI was green first try after the local mirror,
-and the born-red/force-with-lease branch restart (last PR merged) went cleanly once the stale remote ref was
-refreshed (already a documented journal Rule: sync/branch-fresh on a resumed session). No new guard warranted.
+**The existing guard did its job — no new one needed.** The mod/audit extension's `_resolve_subject_user`
+first used a raw `guild.get_member(...)`, which the **`test_no_raw_guild_lookups_outside_resolver` invariant**
+caught in the full CI mirror (raw member/role/channel lookups must go through `core.runtime.guild_resources`).
+Fixed by routing through `resources.resolve_member`. This is exactly the "enforce, don't exhort" loop working:
+a checker caught a footgun I'd have otherwise shipped, so there's nothing to add — the guard already exists
+and fired. (Lesson logged, not a new guard.) The passive-event half was clean first try; the born-red /
+force-with-lease branch restart (last PR merged) went fine once the stale remote ref was refreshed (already
+a journal Rule).
 
 ## 💡 Session idea
 

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -928,6 +928,28 @@ def _relative_ts(when: datetime.datetime | None) -> str | None:
     return f"<t:{int(when.timestamp())}:R>"
 
 
+def _set_subject_author(embed: discord.Embed, user: Any) -> None:
+    """Put the event *subject*'s avatar + name in the embed's author slot.
+
+    Discord renders the author slot as a small round avatar beside a name at the
+    top of the embed, so every log entry gets a face — the "who" of the event at
+    a glance while scanning the channel (what mature log bots show).  Purely
+    additive: the structured fields below (the mention + copyable id, channel,
+    content…) are untouched, and there is **no network on our side** — the embed
+    just references the avatar's CDN url, so nothing is fetched and there is no
+    failure path to guard.  Defensive so a partial object (a bare id, an odd
+    fake) yields no author line rather than raising into the fail-safe handler;
+    ``display_name`` / ``display_avatar`` exist on both ``discord.User`` and
+    ``discord.Member``.
+    """
+    name = getattr(user, "display_name", None) or getattr(user, "name", None)
+    if not name:
+        return
+    avatar = getattr(user, "display_avatar", None)
+    icon_url = getattr(avatar, "url", None)
+    embed.set_author(name=str(name)[:256], icon_url=icon_url)
+
+
 def format_message_delete_embed(message: discord.Message) -> discord.Embed:
     """Render a deleted message as a log embed (author · channel · content)."""
     embed = discord.Embed(
@@ -936,6 +958,7 @@ def format_message_delete_embed(message: discord.Message) -> discord.Embed:
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
     author = message.author
+    _set_subject_author(embed, author)
     embed.add_field(
         name="Author",
         value=f"<@{author.id}> (`{author.id}`)",
@@ -969,6 +992,7 @@ def format_message_edit_embed(
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
     author = after.author
+    _set_subject_author(embed, author)
     embed.add_field(
         name="Author",
         value=f"<@{author.id}> (`{author.id}`)",
@@ -1002,6 +1026,7 @@ def format_member_join_embed(member: discord.Member) -> discord.Embed:
         color=discord.Color.green(),
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    _set_subject_author(embed, member)
     embed.add_field(
         name="Member",
         value=f"<@{member.id}> (`{member.id}`)",
@@ -1023,6 +1048,7 @@ def format_member_leave_embed(member: discord.Member) -> discord.Embed:
         color=discord.Color.dark_orange(),
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    _set_subject_author(embed, member)
     # Show the username too — a mention of a departed member often won't
     # resolve to a name in the client.
     embed.add_field(
@@ -1054,6 +1080,7 @@ def format_role_change_embed(
         color=discord.Color.blurple(),
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    _set_subject_author(embed, member)
     embed.add_field(
         name="Member",
         value=f"<@{member.id}> (`{member.id}`)",

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -425,6 +425,58 @@ _MAX_EXTRA_FIELDS = 6
 _EXTRA_VALUE_CAP = 500
 
 
+def _set_subject_author(embed: discord.Embed, user: Any) -> None:
+    """Put the event *subject*'s avatar + name in the embed's author slot.
+
+    Discord renders the author slot as a small round avatar beside a name at the
+    top of the embed, so every log entry gets a face — the "who" of the event at
+    a glance while scanning the channel (what mature log bots show).  Purely
+    additive: the structured fields below (the mention + copyable id, channel,
+    content…) are untouched, and there is **no network on our side** — the embed
+    just references the avatar's CDN url, so nothing is fetched and there is no
+    failure path to guard.  Defensive so a partial object (a bare id, an odd
+    fake, or ``None``) yields no author line rather than raising into the
+    fail-safe handler; ``display_name`` / ``display_avatar`` exist on both
+    ``discord.User`` and ``discord.Member``.
+    """
+    if user is None:
+        return
+    name = getattr(user, "display_name", None) or getattr(user, "name", None)
+    if not name:
+        return
+    avatar = getattr(user, "display_avatar", None)
+    icon_url = getattr(avatar, "url", None)
+    embed.set_author(name=str(name)[:256], icon_url=icon_url)
+
+
+def _resolve_subject_user(guild: discord.Guild, user_id: int | None) -> Any:
+    """Best-effort resolve a user id to a member/user object for the avatar.
+
+    The passive-event embeds already hold the ``discord.Member``/``User`` object
+    they log; the moderation + audit embeds carry only ids, so this is how they
+    get the same face.  Tries the guild member cache first (via the canonical
+    ``resources.resolve_member`` resolver — the invariant forbids a raw
+    ``guild.get_member`` here), then the bot's global user cache (covers a
+    just-banned/kicked member no longer in the guild).  **Cache lookups only —
+    never a network call** in the hot logging path.  Returns ``None`` when
+    neither resolves, so the embed simply gets no author line (the same graceful
+    degradation as a departed member in the passive log).
+    """
+    if user_id is None:
+        return None
+    # Lazy import: this module never imports core.runtime at module load (it
+    # would re-enter a partially-loaded core.runtime during startup) — mirrors
+    # resolve_log_channel below.
+    from core.runtime.guild_resources import resolve_member
+
+    member = resolve_member(guild, user_id)
+    if member is not None:
+        return member
+    bot = _BOT
+    get_user = getattr(bot, "get_user", None) if bot is not None else None
+    return get_user(user_id) if get_user is not None else None
+
+
 def format_log_embed(
     *,
     action: str,
@@ -433,6 +485,7 @@ def format_log_embed(
     actor_id: int | None,
     reason: str,
     extras: dict[str, Any] | None = None,
+    subject: Any = None,
 ) -> discord.Embed:
     """Render a moderation/cleanup payload as a Discord embed.
 
@@ -442,7 +495,9 @@ def format_log_embed(
     :data:`_MAX_EXTRA_FIELDS` slots and each value is truncated to
     :data:`_EXTRA_VALUE_CAP` chars; if more keys are supplied, a
     single ``"... truncated"`` field reports the count so the embed
-    stays under Discord's 25-field / 6000-char limits.
+    stays under Discord's 25-field / 6000-char limits.  ``subject`` (the
+    resolved target member/user, when the sender could look it up) puts a
+    face in the author slot, matching the passive-event embeds.
     """
     root = _root_action(action)
     color = _ACTION_COLOR.get(root, discord.Color.dark_grey())
@@ -453,6 +508,7 @@ def format_log_embed(
         color=color,
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    _set_subject_author(embed, subject)
     embed.add_field(name="Target", value=f"<@{target_id}> (`{target_id}`)", inline=True)
     actor_display = f"<@{actor_id}>" if actor_id else "system"
     embed.add_field(name="Actor", value=actor_display, inline=True)
@@ -482,13 +538,16 @@ def format_public_log_embed(
     action: str,
     target_id: int,
     reason: str,
+    subject: Any = None,
 ) -> discord.Embed:
     """Render the **public** moderation-log embed (server-management PR10).
 
     Deliberately narrower than :func:`format_log_embed`: it shows the action,
     the affected member, and the reason — but **never the acting moderator**
     (the maintainer's choice for the public surface) nor the internal guild id.
-    The staff mod-log keeps the full record.
+    The staff mod-log keeps the full record.  ``subject`` (the affected member)
+    rides the author slot for the same face-per-entry look; it is the *target*,
+    never the moderator, so the public surface still never reveals who acted.
     """
     root = _root_action(action)
     embed = discord.Embed(
@@ -496,6 +555,7 @@ def format_public_log_embed(
         color=_ACTION_COLOR.get(root, discord.Color.dark_grey()),
         timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    _set_subject_author(embed, subject)
     embed.add_field(name="Member", value=f"<@{target_id}> (`{target_id}`)", inline=True)
     if reason:
         embed.add_field(name="Reason", value=reason[:1000], inline=False)
@@ -541,6 +601,7 @@ async def log_event(
         actor_id=actor_id,
         reason=reason,
         extras=extras,
+        subject=_resolve_subject_user(guild, target_id),
     )
     try:
         await channel.send(embed=embed)
@@ -588,13 +649,16 @@ def format_audit_embed(
     actor_id: int | None,
     actor_type: str,
     occurred_at: str,
+    subject: Any = None,
 ) -> discord.Embed:
     """Render an ``audit.action_recorded`` payload as a Discord embed.
 
     Phase 9c.1 — generic audit-trail rendering. The payload contract
     matches what :func:`services.rollout_mutation._emit_audit_event`
     sends; future publishers (other mutation pipelines) MUST use the
-    same field names.
+    same field names.  ``subject`` (the resolved **actor**, when a user
+    made the change) rides the author slot for the same face-per-entry
+    look; a system/pipeline actor simply has no face.
     """
     embed = discord.Embed(
         title=f"📋 {mutation_type}",
@@ -604,6 +668,7 @@ def format_audit_embed(
         ),
         color=discord.Color.dark_teal(),
     )
+    _set_subject_author(embed, subject)
     embed.add_field(name="Target", value=f"`{target}`", inline=True)
     actor_display = f"<@{actor_id}>" if actor_id else f"`{actor_type}`"
     embed.add_field(name="Actor", value=actor_display, inline=True)
@@ -670,6 +735,7 @@ async def log_audit_event(
         actor_id=actor_id,
         actor_type=actor_type,
         occurred_at=occurred_at,
+        subject=_resolve_subject_user(guild, actor_id),
     )
     try:
         await channel.send(embed=embed)
@@ -843,7 +909,12 @@ async def maybe_log_public(
     if not isinstance(channel, discord.TextChannel):
         _bump("mod_public_skipped")  # channel unset or stale/invalid
         return False
-    embed = format_public_log_embed(action=action, target_id=target_id, reason=reason)
+    embed = format_public_log_embed(
+        action=action,
+        target_id=target_id,
+        reason=reason,
+        subject=_resolve_subject_user(guild, target_id),
+    )
     try:
         await channel.send(embed=embed)
     except (discord.Forbidden, discord.HTTPException) as exc:
@@ -926,28 +997,6 @@ def _relative_ts(when: datetime.datetime | None) -> str | None:
     if when is None:
         return None
     return f"<t:{int(when.timestamp())}:R>"
-
-
-def _set_subject_author(embed: discord.Embed, user: Any) -> None:
-    """Put the event *subject*'s avatar + name in the embed's author slot.
-
-    Discord renders the author slot as a small round avatar beside a name at the
-    top of the embed, so every log entry gets a face — the "who" of the event at
-    a glance while scanning the channel (what mature log bots show).  Purely
-    additive: the structured fields below (the mention + copyable id, channel,
-    content…) are untouched, and there is **no network on our side** — the embed
-    just references the avatar's CDN url, so nothing is fetched and there is no
-    failure path to guard.  Defensive so a partial object (a bare id, an odd
-    fake) yields no author line rather than raising into the fail-safe handler;
-    ``display_name`` / ``display_avatar`` exist on both ``discord.User`` and
-    ``discord.Member``.
-    """
-    name = getattr(user, "display_name", None) or getattr(user, "name", None)
-    if not name:
-        return
-    avatar = getattr(user, "display_avatar", None)
-    icon_url = getattr(avatar, "url", None)
-    embed.set_author(name=str(name)[:256], icon_url=icon_url)
 
 
 def format_message_delete_embed(message: discord.Message) -> discord.Embed:

--- a/docs/owner/claims/claude-visual-comparison-other-bots-89vna4.md
+++ b/docs/owner/claims/claude-visual-comparison-other-bots-89vna4.md
@@ -1,1 +1,0 @@
-- `claude/visual-comparison-other-bots-89vna4` · server-log embeds gain the subject's avatar + name in the embed author slot (Dyno-style "who" at a glance; purely additive) · `disbot/services/server_logging.py` · `tests/unit/services/test_server_logging_events.py` · 2026-07-01

--- a/docs/owner/claims/claude-visual-comparison-other-bots-89vna4.md
+++ b/docs/owner/claims/claude-visual-comparison-other-bots-89vna4.md
@@ -1,0 +1,1 @@
+- `claude/visual-comparison-other-bots-89vna4` · server-log embeds gain the subject's avatar + name in the embed author slot (Dyno-style "who" at a glance; purely additive) · `disbot/services/server_logging.py` · `tests/unit/services/test_server_logging_events.py` · 2026-07-01

--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -254,14 +254,19 @@ activity is deliberately out of v1 scope.
   `log_member_leave` / `log_role_change`, plus the matching
   `format_*_embed` builders). Each handler loads the policy, gates,
   resolves the routed channel, and posts — fully fail-safe. Each
-  `format_*_embed` also puts the event **subject's** avatar + display name
-  in the embed **author slot** (`_set_subject_author`) — a face per entry
-  for at-a-glance scanning. Purely additive (the structured fields are
-  unchanged) and network-free (the embed just references the avatar's CDN
-  url, so there is nothing to fetch and no failure path). The
-  moderation/audit embeds (`format_log_embed` / `format_audit_embed`)
-  carry only ids, so their avatar is a follow-up (resolve the member from
-  the guild at send time).
+  `format_*_embed` also puts the relevant **subject's** avatar + display
+  name in the embed **author slot** (`_set_subject_author`) — a face per
+  entry for at-a-glance scanning. Purely additive (the structured fields
+  are unchanged) and network-free (the embed just references the avatar's
+  CDN url, so there is nothing to fetch and no failure path). **Every log
+  surface carries the same face:** the passive-event embeds use the object
+  they already hold, and the **moderation** + **audit** embeds — which
+  carry only ids — resolve one via `_resolve_subject_user` (guild member
+  cache, then the bot's global user cache, so a just-banned member still
+  gets a face; cache-only, never a network call). The mod-log shows the
+  **target**; the audit embed shows the **actor**; the public mod-log shows
+  the **target** only (never the moderator, preserving that surface's
+  redaction).
 * **Config read model** — `services/server_logging_config.py`
   (`EventLoggingPolicy` + `load_policy`), mirroring `automod_config`.
 

--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -253,7 +253,15 @@ activity is deliberately out of v1 scope.
   (`log_message_delete` / `log_message_edit` / `log_member_join` /
   `log_member_leave` / `log_role_change`, plus the matching
   `format_*_embed` builders). Each handler loads the policy, gates,
-  resolves the routed channel, and posts — fully fail-safe.
+  resolves the routed channel, and posts — fully fail-safe. Each
+  `format_*_embed` also puts the event **subject's** avatar + display name
+  in the embed **author slot** (`_set_subject_author`) — a face per entry
+  for at-a-glance scanning. Purely additive (the structured fields are
+  unchanged) and network-free (the embed just references the avatar's CDN
+  url, so there is nothing to fetch and no failure path). The
+  moderation/audit embeds (`format_log_embed` / `format_audit_embed`)
+  carry only ids, so their avatar is a follow-up (resolve the member from
+  the guild at send time).
 * **Config read model** — `services/server_logging_config.py`
   (`EventLoggingPolicy` + `load_policy`), mirroring `automod_config`.
 

--- a/tests/unit/services/test_server_logging.py
+++ b/tests/unit/services/test_server_logging.py
@@ -263,6 +263,72 @@ def test_format_log_embed_extra_value_truncated_at_cap():
 
 
 # ---------------------------------------------------------------------------
+# Subject avatar — the mod-log embed matches the passive-event embeds
+# ---------------------------------------------------------------------------
+
+
+def _subject(name: str = "TargetUser", url: str = "https://cdn.example/t.png") -> MagicMock:
+    s = MagicMock()
+    s.display_name = name
+    s.display_avatar = MagicMock()
+    s.display_avatar.url = url
+    return s
+
+
+def test_format_log_embed_subject_sets_author_avatar():
+    embed = format_log_embed(
+        action="ban",
+        guild_id=1,
+        target_id=7,
+        actor_id=2,
+        reason="x",
+        subject=_subject(),
+    )
+    assert embed.author.name == "TargetUser"
+    assert embed.author.icon_url == "https://cdn.example/t.png"
+
+
+def test_format_log_embed_without_subject_has_no_author():
+    embed = format_log_embed(action="ban", guild_id=1, target_id=7, actor_id=2, reason="x")
+    assert embed.author.name is None
+
+
+def test_format_public_log_embed_subject_sets_author_avatar():
+    embed = format_public_log_embed(action="ban", target_id=7, reason="x", subject=_subject())
+    assert embed.author.name == "TargetUser"
+
+
+def test_resolve_subject_user_prefers_guild_member():
+    guild = _make_guild()
+    member = _subject()
+    guild.get_member = MagicMock(return_value=member)
+    assert server_logging._resolve_subject_user(guild, 7) is member
+
+
+def test_resolve_subject_user_falls_back_to_bot_user_cache():
+    # A just-banned member is gone from the guild cache but still in the bot's
+    # global user cache — so bans/kicks still get a face.
+    guild = _make_guild()
+    guild.get_member = MagicMock(return_value=None)
+    user = _subject()
+    fake_bot = MagicMock()
+    fake_bot.get_user = MagicMock(return_value=user)
+    server_logging._BOT = fake_bot
+    try:
+        assert server_logging._resolve_subject_user(guild, 7) is user
+    finally:
+        server_logging._BOT = None
+
+
+def test_resolve_subject_user_none_when_unresolvable_or_no_id():
+    guild = _make_guild()
+    guild.get_member = MagicMock(return_value=None)
+    server_logging._BOT = None
+    assert server_logging._resolve_subject_user(guild, 7) is None
+    assert server_logging._resolve_subject_user(guild, None) is None
+
+
+# ---------------------------------------------------------------------------
 # resolve_log_channel
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/test_server_logging_audit.py
+++ b/tests/unit/services/test_server_logging_audit.py
@@ -136,6 +136,48 @@ def test_format_audit_embed_renders_expected_fields():
     assert "set_flag_state" in (embed.title or "")
 
 
+def test_format_audit_embed_subject_sets_actor_avatar():
+    # The audit embed's face is the *actor* (who made the change), matching the
+    # face-per-entry look of every other log embed.
+    subject = MagicMock()
+    subject.display_name = "ActorUser"
+    subject.display_avatar = MagicMock()
+    subject.display_avatar.url = "https://cdn.example/a.png"
+    embed = format_audit_embed(
+        mutation_id="abc-123",
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target="flag:x",
+        scope="guild",
+        guild_id=42,
+        prev_value="off",
+        new_value="on",
+        actor_id=99,
+        actor_type="platform_owner",
+        occurred_at="2026-05-19T12:00:00+00:00",
+        subject=subject,
+    )
+    assert embed.author.name == "ActorUser"
+    assert embed.author.icon_url == "https://cdn.example/a.png"
+
+
+def test_format_audit_embed_without_subject_has_no_author():
+    embed = format_audit_embed(
+        mutation_id="x",
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target="flag:x",
+        scope="guild",
+        guild_id=42,
+        prev_value="off",
+        new_value="on",
+        actor_id=None,
+        actor_type="system",
+        occurred_at="2026-05-19T12:00:00+00:00",
+    )
+    assert embed.author.name is None
+
+
 def test_format_audit_embed_handles_cleared_value():
     embed = format_audit_embed(
         mutation_id="x",

--- a/tests/unit/services/test_server_logging_events.py
+++ b/tests/unit/services/test_server_logging_events.py
@@ -74,6 +74,9 @@ def _message(*, content: str = "hi", bot: bool = False) -> MagicMock:
     author = MagicMock()
     author.id = 7
     author.bot = bot
+    author.display_name = "AuthorName"
+    author.display_avatar = MagicMock()
+    author.display_avatar.url = "https://cdn.example/author.png"
     msg.author = author
     msg.content = content
     channel = MagicMock(spec=discord.TextChannel)
@@ -92,6 +95,9 @@ def _member(*, bot: bool = False, roles: list | None = None) -> MagicMock:
     member.created_at = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
     member.joined_at = datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc)
     member.roles = roles if roles is not None else [_role(1, "@everyone", default=True)]
+    member.display_name = "MemberName"
+    member.display_avatar = MagicMock()
+    member.display_avatar.url = "https://cdn.example/member.png"
     member.__str__ = lambda self: "TestUser"  # type: ignore[assignment]
     return member
 
@@ -247,6 +253,43 @@ def test_role_change_embed_shows_added_and_removed():
     names = {f.name for f in embed.fields}
     assert "➕ Added" in names
     assert "➖ Removed" in names
+
+
+# ---------------------------------------------------------------------------
+# Subject avatar in the embed author slot (a face per log entry)
+# ---------------------------------------------------------------------------
+
+
+def test_message_embeds_set_subject_avatar_in_author_slot():
+    # The message author's avatar + name ride the embed author slot (the "who"
+    # at a glance), while the structured fields are unchanged.
+    deleted = server_logging.format_message_delete_embed(_message(content="x"))
+    assert deleted.author.name == "AuthorName"
+    assert deleted.author.icon_url == "https://cdn.example/author.png"
+    edited = server_logging.format_message_edit_embed(_message(), _message())
+    assert edited.author.name == "AuthorName"
+    assert edited.author.icon_url == "https://cdn.example/author.png"
+
+
+def test_member_and_role_embeds_set_subject_avatar_in_author_slot():
+    for embed in (
+        server_logging.format_member_join_embed(_member()),
+        server_logging.format_member_leave_embed(_member()),
+        server_logging.format_role_change_embed(_member(), [_role(3, "Added")], []),
+    ):
+        assert embed.author.name == "MemberName"
+        assert embed.author.icon_url == "https://cdn.example/member.png"
+
+
+def test_set_subject_author_is_defensive_on_partial_object():
+    # A subject with no display_name / name → no author line, never a raise
+    # (keeps the fail-safe handler honest for a partial/odd object).
+    class _Bare:
+        pass
+
+    embed = discord.Embed()
+    server_logging._set_subject_author(embed, _Bare())
+    assert embed.author.name is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Comparing our `#server-log` style with Dyno's, ours is already strong (colour-coded borders, emoji titles, structured Author/Channel/Content/Before/After/Attachments/Jump fields, full IDs). The **one thing Dyno has that we don't** is a per-entry **avatar** — a small round face beside the name at the top of each log embed, so you can see *who* at a glance while scanning.

This adds exactly that, to **every** log surface, and nothing else:

- **Passive events** (message delete/edit, member join/leave, role change) already hold the member/user object, so they set the author slot directly.
- **Moderation + audit** embeds carry only IDs, so the sender resolves the person via `_resolve_subject_user` (guild member cache → the bot's global user cache, so a just-banned member still gets a face) and passes it in. **Cache-only — never a network call** in the hot logging path.

Whose face per surface: mod-log → the **target**; audit → the **actor** (who made the change); public mod-log → the **target only**, never the moderator (preserving that surface's redaction).

It's **purely additive** — every existing field is untouched — and network-free, with a defensive helper so a partial/unresolvable subject yields no author line rather than raising into the fail-safe handler.

+11 tests; full CI mirror green; arch 0. Born-red per Q-0133; flips to ready when green. Mockup in the session log / chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)