### PR TITLE
Karma reaction-to-thank (completion-first deepening)

### DIFF
--- a/.sessions/2026-07-01-karma-reaction-to-thank.md
+++ b/.sessions/2026-07-01-karma-reaction-to-thank.md
@@ -1,0 +1,25 @@
+# 2026-07-01 — Karma reaction-to-thank (completion-first deepening)
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
+
+**PR:** (opening) — Karma reaction-to-thank.
+**Branch:** `claude/funny-franklin-jqv6ne` (from origin/main #1619).
+**Run type:** `routine · dispatch`
+
+## What this run is doing
+
+Empty scheduled fire → advancing the next plan slice. Recent runs have been fishing-structure
+heavy; diversifying to a **non-fishing** completion-first deepening. Picking the **Karma** unit's
+rubric-C **"React-to-thank"** box (cert `units/karma.md` punch-list #2 sub-item) — a named
+best-in-class gap (Carl-bot has it), self-contained and offline.
+
+Plan: add an opt-in per-guild **trigger emoji** setting; a `on_raw_reaction_add` listener in
+`KarmaCog` grants karma to the reacted message's author through the **existing audited
+`karma_service.give(source="reaction")` seam** (the service already documents `"reaction"` as an
+anticipated source — no new mutation path; all anti-abuse: self-give guard, cooldown, daily cap
+reused for free). Default off ⇒ byte-identical for existing guilds.
+
+## Shipped
+
+(to be filled at close)

--- a/.sessions/2026-07-01-karma-reaction-to-thank.md
+++ b/.sessions/2026-07-01-karma-reaction-to-thank.md
@@ -1,25 +1,113 @@
 # 2026-07-01 — Karma reaction-to-thank (completion-first deepening)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 <!-- born-red flow (Q-0133): `in-progress` while open; flipped to `complete` as the final close step. -->
 
-**PR:** (opening) — Karma reaction-to-thank.
+**PR:** [#1620](https://github.com/menno420/superbot/pull/1620) — Karma reaction-to-thank.
 **Branch:** `claude/funny-franklin-jqv6ne` (from origin/main #1619).
 **Run type:** `routine · dispatch`
 
-## What this run is doing
+## What this run did
 
-Empty scheduled fire → advancing the next plan slice. Recent runs have been fishing-structure
-heavy; diversifying to a **non-fishing** completion-first deepening. Picking the **Karma** unit's
-rubric-C **"React-to-thank"** box (cert `units/karma.md` punch-list #2 sub-item) — a named
-best-in-class gap (Carl-bot has it), self-contained and offline.
+Empty scheduled fire → advanced the next plan slice. Recent runs have been fishing-structure heavy
+(tide pool / dock / structures sub-hub / boathouse), so I **diversified** to a non-fishing
+completion-first deepening. Picked the **Karma** unit's rubric-C **"React-to-thank"** box
+(`units/karma.md`, punch-list #2 sub-item) — a named best-in-class gap (Carl-bot has it),
+self-contained and offline-shippable.
 
-Plan: add an opt-in per-guild **trigger emoji** setting; a `on_raw_reaction_add` listener in
-`KarmaCog` grants karma to the reacted message's author through the **existing audited
-`karma_service.give(source="reaction")` seam** (the service already documents `"reaction"` as an
-anticipated source — no new mutation path; all anti-abuse: self-give guard, cooldown, daily cap
-reused for free). Default off ⇒ byte-identical for existing guilds.
+The `karma_service.give()` docstring already listed `"reaction"` as an anticipated `source` — this
+extension was designed-for, so there is **no new mutation path**: the grant flows through the same
+audited seam as `!thanks`, reusing the self-give guard, per-(giver→receiver) cooldown, and per-giver
+daily cap for free.
 
-## Shipped
+## Shipped (PR #1620)
 
-(to be filled at close)
+- **`utils/settings_keys/karma.py`** (+`__init__` export) — new `KARMA_REACTION_EMOJI` scalar key.
+- **`services/karma_config.py`** — `DEFAULT_REACTION_EMOJI = ""` (off) + `MAX_REACTION_EMOJI_LEN`,
+  a `reaction_emoji: str` field on the frozen `KarmaPolicy`, resolved in `load_policy` via
+  `resolve_value` (same single-source-of-truth-default pattern as the other three specs).
+- **`cogs/karma/schemas.py`** — a 4th `SettingSpec` (`reaction_emoji`, free-text, `_validate_reaction_emoji`
+  = str + length-bounded; empty allowed), gated on `karma.settings.configure`.
+- **`cogs/karma_cog.py`** — an `on_raw_reaction_add` listener (starboard-style fast gate: `guild_id`
+  present → reactor-not-bot pre-filter → **one** policy read → emoji match → message fetch). Grants
+  through `karma_service.give(source="reaction", policy=…)` (reuses the already-loaded policy — one DB
+  read, not two). Skips bot authors + self-reactions; **swallows `KarmaError`** (cooldown/cap/self/
+  disabled) silently — a reaction never spams the channel.
+- **Tests (+11):** `test_karma_reaction.py` (9 listener cases: grant · feature-off · disabled · emoji
+  mismatch · bot-reactor-pre-filter · DM · bot-author · self-reaction · blocked-grant-swallowed) +
+  2 validator cases in `test_karma_schemas.py`; the schema default-drift test extended for the new spec.
+- **De-staled docs my work touched:** the Karma completion cert (`units/karma.md` — rubric C box
+  ticked, A/E/punch-list updated, 3-spec → 4-spec), the karma folio (`subsystems/karma.md` — PR-3
+  reaction-grant marked shipped), the settings command-map doc, the S1 sector recently-shipped, and the
+  regenerated dashboard/site artifacts (`export_dashboard_data.py`).
+
+**Safety:** default off ⇒ **byte-identical** for every existing guild (no reaction silently mints
+karma). Full CI mirror green (**13,664 passed**, 48 skipped); `check_architecture --mode strict` 0
+errors; artifact-freshness OK; no migration. Self-merge on green.
+
+## Decisions made alone (owner should be aware)
+
+- **Default OFF (empty emoji), not a preset default emoji.** Silently granting karma on a common
+  reaction (👍) would surprise operators; opt-in is the safe, byte-identical choice and matches how
+  Carl-bot exposes its "thank" trigger. An operator sets `!settings → Karma → reaction_emoji` to turn
+  it on.
+- **Silent grants (no channel confirmation message).** A per-reaction confirmation would be spammy;
+  the karma card reflects the new total. Matches the "in-place, not spammy" rubric-B item and the
+  starboard listener's quiet style.
+
+## ⚑ Self-initiated
+
+`none` — this is a completion-first deepening of an already-started unit (Karma), which the S1
+posture (Q-0209) explicitly treats as in-scope/prioritized, not a new-unit promotion.
+
+## 💡 Session idea
+
+**A "karma role reward" tier** (deferred breadth, karma cert punch-list #2): auto-grant a configurable
+role at a karma threshold (e.g. "Trusted Helper" @ 50) through the existing `RoleLifecycleService`
+audited seam, fired off the `EVT_KARMA_GRANTED` event the service already emits. Worth having because
+it turns karma from a vanity number into a real progression hook, and the wiring (event → threshold
+check → audited role grant) reuses seams that all exist today — a clean next deepening slice once the
+owner greenlights karma-roles. (Already the folio's documented PR-3 deferral, now one item lighter
+after this run.)
+
+## ⟲ Previous-session review
+
+The recent fishing-structure runs (tide pool → dock → structures sub-hub → boathouse, #1598–#1605)
+were individually clean and well-tested, and the sub-hub (#1603) was the *right* move — it kept the
+fishing menu lean as the structure count grew. The honest miss across the streak is **breadth
+concentration**: four consecutive dispatch runs all deepened the *same* coral-structure lane, which
+is exactly the kind of local-maximum a completion-first arc with 36 units should avoid — other units
+(Karma, Economy, Treasury) had untouched offline punch-lists the whole time. **System improvement
+this surfaces:** the dispatch orient step would benefit from a cheap "lane-recency" signal — e.g.
+`dispatch_menu.py` (or the sector "▶ Next startable" block) flagging when the last N self-merged PRs
+all touched one sub-area, nudging the next empty-fire run to diversify. This run did that manually by
+reading the `.sessions/` log titles; encoding it would make it automatic.
+
+## Doc audit (Q-0104)
+
+- `check_current_state_ledger.py --strict` → exit 0 (28 merges newer than marker #1590 = benign lag,
+  the reconciliation routine's job).
+- `check_docs.py --strict` → passed (536 docs; top-level 20/20; recently-shipped 20/20).
+- `check_generated_artifacts_fresh.py` → OK (4 artifacts fresh after re-export).
+- New settings key documented in the command-map doc; cert + folio de-staled; no owner decision to
+  route to the router (defaults were implementation choices within an approved completion lane).
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **What shipped:** Karma react-to-thank (opt-in trigger emoji → audited grant seam) — PR #1620.
+- **⚑ Owner-decisions:** `none`
+- **⚑ Owner-manual-steps:** `none` (no migration; merge auto-deploys via Railway).
+- **⚑ Self-initiated:** `none` (completion-first deepening of an existing unit; in-scope by Q-0209).
+- **Next ▶:** Karma is now one punch-list item lighter; its remaining offline gaps are the
+  audit-consistency call (#3) + cog-integration tests (#4). Other untouched offline punch-lists:
+  Economy (currency-name is a broad 173-usage refactor — needs a scoped plan, not a one-shot; admin
+  balance panel #3 is cleaner) · Treasury · Karma admin-adjust panel. Fishing structures are
+  well-covered — diversify next.
+
+## Continuation steps for the next agent
+
+1. Nothing is mid-flight — this PR is a complete, self-contained slice.
+2. If picking up Karma: punch-list #3 (add generic `audit.action_recorded` alongside the domain log)
+   and #4 (bot-recipient + event-catalogue cog tests) are both small + offline.
+3. Consider the "lane-recency diversify" tooling nudge from the review above before the next empty fire.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T15:41:50Z",
+    "generated_at": "2026-07-01T18:12:08Z",
     "build": {
-      "commit": "22cb0e9",
-      "subject": "xp-import: add button entry point + generic \"another bot\" framing",
-      "committed_at": "2026-07-01T15:41:50Z"
+      "commit": "2f3fbd1c",
+      "subject": "Karma reaction-to-thank: open born-red session card + claim",
+      "committed_at": "2026-07-01T18:12:08Z"
     }
   },
   "counts": {
@@ -12676,8 +12676,13 @@
         "!farmlb",
         "!countlb"
       ],
-      "status": "finished",
-      "linked_ideas": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea: leaderboard row avatars (the Arcane-defining visual)",
+          "status": "ideas"
+        }
+      ],
       "notes": null
     },
     {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7375,7 +7375,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "22cb0e9",
+    "build": "2f3fbd1c",
     "title": "New public bot website",
     "changes": [
       {
@@ -7387,7 +7387,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "22cb0e9",
+    "build": "2f3fbd1c",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7399,7 +7399,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "22cb0e9",
+    "build": "2f3fbd1c",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-07-01T18:10:33Z",
+    "generated_at": "2026-07-01T18:12:08Z",
     "build": {
-      "commit": "daa91151",
-      "subject": "Merge pull request #1613 from menno420/claude/reaction-roles-counter-bgxnyd",
-      "committed_at": "2026-07-01T18:10:33Z"
+      "commit": "2f3fbd1c",
+      "subject": "Karma reaction-to-thank: open born-red session card + claim",
+      "committed_at": "2026-07-01T18:12:08Z"
     },
     "counts": {
       "functions": 43,
-      "ideas": 159,
+      "ideas": 160,
       "bugs": 30,
       "reviews": 0,
       "reviews_open": 0,
@@ -16,9 +16,9 @@
       "env_vars": 39,
       "cogs": 55,
       "commands": 483,
-      "setting_keys": 115,
+      "setting_keys": 116,
       "setting_domains": 17,
-      "typed_settings": 95,
+      "typed_settings": 96,
       "visible_subsystems": 43,
       "synonyms": 87,
       "bot_changelog": 3
@@ -1164,6 +1164,14 @@
     }
   ],
   "ideas": [
+    {
+      "file": "leaderboard-row-avatars-2026-07-01.md",
+      "title": "Idea: leaderboard row avatars (the Arcane-defining visual)",
+      "status": "ideas",
+      "date": "2026-07-01",
+      "summary": "The leaderboard **image card** now reads well (outlier-safe bars, podium colours, clean values — this",
+      "subsystems": null
+    },
     {
       "file": "compute-dont-refuse-capability-sweep-2026-06-30.md",
       "title": "\"Compute, don't refuse\" — a capability sweep over the review log",
@@ -2715,6 +2723,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-07-01-visual-comparison-cards.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Visual comparison: out-read Arcane/MEE6 on the rank + leaderboard cards",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-01-utility-completion-deepening.md",
       "date": "2026-07-01",
       "title": "2026-07-01 — Utility completion-first deepening",
@@ -2728,6 +2744,22 @@
       "title": "2026-07-01 — Treasury completion tests (cog + modal)",
       "status": "complete",
       "run_type": "routine",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-01-settings-order-sim-and-binding-back-button-bugs.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Server-logging: per-route binding crash + disappearing back button + settings-order sim",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-07-01-server-log-avatar.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Server-log embeds: a face per entry (avatar in the author slot)",
+      "status": "complete",
+      "run_type": "",
       "self_initiated": false
     },
     {
@@ -2747,6 +2779,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-07-01-role-menu-builder-lean-layout.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Role-menu builder \"slim\" lean layout",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
       "file": "2026-07-01-owner-bypass-all-permission-gates.md",
       "date": "2026-07-01",
       "title": "2026-07-01 — Owner bypasses ALL permission gates (not just administrator)",
@@ -2761,6 +2801,14 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
+    },
+    {
+      "file": "2026-07-01-karma-reaction-to-thank.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — Karma reaction-to-thank (completion-first deepening)",
+      "status": "in-progress",
+      "run_type": "routine",
+      "self_initiated": false
     },
     {
       "file": "2026-07-01-inventory-density.md",
@@ -2816,6 +2864,14 @@
       "title": "2026-07-01 — Fishing Boathouse (third coral structure — energy-regen payoff)",
       "status": "complete",
       "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-07-01-btd6-menu-layout-design.md",
+      "date": "2026-07-01",
+      "title": "2026-07-01 — BTD6 menu layout design (simulator) + round-range NL answer fix",
+      "status": "complete",
+      "run_type": "",
       "self_initiated": true
     },
     {
@@ -3126,54 +3182,6 @@
       "file": "2026-06-28-no-dead-end-view-guard.md",
       "date": "2026-06-28",
       "title": "2026-06-28 — No-dead-end terminal-view arch guard (friction→guard)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-28-mining-creatures-completion-assessments.md",
-      "date": "2026-06-28",
-      "title": "Session — feature-completion assessments: Mining + Creatures + Welcome (Q-0209)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-28-fishing-pearl-rare-material.md",
-      "date": "2026-06-28",
-      "title": "2026-06-28 — Fishing: the \"pearl\" rare-material drop + a premium-bait pearl craft",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-28-fishing-counting-completion-punchlist.md",
-      "date": "2026-06-28",
-      "title": "2026-06-28 — Fishing + Counting feature-completion punch-list clears",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-28-feature-completion-games-and-gate-fix.md",
-      "date": "2026-06-28",
-      "title": "2026-06-28 — Feature-completion assessments (RPS · Deathmatch · Chicken farm) + born-red gate collision fix",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-28-feature-completion-assessments.md",
-      "date": "2026-06-28",
-      "title": "2026-06-28 — Feature-completion unit assessments + counting leaderboard",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-28-deathmatch-pvp-deadend.md",
-      "date": "2026-06-28",
-      "title": "2026-06-28 — Deathmatch + RPS PvP trapped-view dead-end fixes (completion-first)",
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
@@ -10407,6 +10415,14 @@
           "hint": "Maximum karma grants one member can give per rolling 24 hours.",
           "allowed_values": [],
           "default": 10
+        },
+        {
+          "constant": "KARMA_REACTION_EMOJI",
+          "key": "karma_reaction_emoji",
+          "type": "str",
+          "hint": "React-to-thank: set an emoji (e.g. ✨) and reacting with it on a message grants karma to that message's author — same cooldown and daily cap as !thanks. Leave empty to disable (the default).",
+          "allowed_values": [],
+          "default": ""
         }
       ]
     },

--- a/disbot/cogs/karma/schemas.py
+++ b/disbot/cogs/karma/schemas.py
@@ -22,8 +22,10 @@ from services.karma_config import (
     DEFAULT_COOLDOWN_SECONDS,
     DEFAULT_DAILY_CAP,
     DEFAULT_ENABLED,
+    DEFAULT_REACTION_EMOJI,
     MAX_COOLDOWN_SECONDS,
     MAX_DAILY_CAP,
+    MAX_REACTION_EMOJI_LEN,
     MIN_COOLDOWN_SECONDS,
     MIN_DAILY_CAP,
 )
@@ -31,6 +33,7 @@ from utils.settings_keys import (
     KARMA_COOLDOWN,
     KARMA_DAILY_CAP,
     KARMA_ENABLED,
+    KARMA_REACTION_EMOJI,
 )
 
 _KARMA_CAPABILITY = "karma.settings.configure"
@@ -55,6 +58,17 @@ def _validate_cooldown(value: object) -> None:
 
 def _validate_daily_cap(value: object) -> None:
     _bounded_int(value, MIN_DAILY_CAP, MAX_DAILY_CAP)
+
+
+def _validate_reaction_emoji(value: object) -> None:
+    # A free-text emoji trigger: a single unicode emoji or a custom
+    # ``<:name:id>`` form.  Empty string = OFF (the default).  We keep the
+    # check permissive (Discord validates the actual reaction at add-time);
+    # the guard is only against absurd lengths / wrong type.
+    if not isinstance(value, str):
+        raise ValueError(f"expected str, got {value!r}")
+    if len(value) > MAX_REACTION_EMOJI_LEN:
+        raise ValueError(f"emoji must be at most {MAX_REACTION_EMOJI_LEN} characters")
 
 
 KARMA_SETTINGS: tuple[SettingSpec, ...] = (
@@ -94,6 +108,19 @@ KARMA_SETTINGS: tuple[SettingSpec, ...] = (
         validator=_validate_daily_cap,
         input_hint="numeric_presets",
         presets=(5, 10, 25),
+    ),
+    SettingSpec(
+        name="reaction_emoji",
+        value_type=str,
+        default=DEFAULT_REACTION_EMOJI,
+        settings_key=KARMA_REACTION_EMOJI,
+        capability_required=_KARMA_CAPABILITY,
+        hint=(
+            "React-to-thank: set an emoji (e.g. ✨) and reacting with it on a "
+            "message grants karma to that message's author — same cooldown and "
+            "daily cap as !thanks. Leave empty to disable (the default)."
+        ),
+        validator=_validate_reaction_emoji,
     ),
 )
 

--- a/disbot/cogs/karma_cog.py
+++ b/disbot/cogs/karma_cog.py
@@ -21,11 +21,12 @@ from discord import app_commands
 from discord.ext import commands
 
 from core.runtime.interaction_helpers import safe_defer, safe_followup
-from services import karma_service
+from services import karma_config, karma_service
 from services.karma_service import (
     KarmaCooldownError,
     KarmaDailyCapError,
     KarmaDisabledError,
+    KarmaError,
     SelfKarmaError,
 )
 from utils import embeds as em
@@ -88,6 +89,65 @@ class KarmaCog(commands.Cog):
         )
         embed = _karma_card(interaction.guild, interaction.user, record)
         return embed, HubView(interaction.user)
+
+    # --------------------------------------------------------------- reaction
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(
+        self,
+        payload: discord.RawReactionActionEvent,
+    ) -> None:
+        """React-to-thank: reacting with the guild's configured emoji grants
+        karma to the reacted message's author.
+
+        Opt-in per guild (``karma.reaction_emoji`` — empty by default, so a
+        server that never configures it behaves exactly as before). The grant
+        flows through the same audited :func:`karma_service.give` seam as
+        ``!thanks``, so the self-give guard, per-recipient cooldown, and daily
+        cap all apply. Blocked grants are swallowed silently — a reaction must
+        never spam the channel with error messages.
+        """
+        if payload.guild_id is None:
+            return
+        member = payload.member  # set for guild reaction-adds (the reactor)
+        if member is None or member.bot:
+            return
+
+        # Fast gate: one settings read (like the starboard listener). Bail
+        # unless react-to-thank is enabled and this is the trigger emoji —
+        # true for the vast majority of reactions, before any message fetch.
+        policy = await karma_config.load_policy(payload.guild_id)
+        if not policy.enabled or not policy.reaction_emoji:
+            return
+        if str(payload.emoji) != policy.reaction_emoji:
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        if not isinstance(channel, discord.abc.Messageable):
+            return
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return
+
+        author = message.author
+        # Can't thank a bot; a self-reaction is a no-op (the service guards it
+        # too, but skip the write path entirely).
+        if author.bot or author.id == payload.user_id:
+            return
+
+        try:
+            await karma_service.give(
+                payload.guild_id,
+                from_user=payload.user_id,
+                to_user=author.id,
+                source="reaction",
+                reason=None,
+                policy=policy,  # reuse the policy already loaded above
+            )
+        except KarmaError:
+            # Disabled / self / cooldown / daily-cap — stay silent.
+            return
 
     # ------------------------------------------------------------------ grant
 

--- a/disbot/services/karma_config.py
+++ b/disbot/services/karma_config.py
@@ -48,6 +48,14 @@ DEFAULT_DAILY_CAP = 10
 MIN_DAILY_CAP = 1
 MAX_DAILY_CAP = 1000
 
+# React-to-thank trigger emoji: when set, reacting with this emoji on a
+# message grants karma to that message's author (through the same audited
+# service seam, so the cooldown + daily cap + self-give guard all apply).
+# The empty string means the feature is OFF — the safe, byte-identical
+# default, so no existing guild's reactions ever silently mint karma.
+DEFAULT_REACTION_EMOJI = ""
+MAX_REACTION_EMOJI_LEN = 64  # a unicode emoji or a <:name:id> custom form
+
 
 @dataclass(frozen=True)
 class KarmaPolicy:
@@ -59,6 +67,7 @@ class KarmaPolicy:
     enabled: bool = DEFAULT_ENABLED
     cooldown_seconds: int = DEFAULT_COOLDOWN_SECONDS
     daily_cap: int = DEFAULT_DAILY_CAP
+    reaction_emoji: str = DEFAULT_REACTION_EMOJI
 
 
 async def load_policy(guild_id: int) -> KarmaPolicy:
@@ -83,8 +92,15 @@ async def load_policy(guild_id: int) -> KarmaPolicy:
         "daily_cap",
         DEFAULT_DAILY_CAP,
     )
+    reaction_emoji = await resolve_value(
+        guild_id,
+        SUBSYSTEM,
+        "reaction_emoji",
+        DEFAULT_REACTION_EMOJI,
+    )
     return KarmaPolicy(
         enabled=enabled,
         cooldown_seconds=cooldown_seconds,
         daily_cap=daily_cap,
+        reaction_emoji=reaction_emoji,
     )

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -87,6 +87,7 @@ from utils.settings_keys.karma import (
     KARMA_COOLDOWN,
     KARMA_DAILY_CAP,
     KARMA_ENABLED,
+    KARMA_REACTION_EMOJI,
 )
 from utils.settings_keys.logging import (
     DEFAULT_CLEANUP_CHANNEL_NAME,
@@ -220,6 +221,7 @@ __all__ = [
     "KARMA_COOLDOWN",
     "KARMA_DAILY_CAP",
     "KARMA_ENABLED",
+    "KARMA_REACTION_EMOJI",
     "LOGGING_AUTO_CREATE_CHANNELS",
     "LOGGING_CLEANUP_CHANNEL",
     "LOGGING_ENABLED",

--- a/disbot/utils/settings_keys/karma.py
+++ b/disbot/utils/settings_keys/karma.py
@@ -3,3 +3,4 @@
 KARMA_ENABLED = "karma_enabled"
 KARMA_COOLDOWN = "karma_cooldown"
 KARMA_DAILY_CAP = "karma_daily_cap"
+KARMA_REACTION_EMOJI = "karma_reaction_emoji"

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -16,6 +16,14 @@
 > evidence + owner sign-off. Soft default — the owner greenlights brand-new units freely.
 
 **Recently shipped (this sector):**
+- **Karma react-to-thank** (PR #1620, completion-first deepening — closes the Karma cert's rubric-C
+  "React-to-thank" box) — an **opt-in per-guild trigger emoji** (`karma.reaction_emoji`, empty = off, the
+  4th karma setting-spec). When set, reacting with it on a message grants karma to that message's author
+  through the **existing audited `karma_service.give(source="reaction")` seam** — no new mutation path; the
+  self-give guard, per-(giver→receiver) cooldown, and per-giver daily cap all apply. An `on_raw_reaction_add`
+  listener in `karma_cog` (starboard-style fast gate: bot pre-filter → one policy read → emoji match →
+  message fetch). Silent (no channel spam); blocked grants swallowed; **byte-identical when unset** (no
+  existing guild's reactions silently mint karma). +11 tests; no migration; self-merge on green.
 - **Reaction-roles builder — "slim" lean layout** (owner-directed, from the layout sim #1612/#1613) —
   the role-menu builder went from **14 buttons / 3 rows** (felt dense in a live test) to a **lean 2-row**
   layout the optimizer recommended: row 0 = Template · Packs · Roles · **Style** · Text; row 1 = Colours ·

--- a/docs/owner/claims/claude-funny-franklin-jqv6ne.md
+++ b/docs/owner/claims/claude-funny-franklin-jqv6ne.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-jqv6ne` · Karma reaction-to-thank (completion-first deepening) · disbot/cogs/karma_cog.py, disbot/services/karma_config.py, disbot/cogs/karma/schemas.py, disbot/utils/settings_keys/karma.py, tests/unit/**karma** · 2026-07-01

--- a/docs/planning/feature-completion/units/karma.md
+++ b/docs/planning/feature-completion/units/karma.md
@@ -8,7 +8,7 @@
 > Source: `disbot/cogs/karma_cog.py` (`!thanks`/`!karma` + Help hook) ·
 > `disbot/services/karma_service.py` (audited grant seam) · `disbot/services/karma_config.py` (policy
 > read model) · `disbot/utils/db/karma.py` (migration; credit + audit log + anti-abuse reads) ·
-> `disbot/cogs/karma/schemas.py` (3-spec settings group) · `disbot/utils/settings_keys/karma.py` ·
+> `disbot/cogs/karma/schemas.py` (4-spec settings group) · `disbot/utils/settings_keys/karma.py` ·
 > the `KarmaProvider` in `services/rank_providers.py` · folio `docs/subsystems/karma.md`
 
 > Assessed during the completion-first arc (Q-0209). Karma is a **clean, well-guarded MVP** peer-
@@ -16,10 +16,12 @@
 > cooldown (default 1h), and a per-giver rolling 24h daily cap (default 10) — all enforced at the service
 > with **no write on a blocked grant**. Every grant appends to `karma_audit_log` (which doubles as the
 > anti-abuse read) and emits `EVT_KARMA_GRANTED`, with INV-K fencing direct writes out of the cog/view;
-> config is a typed 3-spec settings group; the karma leaderboard is a registered provider. The honest
-> gaps are **deliberately-deferred breadth** (reaction-to-thank, karma roles/rewards, decay, negative
-> rep, per-channel enable, an admin adjust panel) and one **audit-consistency** note (it uses a
-> domain-specific audit log like Economy, not the generic `audit.action_recorded`).
+> config is a typed 4-spec settings group; the karma leaderboard is a registered provider. The honest
+> gaps are **deliberately-deferred breadth** (karma roles/rewards, decay, negative rep, per-channel
+> enable, an admin adjust panel) and one **audit-consistency** note (it uses a domain-specific audit log
+> like Economy, not the generic `audit.action_recorded`). *(**React-to-thank shipped 2026-07-01, PR
+> #1620** — an opt-in per-guild trigger emoji, off by default, grants karma through the same audited
+> seam.)*
 
 ## Rubric (server function)
 
@@ -27,9 +29,10 @@
 - [x] **Core promise delivered** — `!thanks @user [reason]` / `!karma give` (aliases `!rep`/`!thank`)
       grants 1 karma; `!karma` shows a reputation card; karma leaderboard via the provider
       (`karma_service.py`, `karma_cog.py`, `rank_providers.py`).
-- [ ] **Every best-in-class sub-option exists** — ❌ **partial.** **Deferred (folio-documented):**
-      reaction-to-thank · karma roles/rewards at thresholds · milestone announcements · decay · negative
-      rep · per-channel enable. → punch-list #2.
+- [ ] **Every best-in-class sub-option exists** — ⚠️ **partial (react-to-thank now done).**
+      ✅ **React-to-thank** (opt-in trigger emoji, PR #1620). **Deferred (folio-documented):** karma
+      roles/rewards at thresholds · milestone announcements · decay · negative rep · per-channel enable.
+      → punch-list #2.
 - [x] **Failure modes honest** — self-give → `SelfKarmaError`; bot recipient rejected at the cog;
       disabled guild, cooldown-active, and daily-cap-hit each return a friendly message; absent target
       reads as zeros.
@@ -51,7 +54,10 @@
 - [x] **In-place, not spammy** — grants post a single confirmation; the card is one message.
 
 ### C. Convenience
-- [ ] **React-to-thank** — ❌ command-only today (reaction grant deferred). → punch-list #2.
+- [x] **React-to-thank** — ✅ **shipped (PR #1620).** An opt-in per-guild trigger emoji
+      (`karma.reaction_emoji`, empty = off); reacting with it grants karma to the message author through
+      the audited `karma_service.give(source="reaction")` seam (cooldown + daily cap + self-give guard
+      all apply). Silent (no channel spam); byte-identical when unset.
 - [x] **Sensible defaults** — cooldown 1h, daily cap 10, enabled by default (opt-out)
       (`karma_config.py`).
 - [x] **Clear feedback** — success shows the recipient's new total; cooldown shows the retry time; cap
@@ -70,12 +76,12 @@
 - [x] **Reuses governance** — capability floor `karma.settings.configure` on the settings specs.
 
 ### E. Configuration
-- [x] **Settings route through the pipeline** — `KARMA_CONFIG_SCHEMA` (3 specs: `enabled`,
-      `cooldown_seconds` 0–604800, `daily_cap` 1–1000) via `SubsystemSchema`/`SettingsMutationPipeline`
+- [x] **Settings route through the pipeline** — `KARMA_CONFIG_SCHEMA` (4 specs: `enabled`,
+      `cooldown_seconds` 0–604800, `daily_cap` 1–1000, `reaction_emoji` free-text) via `SubsystemSchema`/`SettingsMutationPipeline`
       (`karma/schemas.py`); defaults pinned to the policy (single source of truth, tested).
-- [x] **`settings_keys` constants** — `KARMA_ENABLED`/`KARMA_COOLDOWN`/`KARMA_DAILY_CAP`
+- [x] **`settings_keys` constants** — `KARMA_ENABLED`/`KARMA_COOLDOWN`/`KARMA_DAILY_CAP`/`KARMA_REACTION_EMOJI`
       (`utils/settings_keys/karma.py`).
-- [x] **Typed widgets** — bool + numeric-preset specs with validators.
+- [x] **Typed widgets** — bool + numeric-preset + free-text specs with validators.
 
 ### F. Wiring & discoverability
 - [x] **Registry** — key `karma`, `category: progression`, `visibility_tier: user`,
@@ -103,7 +109,7 @@
 1. **Bespoke command panel (rubric B)** *(deepening, or owner waiver)* — an actionable Karma panel (give
    / view card / settings link / back) rather than relying on the card + generic settings group — or the
    owner waives it (the card + settings group may suffice for a light user feature, the Welcome shape).
-2. **Best-in-class breadth (rubric A/C)** *(owner-paced, deferred)* — **reaction-to-thank** · karma
+2. **Best-in-class breadth (rubric A/C)** *(owner-paced, deferred)* — karma
    roles/rewards at thresholds · milestone announcements · decay · negative rep · per-channel enable ·
    an admin adjust/reset panel. The folio already lists these as the phase-2 deferral.
 3. **Audit-consistency** *(offline, minor)* — decide whether karma should also emit the generic
@@ -124,6 +130,6 @@
 Karma is a **clean, well-guarded MVP** — atomic grants, a self-give guard, cooldown + daily-cap
 anti-abuse that never writes on a block, an audited seam (INV-K-fenced), typed config, and a leaderboard
 provider. It is **not yet `✔ certified`**: the gaps are a missing **bespoke panel** (#1, or a waiver),
-**deliberately-deferred breadth** (reaction grant, karma roles, decay — #2), a minor audit-consistency
+**deliberately-deferred breadth** (karma roles, decay, negative rep — #2; react-to-thank ✅ #1620), a minor audit-consistency
 note (#3), small cog-test gaps (#4), and the owner walkthrough/sign-off (#5/#6). No safety/audit/dead-end
 issues found.

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -329,11 +329,14 @@ reputation; per-user totals + a leaderboard category on an audited mutation seam
 7. **dedicated_panel_command**: `none` (card-style embed, no interactive hub yet).
 8. **help_menu_direct_navigation_hook**: `build_help_menu_view` (the viewer's card).
 9. **existing_SettingSpec_declarations**: `enabled`, `cooldown_seconds`,
-   `daily_cap` (`disbot/cogs/karma/schemas.py`). Defaults + bounds are the single
-   source of truth in `disbot/services/karma_config.py`.
+   `daily_cap`, `reaction_emoji` (`disbot/cogs/karma/schemas.py`). Defaults + bounds
+   are the single source of truth in `disbot/services/karma_config.py`. The
+   `reaction_emoji` trigger (empty = off) drives the react-to-thank listener in
+   `karma_cog` — reacting with it grants karma through the same audited seam.
 10. **existing_settings_keys**: `KARMA_ENABLED`, `KARMA_COOLDOWN`,
-    `KARMA_DAILY_CAP` (`disbot/utils/settings_keys/karma.py`). Stored as scalar
-    guild settings — schema-declared, with the two karma tables in migration 093.
+    `KARMA_DAILY_CAP`, `KARMA_REACTION_EMOJI` (`disbot/utils/settings_keys/karma.py`).
+    Stored as scalar guild settings — schema-declared, with the two karma tables in
+    migration 093.
 11. **existing_BindingSpec_entries**: none.
 12. **existing_ResourceRequirement_entries**: none.
 13. **current_access_policy_behavior**: `visibility_tier=user`; grant/card are

--- a/docs/subsystems/karma.md
+++ b/docs/subsystems/karma.md
@@ -68,8 +68,12 @@ Karma is pure social reputation — non-spendable, no paywall, no P2W.
 
 ## Plans / pending (deferred)
 
-Per the plan's recommended defaults, **PR 3 is deferred** (owner-gated):
-- **Reaction-grant** — react with a configured emoji to grant karma, behind a
-  `karma_reaction_enabled` setting (reuses the reaction-roles raw seam).
+- **Reaction-grant (react-to-thank)** — ✅ **shipped 2026-07-01 (PR #1620).** React with the guild's
+  configured trigger emoji (`karma_reaction_emoji`, empty = off) to grant karma to the message author;
+  the `on_raw_reaction_add` listener in `karma_cog` routes through the same audited
+  `karma_service.give(source="reaction")` seam (cooldown + daily cap + self-give guard apply), silent,
+  byte-identical when unset.
+
+Per the plan's recommended defaults, the rest of **PR 3 stays deferred** (owner-gated):
 - **Karma roles** — auto-assign a role at thresholds (e.g. "Trusted Helper" @ 50).
 - **Milestone announcements** — a `karma.milestone` event + optional log channel.

--- a/tests/unit/cogs/test_karma_reaction.py
+++ b/tests/unit/cogs/test_karma_reaction.py
@@ -1,0 +1,211 @@
+"""Tests for the karma react-to-thank listener (cogs.karma_cog).
+
+Reacting with the guild's configured trigger emoji grants karma to the
+reacted message's author through the audited ``karma_service.give`` seam.
+These tests pin the listener's gating: it only fires when react-to-thank is
+enabled *and* the emoji matches, never for bots or self-reactions, and it
+swallows a blocked grant (cooldown / cap / self / disabled) silently.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.karma_cog import KarmaCog
+from services.karma_config import KarmaPolicy
+from services.karma_service import KarmaCooldownError
+
+
+def _policy(*, enabled: bool = True, emoji: str = "✨") -> KarmaPolicy:
+    return KarmaPolicy(
+        enabled=enabled,
+        cooldown_seconds=3600,
+        daily_cap=10,
+        reaction_emoji=emoji,
+    )
+
+
+def _cog(*, author_id: int = 20, author_bot: bool = False) -> KarmaCog:
+    """Build a KarmaCog whose bot resolves a fake channel + message."""
+    author = SimpleNamespace(id=author_id, bot=author_bot)
+    message = SimpleNamespace(author=author)
+    channel = MagicMock(spec=discord.TextChannel)  # passes isinstance(Messageable)
+    channel.fetch_message = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel.return_value = channel
+    return KarmaCog(bot)
+
+
+def _payload(
+    *,
+    guild_id: int | None = 1,
+    reactor_id: int = 10,
+    reactor_bot: bool = False,
+    emoji: str = "✨",
+) -> SimpleNamespace:
+    member = None if reactor_bot is None else SimpleNamespace(bot=reactor_bot)
+    return SimpleNamespace(
+        guild_id=guild_id,
+        user_id=reactor_id,
+        member=member,
+        emoji=emoji,
+        channel_id=100,
+        message_id=200,
+    )
+
+
+class TestReactionToThank:
+    @pytest.mark.asyncio
+    async def test_matching_emoji_grants_karma(self):
+        cog = _cog(author_id=20)
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(emoji="✨"),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(emoji="✨", reactor_id=10))
+        give.assert_awaited_once()
+        kwargs = give.await_args.kwargs
+        assert kwargs["from_user"] == 10
+        assert kwargs["to_user"] == 20
+        assert kwargs["source"] == "reaction"
+
+    @pytest.mark.asyncio
+    async def test_feature_off_when_emoji_unset(self):
+        cog = _cog()
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(emoji=""),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(emoji="✨"))
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disabled_policy_skips(self):
+        cog = _cog()
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(enabled=False),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(emoji="✨"))
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_matching_emoji_skips(self):
+        cog = _cog()
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(emoji="✨"),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(emoji="👍"))
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bot_reactor_skips_before_policy_read(self):
+        cog = _cog()
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+            ) as load,
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(reactor_bot=True))
+        load.assert_not_awaited()  # bot pre-filter runs before any DB read
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dm_reaction_skips(self):
+        cog = _cog()
+        with patch(
+            "services.karma_service.give",
+            new_callable=AsyncMock,
+        ) as give:
+            await cog.on_raw_reaction_add(_payload(guild_id=None))
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bot_author_not_thanked(self):
+        cog = _cog(author_bot=True)
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(emoji="✨"),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(emoji="✨"))
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_self_reaction_is_noop(self):
+        cog = _cog(author_id=10)  # author == reactor
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(emoji="✨"),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+            ) as give,
+        ):
+            await cog.on_raw_reaction_add(_payload(emoji="✨", reactor_id=10))
+        give.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blocked_grant_is_swallowed(self):
+        cog = _cog(author_id=20)
+        with (
+            patch(
+                "services.karma_config.load_policy",
+                new_callable=AsyncMock,
+                return_value=_policy(emoji="✨"),
+            ),
+            patch(
+                "services.karma_service.give",
+                new_callable=AsyncMock,
+                side_effect=KarmaCooldownError(60),
+            ),
+        ):
+            # must not raise — a reaction never spams the channel with an error
+            await cog.on_raw_reaction_add(_payload(emoji="✨", reactor_id=10))

--- a/tests/unit/cogs/test_karma_schemas.py
+++ b/tests/unit/cogs/test_karma_schemas.py
@@ -42,6 +42,7 @@ _EXPECTED_DEFAULTS = {
     "enabled": karma_config.DEFAULT_ENABLED,
     "cooldown_seconds": karma_config.DEFAULT_COOLDOWN_SECONDS,
     "daily_cap": karma_config.DEFAULT_DAILY_CAP,
+    "reaction_emoji": karma_config.DEFAULT_REACTION_EMOJI,
 }
 
 
@@ -59,3 +60,20 @@ def test_all_specs_require_the_configure_capability():
 
     for spec in KARMA_SETTINGS:
         assert spec.capability_required == "karma.settings.configure"
+
+
+def test_reaction_emoji_validator_accepts_empty_and_an_emoji():
+    from cogs.karma.schemas import _validate_reaction_emoji
+
+    _validate_reaction_emoji("")  # empty = off, valid
+    _validate_reaction_emoji("✨")
+    _validate_reaction_emoji("<:thanks:123456789012345678>")
+
+
+def test_reaction_emoji_validator_rejects_overlong_and_non_str():
+    from cogs.karma.schemas import _validate_reaction_emoji
+
+    with pytest.raises(ValueError):
+        _validate_reaction_emoji("x" * 65)
+    with pytest.raises(ValueError):
+        _validate_reaction_emoji(123)


### PR DESCRIPTION
Completion-first deepening of the **Karma** unit (`docs/planning/feature-completion/units/karma.md`) — closes the rubric-C **"React-to-thank"** box (a named best-in-class gap; Carl-bot has it).

**What:** an opt-in per-guild **trigger emoji** setting. When set, reacting with that emoji on a message grants karma to the message author through the **existing audited `karma_service.give(source="reaction")` seam** — the service already documents `"reaction"` as an anticipated source, so there is **no new mutation path**; the self-give guard, per-(giver→receiver) cooldown, and per-giver daily cap are all reused for free.

**Safety:** default off (empty emoji) ⇒ **byte-identical** for every existing guild — no reaction silently grants karma unless an operator turns it on. Reaction grants are silent (no channel spam); blocked grants (cooldown/cap/self/bot) are swallowed.

Born-red per Q-0133; self-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019f5rPqWRwoSos4VpCo2Uni)_