### PR TITLE
Server-logging: fix per-route binding crash + disappearing back button + settings-order simulation

### DIFF
--- a/.sessions/2026-07-01-settings-order-sim-and-binding-back-button-bugs.md
+++ b/.sessions/2026-07-01-settings-order-sim-and-binding-back-button-bugs.md
@@ -1,43 +1,136 @@
 # 2026-07-01 — Server-logging: per-route binding crash + disappearing back button + settings-order sim
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-**Run type:** `manual` — owner bug report (screen recording of the live bot).
+**Run type:** `manual` — owner bug report (50s Discord screen recording of the live bot).
 
-## What I'm about to do
+## Arc
 
-Owner sent a 50s Discord screen recording (`!settings` → Server Logging → Routes) with three
-asks + a simulation. Frame-by-frame analysis (frames extracted via PyAV; contact sheets in the
-session scratchpad) pinned all of it:
-
-1. **Per-action binding crash (root cause found).** In the Routes panel, picking an *event* route
-   (`events` / `message_log` / `member_log` / `role_log`) and clicking **Set Channel** shows
-   *"An error occurred. Please try again."* Cause: `cogs/logging/select_view.py::_KIND_TO_LABEL`
-   was never extended when the Q-0109 event routes were added to `_KIND_TO_BINDING` — it stops at
-   `audit`. `_LogChannelSelect.__init__` does `_KIND_TO_LABEL[kind]` → **KeyError** for the four
-   event routes → the view's `on_error` emits the generic message. `provision_view._KIND_TO_LABEL`
-   *does* have them (so **Create** works, **Set** crashes) — a copy-paste drift the route-table
-   consistency test never caught because it pins `_KIND_TO_BINDING` but not `_KIND_TO_LABEL`.
-   Fix: complete the label map + make the lookup total (`_label_for`) + extend the pin test.
-
-2. **Disappearing "Back to Settings"/"Back to Help" (root cause found).** `LoggingPanelView`
-   declares `SUBSYSTEM="logging"` so the linter (`_class_gets_auto_nav`) assumes the universal
-   `attach_standard_nav` gives it a Help/hub back button — but at runtime `_self_navigates()`
-   sees its **"↩ Overview"** button (a no-op self-refresh) and *skips* the auto-nav. So the panel
-   depends on the *externally*-attached "↩ Back to Settings"/"Back to Help", which is dropped the
-   moment it rebuilds a fresh view instance (the Routes round-trip: `routes_btn` and
-   `LoggingRoutesView.btn_back` rebuild without `carry_back`). Fix: stop treating "overview" as
-   self-nav (so `attach_standard_nav` covers these panels) + `carry_back` across the Routes hops.
-   Enumerating the other panels in this class ("↩ Overview" self-refresh under a `SUBSYSTEM`).
-
-3. **Settings-order simulation + "easy and clear to change all this."** Build
-   `tools/sim/settings_order_sim.py` (the `help_menu_grouping_sim` pattern): score orderings of the
-   11 logging routes (fallback-coverage + category cohesion) and the settings-group dropdown
-   (`ui_priority`/setup-journey), recommend + apply the winner, and make the routes panel state the
-   "set `mod` + `events` first, the rest fall back" model up front.
-
-Additive / reversible / test-covered. Then flip this card to `complete`.
+Owner recorded himself walking `!settings` → **Server Logging** → **Routes** and asked for four
+things: (1) analyse the recording frame-by-frame; (2) a **simulation** to find the best order of
+these settings, "easy and clear to change all this"; (3) why the **back-to-help / back-to-settings**
+buttons disappear + which other menus; (4) why he **can't independently bind each action's channel**
+("all enabled but I can't change their bindings"). Extracted frames with PyAV (no ffmpeg in the
+sandbox), built contact sheets, and read every UI state. All four resolved on PR #1619.
 
 ## What shipped
 
-_(pending — filled in at close)_
+### 1. Per-action binding crash — `fix(logging)` (commit 80747c2)
+Frame #88 caught the live failure: picking an **event** route (`message_log`) + **Set Channel** →
+*"An error occurred. Please try again."* Root cause: `cogs/logging/select_view.py::_KIND_TO_LABEL`
+was never extended when the Q-0109 event routes (`events`/`message_log`/`member_log`/`role_log`) were
+added to `_KIND_TO_BINDING`, so `_LogChannelSelect.__init__` did `_KIND_TO_LABEL[kind]` → **KeyError**
+→ the view's `on_error` emitted the generic ephemeral. `provision_view` *had* the labels (so **Create**
+worked, **Set** crashed) — a copy-paste drift the route-table consistency test missed because it pins
+`_KIND_TO_BINDING` but not the label map. Fix: complete the map, add a **total** `_label_for()`
+backstop (never `KeyError`) in both view modules, route every label lookup through it, and **pin
+`_KIND_TO_LABEL` coverage** in the consistency test + a per-route construction test.
+
+### 2. Disappearing "↩ Back to Settings" / "↩ Back to Help" — `fix(logging)` (commit 80747c2)
+Frames u080 vs u113 caught it: the panel had "↩ Back to Settings" right after **Open Panel**, then
+lost it after the Routes round-trip. **Two compounding defects:**
+- `navigation._self_navigates()` treated the panel's **"↩ Overview"** (a *self-refresh*, not
+  parent-nav) as self-navigation, so `attach_standard_nav` **skipped** `LoggingPanelView` — even
+  though it declares `SUBSYSTEM="logging"` and the `back_button` linter (`_class_gets_auto_nav`)
+  *assumes* SUBSYSTEM panels get auto-nav. Static check said "covered"; runtime opted out. Fix: drop
+  "overview" from the self-nav signal → the panel now auto-gets **📚 Help + ↩ Moderation**.
+- The externally-attached back was dropped on every fresh-instance rebuild. Fix: `carry_back()` at the
+  three verified sites — `LoggingPanelView.routes_btn`, `LoggingRoutesView.btn_back`, and (same class,
+  self-initiated) `_PlatformHubView.btn_flag_manager`.
+- **Which other menus (verified sweep):** `EconomyPanelView` was the same "Overview false-positive"
+  class — fixed by the single `_self_navigates` change (it now auto-gets 📚 Help). The other
+  `↩ Overview` panels (four_twenty/admin/utility/general) **don't** declare `SUBSYSTEM`, so they were
+  never in this class. `_PlatformHubView → Flag Manager` was the third drop-back site.
+
+### 3. Settings-order simulation + apply — `feat(settings)` (commit 9cfc574)
+`tools/sim/settings_order_sim.py` (the `help_menu_grouping_sim` pattern; live tables, stdlib, `--check`
+guard) scores the two ordered surfaces in the clip:
+- **Logging routes:** roots-first (`mod`, `events` lead — the two fallback roots) beats the old
+  category-first order — **scroll-to-full-coverage 7 → 1**. Applied to `_ROUTE_DISPLAY_ORDER`; the
+  Routes panel now opens with *"set `mod` + `events` and everything is covered."*
+- **Settings dropdown:** `!settings` is admin-only, yet it sorted by the **global** `ui_priority`
+  (games/economy first, admin/config last) — so the owner scrolled past ~15 fun groups to reach
+  Logging(85)/Moderation(80). That's the long scroll in the clip. Fix: a **settings-surface-only**
+  admin-config-first sort in `actionable_settings_groups()` (server-ops groups first, `ui_priority`
+  within each tier) — mean config-group **find-cost ~28 → ~8 rows**. Global `ui_priority` (Help/hubs)
+  is untouched (verified `actionable_settings_groups` is consumed only by the Settings hub).
+
+## Verification
+
+- `check_quality.py --full`: **green** — 13620 passed, 48 skipped, 2 xfailed; black/isort/ruff (CI
+  scope) + `mypy disbot/` clean.
+- `check_architecture --mode strict`: 0 new errors (only pre-existing warnings).
+  `check_consistency --mode strict`: passed. `check_docs --strict`: passed.
+- `settings_order_sim.py --check`: OK (shipped `_ROUTE_DISPLAY_ORDER` == the roots-first recommendation).
+- Live-constructed `LoggingPanelView` → now carries `nav:help` + `nav:hub:moderation`;
+  `EconomyPanelView` → now carries `nav:help`.
+
+## Context delta
+
+- **Needed but not pointed to:** the runtime-vs-static nav mismatch — `_self_navigates` (runtime, in
+  `navigation.py`) and `_class_gets_auto_nav` (the `check_consistency` `back_button` rule) each decide
+  "does this panel have nav" by *different* signals, so a panel can pass the linter while runtime
+  strands it. Nothing documents that they must agree. Filed as the session idea.
+- **Discovered by hand:** `ui_priority` is a **global** ordering knob shared by Help / hubs / selectors
+  / the settings dropdown. The "best order" for an admin surface differs from the discovery order, so
+  the fix had to be a settings-*local* sort, not a global re-prioritisation.
+- **Pointed to but didn't need:** CodeGraph — a `context_map` + targeted grep + reading the four
+  panel/view modules carried the whole diagnosis (the frames pre-localised it).
+- **Decisions made alone:** (1) applied the routes reorder (local, reversible, guarded) but made the
+  settings-dropdown change a *sort policy* rather than rewriting 19 subsystems' `ui_priority` (that
+  would have reordered Help too). (2) Fixed `EconomyPanelView` + the platform→flag-manager drop-back
+  as the same verified class (root-cause over the single reported symptom). All reversible.
+
+## 💡 Session idea
+
+**A guard that reconciles runtime auto-nav with the `back_button` linter's assumption.** This bug hid
+in the seam between two "does this panel have a back?" oracles that use *different* signals:
+`navigation._self_navigates` (runtime — label/custom_id heuristic that *excludes* a panel from
+auto-nav) and `check_consistency._class_gets_auto_nav` (static — assumes any `SUBSYSTEM` panel *gets*
+auto-nav). A `SUBSYSTEM` panel whose only nav-shaped control is an `↩ Overview` self-refresh satisfies
+the linter but is stranded at runtime. Concrete guard: a consistency rule that flags a decorated
+button whose label is back-shaped (`↩`/"Back"/"Overview") **but whose callback only re-renders
+`view=self`** (a no-op masquerading as navigation) — the exact tell that let this ship. Complements the
+2026-06-20 idea (extend `back_button` to `add_item` controls): that one widened *what* the linter sees;
+this one checks the *label doesn't lie about behaviour*. Small, disposable, high-signal.
+
+## ⟲ Previous-session review
+
+The 2026-07-01 fishing-structures-subhub run (#1603) did the back-nav **right**: the new
+`StructuresView` set `SUBSYSTEM="fishing"` explicitly "so `attach_standard_nav` keeps Help + Games —
+never a dead-end," and re-parented each structure's ↩ to the sub-hub with tests for every hop. Clean,
+and a good model. **What it (unknowingly) dodged:** it relied on `attach_standard_nav` as the safety
+net — the very mechanism this session found had the `_self_navigates` "Overview" blind spot. Had that
+sub-hub carried an `↩ Overview` button, it would have been silently excluded from the auto-nav it was
+counting on, exactly like `LoggingPanelView`. **System improvement:** the session idea above closes
+that blind spot so "I declared `SUBSYSTEM`, so I'm never stranded" is actually *true* — the assumption
+every recent nav-conscious session (this one included) leans on.
+
+## 📤 Run report
+
+- **Did:** diagnosed a 50s screen recording frame-by-frame; fixed the per-route Set-Channel crash + the
+  disappearing back button (2 root causes, 3 panels) + built a settings-order simulation and applied
+  its roots-first routes / admin-config-first dropdown recommendations. · **Outcome:** shipped, CI green.
+- **Shipped:** PR #1619 (`claude/settings-simulation-binding-bugs-5ohozq`), born-red → complete.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none. (The settings-dropdown reorder is a defensible admin-UX default;
+  say the word if you'd prefer the old global-priority order there.)
+- **⚑ Owner manual steps:** none — merge auto-deploys (`worker` redeploys on merge to `main`); no data
+  step. Live-verify the Routes → Set Channel binding + the reordered dropdown after deploy.
+- **⚑ Self-initiated:** `EconomyPanelView` back-nav fix + `_PlatformHubView → Flag Manager` `carry_back`
+  (same verified class as the reported logging bug, beyond the literal ask); the settings-dropdown
+  admin-first sort (the sim surfaced it from the clip's long scroll).
+- **↪ Next:** if the nav guard idea appeals, build it as a focused `check_consistency` rule.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs opened this session | 1 (#1619) |
+| Commits | 4 (born-red card · bug fixes · sim+apply · test-format) |
+| CI-red rounds | 0 (green first full run; one local black pass on the sim/tests) |
+| Root causes fixed | 2 (label-map drift · Overview-false-positive + missing carry_back) |
+| Panels de-stranded | 3 (Logging, Economy, Platform→FlagManager) |
+| New tests | 8 (label coverage · per-route construct · overview-not-self-nav ×2 · sim guards ×3 · dropdown order) |
+| New ideas contributed | 1 (nav runtime-vs-linter reconciliation guard) |
+| New tools | 1 (`tools/sim/settings_order_sim.py`) |

--- a/.sessions/2026-07-01-settings-order-sim-and-binding-back-button-bugs.md
+++ b/.sessions/2026-07-01-settings-order-sim-and-binding-back-button-bugs.md
@@ -1,0 +1,43 @@
+# 2026-07-01 — Server-logging: per-route binding crash + disappearing back button + settings-order sim
+
+> **Status:** `in-progress`
+
+**Run type:** `manual` — owner bug report (screen recording of the live bot).
+
+## What I'm about to do
+
+Owner sent a 50s Discord screen recording (`!settings` → Server Logging → Routes) with three
+asks + a simulation. Frame-by-frame analysis (frames extracted via PyAV; contact sheets in the
+session scratchpad) pinned all of it:
+
+1. **Per-action binding crash (root cause found).** In the Routes panel, picking an *event* route
+   (`events` / `message_log` / `member_log` / `role_log`) and clicking **Set Channel** shows
+   *"An error occurred. Please try again."* Cause: `cogs/logging/select_view.py::_KIND_TO_LABEL`
+   was never extended when the Q-0109 event routes were added to `_KIND_TO_BINDING` — it stops at
+   `audit`. `_LogChannelSelect.__init__` does `_KIND_TO_LABEL[kind]` → **KeyError** for the four
+   event routes → the view's `on_error` emits the generic message. `provision_view._KIND_TO_LABEL`
+   *does* have them (so **Create** works, **Set** crashes) — a copy-paste drift the route-table
+   consistency test never caught because it pins `_KIND_TO_BINDING` but not `_KIND_TO_LABEL`.
+   Fix: complete the label map + make the lookup total (`_label_for`) + extend the pin test.
+
+2. **Disappearing "Back to Settings"/"Back to Help" (root cause found).** `LoggingPanelView`
+   declares `SUBSYSTEM="logging"` so the linter (`_class_gets_auto_nav`) assumes the universal
+   `attach_standard_nav` gives it a Help/hub back button — but at runtime `_self_navigates()`
+   sees its **"↩ Overview"** button (a no-op self-refresh) and *skips* the auto-nav. So the panel
+   depends on the *externally*-attached "↩ Back to Settings"/"Back to Help", which is dropped the
+   moment it rebuilds a fresh view instance (the Routes round-trip: `routes_btn` and
+   `LoggingRoutesView.btn_back` rebuild without `carry_back`). Fix: stop treating "overview" as
+   self-nav (so `attach_standard_nav` covers these panels) + `carry_back` across the Routes hops.
+   Enumerating the other panels in this class ("↩ Overview" self-refresh under a `SUBSYSTEM`).
+
+3. **Settings-order simulation + "easy and clear to change all this."** Build
+   `tools/sim/settings_order_sim.py` (the `help_menu_grouping_sim` pattern): score orderings of the
+   11 logging routes (fallback-coverage + category cohesion) and the settings-group dropdown
+   (`ui_priority`/setup-journey), recommend + apply the winner, and make the routes panel state the
+   "set `mod` + `events` first, the rest fall back" model up front.
+
+Additive / reversible / test-covered. Then flip this card to `complete`.
+
+## What shipped
+
+_(pending — filled in at close)_

--- a/disbot/cogs/logging/panel.py
+++ b/disbot/cogs/logging/panel.py
@@ -178,10 +178,15 @@ class LoggingPanelView(HubView):
             LoggingRoutesView,
             build_routes_embed,
         )
+        from views.navigation import carry_back
 
         if not await safe_defer(interaction):
             return
         view = LoggingRoutesView(interaction.user)
+        # Carry any externally-attached back (↩ Back to Settings / Help, added
+        # by the opener) onto the fresh Routes view so it survives the round
+        # trip — without this the panel loses its parent-nav going into Routes.
+        carry_back(self, view)
         embed = await build_routes_embed(interaction.guild)
         await safe_edit(interaction, embed=embed, view=view)
 

--- a/disbot/cogs/logging/provision_view.py
+++ b/disbot/cogs/logging/provision_view.py
@@ -63,6 +63,16 @@ def _binding_name_for(kind: str) -> str:
     return binding_name
 
 
+def _label_for(kind: str) -> str:
+    """Human label for *kind* — **total**, never raises (mirror of
+    ``select_view._label_for``). Every known kind still gets an explicit,
+    nicer label (pinned by ``test_route_labels_cover_every_kind``); the
+    derived fallback only guards a future kind added to the binding map but
+    not here.
+    """
+    return _KIND_TO_LABEL.get(kind, f"{kind.replace('_', ' ')} log")
+
+
 async def build_preview_embed(
     guild: discord.Guild,
     kind: str,
@@ -89,7 +99,7 @@ async def build_preview_embed(
     preview = await ResourceProvisioningPipeline().preview(guild, request)
 
     color = discord.Color.green() if preview.allowed else discord.Color.orange()
-    label = _KIND_TO_LABEL[kind]
+    label = _label_for(kind)
     embed = discord.Embed(
         title=f"🆕 Provision {label} channel — preview",
         description=(
@@ -273,7 +283,7 @@ async def _commit_provision(
         f"<#{result.resource_id}>" if result.resource_id is not None else "*(unknown)*"
     )
     embed = discord.Embed(
-        title=f"✅ {_KIND_TO_LABEL[kind].title()} channel provisioned",
+        title=f"✅ {_label_for(kind).title()} channel provisioned",
         description=(
             f"Created {channel_mention} and bound it to "
             f"`logging.{binding_name}`.\n"

--- a/disbot/cogs/logging/routes_panel.py
+++ b/disbot/cogs/logging/routes_panel.py
@@ -32,19 +32,24 @@ if TYPE_CHECKING:
 logger = logging.getLogger("bot.cogs.logging.routes_panel")
 
 
-# Display order for the routes embed. Sources first, then severity,
-# then audit, then the server-event routes — mirrors the operator's
-# typical mental model.
+# Display order for the routes embed + select — **roots-first**
+# (tools/sim/settings_order_sim.py, 2026-07-01). The two fallback roots lead so
+# the operator sees the minimum coverage set immediately: set ``mod`` + those
+# two and every route is delivered *somewhere*; everything below refines one of
+# them. This cut scroll-to-full-coverage from 7 → 1 vs the old category-first
+# order (pinned to the sim by tests/unit/invariants/test_settings_order.py).
 _ROUTE_DISPLAY_ORDER: tuple[str, ...] = (
-    "mod",
+    # Roots — set these two and everything is covered by fallback.
+    "mod",  # ROOT: severity / audit / cleanup fall back here
+    "events",  # ROOT: message / member / role fall back here
+    # ``mod`` overrides (moderation sources + severity + audit):
     "cleanup",
     "debug",
     "info",
     "warning",
     "error",
     "audit",
-    # Server event logging v1 (Q-0109).
-    "events",
+    # ``events`` overrides (per-category server events, Q-0109):
     "message_log",
     "member_log",
     "role_log",
@@ -125,10 +130,14 @@ async def build_routes_embed(guild: discord.Guild | None) -> discord.Embed:
     embed = discord.Embed(
         title="🗺️ Logging Routes",
         description=(
-            "Every logging route, its current binding, and where it "
-            "resolves today. Set / Create through the buttons below — "
-            "writes route through `BindingMutationPipeline` / "
-            "`ResourceProvisioningPipeline` and record an audit row."
+            "**Quick start:** set the top two — **`mod`** and **`events`** — "
+            "and every route is delivered somewhere (the rest fall back to "
+            "them). Split out any route below only when you want it in its own "
+            "channel.\n\n"
+            "Each row shows a route, its binding, and where it resolves today. "
+            "Pick one, then **Set Channel** (bind an existing channel) or "
+            "**Create Channel** — both route through `BindingMutationPipeline` "
+            "/ `ResourceProvisioningPipeline` and record an audit row."
         ),
         color=ADMIN_COLOR,
     )

--- a/disbot/cogs/logging/routes_panel.py
+++ b/disbot/cogs/logging/routes_panel.py
@@ -308,7 +308,7 @@ class LoggingRoutesView(HubView):
     ) -> None:
         # Phase 3.5 — share the defer + edit + error-handling flow with
         # every other back-button in the codebase via views.navigation.
-        from views.navigation import transition_to
+        from views.navigation import carry_back, transition_to
 
         async def _build_logging_parent(
             interaction: discord.Interaction,
@@ -316,6 +316,10 @@ class LoggingRoutesView(HubView):
             from cogs.logging.panel import LoggingPanelView, build_panel_embed
 
             view = LoggingPanelView(self._author)
+            # Carry the externally-attached back (↩ Back to Settings / Help)
+            # forward onto the rebuilt panel so returning from Routes does not
+            # strand the operator one level up from where they entered.
+            carry_back(self, view)
             embed = await build_panel_embed(interaction.guild)
             return embed, view
 

--- a/disbot/cogs/logging/select_view.py
+++ b/disbot/cogs/logging/select_view.py
@@ -53,6 +53,16 @@ _KIND_TO_LABEL: dict[str, str] = {
     "warning": "warning log",
     "error": "error log",
     "audit": "audit log",
+    # Server event logging v1 (Q-0109) — passive-event routes. Kept in sync
+    # with ``_KIND_TO_BINDING`` (and ``provision_view._KIND_TO_LABEL``) by
+    # ``test_logging_routes_panel.test_route_labels_cover_every_kind``. These
+    # were missing until the Routes "Set Channel" crash: ``_LogChannelSelect``
+    # indexed ``_KIND_TO_LABEL[kind]`` for the placeholder and raised KeyError
+    # for every event route, surfacing as the generic view-error ephemeral.
+    "events": "server event log",
+    "message_log": "message event log",
+    "member_log": "member event log",
+    "role_log": "role event log",
 }
 
 
@@ -61,6 +71,20 @@ def _binding_name_for(kind: str) -> str:
     if binding_name is None:
         raise ValueError(f"unknown logging channel kind: {kind!r}")
     return binding_name
+
+
+def _label_for(kind: str) -> str:
+    """Human label for *kind* — **total**, never raises.
+
+    Falls back to a derived ``"<kind> log"`` for any route not explicitly
+    named, so a future route added to ``_KIND_TO_BINDING`` can never crash the
+    channel picker the way the Q-0109 event routes did (added to the binding
+    map but not this label map → KeyError at the ``_LogChannelSelect``
+    placeholder). The pin test still requires an explicit, nicer label for
+    every known kind — this is the defence-in-depth backstop, not a licence to
+    skip the map.
+    """
+    return _KIND_TO_LABEL.get(kind, f"{kind.replace('_', ' ')} log")
 
 
 class _LogChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
@@ -72,7 +96,7 @@ class _LogChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
         _binding_name_for(kind)
         self.kind = kind
         super().__init__(
-            placeholder=f"Pick the {_KIND_TO_LABEL[kind]} channel…",
+            placeholder=f"Pick the {_label_for(kind)} channel…",
             min_values=1,
             max_values=1,
             channel_types=[discord.ChannelType.text],
@@ -198,14 +222,14 @@ async def _commit_selection(
             exc,
         )
         await interaction.response.send_message(
-            f"❌ Could not bind {_KIND_TO_LABEL[kind]} channel: "
+            f"❌ Could not bind {_label_for(kind)} channel: "
             f"`{type(exc).__name__}`: {exc!s:.200}",
             ephemeral=True,
         )
         return
 
     embed = discord.Embed(
-        title=f"✅ {_KIND_TO_LABEL[kind].title()} channel bound",
+        title=f"✅ {_label_for(kind).title()} channel bound",
         description=(
             f"Bound `logging.{binding_name}` → {target.mention}.\n"
             f"Status: `{result.new_status.value}`."
@@ -260,14 +284,14 @@ async def _commit_clear(
             exc,
         )
         await interaction.response.send_message(
-            f"❌ Could not clear {_KIND_TO_LABEL[kind]} channel: "
+            f"❌ Could not clear {_label_for(kind)} channel: "
             f"`{type(exc).__name__}`: {exc!s:.200}",
             ephemeral=True,
         )
         return
 
     embed = discord.Embed(
-        title=f"✅ {_KIND_TO_LABEL[kind].title()} channel cleared",
+        title=f"✅ {_label_for(kind).title()} channel cleared",
         description=(
             f"Cleared `logging.{binding_name}`.  Falls back to "
             "the legacy scalar key (or, for cleanup, to the mod "

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -562,6 +562,28 @@ class ActionableGroup:
         return tuple(out)
 
 
+# Settings-dropdown ordering (tools/sim/settings_order_sim.py, 2026-07-01).
+# `!settings` is an admin-only surface: the operator opens it to *configure the
+# server*, so the server-operations groups (moderation / management / admin +
+# admin-tier community like welcome / counters) sort to the TOP — ahead of the
+# games / economy / progression groups that lead the *global* ``ui_priority``
+# discovery order. This is settings-surface-only: Help and the hubs still sort
+# by the global ``ui_priority``, untouched. The sim measured this cut the mean
+# config-group find-cost from ~28 to ~8 rows of scrolling.
+_SETTINGS_CONFIG_CATEGORIES = frozenset({"moderation", "management", "admin"})
+_SETTINGS_ADMIN_TIERS = frozenset({"staff", "moderator", "administrator", "owner"})
+
+
+def _settings_config_tier(meta: dict[str, object]) -> int:
+    """0 for server-config groups (sorted first in ``!settings``), else 1."""
+    category = meta.get("category")
+    if category in _SETTINGS_CONFIG_CATEGORIES:
+        return 0
+    if category == "community" and meta.get("visibility_tier") in _SETTINGS_ADMIN_TIERS:
+        return 0
+    return 1
+
+
 def actionable_settings_groups() -> tuple[ActionableGroup, ...]:
     """Every subsystem the Settings hub should offer, sorted for display.
 
@@ -577,10 +599,13 @@ def actionable_settings_groups() -> tuple[ActionableGroup, ...]:
       a declared binding, a declared resource requirement, or a
       registered domain-config panel.
 
-    Deterministic and side-effect-free; sorted by ``ui_priority`` then
-    display name. Discovery only — mutation stays with each surface's
-    canonical owner (scalar pipeline / binding / provisioning / domain
-    services).
+    Deterministic and side-effect-free; sorted **server-config groups first**
+    (see :func:`_settings_config_tier`), then by ``ui_priority`` then display
+    name within each tier — so an admin opening ``!settings`` reaches the
+    moderation / logging / welcome / roles groups without scrolling past the
+    games and economy groups. Discovery only — mutation stays with each
+    surface's canonical owner (scalar pipeline / binding / provisioning /
+    domain services).
     """
     # Function-local imports: keep this module import-light and let tests
     # monkeypatch the manifest/schema sources.
@@ -589,6 +614,7 @@ def actionable_settings_groups() -> tuple[ActionableGroup, ...]:
 
     schemas = all_schemas()
     groups: list[ActionableGroup] = []
+    tier_by_sub: dict[str, int] = {}
     for name, meta in SUBSYSTEMS.items():
         if meta.get("visibility_mode", "normal") == "internal":
             continue
@@ -603,6 +629,7 @@ def actionable_settings_groups() -> tuple[ActionableGroup, ...]:
         domain_panel = bool(schema.domain_panels) if schema is not None else False
         if not (editable or bindings or resources or domain_panel):
             continue
+        tier_by_sub[name] = _settings_config_tier(meta)
         groups.append(
             ActionableGroup(
                 subsystem=name,
@@ -616,7 +643,14 @@ def actionable_settings_groups() -> tuple[ActionableGroup, ...]:
                 has_domain_panel=domain_panel,
             ),
         )
-    groups.sort(key=lambda g: (g.ui_priority, g.display_name.lower(), g.subsystem))
+    groups.sort(
+        key=lambda g: (
+            tier_by_sub[g.subsystem],
+            g.ui_priority,
+            g.display_name.lower(),
+            g.subsystem,
+        ),
+    )
     return tuple(groups)
 
 

--- a/disbot/views/diagnostic/platform_panel.py
+++ b/disbot/views/diagnostic/platform_panel.py
@@ -402,9 +402,15 @@ class _PlatformHubView(HubView):
             FlagManagerView,
             build_flag_manager_overview_embed,
         )
+        from views.navigation import carry_back
 
         guild_id = interaction.guild.id if interaction.guild else None
         manager = FlagManagerView(self._author, guild_id=guild_id)
+        # Carry the externally-attached back (↩ Back to Admin, added by the
+        # admin-hub opener) onto the fresh Flag Manager so the grandparent link
+        # is not dropped entering it (the same fresh-instance back-loss class as
+        # the logging Routes round-trip).
+        carry_back(self, manager)
         await safe_edit(
             interaction,
             embed=build_flag_manager_overview_embed(),

--- a/disbot/views/navigation.py
+++ b/disbot/views/navigation.py
@@ -366,20 +366,29 @@ def has_standard_nav(view: discord.ui.View) -> bool:
 
 
 def _self_navigates(view: discord.ui.View) -> bool:
-    """True when ``view`` already provides its own hub/help/back navigation.
+    """True when ``view`` already provides its own hub/help/**parent** navigation.
 
-    The mother-hub and operator panels (admin, utility, logging, settings, …)
-    define their own ``📚 Help`` / ``↩ Overview`` / ``↩ Back to <hub>`` buttons
-    as decorated components, so they keep that nav across redraws on their own
-    and must NOT receive a duplicate from :func:`attach_standard_nav`. The
-    panels that genuinely lose nav (the leaf panels — farm, mining, the game
-    panels, the AI/channel/ux_lab panels) have *no* nav button of their own and
+    The mother-hub and operator panels (admin, utility, settings, …) define
+    their own ``📚 Help`` / ``↩ Back to <hub>`` buttons as decorated
+    components, so they keep that nav across redraws on their own and must NOT
+    receive a duplicate from :func:`attach_standard_nav`. The panels that
+    genuinely lose nav (the leaf panels — farm, mining, the game panels, the
+    AI/channel/ux_lab panels) have *no* parent-nav button of their own and
     relied on an externally-attached back; those are exactly the ones that get
     auto-nav.
 
-    Detection is label-based (the codebase uses stable ``Help`` / ``Overview``
-    / ``Back to`` button copy) plus the canonical nav custom_ids. Heuristic —
-    if a future panel's button copy diverges this may misfire; revisit if a
+    An ``↩ Overview`` button does **not** count: it is a *self-refresh*
+    (re-renders the same panel in place), not navigation to a parent, so a
+    panel whose only nav-shaped control is Overview is genuinely stranded and
+    must still receive auto-nav. Treating "overview" as self-navigation was the
+    bug that stranded ``LoggingPanelView`` / ``EconomyPanelView``: they declare
+    a ``SUBSYSTEM`` (so the ``back_button`` linter assumes auto-nav covers
+    them) yet opted themselves *out* of it here, leaving only a fragile
+    externally-attached back that vanished on the first redraw.
+
+    Detection is label-based (the codebase uses stable ``Help`` / ``Back to``
+    button copy) plus the canonical nav custom_ids. Heuristic — if a future
+    panel's button copy diverges this may misfire; revisit if a
     self-navigating panel ever shows a duplicate or a leaf panel stays
     stranded.
     """
@@ -388,7 +397,9 @@ def _self_navigates(view: discord.ui.View) -> bool:
         if cid == NAV_HELP_ID or cid.startswith(NAV_HUB_ID_PREFIX):
             return True
         label = (getattr(child, "label", None) or "").lower()
-        if "help" in label or "overview" in label or "back to" in label:
+        # "overview" is deliberately absent — it is a self-refresh, not
+        # parent-nav (the LoggingPanelView / EconomyPanelView stranding class).
+        if "help" in label or "back to" in label:
             return True
     return False
 

--- a/docs/owner/claims/claude__settings-simulation-binding-bugs-5ohozq.md
+++ b/docs/owner/claims/claude__settings-simulation-binding-bugs-5ohozq.md
@@ -1,1 +1,0 @@
-- `claude/settings-simulation-binding-bugs-5ohozq` · Server-logging routes: per-route binding-edit crash + disappearing back-to-settings/help button + a settings-order simulation · `disbot/cogs/logging/{select_view,provision_view,panel,routes_panel}.py`, `disbot/views/navigation.py`, `tools/sim/settings_order_sim.py`, tests · 2026-07-01

--- a/docs/owner/claims/claude__settings-simulation-binding-bugs-5ohozq.md
+++ b/docs/owner/claims/claude__settings-simulation-binding-bugs-5ohozq.md
@@ -1,0 +1,1 @@
+- `claude/settings-simulation-binding-bugs-5ohozq` · Server-logging routes: per-route binding-edit crash + disappearing back-to-settings/help button + a settings-order simulation · `disbot/cogs/logging/{select_view,provision_view,panel,routes_panel}.py`, `disbot/views/navigation.py`, `tools/sim/settings_order_sim.py`, tests · 2026-07-01

--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -298,6 +298,26 @@ Critically, the event routes fall back to `events` (then nothing), never
 to `mod` — passive-event noise must not land in the moderation-action
 channel.
 
+### Routes panel order + per-route binding (operator UX)
+
+The Routes panel (`!logging routes`, or the 🗺️ **Routes** button on the logging
+panel) lists every route in **roots-first** order — `mod` and `events` lead
+because they are the two fallback roots: set those two and every route is
+delivered *somewhere* (severity / audit / cleanup fall back to `mod`; the
+per-category event routes fall back to `events`). Everything below refines one of
+them. The order is derived from the live fallback DAG and pinned to
+`tools/sim/settings_order_sim.py` by
+`tests/unit/invariants/test_settings_order.py` — roots-first cut
+scroll-to-full-coverage from 7 → 1 vs the old category-first order.
+
+Each route binds **independently**: pick it, then **Set Channel** (bind an
+existing channel, via `BindingMutationPipeline`) or **Create Channel** (provision
+a new one, via `ResourceProvisioningPipeline`). Per-route Set Channel works for
+**every** route, including the Q-0109 event routes — the `_KIND_TO_LABEL` gap
+that crashed Set Channel for `events` / `message_log` / `member_log` / `role_log`
+(a `KeyError` surfaced as *"An error occurred. Please try again."*) is fixed and
+guarded by `test_logging_routes_panel.test_route_labels_cover_every_kind`.
+
 ### Privacy
 
 Deleted-message logging surfaces content members removed. Q-0109

--- a/tests/unit/cogs/test_logging_panel.py
+++ b/tests/unit/cogs/test_logging_panel.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
-from cogs.logging.panel import LoggingPanelView, build_panel_embed
+from cogs.logging.panel import LoggingPanelView
 from cogs.logging.provision_view import LogChannelProvisionView
 from cogs.logging.select_view import LogChannelSelectView
 from cogs.logging_cog import LoggingCog
@@ -116,19 +116,23 @@ async def test_status_button_re_renders_panel_embed_in_place():
 
     fake_embed = discord.Embed(title="📝 Server logging — status")
 
-    with patch(
-        "cogs.logging.panel.safe_defer",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch(
-        "cogs.logging.panel.build_panel_embed",
-        new_callable=AsyncMock,
-        return_value=fake_embed,
-    ), patch(
-        "cogs.logging.panel.safe_edit",
-        new_callable=AsyncMock,
-        return_value=True,
-    ) as edit:
+    with (
+        patch(
+            "cogs.logging.panel.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "cogs.logging.panel.build_panel_embed",
+            new_callable=AsyncMock,
+            return_value=fake_embed,
+        ),
+        patch(
+            "cogs.logging.panel.safe_edit",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as edit,
+    ):
         await btn.callback(interaction)
     edit.assert_awaited_once()
     assert edit.await_args.kwargs["view"] is view
@@ -143,19 +147,23 @@ async def test_overview_button_renders_panel_embed():
     interaction.user = view._author
     interaction.guild = MagicMock()
 
-    with patch(
-        "cogs.logging.panel.safe_defer",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch(
-        "cogs.logging.panel.build_panel_embed",
-        new_callable=AsyncMock,
-        return_value=discord.Embed(title="overview"),
-    ), patch(
-        "cogs.logging.panel.safe_edit",
-        new_callable=AsyncMock,
-        return_value=True,
-    ) as edit:
+    with (
+        patch(
+            "cogs.logging.panel.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "cogs.logging.panel.build_panel_embed",
+            new_callable=AsyncMock,
+            return_value=discord.Embed(title="overview"),
+        ),
+        patch(
+            "cogs.logging.panel.safe_edit",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as edit,
+    ):
         await btn.callback(interaction)
     edit.assert_awaited_once()
     assert edit.await_args.kwargs["view"] is view
@@ -286,15 +294,18 @@ async def test_test_button_calls_log_event_with_warn_action():
     interaction.response.defer = AsyncMock()
     interaction.followup.send = AsyncMock()
 
-    with patch(
-        "cogs.logging.panel.safe_defer",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch(
-        "services.server_logging.log_event",
-        new_callable=AsyncMock,
-        return_value=True,
-    ) as log_event:
+    with (
+        patch(
+            "cogs.logging.panel.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "services.server_logging.log_event",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as log_event,
+    ):
         await btn.callback(interaction)
     log_event.assert_awaited_once()
     kwargs = log_event.await_args.kwargs

--- a/tests/unit/cogs/test_logging_panel.py
+++ b/tests/unit/cogs/test_logging_panel.py
@@ -55,13 +55,34 @@ def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
 # ---------------------------------------------------------------------------
 
 
-def test_panel_view_has_eight_buttons_across_five_rows():
-    """Phase 9b added a Routes button alongside Test at row 3."""
+def test_panel_view_has_its_actions_plus_durable_nav():
+    """Eight panel actions PLUS the universal durable nav.
+
+    The eight actions (Refresh, Set Mod/Cleanup, Create Mod/Cleanup, Test,
+    Routes, Overview) are joined by the auto-attached 📚 Help + ↩ Moderation
+    controls: logging declares ``SUBSYSTEM`` with ``parent_hub="moderation"``,
+    and the ``↩ Overview`` self-refresh no longer opts the panel out of
+    standard nav (the stranding-fix — previously it did, leaving the panel
+    dependent on a fragile externally-attached back).
+    """
     view = LoggingPanelView(_author())
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-    # Refresh, Set Mod, Set Cleanup, Create Mod, Create Cleanup, Test,
-    # Routes (new in 9b), Overview.
-    assert len(buttons) == 8
+    labels = [b.label or "" for b in buttons]
+    for expected in (
+        "Refresh Status",
+        "Set Mod Channel",
+        "Set Cleanup Channel",
+        "Create Mod Channel",
+        "Create Cleanup Channel",
+        "Test",
+        "Routes",
+        "Overview",
+    ):
+        assert any(expected in lbl for lbl in labels), f"missing action: {expected}"
+    nav_ids = {b.custom_id for b in buttons if b.custom_id}
+    assert "nav:help" in nav_ids, "expected the universal 📚 Help back button"
+    assert "nav:hub:moderation" in nav_ids, "expected the ↩ Moderation hub back"
+    assert len(buttons) == 10  # 8 actions + Help + hub-back
     rows = sorted({b.row for b in buttons})
     assert rows == [0, 1, 2, 3, 4]
 

--- a/tests/unit/cogs/test_logging_routes_panel.py
+++ b/tests/unit/cogs/test_logging_routes_panel.py
@@ -108,13 +108,13 @@ def test_route_labels_cover_every_kind():
 
     for kind in _ROUTE_TO_BINDING:
         assert kind in SELECT_LABELS, f"select_view._KIND_TO_LABEL missing {kind!r}"
-        assert kind in PROVISION_LABELS, (
-            f"provision_view._KIND_TO_LABEL missing {kind!r}"
-        )
+        assert (
+            kind in PROVISION_LABELS
+        ), f"provision_view._KIND_TO_LABEL missing {kind!r}"
 
 
 @pytest.mark.parametrize(
-    "kind", ["mod", "cleanup", "events", "message_log", "member_log", "role_log"]
+    "kind", ["mod", "cleanup", "events", "message_log", "member_log", "role_log"],
 )
 def test_select_view_constructs_for_every_route(kind: str):
     """The Routes 'Set Channel' path must build the picker without raising.
@@ -246,9 +246,7 @@ async def test_set_delegates_to_open_select_with_chosen_kind():
         for c in view.children
         if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.set"
     )
-    with patch(
-        "cogs.logging.panel._open_select", new_callable=AsyncMock
-    ) as fake_open:
+    with patch("cogs.logging.panel._open_select", new_callable=AsyncMock) as fake_open:
         await btn.callback(interaction)  # type: ignore[union-attr,misc]
     fake_open.assert_awaited_once()
     _args, kwargs = fake_open.call_args
@@ -266,7 +264,7 @@ async def test_create_delegates_to_open_provision_with_chosen_kind():
         if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.create"
     )
     with patch(
-        "cogs.logging.panel._open_provision", new_callable=AsyncMock
+        "cogs.logging.panel._open_provision", new_callable=AsyncMock,
     ) as fake_open:
         await btn.callback(interaction)  # type: ignore[union-attr,misc]
     fake_open.assert_awaited_once()

--- a/tests/unit/cogs/test_logging_routes_panel.py
+++ b/tests/unit/cogs/test_logging_routes_panel.py
@@ -90,6 +90,49 @@ def test_route_display_order_covers_every_route():
     assert set(_ROUTE_DISPLAY_ORDER) == set(_ROUTE_TO_BINDING)
 
 
+def test_route_labels_cover_every_kind():
+    """Every route kind must have an explicit human label in BOTH view modules.
+
+    Regression guard for the Routes "Set Channel" crash: the Q-0109 event
+    routes (``events`` / ``message_log`` / ``member_log`` / ``role_log``) were
+    added to ``_KIND_TO_BINDING`` but not to ``select_view._KIND_TO_LABEL``, so
+    ``_LogChannelSelect`` raised ``KeyError`` building its placeholder and the
+    view surfaced the generic "An error occurred" ephemeral. The existing
+    binding-table pin (:func:`test_route_tables_are_in_sync_across_modules`)
+    never caught it because it checks ``_KIND_TO_BINDING`` only — this closes
+    the gap for the label map too.
+    """
+    from cogs.logging.provision_view import _KIND_TO_LABEL as PROVISION_LABELS
+    from cogs.logging.select_view import _KIND_TO_LABEL as SELECT_LABELS
+    from services.server_logging import _ROUTE_TO_BINDING
+
+    for kind in _ROUTE_TO_BINDING:
+        assert kind in SELECT_LABELS, f"select_view._KIND_TO_LABEL missing {kind!r}"
+        assert kind in PROVISION_LABELS, (
+            f"provision_view._KIND_TO_LABEL missing {kind!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "kind", ["mod", "cleanup", "events", "message_log", "member_log", "role_log"]
+)
+def test_select_view_constructs_for_every_route(kind: str):
+    """The Routes 'Set Channel' path must build the picker without raising.
+
+    Repro for the live crash: picking an event route and clicking Set Channel
+    ran ``_open_select`` → ``LogChannelSelectView(user, kind)`` →
+    ``_LogChannelSelect(kind)``, which indexed ``_KIND_TO_LABEL[kind]`` and
+    raised ``KeyError`` for the four event routes. Constructing the view for
+    every route must now succeed with a non-empty placeholder.
+    """
+    from cogs.logging.select_view import LogChannelSelectView
+
+    view = LogChannelSelectView(_author(), kind)
+    selects = [c for c in view.children if isinstance(c, discord.ui.ChannelSelect)]
+    assert selects, "expected a ChannelSelect child"
+    assert selects[0].placeholder and "channel" in selects[0].placeholder.lower()
+
+
 # ---------------------------------------------------------------------------
 # Routes embed
 # ---------------------------------------------------------------------------

--- a/tests/unit/invariants/test_settings_order.py
+++ b/tests/unit/invariants/test_settings_order.py
@@ -1,0 +1,67 @@
+"""Invariant: the shipped settings orders match the simulation's recommendation.
+
+The ordering logic lives in the settings-order simulation
+(``tools/sim/settings_order_sim.py``), which reads the LIVE route + subsystem
+tables and derives the roots-first routes order. This test pins the shipped
+``_ROUTE_DISPLAY_ORDER`` to that recommendation so a future edit to the routes
+list (or the fallback DAG) can't silently drift the operator-facing order. The
+sim is loaded by file path because ``tools/`` is not an importable package.
+
+(The settings-dropdown ordering is a schema-registry-dependent surface and is
+guarded separately by ``tests/unit/views/test_settings_hub_view.py``.)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SIM_PATH = (
+    Path(__file__).resolve().parents[3] / "tools" / "sim" / "settings_order_sim.py"
+)
+
+
+def _load_sim():
+    spec = importlib.util.spec_from_file_location("settings_order_sim", _SIM_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def sim():
+    return _load_sim()
+
+
+def test_shipped_route_order_matches_the_recommendation(sim):
+    """``check_orders`` returns no drift problems for the shipped order."""
+    problems = sim.check_orders()
+    assert problems == [], "\n".join(problems)
+
+
+def test_recommended_route_order_leads_with_the_fallback_roots(sim):
+    """The two fallback roots (``mod`` / ``events``) lead the recommendation —
+    the property that makes 'set these two and you're covered' true.
+    """
+    order = sim.recommended_route_order()
+    assert order[0] == "mod"
+    assert order[1] == "events"
+    # And it is a permutation of the live route set (nothing dropped/added).
+    from cogs.logging.routes_panel import _ROUTE_DISPLAY_ORDER
+
+    assert set(order) == set(_ROUTE_DISPLAY_ORDER)
+
+
+def test_roots_first_beats_the_old_category_first_scroll_cost(sim):
+    """Scroll-to-full-coverage strictly improves under the recommendation —
+    the sim's headline "easy and clear to change all this" metric.
+    """
+    rec = sim.recommended_route_order()
+    alpha = tuple(sorted(sim._ROUTE_TO_BINDING))
+    assert sim.scroll_to_full_coverage(rec) < sim.scroll_to_full_coverage(alpha)
+    assert sim.scroll_to_full_coverage(rec) <= 1

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -221,7 +221,8 @@ async def test_attach_back_button_callback_forwards_the_parent_help_nav_card():
     """Forward-path pin (help-nav attachment seam, H3): when the rebuilt parent
     carries a ``help_nav_card``, the in-place edit must forward it as
     ``attachments=[card]`` so the card survives the back-navigation. A future
-    edit that drops the forwarding fails here."""
+    edit that drops the forwarding fails here.
+    """
     view = discord.ui.View()
     parent_embed = discord.Embed(title="parent")
     parent_view = discord.ui.View()
@@ -943,11 +944,11 @@ def test_carry_back_carries_the_back_target_for_chaining():
 def test_attach_back_button_is_idempotent_by_custom_id():
     view = discord.ui.View()
     assert attach_back_button(
-        view, label="A", custom_id="dup", parent_builder=_parent_builder
+        view, label="A", custom_id="dup", parent_builder=_parent_builder,
     )
     # Second attach with the same custom_id (different label) is a no-op.
     assert attach_back_button(
-        view, label="B", custom_id="dup", parent_builder=_parent_builder
+        view, label="B", custom_id="dup", parent_builder=_parent_builder,
     )
     dup_buttons = [c for c in view.children if getattr(c, "custom_id", None) == "dup"]
     assert len(dup_buttons) == 1
@@ -1047,7 +1048,7 @@ def test_standard_nav_skips_a_panel_with_its_own_back_to_parent():
 def test_has_standard_nav_detects_hub_back_without_help():
     view = discord.ui.View()
     attach_back_button(
-        view, label="↩ Games", custom_id="nav:hub:games", parent_builder=_parent_builder
+        view, label="↩ Games", custom_id="nav:hub:games", parent_builder=_parent_builder,
     )
     assert has_standard_nav(view)
 

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -1011,6 +1011,39 @@ def test_standard_nav_skips_unknown_subsystem():
     assert _back_ids(view) == set()
 
 
+class _OverviewNavView(discord.ui.View):
+    """A SUBSYSTEM panel whose only nav-shaped control is a labelled button —
+    the ``LoggingPanelView`` / ``EconomyPanelView`` shape (an ``↩ Overview``
+    self-refresh). The button is added before ``attach_standard_nav`` so the
+    ``_self_navigates`` heuristic sees it, as it does at runtime.
+    """
+
+    def __init__(self, subsystem: str, label: str) -> None:
+        super().__init__(timeout=None)
+        self.SUBSYSTEM = subsystem
+        self.add_item(discord.ui.Button(label=label, custom_id="panel.local"))
+        attach_standard_nav(self)
+
+
+def test_standard_nav_covers_a_panel_whose_only_nav_is_overview():
+    """Regression (LoggingPanelView / EconomyPanelView): an ``↩ Overview``
+    button is a self-refresh, NOT parent-nav, so a panel whose only nav-shaped
+    control is Overview must still receive the universal Help + hub back.
+    """
+    view = _OverviewNavView("farm", "↩ Overview")  # farm → parent_hub games
+    assert {NAV_HELP_ID, "nav:hub:games"} <= _back_ids(view)
+
+
+def test_standard_nav_skips_a_panel_with_its_own_back_to_parent():
+    """A genuine ``↩ Back to <parent>`` button IS self-navigation — the panel
+    keeps its own nav and must not get a duplicate from auto-nav.
+    """
+    view = _OverviewNavView("farm", "↩ Back to Games")
+    ids = _back_ids(view)
+    assert NAV_HELP_ID not in ids
+    assert "nav:hub:games" not in ids
+
+
 def test_has_standard_nav_detects_hub_back_without_help():
     view = discord.ui.View()
     attach_back_button(

--- a/tests/unit/views/test_settings_hub_view.py
+++ b/tests/unit/views/test_settings_hub_view.py
@@ -73,6 +73,50 @@ def _select(view: SettingsHubView) -> discord.ui.Select:
 
 
 # ---------------------------------------------------------------------------
+# Dropdown ordering — server-config groups first (settings_order_sim)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_dropdown_sorts_server_config_groups_first(monkeypatch):
+    """`!settings` is an admin surface, so a server-config group (moderation)
+    sorts ABOVE a fun group (economy) even when the fun group has a lower
+    (earlier) *global* ``ui_priority``. Regression guard for the settings-order
+    sim's ~28→~8 find-cost win; the global ``ui_priority`` (Help / hubs) is
+    untouched because only this dropdown reads ``actionable_settings_groups``.
+    """
+    import utils.subsystem_registry as registry_mod
+
+    fake = {
+        # Fun group — LOW global ui_priority (would lead the old order).
+        "econ_fun": {
+            "display_name": "Economy",
+            "description": "coins",
+            "visibility_mode": "normal",
+            "category": "economy",
+            "visibility_tier": "user",
+            "ui_priority": 10,
+        },
+        # Server-config group — HIGH global ui_priority (buried in the old
+        # order); must lead the settings dropdown now.
+        "mod_cfg": {
+            "display_name": "Moderation",
+            "description": "warns, bans",
+            "visibility_mode": "normal",
+            "category": "moderation",
+            "visibility_tier": "moderator",
+            "ui_priority": 80,
+        },
+    }
+    monkeypatch.setattr(registry_mod, "SUBSYSTEMS", fake)
+    for name in fake:
+        schema_mod.register(
+            SubsystemSchema(subsystem=name, settings=(_editable_spec(),)),
+        )
+    order = [g.subsystem for g in actionable_settings_groups()]
+    assert order.index("mod_cfg") < order.index("econ_fun")
+
+
+# ---------------------------------------------------------------------------
 # Actionable-group discovery (audit §6 inclusion rule)
 # ---------------------------------------------------------------------------
 
@@ -330,9 +374,19 @@ async def test_create_reads_guild_routing_for_labels(monkeypatch):
         "list_for_guild",
         AsyncMock(
             return_value=[
-                {"scope_type": "guild", "scope_id": None, "cog_name": "xp", "enabled": False},
+                {
+                    "scope_type": "guild",
+                    "scope_id": None,
+                    "cog_name": "xp",
+                    "enabled": False,
+                },
                 # Channel-scope restrictions are not a group-level state.
-                {"scope_type": "channel", "scope_id": 5, "cog_name": "cleanup", "enabled": False},
+                {
+                    "scope_type": "channel",
+                    "scope_id": 5,
+                    "cog_name": "cleanup",
+                    "enabled": False,
+                },
             ],
         ),
     )

--- a/tools/sim/settings_order_sim.py
+++ b/tools/sim/settings_order_sim.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+Settings-order simulation.
+
+The owner recorded himself walking `!settings` → **Server Logging** → **Routes**
+and asked, before I reorder anything, to "run a simulation to find out the best
+order of these settings" and make it "easy and clear to change all this". This
+script answers that for the *two* ordered surfaces in that walk, scoring
+candidate orders against a cost model that reflects what the operator is
+actually trying to do — not a sketch:
+
+  A. The Server-Logging **routes** (the 11 per-action channel bindings:
+     ``mod`` / ``cleanup`` / ``debug`` / ``info`` / ``warning`` / ``error`` /
+     ``audit`` / ``events`` / ``message_log`` / ``member_log`` / ``role_log``).
+     Their inventory + fallback DAG are read LIVE from
+     ``services.server_logging`` so the sim never drifts from the bot. The
+     operator's goal is "every event is logged *somewhere*". Because routes
+     fall back along the DAG, setting a fallback **root** (``mod`` covers the
+     severity/audit/cleanup tier; ``events`` covers the message/member/role
+     tier) instantly satisfies everything beneath it — so the clearest order
+     puts the two roots FIRST ("set these two and you're covered"), then the
+     per-route overrides grouped under the root they refine. The dominant
+     metric is *scroll-to-full-coverage*: how far down the list the operator
+     must read before they have seen every channel they must set.
+
+  B. The Settings-group **dropdown** (the long list the owner scrolled through
+     for ~40s of the clip). It is sorted by the GLOBAL ``ui_priority`` — the
+     user-facing *discovery* order (games/economy first, admin/config last).
+     That is right for the Help menu, but `!settings` is an admin-only surface:
+     the operator came to configure moderation / logging / security / welcome /
+     roles and must scroll past ~15 fun/economy groups to reach them. The sim
+     scores the admin's *find-cost* (mean dropdown index of the config groups)
+     under the current order vs a settings-specific **admin-config-first**
+     order, and shows the scroll saved.
+
+Stdlib only. Read-only. Deterministic (no RNG, no clock).
+  Report:  python3.10 tools/sim/settings_order_sim.py
+  Guard:   python3.10 tools/sim/settings_order_sim.py --check   (exit 1 if the
+           shipped `_ROUTE_DISPLAY_ORDER` has drifted from the recommended
+           roots-first order; wired into CI via
+           tests/unit/invariants/test_settings_order.py).
+
+Provenance: added 2026-07-01 for the owner's screen-recording bug report (the
+Routes walk). Verifiable: its route inventory + fallback DAG are the live
+``services.server_logging`` tables and the routes recommendation is pinned to
+the shipped ``_ROUTE_DISPLAY_ORDER`` by the --check guard — re-run after any
+route-table change. Disposable: if the routes/settings ordering model changes
+shape, delete this rather than work around it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+
+# --- load the live tables (ground-truth inventory) -------------------------
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_REPO, "disbot"))
+
+from cogs.logging.routes_panel import _ROUTE_DISPLAY_ORDER  # noqa: E402
+from services.server_logging import (  # noqa: E402
+    _ROUTE_FALLBACK,
+    _ROUTE_TO_BINDING,
+)
+from utils.subsystem_registry import SUBSYSTEMS  # noqa: E402
+
+# Semantic group of each route — used only for the cohesion metric / display.
+_ROUTE_GROUP: dict[str, str] = {
+    "mod": "sources",
+    "cleanup": "sources",
+    "debug": "severity",
+    "info": "severity",
+    "warning": "severity",
+    "error": "severity",
+    "audit": "audit",
+    "events": "events",
+    "message_log": "events",
+    "member_log": "events",
+    "role_log": "events",
+}
+
+
+# ---------------------------------------------------------------------------
+# A. Logging routes
+# ---------------------------------------------------------------------------
+
+
+def _root_of(kind: str) -> str:
+    """Walk the fallback DAG to the terminal root a route resolves under."""
+    seen: set[str] = set()
+    cur = kind
+    while True:
+        nxt = _ROUTE_FALLBACK.get(cur)
+        if nxt is None or cur in seen:
+            return cur
+        seen.add(cur)
+        cur = nxt
+
+
+def _roots() -> list[str]:
+    """Fallback roots (``_ROUTE_FALLBACK[k] is None``), most-covering first."""
+    roots = [k for k in _ROUTE_TO_BINDING if _ROUTE_FALLBACK.get(k) is None]
+    # Descendant count = how many routes resolve under this root (self incl.).
+    cover = {r: sum(1 for k in _ROUTE_TO_BINDING if _root_of(k) == r) for r in roots}
+    # Most-covering root first; tie-break by first appearance in the live order.
+    return sorted(roots, key=lambda r: (-cover[r], _ROUTE_DISPLAY_ORDER.index(r)))
+
+
+def recommended_route_order() -> tuple[str, ...]:
+    """Roots-first, then each root's overrides grouped under it.
+
+    Deterministic and derived entirely from the live fallback table: the two
+    roots lead (so the operator sees the minimum coverage set immediately),
+    then every non-root route follows under its root, preserving the existing
+    within-tier order for stability (cleanup → severity → audit; message →
+    member → role).
+    """
+    order: list[str] = []
+    roots = _roots()
+    order.extend(roots)
+    for root in roots:
+        for kind in _ROUTE_DISPLAY_ORDER:
+            if kind not in roots and _root_of(kind) == root:
+                order.append(kind)
+    # Any route not reached above (defensive — shouldn't happen) keeps its spot.
+    for kind in _ROUTE_DISPLAY_ORDER:
+        if kind not in order:
+            order.append(kind)
+    return tuple(order)
+
+
+def scroll_to_full_coverage(order: tuple[str, ...] | list[str]) -> int:
+    """0-based index by which every fallback root has been *seen*.
+
+    This is the "easy and clear" metric: the operator can stop reading once
+    they have seen both roots (set those two → everything is covered), so a
+    lower number means less scrolling before the job is understood.
+    """
+    roots = [k for k in _ROUTE_TO_BINDING if _ROUTE_FALLBACK.get(k) is None]
+    return max(order.index(r) for r in roots)
+
+
+def fallback_inversions(order: tuple[str, ...] | list[str]) -> int:
+    """Routes listed BEFORE the root they fall back to.
+
+    A non-root route reads naturally as "overrides <root>" only if its root was
+    already shown, so inversions are confusing. Lower is better (0 is ideal).
+    """
+    pos = {k: i for i, k in enumerate(order)}
+    bad = 0
+    for kind in order:
+        root = _root_of(kind)
+        if root != kind and pos[kind] < pos[root]:
+            bad += 1
+    return bad
+
+
+def category_runs(order: tuple[str, ...] | list[str]) -> int:
+    """Number of contiguous same-group runs (fewer = more cohesive blocks)."""
+    runs = 0
+    prev: str | None = None
+    for kind in order:
+        g = _ROUTE_GROUP.get(kind, "?")
+        if g != prev:
+            runs += 1
+            prev = g
+    return runs
+
+
+@dataclass
+class RouteScore:
+    name: str
+    order: tuple[str, ...]
+    scroll: int
+    inversions: int
+    runs: int
+
+    @property
+    def composite(self) -> float:
+        # Scroll dominates (the owner's explicit "easy and clear" goal), then
+        # correctness (inversions), then cohesion (runs) as a gentle tie-break.
+        return self.scroll * 10 + self.inversions * 5 + self.runs * 0.5
+
+
+def _score_route_order(name: str, order: tuple[str, ...]) -> RouteScore:
+    return RouteScore(
+        name=name,
+        order=order,
+        scroll=scroll_to_full_coverage(order),
+        inversions=fallback_inversions(order),
+        runs=category_runs(order),
+    )
+
+
+def route_candidates() -> dict[str, tuple[str, ...]]:
+    return {
+        "current": tuple(_ROUTE_DISPLAY_ORDER),
+        "alpha": tuple(sorted(_ROUTE_TO_BINDING)),
+        "roots_first": recommended_route_order(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# B. Settings-group dropdown
+# ---------------------------------------------------------------------------
+
+# Categories an admin opens `!settings` to configure — the "server operations"
+# groups. Everything else (games / economy / progression / fun) is discovery,
+# not configuration, and belongs below in the admin surface.
+_CONFIG_CATEGORIES = frozenset({"moderation", "management", "admin"})
+# Community carries a mix (welcome / counters are admin-config; spotlight is
+# fun) — split it by visibility tier instead of category.
+_ADMIN_TIERS = frozenset({"staff", "moderator", "administrator", "owner"})
+
+
+def _is_config_group(subsystem: str) -> bool:
+    meta = SUBSYSTEMS.get(subsystem, {})
+    if meta.get("category") in _CONFIG_CATEGORIES:
+        return True
+    # Admin-tier community groups (welcome, counters) are config too.
+    return (
+        meta.get("category") == "community"
+        and meta.get("visibility_tier") in _ADMIN_TIERS
+    )
+
+
+def settings_sort_rank(subsystem: str) -> tuple[int, int, str]:
+    """The recommended settings-dropdown sort key (admin-config-first).
+
+    Tier 0 = server-operations groups (moderation / management / admin +
+    admin-tier community), tier 1 = everything else; ``ui_priority`` then key
+    order the members *within* each tier so the existing intuition is kept
+    inside the block. This is settings-surface-only — the global
+    ``ui_priority`` (Help / hub discovery order) is untouched.
+    """
+    meta = SUBSYSTEMS.get(subsystem, {})
+    tier = 0 if _is_config_group(subsystem) else 1
+    return (tier, int(meta.get("ui_priority", 99)), subsystem)
+
+
+def _settings_candidate_members() -> list[str]:
+    """Approximate the dropdown membership: every subsystem that plausibly
+    exposes settings/bindings (has a parent-config signal). The ordering
+    *policy* conclusion is membership-independent, but using the real registry
+    keeps the find-cost numbers honest.
+    """
+    members = []
+    for name, meta in SUBSYSTEMS.items():
+        if name == "help":
+            continue
+        # A crude but registry-grounded proxy for "actionable in settings":
+        # anything that declares config-ish capabilities or is an admin surface.
+        if meta.get("category") in _CONFIG_CATEGORIES or _is_config_group(name):
+            members.append(name)
+            continue
+        # Plus the user-facing groups the live dropdown also lists (economy /
+        # games / progression) so the find-cost reflects the real scroll.
+        if meta.get("category") in {"economy", "games", "progression", "community"}:
+            members.append(name)
+    return members
+
+
+def _current_settings_order(members: list[str]) -> list[str]:
+    return sorted(
+        members,
+        key=lambda s: (int(SUBSYSTEMS.get(s, {}).get("ui_priority", 99)), s),
+    )
+
+
+def _admin_first_settings_order(members: list[str]) -> list[str]:
+    return sorted(members, key=settings_sort_rank)
+
+
+def _config_find_cost(order: list[str]) -> float:
+    """Mean 0-based dropdown index of the config groups (lower = less scroll)."""
+    config = [s for s in order if _is_config_group(s)]
+    if not config:
+        return 0.0
+    return sum(order.index(s) for s in config) / len(config)
+
+
+# ---------------------------------------------------------------------------
+# Guard + report
+# ---------------------------------------------------------------------------
+
+
+def check_orders() -> list[str]:
+    """Return drift problems (empty = shipped orders match the recommendation).
+
+    Only the routes order is hard-guarded here — it is deterministic and
+    importable without registered schemas. The settings-dropdown ordering is
+    guarded by ``tests/unit/views`` (where the schema registry is populated).
+    """
+    problems: list[str] = []
+    rec = recommended_route_order()
+    if tuple(_ROUTE_DISPLAY_ORDER) != rec:
+        problems.append(
+            "_ROUTE_DISPLAY_ORDER has drifted from the roots-first "
+            f"recommendation.\n    shipped:     {list(_ROUTE_DISPLAY_ORDER)}\n"
+            f"    recommended: {list(rec)}",
+        )
+    return problems
+
+
+def _print_routes_report() -> None:
+    print("=" * 72)
+    print("A. Server-Logging routes — best binding order")
+    print("=" * 72)
+    print(
+        "\nGoal: every event logged somewhere. Fallback roots "
+        f"{_roots()} cover the rest, so a clear order shows them first.\n",
+    )
+    scored = [_score_route_order(n, o) for n, o in route_candidates().items()]
+    scored.sort(key=lambda s: s.composite)
+    print(f"  {'candidate':13}  {'scroll':>6}  {'inv':>4}  {'runs':>4}  score")
+    print(f"  {'-' * 13}  {'-' * 6}  {'-' * 4}  {'-' * 4}  -----")
+    for s in scored:
+        star = "  ★ best" if s is scored[0] else ""
+        print(
+            f"  {s.name:13}  {s.scroll:>6}  {s.inversions:>4}  "
+            f"{s.runs:>4}  {s.composite:5.1f}{star}",
+        )
+    best = scored[0]
+    print(
+        "\n  metrics: scroll = routes to read before both coverage-roots are "
+        "seen\n           inv = routes shown before their fallback root · "
+        "runs = category blocks",
+    )
+    print(f"\n  ★ recommended order ({best.name}):")
+    for i, kind in enumerate(best.order):
+        root = _root_of(kind)
+        tag = "ROOT — covers its tier" if root == kind else f"↪ falls back to {root}"
+        print(f"     {i + 1:>2}. {kind:12} ({tag})")
+    cur = _score_route_order("current", tuple(_ROUTE_DISPLAY_ORDER))
+    print(
+        f"\n  vs current: scroll {cur.scroll} → {best.scroll} "
+        f"({cur.scroll - best.scroll} fewer routes to read before full "
+        "coverage is understood).",
+    )
+    print(
+        "  shipped `_ROUTE_DISPLAY_ORDER` "
+        + ("MATCHES ✓" if tuple(_ROUTE_DISPLAY_ORDER) == best.order else "DRIFTED ✗")
+        + " the recommendation.",
+    )
+
+
+def _print_settings_report() -> None:
+    print("\n" + "=" * 72)
+    print("B. Settings-group dropdown — admin-config-first")
+    print("=" * 72)
+    members = _settings_candidate_members()
+    cur = _current_settings_order(members)
+    rec = _admin_first_settings_order(members)
+    cur_cost = _config_find_cost(cur)
+    rec_cost = _config_find_cost(rec)
+    print(
+        f"\n  {len(members)} candidate groups · "
+        f"{sum(1 for s in members if _is_config_group(s))} are server-config.\n",
+    )
+    print("  find-cost (mean dropdown index of config groups, lower=better):")
+    print(f"     current  (global ui_priority) : {cur_cost:5.1f}")
+    print(f"     admin_first (settings-only)   : {rec_cost:5.1f}")
+    print(f"     → {cur_cost - rec_cost:.1f} fewer rows of scrolling on average\n")
+    print("  first 8 of each order (what the admin sees without scrolling):")
+    print(f"     current    : {', '.join(cur[:8])}")
+    print(f"     admin_first: {', '.join(rec[:8])}")
+    print(
+        "\n  recommendation: sort the Settings dropdown by "
+        "`settings_sort_rank` (server-config groups first, ui_priority within\n"
+        "  each tier). This is applied in "
+        "`customization_catalogue.actionable_settings_groups` and touches ONLY\n"
+        "  the settings surface — the global ui_priority (Help / hub discovery "
+        "order) is unchanged.",
+    )
+
+
+def main() -> None:
+    _print_routes_report()
+    _print_settings_report()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Settings-order simulation + routes-order drift guard.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "exit non-zero if the shipped _ROUTE_DISPLAY_ORDER has drifted "
+            "from the roots-first recommendation"
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        issues = check_orders()
+        if issues:
+            print("settings-order check FAILED:")
+            for p in issues:
+                print(f"  - {p}")
+            sys.exit(1)
+        print("settings-order check OK — routes match the roots-first order.")
+        sys.exit(0)
+
+    main()


### PR DESCRIPTION
Owner screen-recording bug report (`!settings` → **Server Logging** → **Routes**). Frame-by-frame analysis pinned three defects + a simulation ask. **Born-red** — the session card flips to `complete` as the final step so auto-merge can't fire on a partial PR.

## 1. Per-action binding crash (`Set Channel` → "An error occurred")
Picking an **event** route (`events`/`message_log`/`member_log`/`role_log`) and clicking **Set Channel** crashes. `cogs/logging/select_view.py::_KIND_TO_LABEL` was never extended when the Q-0109 event routes were added to `_KIND_TO_BINDING`, so `_LogChannelSelect.__init__`'s `_KIND_TO_LABEL[kind]` raises `KeyError`. `provision_view` *has* the labels (so **Create** works, **Set** crashes) — a copy-paste drift the route-table consistency test missed because it pins `_KIND_TO_BINDING` but not `_KIND_TO_LABEL`.
- Complete the label map + make the lookup total (`_label_for`, never `KeyError`).
- Extend the route-table pin test to cover `_KIND_TO_LABEL`.

## 2. Disappearing "Back to Settings" / "Back to Help"
`LoggingPanelView` (`SUBSYSTEM="logging"`) is assumed by the linter to get universal Help/hub nav, but at runtime `attach_standard_nav` → `_self_navigates()` **skips** it because of its **"↩ Overview"** button (a no-op refresh). It then relies on the *externally*-attached back button, which is dropped on the Routes round-trip (fresh views rebuilt without `carry_back`).
- Stop treating "overview" as self-navigation → these panels get the universal Help/hub nav.
- `carry_back` across the Routes hops so the contextual back survives.

## 3. Settings-order simulation ("easy and clear to change all this")
`tools/sim/settings_order_sim.py` (the `help_menu_grouping_sim` pattern) scores orderings of the 11 logging routes (fallback-coverage + category cohesion) and the settings-group dropdown, recommends + applies the winner, and makes the routes panel state the "set `mod` + `events` first, the rest fall back" model up front.

Additive / reversible / test-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138KwZ676qWeG5zQSkFC8gS

---
_Generated by [Claude Code](https://claude.ai/code/session_0138KwZ676qWeG5zQSkFC8gS)_