### PR TITLE
BTD6 panel: Layout-B category hub

### DIFF
--- a/.sessions/2026-07-01-btd6-menu-panel-hub.md
+++ b/.sessions/2026-07-01-btd6-menu-panel-hub.md
@@ -1,34 +1,125 @@
 # 2026-07-01 — BTD6 panel: Layout-B category hub (owner picked B)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** `owner-directed`
 
-## What I'm about to do
+## What I did
 
 Continuation of the menu-layout session (PR #1617 merged: round-range fix + the layout
 simulator + design doc). The owner reviewed the simulator and **picked Layout B** (category
-hub). Implement it in the live panel:
+hub). Implemented it in the live `/btd6menu` panel.
 
-- Rebuild `BTD6PanelView` (`disbot/views/btd6/panel.py`) as an **8-category hub** (≤4 buttons/row
-  per the mobile-truncation finding): 🧠 Ask (modal) · 🎯 Events · 🗼 Units · 🎲 Rounds & Economy ·
-  🗺️ Maps & Modes · 📋 Strategy · 📊 Status · 🛠️ Admin. (Calculators + Challenge-Index categories
-  are omitted — all-unbuilt `add` functions; they get their own future slices.)
-- New `disbot/views/btd6/hub_panels.py` — ephemeral `BaseView` sub-panels per category, wiring the
-  existing browsers (`open_tower_browser` / `open_hero_browser` / `open_paragon_calculator` /
-  `open_live_events_browser` / `open_leaderboard_browser` / CT / maps / modes / status / strategy)
-  + input modals for the previously-panel-invisible Rounds & Economy functions (Round/RBE/Income,
-  Bloon lookup).
-- Back-compat: reused custom_ids (`btd6:ask/events/maps/strategy/status/admin`) keep routing; the
-  6 dropped leaf ids need a one-time panel **re-post** (`!btd6menu`) — noted for the owner.
-- Tests: category buttons open their sub-panels; custom_ids stable; staff gating on Admin.
+## What shipped (PR #1621)
 
-Every function stays ≤2 clicks; the top panel drops from a 13-button wall to 8 clean subdivisions.
+- **`disbot/views/btd6/panel.py`** — `BTD6PanelView` is now an **8-subdivision hub** (≤4/row per
+  the mobile-truncation finding): 🧠 Ask (modal) · 🎯 Live Events · 🗼 Units · 🎲 Rounds & Economy ·
+  🗺️ Maps & Modes · 📋 Strategy · 📊 Status · 🛠️ Admin. Dropped the flat 13-button wall; the public
+  anchor embed is never edited on click.
+- **`disbot/views/btd6/hub_panels.py`** (new) — ephemeral `BTD6CategoryView` sub-panels per
+  category, wiring the already-shipped browsers (`open_tower_browser` / `open_hero_browser` /
+  `open_paragon_calculator` / `open_live_events_browser` / `open_leaderboard_browser` / CT+map /
+  maps / modes / status / strategy) **plus input modals** for the round/economy lookups that had
+  **no panel entry point before** — Round/range, RBE, Income (`_RoundModal`) and Bloon lookup
+  (`_BloonModal`). Every leaf reuses the exact function the `/btd6` slash calls — no logic
+  duplicated. `open_category` defers before its follow-up; sub-panels are invoker-locked with no
+  standard nav.
+- **Back-compat:** reused custom_ids (`btd6:ask/events/maps/strategy/status/admin`) keep existing
+  anchors routing; the leaf ids folded into sub-panels (`towers/heroes/modes/leaderboards/paragon/
+  ct`) are **retired** and need a one-time panel re-post (`!btd6menu`) — which happens naturally
+  when the new panel is posted.
+- **Tests:** updated the three pins that encoded the old flat layout — custom-id contract
+  (kept/new/**retired** sets), interaction-safety (new button set + an `open_category`
+  defer-before-followup check + accept the delegation), paragon-reachability (now via the Units
+  sub-panel) — and added `test_btd6_hub_panels.py` (round parsing, category registry well-formed,
+  **panel↔category alignment**, sub-panel construction/lock). 412 btd6 tests green.
 
-## What shipped
+Calculators + Challenge-Index categories from the design doc are **omitted** — all-unbuilt
+candidate functions; they get their own future slices (the categories are ready to receive them).
 
-_(filled in at close)_
+CI mirror: `check_quality.py --full` green; arch 0 errors.
 
 ## 📤 Run report
 
-_(filled in at close)_
+- **Did:** implemented the owner-chosen Layout B (category hub) in the live BTD6 panel — 8 clear
+  subdivisions replacing the 13-button wall, every function ≤2 clicks, plus the previously
+  panel-invisible round/economy lookups surfaced via modals · **Outcome:** shipped, CI green,
+  auto-merge armed.
+- **Shipped:** #1621 (follows #1617).
+- **Run type:** `owner-directed`.
+- **⚑ Owner decisions needed:** none (B was the pick).
+- **⚑ Owner manual steps:** **re-post the BTD6 panel once** after the deploy — `!btd6menu` (or
+  `/btd6menu`) — so the pinned anchor shows the new hub; old anchors' retired buttons
+  (towers/heroes/modes/leaderboards/paragon/ct) otherwise "interaction failed" on click. Live on
+  the next auto-deploy.
+- **⚑ Self-initiated:** no — this is the direct owner-picked follow-up ("B").
+- **↪ Next:** build the two omitted categories as their own slices — **Calculators** (cost/cash,
+  temple sacrifice, hero-leveling, glue, decay, adora) and **Challenge Index** (2TC/2MP/LTC/LCC/
+  LCD/FTTC), the `add` backlog from the design doc; the hub categories are ready to receive them.
+
+## 💡 Session idea (Q-0089)
+
+**A "panel reachability" checker for subsystem hubs.** This session (and the design study) turned
+on one fact: a subsystem can *own* a function (a slash command / service) that the **panel never
+surfaces**, so it's undiscoverable by clicking. I proved it by hand-diffing the `/btd6` slash tree
+against the panel buttons. A small checker that, per hub subsystem, lists the registered
+functions and flags those with **no button/sub-panel path** would make "slash-only, panel-invisible"
+a visible signal for every hub (mining, economy, BTD6…) — the menu analogue of the help-catalogue
+projection. Genuine (it *is* the lever this whole arc turned on); captured for a router nod on
+scope (per-subsystem opt-in) before it becomes a plan. *(Same idea I flagged in the #1617 log —
+re-raising because implementing the hub made it concrete: the Units/Rounds sub-panels are exactly
+where the previously-invisible functions now live.)*
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1617, this arc's PR 1) did the right thing by **not** implementing the panel and
+instead shipping the simulator + design doc for the owner to choose from — that respected
+"he designs/visualizes, you build" and made *this* session a clean, unambiguous execution once he
+picked B. What it slightly under-did: it didn't pre-flag that the redesign would **break old panel
+anchors** (a re-post is required) — I only discovered that constraint here, tracing the
+persistent-view custom_id matching. **System improvement:** the design doc's implementation plan
+should carry an explicit **"migration / re-post cost"** line for any persistent-view redesign, so
+the owner sees the operational step at decision time, not after the build. I've put the re-post
+step in this run report's ⚑ Owner-manual-steps; the durable fix is to add that line to the design
+doc — done implicitly via the panel docstring + this note.
+
+## Doc audit (Q-0104)
+
+- No new owner *decision* to route (the decision was "B", captured in the design doc's
+  recommendation + this session).
+- Ledger: #1621 is a newest merge; living-ledger reconciliation is the recon routine's job (next
+  pass at #1620 — this crosses it, so the next routine recon will fold #1617/#1621). Did **not**
+  hand-add my own unmerged PR (born-red rule's anti-pattern).
+- The design doc (`btd6-menu-layout-design-2026-07-01.md`, shipped in #1617) already documents the
+  implementation plan this session executed + the back-compat/re-post note; no new doc needed. The
+  panel/hub modules are self-documented (docstrings cite the design doc + simulator).
+
+## 🛠 Friction → guard (Q-0194)
+
+- **Friction:** `git push` after the merged-PR branch restart was rejected (the remote still held
+  the squash-merged feature history, so a main-based restart isn't a fast-forward). **Guard
+  (applied + durable):** the sanctioned move is `git push --force-with-lease=<branch>:<old-sha>`
+  **after** confirming the remote branch content is fully in `main` (I re-grepped `origin/main` for
+  the shipped artifacts first). Recorded so the next agent restarting a merged branch does the
+  lease-guarded force, not a blind `-f`.
+- **Friction:** a bash `if git push ... | tail -N` masks git's real exit code (the pipe's status is
+  `tail`'s), so a failed push printed a false "PUSH_OK" (carried over from the #1617 close).
+  **Guard (habit):** never gate on a *piped* git push; use `until git push ...; do` on the bare
+  command. Cheap, high-value — it nearly let a rejected push read as success.
+- **Friction:** `black` reflowed a multi-line type annotation and then `ruff` (COM812) wanted a
+  trailing comma inside it — a black↔ruff interplay the per-edit hook didn't pre-settle. **Guard
+  (existing):** `check_quality.py --check-only` caught it; the fix is `ruff --fix` then `black`.
+  Already enforced by CI; noted so it's not re-diagnosed.
+
+## Context delta
+
+- **Needed but not pointed to:** persistent-view custom_id matching semantics — that a redesign
+  which *drops* a top-level button's `custom_id` breaks *existing* anchors (they still render the
+  old button, which no longer routes) — is the load-bearing back-compat fact for any panel
+  redesign. It's implicit in `persistent_views.py` + the old legacy-id test's docstring but not
+  called out as "redesign = re-post". The updated custom-id test now encodes it (kept / new /
+  **retired** sets + the re-post note).
+- **Pointed to but didn't need:** `docs/building-roadmap/hub-ui-standard.md` (surfaced by the
+  context map) — the btd6 panel predates and diverges from that standard (ephemeral drill-downs,
+  not `HubView`), so the existing btd6 pattern (browsers opened via `safe_followup`) was the right
+  precedent to mirror, not the generic hub standard.

--- a/.sessions/2026-07-01-btd6-menu-panel-hub.md
+++ b/.sessions/2026-07-01-btd6-menu-panel-hub.md
@@ -1,0 +1,34 @@
+# 2026-07-01 — BTD6 panel: Layout-B category hub (owner picked B)
+
+> **Status:** `in-progress`
+
+**Run type:** `owner-directed`
+
+## What I'm about to do
+
+Continuation of the menu-layout session (PR #1617 merged: round-range fix + the layout
+simulator + design doc). The owner reviewed the simulator and **picked Layout B** (category
+hub). Implement it in the live panel:
+
+- Rebuild `BTD6PanelView` (`disbot/views/btd6/panel.py`) as an **8-category hub** (≤4 buttons/row
+  per the mobile-truncation finding): 🧠 Ask (modal) · 🎯 Events · 🗼 Units · 🎲 Rounds & Economy ·
+  🗺️ Maps & Modes · 📋 Strategy · 📊 Status · 🛠️ Admin. (Calculators + Challenge-Index categories
+  are omitted — all-unbuilt `add` functions; they get their own future slices.)
+- New `disbot/views/btd6/hub_panels.py` — ephemeral `BaseView` sub-panels per category, wiring the
+  existing browsers (`open_tower_browser` / `open_hero_browser` / `open_paragon_calculator` /
+  `open_live_events_browser` / `open_leaderboard_browser` / CT / maps / modes / status / strategy)
+  + input modals for the previously-panel-invisible Rounds & Economy functions (Round/RBE/Income,
+  Bloon lookup).
+- Back-compat: reused custom_ids (`btd6:ask/events/maps/strategy/status/admin`) keep routing; the
+  6 dropped leaf ids need a one-time panel **re-post** (`!btd6menu`) — noted for the owner.
+- Tests: category buttons open their sub-panels; custom_ids stable; staff gating on Admin.
+
+Every function stays ≤2 clicks; the top panel drops from a 13-button wall to 8 clean subdivisions.
+
+## What shipped
+
+_(filled in at close)_
+
+## 📤 Run report
+
+_(filled in at close)_

--- a/disbot/views/btd6/hub_panels.py
+++ b/disbot/views/btd6/hub_panels.py
@@ -1,0 +1,349 @@
+"""BTD6 hub category sub-panels (menu Layout B).
+
+The persistent :class:`views.btd6.panel.BTD6PanelView` shows one button per
+**subdivision**; each opens one of these ephemeral :class:`BaseView` sub-panels,
+which wire the already-shipped browsers + embed builders (and a couple of input
+modals for the round/economy lookups that had no panel entry point before). The
+design study is ``docs/btd6/btd6-menu-layout-design-2026-07-01.md``; the shape
+was chosen with ``tools/btd6/menu_layout_simulator.html`` (owner picked Layout B).
+
+Ephemeral + short-lived, so ``BaseView`` (invoker-locked, auto-timeout) is the
+right base — not ``PersistentView``. Sub-panel buttons carry no ``custom_id``:
+discord.py generates them for a non-persistent view, and nothing needs to match
+these across a restart. Each leaf action opens its own follow-up ephemeral (or a
+modal), reusing the exact functions the ``/btd6`` slash commands call, so the
+hub adds discoverability without duplicating any logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_followup
+from views.base import BaseView
+
+_Handler = Callable[[discord.Interaction], Awaitable[None]]
+_HUB_COLOR = discord.Color.green()
+
+
+# ---------------------------------------------------------------------------
+# Leaf actions — each reuses the existing browser / builder the slash uses.
+# ---------------------------------------------------------------------------
+
+
+async def _open_towers(interaction: discord.Interaction) -> None:
+    from views.btd6.tower_browser_view import open_tower_browser
+
+    await open_tower_browser(interaction)
+
+
+async def _open_heroes(interaction: discord.Interaction) -> None:
+    from views.btd6.hero_browser_view import open_hero_browser
+
+    await open_hero_browser(interaction)
+
+
+async def _open_paragon(interaction: discord.Interaction) -> None:
+    from views.btd6.paragon_view import open_paragon_calculator
+
+    await open_paragon_calculator(interaction)
+
+
+async def _open_live_events(interaction: discord.Interaction) -> None:
+    from views.btd6.live_events_view import open_live_events_browser
+
+    await open_live_events_browser(interaction)
+
+
+async def _open_leaderboards(interaction: discord.Interaction) -> None:
+    from views.btd6.leaderboard_browser_view import open_leaderboard_browser
+
+    await open_leaderboard_browser(interaction)
+
+
+async def _open_ct(interaction: discord.Interaction) -> None:
+    # Contested Territory browser + rendered hex map (mirrors the old btd6:ct button).
+    from cogs.btd6._builders import build_ct_browser_embed
+    from views.btd6.ct_map_view import build_ct_map_file
+
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    embed = await build_ct_browser_embed()
+    map_file, _ = await build_ct_map_file()
+    if map_file is not None:
+        embed.set_image(url="attachment://ct_map.png")
+    await safe_followup(interaction, embed=embed, file=map_file, ephemeral=True)
+
+
+async def _show_maps(interaction: discord.Interaction) -> None:
+    from cogs.btd6._embeds import build_maps_embed
+
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    await safe_followup(interaction, embed=build_maps_embed(), ephemeral=True)
+
+
+async def _show_modes(interaction: discord.Interaction) -> None:
+    from cogs.btd6._embeds import build_modes_embed
+
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    await safe_followup(interaction, embed=build_modes_embed(), ephemeral=True)
+
+
+async def _show_status(interaction: discord.Interaction) -> None:
+    from cogs.btd6._embeds import build_status_embed
+
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    await safe_followup(interaction, embed=await build_status_embed(), ephemeral=True)
+
+
+async def _show_strategy(interaction: discord.Interaction) -> None:
+    from views.btd6 import strategy_browse
+
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    await safe_followup(
+        interaction,
+        embed=await strategy_browse.build_browse_embed(limit=10),
+        ephemeral=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input modals — the round/economy + bloon lookups that had no panel entry.
+# ---------------------------------------------------------------------------
+
+
+def _parse_round(raw: str | None) -> int | None:
+    """A round number in 1..140, or ``None`` when blank / out of range."""
+    text = (raw or "").strip().lstrip("rR")
+    if not text.isdigit():
+        return None
+    value = int(text)
+    return value if 1 <= value <= 140 else None
+
+
+_ROUND_TITLES = {
+    "round": "Round lookup",
+    "rbe": "RBE lookup",
+    "income": "Income lookup",
+}
+
+
+class _RoundModal(discord.ui.Modal):
+    """One round, or an inclusive range, for the round / RBE / income builders."""
+
+    def __init__(self, kind: str) -> None:
+        super().__init__(title=_ROUND_TITLES.get(kind, "Round lookup"))
+        self._kind = kind
+        self.start_round: discord.ui.TextInput = discord.ui.TextInput(
+            label="Round (or first round of a range)",
+            placeholder="e.g. 63",
+            required=True,
+            max_length=3,
+        )
+        self.end_round: discord.ui.TextInput = discord.ui.TextInput(
+            label="Last round (optional — for a range)",
+            placeholder="e.g. 100",
+            required=False,
+            max_length=3,
+        )
+        self.add_item(self.start_round)
+        self.add_item(self.end_round)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        start = _parse_round(str(self.start_round.value))
+        raw_end = str(self.end_round.value).strip()
+        end = _parse_round(raw_end) if raw_end else None
+        if start is None or (raw_end and end is None):
+            await interaction.response.send_message(
+                "Enter a round number between 1 and 140.",
+                ephemeral=True,
+            )
+            return
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        from cogs.btd6._builders import (
+            build_income_embed,
+            build_rbe_embed,
+            build_round_embed,
+        )
+
+        if self._kind == "rbe":
+            embed = await build_rbe_embed(start, end)
+        elif self._kind == "income":
+            embed = await build_income_embed(start, end)
+        else:
+            embed = await build_round_embed(start, end)
+        await safe_followup(interaction, embed=embed, ephemeral=True)
+
+
+class _BloonModal(discord.ui.Modal, title="Bloon lookup"):
+    """A bloon name → the deterministic bloon answer (stats, immunities, children)."""
+
+    name: discord.ui.TextInput = discord.ui.TextInput(
+        label="Bloon name",
+        placeholder="e.g. ceramic, MOAB, lead, BAD",
+        required=True,
+        max_length=40,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        from cogs.btd6._embeds import response_to_embed
+        from services import btd6_ai_service
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        response = await btd6_ai_service.answer_question(str(self.name.value))
+        await safe_followup(
+            interaction,
+            embed=response_to_embed(response),
+            ephemeral=True,
+        )
+
+
+def _round_modal_opener(kind: str) -> _Handler:
+    async def _open(interaction: discord.Interaction) -> None:
+        await interaction.response.send_modal(_RoundModal(kind))
+
+    return _open
+
+
+async def _open_bloon_modal(interaction: discord.Interaction) -> None:
+    await interaction.response.send_modal(_BloonModal())
+
+
+# ---------------------------------------------------------------------------
+# Category registry — one entry list per subdivision.
+# ---------------------------------------------------------------------------
+
+_P = discord.ButtonStyle.primary
+_S = discord.ButtonStyle.secondary
+
+# id -> (emoji, label, blurb, [(emoji, label, style, handler), ...])
+_CATEGORIES: dict[
+    str,
+    tuple[str, str, str, list[tuple[str, str, discord.ButtonStyle, _Handler]]],
+] = {
+    "units": (
+        "🗼",
+        "Units",
+        "Towers, heroes & paragons — stats, upgrades, crosspaths.",
+        [
+            ("🗼", "Towers", _P, _open_towers),
+            ("🦸", "Heroes", _P, _open_heroes),
+            ("🔮", "Paragons", _P, _open_paragon),
+        ],
+    ),
+    "events": (
+        "🎯",
+        "Live Events",
+        "Race / boss / CT / odyssey, leaderboards, relics.",
+        [
+            ("🎯", "Live events", _P, _open_live_events),
+            ("🏆", "Leaderboards", _P, _open_leaderboards),
+            ("🗺️", "CT + map", _S, _open_ct),
+        ],
+    ),
+    "rounds": (
+        "🎲",
+        "Rounds & Economy",
+        "Round detail, RBE & income (single round or a range), bloon lookup.",
+        [
+            ("🎲", "Round / range", _P, _round_modal_opener("round")),
+            ("💥", "RBE", _S, _round_modal_opener("rbe")),
+            ("💰", "Income", _S, _round_modal_opener("income")),
+            ("🎈", "Bloon lookup", _S, _open_bloon_modal),
+        ],
+    ),
+    "maps": (
+        "🗺️",
+        "Maps & Modes",
+        "Maps by difficulty (with water) + mode rules.",
+        [
+            ("🗺️", "Maps", _S, _show_maps),
+            ("🎛️", "Modes", _S, _show_modes),
+        ],
+    ),
+    "strategy": (
+        "📋",
+        "Strategy",
+        "Community strategy memory — published strategies.",
+        [
+            ("📋", "Browse strategies", _S, _show_strategy),
+        ],
+    ),
+    "status": (
+        "📊",
+        "Status",
+        "Assistant status & dataset health.",
+        [
+            ("📊", "Status", _S, _show_status),
+        ],
+    ),
+}
+
+
+class BTD6CategoryView(BaseView):
+    """Ephemeral sub-panel: one button per function in a subdivision.
+
+    Invoker-locked (``BaseView``), no standard nav (``SUBSYSTEM`` unset), 5-min
+    timeout. Each button's callback is one of the leaf handlers above.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        entries: list[tuple[str, str, discord.ButtonStyle, _Handler]],
+    ) -> None:
+        super().__init__(author, timeout=300)
+        for emoji, label, style, handler in entries:
+            button: discord.ui.Button = discord.ui.Button(
+                label=label,
+                emoji=emoji,
+                style=style,
+            )
+            # Dynamically-added items are invoked as ``await item.callback(interaction)``;
+            # our leaf handlers have exactly that shape. (discord.py types callback as
+            # a generic-Client coroutine, hence the assignment ignore.)
+            button.callback = handler  # type: ignore[assignment]
+            self.add_item(button)
+
+
+async def open_category(interaction: discord.Interaction, category_id: str) -> None:
+    """Open the ephemeral sub-panel for ``category_id`` as a follow-up.
+
+    Unknown ids fail closed to a short notice rather than raising — the caller is
+    a persistent button whose custom_id could outlive a category rename.
+    """
+    entry = _CATEGORIES.get(category_id)
+    if entry is None:
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        await safe_followup(
+            interaction,
+            content="That section is unavailable — re-open the BTD6 panel.",
+            ephemeral=True,
+        )
+        return
+    emoji, label, blurb, entries = entry
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    embed = discord.Embed(
+        title=f"{emoji} {label}",
+        description=blurb,
+        color=_HUB_COLOR,
+    )
+    await safe_followup(
+        interaction,
+        embed=embed,
+        view=BTD6CategoryView(interaction.user, entries),
+        ephemeral=True,
+    )
+
+
+__all__ = ["BTD6CategoryView", "open_category"]

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -6,11 +6,15 @@ decorator side-effect on :class:`BTD6PanelView`; the persistent
 view registry then resolves the ``btd6`` subsystem when
 ``on_ready`` restores anchors.
 
-User actions: Ask / Towers / Heroes / Maps / Modes / Status. Staff actions
-sit behind the **🛠️ Admin** button — opens an ephemeral
-:class:`views.btd6.admin_panel.BTD6AdminView` with manual fetch
-controls and diagnostics. Natural-language replies are owned by the
-AI Platform's central stage — this panel never invokes a provider.
+Menu Layout B (category hub, owner-picked 2026-07-01 via
+``tools/btd6/menu_layout_simulator.html``; design study in
+``docs/btd6/btd6-menu-layout-design-2026-07-01.md``): eight labelled
+subdivisions instead of the old 13-button wall. **Ask** opens a modal;
+every other button opens an ephemeral sub-panel
+(:mod:`views.btd6.hub_panels`) for that subdivision — so every function
+is 1–2 clicks away. Staff actions sit behind **🛠️ Admin**. Natural-language
+replies are owned by the AI Platform's central stage — this panel never
+invokes a provider.
 """
 
 from __future__ import annotations
@@ -110,9 +114,9 @@ async def build_btd6_panel_embed() -> discord.Embed:
     embed = discord.Embed(
         title="🐵 BTD6 Assistant",
         description=(
-            "Ask BTD6 questions or browse tower / hero / mode / round "
-            "info. Staff can open the **🛠️ Admin** panel for manual "
-            "data fetches and diagnostics."
+            "Ask BTD6 questions or browse tower / hero / round / event "
+            "info by category. Staff can open the **🛠️ Admin** panel for "
+            "manual data fetches and diagnostics."
         ),
         color=_PANEL_COLOR,
     )
@@ -153,32 +157,32 @@ async def build_btd6_panel_embed() -> discord.Embed:
 
 @register
 class BTD6PanelView(PersistentView):
-    """BTD6 Assistant panel.
+    """BTD6 Assistant panel — Layout B (category hub).
 
-    All non-modal callbacks open ephemeral sub-views via
-    :func:`safe_followup`. The public anchor embed is **never edited**
-    on click — this is a UX upgrade from PR 2 (clicking Towers used to
-    mutate the panel for everyone in the channel).
+    Eight subdivision buttons; **Ask** opens a modal, the rest open an
+    ephemeral :class:`views.btd6.hub_panels.BTD6CategoryView` sub-panel via
+    :func:`safe_followup`. The public anchor embed is **never edited** on
+    click, so a click never mutates the shared panel for the whole channel.
 
     Modal exception: the **Ask** button calls
-    ``interaction.response.send_modal`` as the initial response and
-    does no service work before that — modals require the response
-    slot.
+    ``interaction.response.send_modal`` as the initial response and does no
+    service work before that — modals require the response slot.
 
-    Back-compat: keeps every legacy ``btd6:*`` custom_id so existing
-    panel anchor messages in production keep routing correctly.
-    Discord does not re-render existing anchor messages at restart;
-    the rendered button row is whatever was posted historically. The
-    legacy custom_ids (``btd6:towers`` / ``btd6:heroes`` / ``btd6:modes``)
-    redirect to the new ephemeral browsers.
+    Back-compat: the reused ``btd6:*`` custom_ids (``ask`` / ``events`` /
+    ``maps`` / ``strategy`` / ``status`` / ``admin``) keep existing production
+    anchors routing. The Layout-A leaf ids that were folded into sub-panels
+    (``towers`` / ``heroes`` / ``leaderboards`` / ``ct`` / ``modes`` /
+    ``paragon``) are dropped from the top level — an old anchor still showing
+    those buttons needs a one-time re-post (``!btd6menu``), which happens
+    naturally when the new panel is posted.
     """
 
-    # back-compat redirect — drop after 2026-Q3
     SUBSYSTEM = "btd6"
 
-    # Row 0 — primary user actions (5 buttons)
+    # Row 0 — Ask (modal) + the highest-traffic browse categories.
     @discord.ui.button(
         label="Ask",
+        emoji="🧠",
         style=discord.ButtonStyle.success,
         row=0,
         custom_id="btd6:ask",
@@ -194,6 +198,7 @@ class BTD6PanelView(PersistentView):
 
     @discord.ui.button(
         label="Live Events",
+        emoji="🎯",
         style=discord.ButtonStyle.primary,
         row=0,
         custom_id="btd6:events",
@@ -203,120 +208,79 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        from views.btd6.live_events_view import open_live_events_browser
+        from views.btd6.hub_panels import open_category
 
-        await open_live_events_browser(interaction)
+        await open_category(interaction, "events")
 
     @discord.ui.button(
-        label="Towers",
+        label="Units",
+        emoji="🗼",
         style=discord.ButtonStyle.primary,
         row=0,
-        custom_id="btd6:towers",
+        custom_id="btd6:units",
     )
-    async def towers_btn(
+    async def units_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        from views.btd6.tower_browser_view import open_tower_browser
+        from views.btd6.hub_panels import open_category
 
-        await open_tower_browser(interaction)
+        await open_category(interaction, "units")
 
     @discord.ui.button(
-        label="Heroes",
+        label="Rounds",
+        emoji="🎲",
         style=discord.ButtonStyle.primary,
         row=0,
-        custom_id="btd6:heroes",
+        custom_id="btd6:rounds",
     )
-    async def heroes_btn(
+    async def rounds_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        from views.btd6.hero_browser_view import open_hero_browser
+        from views.btd6.hub_panels import open_category
 
-        await open_hero_browser(interaction)
+        await open_category(interaction, "rounds")
 
+    # Row 1 — reference categories + staff.
     @discord.ui.button(
-        label="Leaderboards",
-        style=discord.ButtonStyle.primary,
-        row=0,
-        custom_id="btd6:leaderboards",
-    )
-    async def leaderboards_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        from views.btd6.leaderboard_browser_view import open_leaderboard_browser
-
-        await open_leaderboard_browser(interaction)
-
-    # Row 1 — secondary actions + staff
-    @discord.ui.button(
-        label="🗺️ CT",
+        label="Maps & Modes",
+        emoji="🗺️",
         style=discord.ButtonStyle.secondary,
         row=1,
-        custom_id="btd6:ct",
+        custom_id="btd6:maps",
     )
-    async def ct_btn(
+    async def maps_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # Contested Territory browser: active CT events + their relic tiles,
-        # with a rendered hex map of the current event when Pillow is present.
-        from cogs.btd6._builders import build_ct_browser_embed
-        from views.btd6.ct_map_view import build_ct_map_file
+        from views.btd6.hub_panels import open_category
 
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        embed = await build_ct_browser_embed()
-        map_file, _ = await build_ct_map_file()
-        if map_file is not None:
-            embed.set_image(url="attachment://ct_map.png")
-        await safe_followup(
-            interaction,
-            embed=embed,
-            file=map_file,
-            ephemeral=True,
-        )
+        await open_category(interaction, "maps")
 
     @discord.ui.button(
-        label="Modes",
+        label="Strategy",
+        emoji="📋",
         style=discord.ButtonStyle.secondary,
         row=1,
-        custom_id="btd6:modes",
+        custom_id="btd6:strategy",
     )
-    async def modes_btn(
+    async def strategy_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # Back-compat redirect: open the modes catalog as an ephemeral.
-        # The old behaviour (editing the public panel in place) was a
-        # UX anti-pattern; PR 2 switches every drill-down to ephemeral.
-        from cogs.btd6._embeds import build_modes_embed
+        from views.btd6.hub_panels import open_category
 
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        await safe_followup(
-            interaction,
-            embed=build_modes_embed(),
-            ephemeral=True,
-        )
+        await open_category(interaction, "strategy")
 
     @discord.ui.button(
         label="Status",
-        style=discord.ButtonStyle.primary,
+        emoji="📊",
+        style=discord.ButtonStyle.secondary,
         row=1,
         custom_id="btd6:status",
     )
@@ -325,29 +289,9 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.btd6._embeds import build_status_embed
+        from views.btd6.hub_panels import open_category
 
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        embed = await build_status_embed()
-        await safe_followup(interaction, embed=embed, ephemeral=True)
-
-    @discord.ui.button(
-        label="🔮 Paragon",
-        style=discord.ButtonStyle.primary,
-        row=1,
-        custom_id="btd6:paragon",
-    )
-    async def paragon_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        from views.btd6.paragon_view import open_paragon_calculator
-
-        await open_paragon_calculator(interaction)
+        await open_category(interaction, "status")
 
     @discord.ui.button(
         label="🛠️ Admin",
@@ -376,52 +320,5 @@ class BTD6PanelView(PersistentView):
             interaction,
             embed=embed,
             view=view,
-            ephemeral=True,
-        )
-
-    # Row 2 — info catalogs that don't fit rows 0/1 (both full at 5).
-    @discord.ui.button(
-        label="🗺️ Maps",
-        style=discord.ButtonStyle.secondary,
-        row=2,
-        custom_id="btd6:maps",
-    )
-    async def maps_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        # All 89 maps grouped by difficulty (with the has_water marker).
-        from cogs.btd6._embeds import build_maps_embed
-
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        await safe_followup(
-            interaction,
-            embed=build_maps_embed(),
-            ephemeral=True,
-        )
-
-    @discord.ui.button(
-        label="📋 Strategy",
-        style=discord.ButtonStyle.secondary,
-        row=2,
-        custom_id="btd6:strategy",
-    )
-    async def strategy_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        # Browse published community strategies — the same surface as
-        # `!btd6 strat browse`, surfaced here so the strategy memory is
-        # reachable by clicking through the BTD6 hub (discoverability audit).
-        from views.btd6 import strategy_browse
-
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        await safe_followup(
-            interaction,
-            embed=await strategy_browse.build_browse_embed(limit=10),
             ephemeral=True,
         )

--- a/docs/owner/claims/claude-btd6-menu-layout-design-mrm358.md
+++ b/docs/owner/claims/claude-btd6-menu-layout-design-mrm358.md
@@ -1,1 +1,1 @@
-- `claude/btd6-menu-layout-design-mrm358` · BTD6 menu layout design + round-range NL bug · disbot/views/btd6/panel.py, disbot/services/btd6_context_service.py, docs/btd6/, tools/btd6/ · 2026-07-01
+- `claude/btd6-menu-layout-design-mrm358` · BTD6 panel Layout-B category hub (owner picked B) · disbot/views/btd6/panel.py, disbot/views/btd6/hub_panels.py · 2026-07-01

--- a/tests/unit/views/btd6/test_btd6_hub_panels.py
+++ b/tests/unit/views/btd6/test_btd6_hub_panels.py
@@ -1,0 +1,101 @@
+"""BTD6 hub sub-panels (menu Layout B) — structure + wiring.
+
+The persistent panel's category buttons delegate to
+``hub_panels.open_category``; these pin that the category registry is
+well-formed, aligns with the panel's category buttons, and that the
+round-lookup modal parses input the way the builders expect.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from views.btd6 import hub_panels
+from views.btd6.hub_panels import BTD6CategoryView, _CATEGORIES, _parse_round
+from views.btd6.panel import BTD6PanelView
+
+
+# --- _parse_round -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("63", 63),
+        ("1", 1),
+        ("140", 140),
+        ("r29", 29),  # r-shorthand
+        ("  R100 ", 100),  # whitespace + capital R
+        ("", None),  # blank → single-round / no-range
+        (None, None),
+        ("0", None),  # below range
+        ("141", None),  # above range
+        ("abc", None),  # non-numeric
+        ("12.5", None),  # not an int
+    ],
+)
+def test_parse_round(raw, expected):
+    assert _parse_round(raw) == expected
+
+
+# --- category registry --------------------------------------------------------
+
+
+def test_category_registry_is_well_formed():
+    for cat_id, (emoji, label, blurb, entries) in _CATEGORIES.items():
+        assert isinstance(cat_id, str) and cat_id
+        assert emoji and label and blurb
+        assert entries, f"category {cat_id!r} has no entries"
+        for entry in entries:
+            e_emoji, e_label, style, handler = entry
+            assert e_emoji and e_label
+            assert isinstance(style, discord.ButtonStyle)
+            assert callable(handler)
+
+
+def test_panel_category_buttons_align_with_registry():
+    # Every non-{ask, admin, nav} panel button opens a category that exists, and
+    # every registered category has a panel button — no orphans either way.
+    panel_ids = {
+        c.custom_id
+        for c in BTD6PanelView().children
+        if getattr(c, "custom_id", None)
+    }
+    category_button_ids = panel_ids - {"btd6:ask", "btd6:admin", "nav:help"}
+    expected = {f"btd6:{cat}" for cat in _CATEGORIES}
+    assert category_button_ids == expected
+
+
+def test_units_category_wires_the_three_unit_browsers():
+    handlers = [entry[3] for entry in _CATEGORIES["units"][3]]
+    assert hub_panels._open_towers in handlers
+    assert hub_panels._open_heroes in handlers
+    assert hub_panels._open_paragon in handlers
+
+
+def test_rounds_category_covers_round_rbe_income_bloon():
+    labels = [entry[1] for entry in _CATEGORIES["rounds"][3]]
+    assert labels == ["Round / range", "RBE", "Income", "Bloon lookup"]
+
+
+# --- BTD6CategoryView ---------------------------------------------------------
+
+
+class _FakeUser:
+    id = 42
+
+
+def test_category_view_has_one_button_per_entry():
+    entries = _CATEGORIES["units"][3]
+    view = BTD6CategoryView(_FakeUser(), entries)
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    # No standard nav is attached (SUBSYSTEM unset), so it's exactly the entries.
+    assert len(buttons) == len(entries)
+    assert [b.label for b in buttons] == [e[1] for e in entries]
+
+
+def test_category_view_is_invoker_locked():
+    view = BTD6CategoryView(_FakeUser(), _CATEGORIES["maps"][3])
+    # BaseView default public=False → only the invoker may interact.
+    assert view._public is False

--- a/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
+++ b/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
@@ -1,48 +1,59 @@
-"""Pin every historical ``btd6:*`` custom_id on the persistent panel.
+"""Pin the ``btd6:*`` custom_ids on the persistent panel (menu Layout B).
 
 Discord does not re-render existing anchor messages at restart — the
-rendered button row is whatever was posted historically; routing
-matches by ``custom_id``. So even after the PR 2 hub refactor, every
-legacy custom_id must still be present on :class:`BTD6PanelView` or
-clicks on old anchors fall through to "interaction failed".
+rendered button row is whatever was posted historically; routing matches
+by ``custom_id``. So the ids reused from the old flat layout must stay
+present on :class:`BTD6PanelView` or clicks on old anchors fall through
+to "interaction failed".
 
-This regression test catches accidental removal during future layout
-changes.
+The 2026-07-01 Layout-B redesign (category hub — design study
+``docs/btd6/btd6-menu-layout-design-2026-07-01.md``) **kept** the ids that map
+cleanly (ask / events / maps / strategy / status / admin) and **retired** the
+Layout-A leaf ids that were folded into ephemeral sub-panels (towers / heroes /
+modes / leaderboards / paragon / ct). Retiring those is an intentional
+back-compat break: an old anchor still showing those buttons needs a one-time
+re-post (``!btd6menu``). This test pins the new contract and the retired set so
+the drop stays deliberate and documented.
 """
 
 from __future__ import annotations
 
 from views.btd6.panel import BTD6PanelView
 
-# Legacy custom_ids that exist on production anchors. NEVER remove
-# without a migration that re-renders all anchor messages.
-_LEGACY_CUSTOM_IDS = frozenset(
+# Reused from the old flat layout — keep these so existing anchors keep routing.
+_KEPT_CUSTOM_IDS = frozenset(
     {
         "btd6:ask",
-        "btd6:towers",
-        "btd6:heroes",
-        "btd6:modes",
+        "btd6:events",
+        "btd6:maps",
+        "btd6:strategy",
         "btd6:status",
         "btd6:admin",
     },
 )
 
-# New custom_ids introduced by PR 2.
+# Introduced by Layout B (the two new subdivision buttons + the universal Help
+# control auto-attached to every SUBSYSTEM panel by
+# views.navigation.attach_standard_nav — btd6 is a top-level hub with no
+# parent_hub, so it gets Help but no Back-to-hub button).
 _NEW_CUSTOM_IDS = frozenset(
     {
-        "btd6:events",
+        "btd6:units",
+        "btd6:rounds",
+        "nav:help",
+    },
+)
+
+# Retired in Layout B — folded into the Units / Live Events / Maps & Modes
+# sub-panels. Deliberately absent from the top level (see module docstring).
+_RETIRED_CUSTOM_IDS = frozenset(
+    {
+        "btd6:towers",
+        "btd6:heroes",
+        "btd6:modes",
         "btd6:leaderboards",
         "btd6:paragon",
         "btd6:ct",
-        "btd6:maps",
-        # Strategy browse — added 2026-06-23 (discoverability audit U4) so the
-        # !btd6strat strategy memory is reachable by clicking through the BTD6 hub.
-        "btd6:strategy",
-        # Universal Help control auto-attached to every SUBSYSTEM panel by
-        # views.navigation.attach_standard_nav (the "never stranded" contract,
-        # owner directive 2026-06-23). btd6 is a top-level hub (no parent_hub),
-        # so it gets the Help button but no Back-to-hub button.
-        "nav:help",
     },
 )
 
@@ -60,18 +71,30 @@ def test_zero_arg_construction() -> None:
     assert view is not None
 
 
-def test_every_legacy_custom_id_present() -> None:
+def test_every_kept_custom_id_present() -> None:
     ids = _view_custom_ids()
-    missing = _LEGACY_CUSTOM_IDS - ids
+    missing = _KEPT_CUSTOM_IDS - ids
     assert (
         not missing
-    ), f"Removed legacy custom_ids would break existing anchors: {missing}"
+    ), f"Removed a reused custom_id would break existing anchors: {missing}"
 
 
 def test_every_new_custom_id_present() -> None:
     ids = _view_custom_ids()
     missing = _NEW_CUSTOM_IDS - ids
-    assert not missing, f"Missing PR 2 custom_ids: {missing}"
+    assert not missing, f"Missing Layout-B custom_ids: {missing}"
+
+
+def test_retired_ids_are_absent() -> None:
+    # The retirement is intentional (folded into sub-panels). If one reappears,
+    # either it was re-added by accident or the layout changed again — make the
+    # decision explicit rather than silent.
+    ids = _view_custom_ids()
+    present = _RETIRED_CUSTOM_IDS & ids
+    assert not present, (
+        f"Retired Layout-A custom_ids reappeared on the top-level panel: "
+        f"{present}. They belong in the hub sub-panels now."
+    )
 
 
 def test_subsystem_name_pinned() -> None:
@@ -81,11 +104,11 @@ def test_subsystem_name_pinned() -> None:
 
 
 def test_no_unknown_custom_ids() -> None:
-    # Any new ID introduced after PR 2 should be explicitly added to
-    # the regression sets above so future readers see the scope grow.
+    # Any new ID should be explicitly added to the sets above so future
+    # readers see the scope change.
     ids = _view_custom_ids()
-    extra = ids - (_LEGACY_CUSTOM_IDS | _NEW_CUSTOM_IDS)
+    extra = ids - (_KEPT_CUSTOM_IDS | _NEW_CUSTOM_IDS)
     assert not extra, (
         f"Undeclared custom_ids on BTD6PanelView: {extra}. Add them to "
-        "_LEGACY_CUSTOM_IDS or _NEW_CUSTOM_IDS in this test file."
+        "_KEPT_CUSTOM_IDS or _NEW_CUSTOM_IDS in this test file."
     )

--- a/tests/unit/views/btd6/test_paragon_view.py
+++ b/tests/unit/views/btd6/test_paragon_view.py
@@ -218,9 +218,16 @@ def test_error_embed_surfaces_valid_towers():
 # --- panel + command wiring --------------------------------------------------
 
 
-def test_btd6_panel_has_paragon_button():
+def test_paragon_reachable_from_panel_units_subpanel():
+    # Layout B (2026-07-01): the Paragon calculator moved from a top-level panel
+    # button into the 🗼 Units sub-panel. Assert the panel exposes the Units
+    # category button AND that the Units sub-panel wires the paragon calculator.
     ids = [getattr(c, "custom_id", None) for c in BTD6PanelView().children]
-    assert "btd6:paragon" in ids
+    assert "btd6:units" in ids
+    from views.btd6.hub_panels import _CATEGORIES, _open_paragon
+
+    units_handlers = [entry[3] for entry in _CATEGORIES["units"][3]]
+    assert _open_paragon in units_handlers
 
 
 def test_cog_registers_paragon_command():

--- a/tests/unit/views/test_btd6_panel_interaction_safety.py
+++ b/tests/unit/views/test_btd6_panel_interaction_safety.py
@@ -45,6 +45,21 @@ def _is_interaction_response_send(expr: ast.expr) -> bool:
     return isinstance(func, ast.Attribute) and func.attr == "send_message"
 
 
+def _is_open_category_call(expr: ast.expr) -> bool:
+    """A delegation to ``hub_panels.open_category`` — a safe first await.
+
+    The Layout-B category buttons are thin delegates: their whole body is
+    ``await open_category(interaction, "<id>")``. ``open_category`` calls
+    ``safe_defer`` before any follow-up work (pinned by
+    :func:`test_open_category_defers_before_followup`), so a button that delegates
+    to it satisfies the same defer-before-service-work contract.
+    """
+    return isinstance(expr, ast.Call) and (
+        (isinstance(expr.func, ast.Name) and expr.func.id == "open_category")
+        or (isinstance(expr.func, ast.Attribute) and expr.func.attr == "open_category")
+    )
+
+
 def _collect_awaits_in_source_order(node: ast.AST) -> list[ast.Await]:
     out: list[ast.Await] = []
     for child in ast.walk(node):
@@ -68,13 +83,14 @@ _MODAL_EXEMPT = frozenset(
     "class_name,method_name",
     [
         ("BTD6AskModal", "on_submit"),
+        # Category buttons — thin delegates to open_category (defers internally).
         ("BTD6PanelView", "events_btn"),
-        ("BTD6PanelView", "towers_btn"),
-        ("BTD6PanelView", "heroes_btn"),
-        ("BTD6PanelView", "leaderboards_btn"),
-        ("BTD6PanelView", "modes_btn"),
+        ("BTD6PanelView", "units_btn"),
+        ("BTD6PanelView", "rounds_btn"),
+        ("BTD6PanelView", "maps_btn"),
+        ("BTD6PanelView", "strategy_btn"),
         ("BTD6PanelView", "status_btn"),
-        ("BTD6PanelView", "paragon_btn"),
+        # Admin does its own safe_defer before the admin-panel build.
         ("BTD6PanelView", "admin_btn"),
     ],
 )
@@ -89,11 +105,52 @@ def test_handler_defers_before_service_work(class_name, method_name):
     for await_node in awaits:
         if _is_interaction_response_send(await_node.value):
             continue
-        assert _is_safe_defer_call(await_node.value), (
+        assert _is_safe_defer_call(await_node.value) or _is_open_category_call(
+            await_node.value
+        ), (
             f"{class_name}.{method_name}: first DB/service await at line "
-            f"{await_node.lineno} is not safe_defer()."
+            f"{await_node.lineno} is not safe_defer() or open_category()."
         )
         return
+
+
+_HUB_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "views"
+    / "btd6"
+    / "hub_panels.py"
+)
+
+
+def test_open_category_defers_before_followup() -> None:
+    """``open_category`` — the delegate every category button routes through —
+    must ``safe_defer`` before its ``safe_followup`` (the guarantee the button
+    delegates inherit)."""
+    tree = ast.parse(_HUB_PATH.read_text())
+    node = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "open_category"
+        ),
+        None,
+    )
+    assert node is not None, "open_category not found in hub_panels.py"
+    awaits = _collect_awaits_in_source_order(node)
+    defer_lines = [a.lineno for a in awaits if _is_safe_defer_call(a.value)]
+    followup_lines = [
+        a.lineno
+        for a in awaits
+        if isinstance(a.value, ast.Call)
+        and isinstance(a.value.func, ast.Name)
+        and a.value.func.id == "safe_followup"
+    ]
+    assert defer_lines, "open_category must call safe_defer"
+    assert followup_lines, "open_category must call safe_followup"
+    assert min(defer_lines) < min(
+        followup_lines
+    ), "open_category must safe_defer before its first safe_followup"
 
 
 def test_ask_button_calls_send_modal_directly() -> None:


### PR DESCRIPTION
Follow-up to #1617 (merged: round-range fix + the layout simulator + design study). The owner reviewed the simulator and **picked Layout B** (category hub); this implements it in the live `/btd6menu` panel.

## What changes
- `BTD6PanelView` becomes an **8-category hub** (≤4 buttons/row per the mobile-truncation finding): 🧠 Ask · 🎯 Events · 🗼 Units · 🎲 Rounds & Economy · 🗺️ Maps & Modes · 📋 Strategy · 📊 Status · 🛠️ Admin — dropping the 13-button flat wall.
- New `disbot/views/btd6/hub_panels.py`: ephemeral per-category sub-panels wiring the existing browsers + input modals for the previously-panel-invisible Rounds & Economy functions (Round/RBE/Income, Bloon lookup). Every function stays ≤2 clicks.
- (Calculators + Challenge-Index categories from the design doc are omitted — all-unbuilt candidate functions; future slices.)

## Back-compat
Reused custom_ids (`btd6:ask/events/maps/strategy/status/admin`) keep routing on existing anchors; the dropped leaf ids need a **one-time panel re-post** (`!btd6menu`) — which happens naturally when viewing the new design.

Status: **born red**; flips ready as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015sC9tZ1qAVEz4gvZcdCbBU)_