### PR TITLE
docs(planning): rebuild strategy + simulation rule + ultracode launch pad + verified Codex preserve-map fold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,10 @@ superbot_btd6_data/
 # Transient git worktrees created by background agents (isolation: worktree).
 # Registered under .git/worktrees and auto-cleaned; never tracked in the parent repo.
 .claude/worktrees/
+
+########################################
+# Ultracode / workflow scratch
+########################################
+# Intermediate per-agent mapper output written by planning workflows; the
+# synthesized artifacts committed alongside are the tracked deliverable.
+docs/planning/rebuild-harvest/_parts/

--- a/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
+++ b/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
@@ -1,10 +1,29 @@
 # 2026-07-02 — Rebuild strategy + substrate-kit planning (interactive, owner-directed)
 
-> **Status:** `in-progress` — planning session **plus an in-session follow-up wave**: verifying the 4
-> Codex rebuild-discovery maps against shipped source (Q-0120) and folding them into one synthesis, and
-> fixing #1634's masked plan-homing CI failure. Original planning: Fable 5 re-introduction context; Max
-> ×20, weekly limits fresh; planning docs + ultracode launch pad captured; the 2-wide `rebuild-harvest`
-> is superseded by the fresh 16-wide Session A (handoff §5); **no code shipped to `disbot/`.**
+> **Status:** `complete` — planning session **plus an in-session follow-up wave**: verified the 4 Codex
+> rebuild-discovery maps against shipped source (Q-0120) and folded them into one synthesis, and fixed
+> #1634's masked plan-homing CI failure. Original planning: Fable 5 re-introduction context; Max ×20,
+> weekly limits fresh; planning docs + ultracode launch pad captured; the 2-wide `rebuild-harvest` is
+> superseded by the Codex maps (handoff §5/§6); **no code shipped to `disbot/`.**
+
+## Follow-up wave (2026-07-02) — Codex maps verified + folded; #1634 CI fixed
+- **#1634 CI, two masked failures fixed in sequence:** (1) `check_docs` — an invalid `analysis` badge +
+  an orphan handoff doc (fixed: badge→`plan`, linked the handoff); this short-circuited the job in 7 s,
+  which **hid** (2) `test_check_plan_homing` — the 3 new `docs/planning/*` plans were unhomed (fixed: a
+  dedicated cross-cutting subsection in `docs/planning/README.md`). **Lesson (durable):** for planning-doc
+  changes run `check_quality --full`, not just `check_docs` — the homing test lives in pytest, not check_docs.
+- **The 4 Codex PRs (#1630–#1633) actually PASSED CI** (correctly `historical`-badged, no session card) —
+  they were unmerged only because `auto-merge-enabler` arms `claude/*`, not `codex/*` (`enable-auto-merge`
+  skipped). Not a CI failure as assumed.
+- **Verify-and-fold workflow** (`codex-rebuild-map-verify-and-fold`, 5 agents, 0 err): checked 59
+  load-bearing claims against source → **48 CONFIRMED / 2 FALSE / 9 PARTIAL**. Folded into
+  `docs/analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md` (+ the 4 raw maps preserved
+  verbatim). **Key catches:** `ActionSpec` hard-collides with the shipped `automation_registry.py:35` (design
+  must rename repo-wide); `BindingSpec`/`LifecycleResult`/`CapabilityDecision` are **already shipped** (extend,
+  don't recreate); `multi_channel.py` doesn't exist; several command tokens (`servermanagement`, not `!server`)
+  and module paths (`ai_review.py`, not `ai_review_log.py`) corrected. The map now feeds the Fable prompt (D).
+- **#1630–#1633 superseded** (closed) — their reports live in #1634 + the synthesis; their stale
+  `dashboard.json` deltas were dropped (would clobber main's newer data).
 
 ## What this session did
 Started as a prompt-review request for a substrate-kit *finalization* pass; evolved (owner-directed) into
@@ -46,6 +65,8 @@ finished first as its foundation.
 - Launched the `rebuild-harvest` ultracode (read-only mapping; writes design docs under
   `docs/planning/rebuild-harvest/`).
 - Fixed stale Fable-availability status in `superbot-fresh-rebuild-vision-2026-06-30.md` (fix-on-sight drift).
+- **Owner-directed** (not unilateral): verified + folded the 4 Codex maps into one synthesis and **closed
+  PRs #1630–#1633 as superseded** (their reports preserved verbatim in #1634). Flagged here for the record.
 
 ## 💡 Session idea
 Simulation-driven design as a first-class, gated design step (owner-originated; captured, generalized,

--- a/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
+++ b/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
@@ -1,9 +1,10 @@
 # 2026-07-02 — Rebuild strategy + substrate-kit planning (interactive, owner-directed)
 
-> **Status:** `complete` — long interactive planning session with the owner (Fable 5 re-introduction
-> context; Max ×20, weekly limits fresh). Planning docs + the ultracode launch pad captured and pushed;
-> the 2-wide `rebuild-harvest` is superseded by the fresh 16-wide Session A (handoff §5); **no code
-> shipped to `disbot/`.** PR opened at session close.
+> **Status:** `in-progress` — planning session **plus an in-session follow-up wave**: verifying the 4
+> Codex rebuild-discovery maps against shipped source (Q-0120) and folding them into one synthesis, and
+> fixing #1634's masked plan-homing CI failure. Original planning: Fable 5 re-introduction context; Max
+> ×20, weekly limits fresh; planning docs + ultracode launch pad captured; the 2-wide `rebuild-harvest`
+> is superseded by the fresh 16-wide Session A (handoff §5); **no code shipped to `disbot/`.**
 
 ## What this session did
 Started as a prompt-review request for a substrate-kit *finalization* pass; evolved (owner-directed) into

--- a/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
+++ b/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
@@ -1,8 +1,9 @@
 # 2026-07-02 — Rebuild strategy + substrate-kit planning (interactive, owner-directed)
 
-> **Status:** `in-progress` — long interactive planning session with the owner (Fable 5 re-introduction
-> context; Max ×20, weekly limits fresh). `rebuild-harvest` ultracode running; planning docs captured;
-> **no code shipped to `disbot/`.**
+> **Status:** `complete` — long interactive planning session with the owner (Fable 5 re-introduction
+> context; Max ×20, weekly limits fresh). Planning docs + the ultracode launch pad captured and pushed;
+> the 2-wide `rebuild-harvest` is superseded by the fresh 16-wide Session A (handoff §5); **no code
+> shipped to `disbot/`.** PR opened at session close.
 
 ## What this session did
 Started as a prompt-review request for a substrate-kit *finalization* pass; evolved (owner-directed) into
@@ -59,7 +60,10 @@ verification: the namespace-guard checker, the golden-harness pattern, and the s
   ~0 actually open); the "956 application files" figure (does not reconcile — 879); the "essential_setup
   fan-out ~210" hotspot.
 - **discovered-by-hand:** the settings two-layer + AI-fork structure + 40 raw-KV bypasses; the 10,036
-  Q-citations; the empty router archive; the file-ordering sim engine already existing (CodeGraph drift 48%).
+  Q-citations; the empty router archive; the file-ordering sim engine already existing (CodeGraph drift 48%);
+  ultracode concurrency = `min(16, cpu_cores−2)`, core-bound (this container = 4 cores → 2; a **fresh**
+  ultracode session provisions a high-core container → 16, owner-confirmed + official-docs-verified);
+  `scripts/extract_video_frames.py` is the repo's tool for viewing uploaded videos (bundled imageio-ffmpeg).
 
 ## Open threads
 - Harvest ultracode completes → commit its 4 artifacts, then fire the Phase 0 + Phase 0.5 ultracodes, then

--- a/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
+++ b/.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md
@@ -1,0 +1,76 @@
+# 2026-07-02 — Rebuild strategy + substrate-kit planning (interactive, owner-directed)
+
+> **Status:** `in-progress` — long interactive planning session with the owner (Fable 5 re-introduction
+> context; Max ×20, weekly limits fresh). `rebuild-harvest` ultracode running; planning docs captured;
+> **no code shipped to `disbot/`.**
+
+## What this session did
+Started as a prompt-review request for a substrate-kit *finalization* pass; evolved (owner-directed) into
+the trustworthy foundation + plan-of-plans for a **from-scratch SuperBot rebuild**, with the substrate-kit
+finished first as its foundation.
+
+1. **Reviewed + improved the substrate-kit finalization prompt** (chat) — flagged the stale "You are Fable 5"
+   framing, the missing born-red/PR workflow, over-prescription vs. Fable prompting guidance, and the
+   re-plan-vs-execute fork; delivered model-agnostic, reasoning-forward rewrites.
+2. **Fable 5 research (verified live):** launched 2026-06-09, withdrawn 2026-06-12, **redeployed 2026-07-01**
+   — clears the vision doc's open gate. Capabilities in strategy §0.
+3. **7-agent verification fleet** → the verified baseline (settings · substrate-kit real state · router ·
+   test-oracle viability · binding-doc rot · arch debt · memory-improvement harvest). Corrected drifted figures.
+4. **Wrote** `docs/planning/fresh-rebuild-strategy-2026-07-02.md` — verified baseline + plan-of-plans +
+   design principles + memory-package improvements.
+5. **Integrated two external GPT streams** (UI/command grammar; control-plane/CI), verified against source
+   (Q-0120) — caught the `ActionSpec` collision + the false "no PR/issue templates" and "hundreds of stale
+   branches" claims. → strategy §6.
+6. **End-to-end execution order + model/ultracode allocation** (Phase 0→5 with gates) → strategy §3/§3.1.
+7. **Launched the `rebuild-harvest` ultracode** (Phase 1) — read-only mapping fleet → 4 design-input artifacts.
+8. **Captured the simulation-driven-design rule** (owner-directed) → `docs/planning/simulation-driven-design-2026-07-02.md`
+   + strategy §4.
+
+## Key decisions / verdicts (durable)
+- The rebuild is the owner's goal; the substrate-kit finishes first as its foundation + clean-doc generator.
+- The existing 11,510-test suite **cannot** be the rebuild oracle (white-box) → build a **black-box golden
+  harness against the live bot BEFORE any freeze** (Phase 0.5). *(Corrected earlier advice.)*
+- The real bot debt is a **missing command/symbol namespace** (2 boot crash-loops in 3 days) + god-functions
+  + lazy-import-hidden coupling — **not** the 49 managed arch warnings.
+- The settings / UI / control-plane rebuild = **"make the good pattern authoritative + generated from one
+  source,"** not greenfield — three independent audits converged on this.
+- **Simulation-driven design** is a standing rule; the manifest grammar must be designed to be simulated over.
+- Model strategy: **Fable where reasoning is the bottleneck** (the design); Opus/Sonnet fleets for parallel
+  throughput. Limits are not the constraint — **wall-clock is** (a Fable fleet clears fewer items/hour).
+
+## ⚑ Self-initiated (flag for review)
+- Created `fresh-rebuild-strategy-2026-07-02.md` (analysis) and `simulation-driven-design-2026-07-02.md`
+  (owner-directed rule) — docs only, no code.
+- Launched the `rebuild-harvest` ultracode (read-only mapping; writes design docs under
+  `docs/planning/rebuild-harvest/`).
+- Fixed stale Fable-availability status in `superbot-fresh-rebuild-vision-2026-06-30.md` (fix-on-sight drift).
+
+## 💡 Session idea
+Simulation-driven design as a first-class, gated design step (owner-originated; captured, generalized,
+manifest-synergy + guardrails added). Plus three portable-kit capabilities synthesized from the
+verification: the namespace-guard checker, the golden-harness pattern, and the seam-authority check.
+
+## Context-delta
+- **needed-not-pointed:** the true substrate-kit completion (~45–55%, docs said ~60%); the test suite's
+  white-box nature (nothing flags it as oracle-unusable); the `ActionSpec` name-collision; that docs
+  describe Fable's *designed* state, not live availability; the CodeGraph "fan-out 210" being a lazy-import
+  artifact.
+- **pointed-not-needed:** the router "60% unclassified / 11 open" framing (artifact of 4 status formats;
+  ~0 actually open); the "956 application files" figure (does not reconcile — 879); the "essential_setup
+  fan-out ~210" hotspot.
+- **discovered-by-hand:** the settings two-layer + AI-fork structure + 40 raw-KV bypasses; the 10,036
+  Q-citations; the empty router archive; the file-ordering sim engine already existing (CodeGraph drift 48%).
+
+## Open threads
+- Harvest ultracode completes → commit its 4 artifacts, then fire the Phase 0 + Phase 0.5 ultracodes, then
+  the **Fable design ultracode** (Phase 2 — clean Fable-usage measurement run).
+- Codex parallel stream (functionality inventory + hidden-dep map) → diff against the harvest, keep the union.
+- Owner decisions pending: backward-compat contract · manifest format · control-plane hardening scope ·
+  rebuild go/no-go (post-design).
+
+## ⟲ Previous-session review
+Prior work (band-#1620 reconciliation + the fresh-rebuild vision capture #1589/#1590) did well to capture
+the rebuild reasoning durably, but left the Fable-availability status as a point-in-time snapshot that went
+stale within 2 days — reinforcing this session's lesson: **docs describe designed state; live status must be
+re-verified, not inherited.** System improvement surfaced: a periodic "live-status re-verify" nudge for any
+doc line asserting an external product's availability (candidate journal rule).

--- a/docs/analysis/rebuild-discovery/admin-safety-server-map.md
+++ b/docs/analysis/rebuild-discovery/admin-safety-server-map.md
@@ -1,0 +1,295 @@
+# Rebuild discovery map — admin, safety, server management, setup, logging
+
+> **Status:** `historical` — rebuild discovery audit report; source-grounded snapshot for future planning.
+>
+> Scope: PART 2 of 4 for a possible future clean SuperBot rebuild. This report is discovery only: it does **not** approve a rebuild, implement changes, or change production state.
+
+## 1. Executive summary
+
+### Best server-owner/admin ideas to preserve
+
+- **Discord-first server-management hub.** `disbot/cogs/server_management_cog.py` routes `!server` / `!servermanage` / `!serverpanel` into `views.server_management.hub.ServerManagementHubView`, which centralizes setup, settings, roles, channels, moderation, logging, diagnostics, help preview, and access-map routes instead of leaving server owners to memorize commands.
+- **Setup as a draft/apply workflow, not direct mutation.** `services.setup_session`, `services.setup_draft`, `services.setup_operations`, and `views.setup.final_review` separate session state, draft operations, review, and apply. This is one of the strongest rebuild patterns.
+- **Settings / bindings / provisioning separation.** Scalar settings go through `SettingsMutationPipeline`; bindings go through `BindingMutationPipeline`; create-or-bind resource work goes through `ResourceProvisioningPipeline`. A fresh repo should keep these as separate primitives rather than one broad “configure server” service.
+- **Lifecycle services with preview/result objects.** `ChannelLifecycleService` and `RoleLifecycleService` already model preview/confirmation/result for Discord resource changes. This is the right foundation for destructive or hierarchy-sensitive operations.
+- **Unified moderation audit seam.** Manual moderation, cleanup auto-delete, automod, counting/chain/image-mod stages, and the message pipeline converge on `services.moderation_service` / `services.server_logging.EVT_MOD_ACTION` so admin-visible history can be consistent.
+- **Read-only diagnostic/platform hubs.** `diagnostic_cog`, `views.diagnostic.hub_panel`, and `views.diagnostic.platform_panel` make runtime facts discoverable without mutating state; the flag manager is the explicit exception and routes through the rollout pipeline.
+- **Passive server event logging with per-category opt-in.** The logging subsystem keeps fresh guild behavior unchanged and lets owners opt into message/member/role/moderation/channel/server/voice categories.
+
+### Best safety/audit/governance ideas
+
+- **Capability-native authority at mutation seams.** `docs/capability-authority.md` and `governance.capability.actor_holds_capability` define the intended central check for settings/bindings/provisioning.
+- **Callbacks must re-check authority.** `BaseView` invoker locking is not authority; mutating panels need a callback-level capability/admin check if reachable from help or hubs.
+- **No silent auto-create.** Provisioning requires explicit confirmation or an operator standing setting, then audits success and failure.
+- **Typed lifecycle outcomes.** `LifecyclePreview`, `LifecycleResult`, `StepResult`, `outcome`, and reversibility vocabulary provide a reusable safety grammar.
+- **Fail-safe diagnostics/logging.** Event emitters and log senders are best-effort; failures should be counted/logged without breaking user commands.
+
+### Highest-risk patterns to avoid in a fresh repo
+
+- Scattered `has_permissions(administrator=True)`, `guild_permissions.*`, owner checks, and raw callback assumptions instead of one `AdminActionSpec`/`CapabilitySpec` resolver.
+- Direct Discord mutations from cogs/views (`guild.create_*`, `channel.delete`, `member.add_roles`, etc.) instead of domain services.
+- Direct legacy KV writes for settings and direct `subsystem_bindings` writes, bypassing audit/event/cache invalidation.
+- Duplicate setup paths (`quicksetup`, setup wizard, hub panels, per-cog commands) that can drift.
+- Inconsistent destructive confirmations: some lifecycle paths preview and confirm; older panels still do command-style one-shot deletes.
+- One-off selectors/modals rather than shared resource picker, settings editor, confirmation, and create-or-bind primitives.
+
+### Future admin UX should centralize around
+
+A single **Server Management / Setup Control Center** with shared primitives: `SettingsPanelSpec`, `BindingSpec`, `ResourceMutationSpec`, `ConfirmationSpec`, `LifecycleResult`, `AuditEventSpec`, and `ServerEventRouteSpec`. Every admin panel should be a projection over these specs, not a bespoke command implementation.
+
+## 2. Source route and verification
+
+### Binding/current-state docs read
+
+Read live repo docs requested by the prompt:
+
+- `.claude/CLAUDE.md`
+- `docs/collaboration-model.md`
+- `docs/current-state.md`
+- `docs/current-state/S1-bot.md`
+- `docs/current-state/S5-ops.md`
+- `docs/AGENT_ORIENTATION.md`
+- `docs/architecture.md`
+- `docs/ownership.md`
+- `docs/runtime_contracts.md`
+- `docs/repo-navigation-map.md`
+- `docs/repo-review-map.md`
+- `docs/ultracode/README.md`
+- `docs/subsystems/server-management.md`
+- `docs/subsystems/settings-bindings-provisioning.md`
+- `docs/server-logging.md`
+- `docs/setup-platform/resource-provisioning-overview.md`
+- `docs/capability-authority.md`
+
+### Source roots inspected
+
+- Cogs: `admin_cog.py`, `diagnostic_cog.py`, `health_maintenance_cog.py`, `ux_lab_cog.py`, `server_management_cog.py`, `setup_cog.py`, `bootstrap_access_cog.py`, `moderation_cog.py`, `cleanup_cog.py`, `automod_cog.py`, `image_moderation_cog.py`, `security_cog.py`, `logging_cog.py`, `welcome_cog.py`, `counters_cog.py`, `channel_cog.py`, `role_cog.py`, `proof_channel_cog.py`, `ticket_cog.py`, plus `cogs/*/schemas.py` and listeners.
+- Views: `views/diagnostic`, `views/server_management`, `views/setup`, `views/moderation`, `views/cleanup`, `views/channels`, `views/roles`, `views/tickets`, `views/ux_lab`, plus logging panel code under `cogs/logging/`.
+- Services: diagnostics, health, setup, resource provisioning, moderation, automod, image moderation, security, server logging, welcome, counters, channel/role lifecycle, role automation, tickets.
+- DB/migrations/utils: `utils/settings_keys/*`, `utils/db/moderation.py`, `utils/db/bindings.py`, `utils/db/resource_provisioning_audit.py`, setup tables, role tables, ticket tables, and migrations 022/029/030/031/035/052/069/078-081/089/098/099.
+- Tests/invariants: moderation, role routing, cleanup schemas, setup delegate boundary, no-silent-auto-create, capability, settings/binding/provisioning tests, server logging tests where named by grep.
+
+### Commands run and results
+
+- `gh pr view 1509 --json number,state,title,url` — failed: `gh: command not found`. Open PR #1509 could not be verified from this container; treated as advisory only per instruction.
+- `find docs/owner/claims -maxdepth 1 -type f -print` — found existing claim files, no file overlap with this report except repo-wide awareness.
+- `rg -n "gate|owner|Hermes|setup|logging|live-bot|off-limits" ...` — active setup/server-management decisions exist; no stop-condition making this read-only mapping lane off-limits was found. Relevant active owner guidance: Discord panels remain the primary owner surface; AI/action gates remain separate; setup mutations require existing setup wizard/apply primitives; owner/Hermes review labels are retired in current binding docs.
+- `python3.10 scripts/context_map.py <major cog>` — initial required command failed because `python3.10` was not active in pyenv. Retried with `PYENV_VERSION=3.10.20`; all context-map attempts then failed with `ModuleNotFoundError: No module named 'yaml'`.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/wiring_map.py --check` — passed with advisory possible dead subscribers for `ticket.opened` and governance events.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/check_architecture.py --mode strict` — failed with `ModuleNotFoundError: No module named 'yaml'`.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/check_docs.py` — run after adding this report; result recorded in final verification section below.
+
+### Verification limits
+
+- No live Discord credentials were used; Discord permission/hierarchy behavior is mapped from source and docs only.
+- PR #1509 was not verifiable because GitHub CLI is unavailable.
+- CodeGraph was not available as a callable local tool in this environment; fallback was docs + ripgrep + direct source reads.
+- Context-map and strict architecture tooling were blocked by missing `yaml` in the selected Python environment.
+
+## 3. Server control surface inventory
+
+### 3.1 Admin and platform operator surfaces
+
+| Subsystem | Entry commands | Panels/views | Services/mutation owners | Settings/bindings/resources | DB/tables | Events/audit | Tests/invariants |
+|---|---|---|---|---|---|---|---|
+| Admin cog | `!admin`, owner/admin utility commands in `admin_cog.py` | Mostly command output; no `views/admin` directory present | Mixed command handlers; rebuild should isolate platform-owner operations | Bot/global operational flags where applicable | feature flag/state tables via rollout service if used | Should emit explicit operator audit; current admin surfaces are more command-shaped | Needs owner-only/admin-only invariant coverage in fresh repo |
+| Diagnostics | `!diagnostics`, `!platform`, health/readiness commands in `diagnostic_cog.py` | `views.diagnostic.hub_panel._DiagnosticsHubView`, `_PaginatorView`, `_PlatformHubView`, `FlagManagerView`, `AutomationPanelView` | `services.diagnostics_service`, `diagnostic_embeds`, `diagnostic_helpers`; `FlagManagerView` writes through rollout mutation; `AutomationPanelView` through `AutomationMutationPipeline` | Read-only registry/platform facts; flag manager includes operator flags such as `settings.mutation.primary` and `resource_provisioning.primary` | feature flag state/audit, automation rules | Read-only panels; flag writes audited by rollout pipeline; automation writes emit `automation.rule_changed` | wiring map includes event subscribers; flag manager source comments explicitly forbid direct delete path |
+| Health maintenance | health-maintenance cog | Command-driven maintenance/readiness | `health_contracts`, `health_findings_service`, `health_observations`, `health_snapshot_service` | Health facts, observations, findings | health storage if configured | Diagnostic/audit logs, not user mutation | Should remain read-only or owner-gated maintenance in rebuild |
+| UX lab | `ux_lab_cog.py` | `views.ux_lab.*` mockups/probes/layout demos | None for production mutation | N/A | N/A | N/A | Treat as design lab, not production owner surface |
+
+### 3.2 Server management and setup
+
+| Subsystem | Entry commands | Panels/views | Services/mutation owners | Settings/bindings/resources | DB/tables/migrations | Events/audit | Tests/invariants |
+|---|---|---|---|---|---|---|---|
+| Server management hub | `!server`, aliases `servermanage`, `serverpanel` | `ServerManagementHubView`, access map panel | Hub routes to existing cogs/services; `server_management_hub` aggregates readiness/capability facts | No own settings; projects setup/settings/bindings/readiness | None | Read-only navigation except routed panels | Rebuild should pin hub route registry |
+| Setup wizard | `!setup`, `!setup scan`, `!setup start`, `!setup resume`, `!setup apply`, `!setup-delegate`, bootstrap access | `views.setup.launcher`, `hub`, `wizard`, `depth_panel`, `scan_panel`, `section_card`, `final_review`, `recovery`, `template_picker`, `essential_setup` | `setup_session`, `setup_draft`, `setup_operations`, `setup_access`, `setup_readiness`, `setup_sections`, `setup_role_templates`, `resource_provisioning` | Draft operations include settings, bindings, role templates, provisioning packs | migrations `031_setup_session`, `035_setup_draft_operations`, `045_setup_draft_provenance`, `046/047/038/069/099` | Setup delegate actor type is audited through settings/binding/provisioning pipelines; provisioning emits `resource.provisioned`; settings/bindings emit own events | `test_setup_delegate_apply.py`, `test_setup_delegate_actor_boundary.py`, setup readiness/tests |
+| Resource provisioning | setup/resource panels and settings missing-binding flows | channel/role pickers; logging provisioning views under `cogs/logging` | `ResourceProvisioningPipeline` is the owner for create-or-reuse + bind | `ResourceRequirement`, `ProvisioningOption`, `BindingSpec` catalogue | `resource_provisioning_audit` migration 030 | emits `resource.provisioned` plus binding changed; audits success/fail/decline | `test_no_silent_auto_create.py`, provisioning pipeline tests |
+
+### 3.3 Moderation and cleanup
+
+| Subsystem | Entry commands | Panels/views | Services/mutation owners | Settings keys | DB/tables | Events/audit | Tests/invariants |
+|---|---|---|---|---|---|---|---|
+| Manual moderation | `!warn`, `!warnings`, `!clearwarnings`, `!mute/timeout`, `!kick`, `!ban`, `!unban`, moderation panel command | `views.moderation.main_panel`, `views.moderation.modals` | `services.moderation_service` should own warn/timeout/kick/ban/unban/clear/manual records | `warn_threshold`, `warn_timeout_minutes`, `moderation_dm_on_action`, `moderation_dm_actions`, `moderation_dm_template`, `moderation_require_reason`, `moderation_ban_delete_message_days`, `moderation_max_timeout_minutes`, `moderation_warn_escalation_action`, `moderation_post_action_cleanup`, `moderation_post_action_cleanup_limit`, `moderation_public_log_channel`, `moderation_public_log_actions` | `utils/db/moderation.py`, `mod_logs` / warnings tables | emits `moderation.action_taken`; server logging consumes for mod/private and public log | moderation tests; governance ADR-008 moderator-role tier grants |
+| Cleanup | cleanup commands/panel | `views.cleanup.policy_panel` | `cleanup_cog` detects spam/cleanup policy; destructive delete/audit routes through `moderation_service.auto_delete` | cleanup settings registered with capability `cleanup.policy.configure`, including spam window | legacy KV settings; moderation logs for deletes | auto-delete emits same moderation event | `test_cleanup_schemas.py` pins capability/spec shape |
+| Automod | `automod_cog.py`, listener stage | no `views/automod` directory present; settings panels via schemas/settings | `automod_service` and listener stage; final delete routes via message pipeline to `moderation_service.auto_delete` | `automod_enabled`, rule flags/counts/windows, exempt role/channel CSVs | legacy KV settings | message pipeline descriptor -> `EVT_MOD_ACTION`; automod-specific audit through moderation logs | automod schema/config tests |
+| Image moderation | `image_moderation_cog.py`, listener stage | no dedicated image moderation views present | `image_moderation_service` external-call scanner; stage only when opted in; delete through moderation seam | `image_moderation_enabled`, per-category flags, threshold, exempt role/channel CSVs | legacy KV settings | emits `image_moderation.flagged`; moderation delete event if action taken | config/listener tests should preserve no-external-call-until-enabled |
+| Security | `security_cog.py` | no `views/security` directory present | `security_service` owns raid/account-age detection and actions | `security_enabled`, raid count/window/slowmode/lockdown/channel, age min/action, alert channel | legacy KV settings | emits `security.raid_detected`, `security.account_flagged`; staff alert channel | security config/service tests |
+| Message pipeline | global `on_message` platform listener | N/A | `core.runtime.message_pipeline` orchestrates staged message handling and routes moderation descriptors to `moderation_service.auto_delete` | N/A | moderation logs via service | ordered stage contract: automod/cleanup/counting/chain/image_mod before XP rewards | pipeline tests/invariants |
+
+### 3.4 Server logging, welcome, counters, passive events
+
+| Subsystem | Entry commands | Panels/views | Services/mutation owners | Settings/bindings/resources | DB/tables | Events/audit | Tests/invariants |
+|---|---|---|---|---|---|---|---|
+| Logging | `logging_cog.py`; panel code in `cogs/logging/*` | `panel.py`, `routes_panel.py`, `select_view.py`, `provision_view.py` | `server_logging` sends embeds; `server_logging_config` reads config; settings/bindings/provisioning pipelines mutate | `logging_enabled`, mod/cleanup channels, auto-create, passive category flags, routing, ignored channels/users; BindingSpecs for mod/cleanup/events/message/member/role channels | legacy KV; subsystem_bindings; provisioning audit | subscribes `moderation.action_taken`, `audit.action_recorded`; gateway/audit-log listeners emit embeds | server-logging docs/tests |
+| Welcome | `welcome_cog.py` | no `views/welcome` directory present | `welcome_service` greets/DMs/entry-role; config service reads | welcome enable flags, channel, templates, entry role, DM/card/min-age/delete-after | legacy KV | emits `welcome.member_greeted`; logs failures | welcome config/service tests |
+| Counters | `counters_cog.py` | no `views/counters` directory present | `counter_service` owns renaming loop; config reads | counters enabled, total/humans/bots channel ids/templates | legacy KV | emits `counters.updated` | counter tests |
+
+### 3.5 Channel and role lifecycle
+
+| Subsystem | Entry commands | Panels/views | Services/mutation owners | Settings/bindings/resources | DB/tables | Events/audit | Tests/invariants |
+|---|---|---|---|---|---|---|---|
+| Channels | `channel_cog.py` channel create/list/delete/restrict/move/visibility commands | `views.channels.main_panel`, create/delete/list/move/restrict/visibility subviews | `ChannelLifecycleService` owns rename/move/delete/reorder preview/apply; provisioning owns subsystem channel creation; some manual channel CRUD remains legacy/grandfathered | Bindings via `BindingMutationPipeline`; resources via provisioning | lifecycle audit via `services.lifecycle.contracts` if used | `channel.lifecycle_changed` or lifecycle audit (service-level) | no-silent-auto-create allowlist documents legacy exceptions |
+| Roles | `role_cog.py` role creation/management/time/XP/reaction-role flows | `views.roles.*` creation, management, diagnostics, exemptions, reaction, role menus, time/xp panels | `RoleLifecycleService` owns operator-driven role create/edit/delete; `role_automation` owns member assignment/removal for progression; reaction roles own self-assign paths | role settings: stack flags, reaction roles enabled; bindings/role thresholds/templates | migrations 003,052,056,078-081,089; role tables | `role.lifecycle_changed`; `audit.action_recorded` for role automation | `test_role_cog_routing.py` pins no direct member role APIs for threshold paths |
+
+### 3.6 Support/proof/access surfaces
+
+| Subsystem | Entry commands | Panels/views | Services/mutation owners | Settings/bindings/resources | DB/tables | Events/audit | Tests/invariants |
+|---|---|---|---|---|---|---|---|
+| Proof channel | `proof_channel_cog.py` | no `views/proof_channel` directory present | Settings/bindings/provisioning pipelines | `proof_channel.settings.configure`, `proof_channel` BindingSpec, ResourceRequirement | subsystem_bindings/provisioning audit | binding/resource events | schema tests likely |
+| Tickets | `ticket_cog.py` | `views.tickets.*` hub/config/control/confirm/launcher | `ticket_service`, `ticket_mutation` own ticket open/close/config operations | ticket config + channel/category resources | migration `098_tickets`, `utils/db/tickets.py` | subscriber for `ticket.opened`; wiring map says possible dead subscriber advisory | ticket tests |
+
+## 4. Best ideas/functions/classes to preserve
+
+| Source | Problem solved | Rebuild disposition | Hidden dependencies |
+|---|---|---|---|
+| `governance.capability.actor_holds_capability` | Central capability decision with target-guild membership, platform-owner override, admin floor, revoke overlay, setup delegate actor type | **Copy idea; redesign API as `CapabilityDecision` service in foundation** | `config.is_platform_owner`, visibility tiers, execution override cache, setup delegate minting |
+| `SettingsMutationPipeline.set_value` | One owner for scalar setting writes: validation, authority, audit, event, cache invalidation | **Copy nearly as-is conceptually** | `SettingSpec`, legacy KV, `settings.mutation.primary`, audit rows, event bus |
+| `BindingMutationPipeline.set_binding/clear_binding` | One owner for binding rows and binding-change events | **Copy nearly as-is conceptually** | `BindingSpec`, subsystem binding table, provisioning delegates to it |
+| `ResourceProvisioningPipeline.preview/provision` | Safe create-or-bind resources with no silent auto-create | **Copy idea; make UI primitive first-class** | Discord permissions, `guild_resources.ensure_*`, binding pipeline, provisioning audit |
+| `services.lifecycle.contracts` | Shared preview/result/outcome/reversibility vocabulary | **Copy nearly as-is** | Domain services must emit lifecycle audit consistently |
+| `ChannelLifecycleService` | Keeps destructive/channel hierarchy mutations out of views | **Copy idea; expand to all channel ops** | Discord hierarchy constraints, old channel cog exceptions |
+| `RoleLifecycleService` | Keeps role create/edit/delete and feasibility checks out of panels | **Copy idea; expand member assignment separations** | Role hierarchy, `role_feasibility`, role automation audit |
+| `role_automation` | Owns progression role assignment/removal; avoids direct `member.add_roles` in cog threshold paths | **Copy nearly as-is idea** | XP/time thresholds, exemptions table, role audit event |
+| `moderation_service.auto_delete` and manual action functions | Unifies deletes and moderator actions into mod log/event flow | **Copy idea; redesign as `ModerationActionSpec` executor** | `mod_logs`, DM policy, cleanup policy, public logging |
+| `message_pipeline.StageResult` / `ModerationActionDescriptor` | Ordered staged message handling; deleted messages do not proceed to rewards; audit is unified | **Copy nearly as-is** | Stage ordering constants; moderation service idempotence around `NotFound` |
+| `server_logging.start/stop` subscriptions | Decouples moderation/audit events from log embeds | **Copy idea; formalize `ServerEventRouteSpec`** | Event names, channel binding/settings, per-category opt-in, ignored IDs |
+| `views.diagnostic.platform_panel._PlatformHubView` | Discoverable read-only operational map for owner/admins | **Copy idea** | Registry completeness, read-only category select grammar |
+| `views.diagnostic.flag_manager.FlagManagerView` | Mutating exception inside platform hub routes through mutation pipeline, not raw DB | **Copy idea but strengthen capability checks** | rollout pipeline, operator flags, admin/platform owner audience |
+| `setup_operations.apply_operations` | Draft apply re-verifies setup access and mints `setup_delegate` actor type for pipelines | **Copy idea** | setup access service, draft operation schemas, audit actor types |
+| `views.setup.final_review` | Human-readable final review before applying setup changes | **Copy idea** | draft rendering, before-state/undo policy, operation risk |
+| `server_management_hub` service | Aggregates bot permission readiness for hub cards | **Copy idea** | moderation/channel/role feasibility utilities |
+
+## 5. Safety and mutation model extraction
+
+### One true mutation owner by action
+
+| Action class | Current owner to preserve | Notes / hazards |
+|---|---|---|
+| Manual warn/timeout/kick/ban/unban/clear warnings | `services.moderation_service` | Commands/panels may initiate; service should own DM policy, reason requirement, ban-delete-days, post-action cleanup request, audit/event. |
+| Automated message delete | `core.runtime.message_pipeline` routes descriptor to `moderation_service.auto_delete` | Stages can detect/delete, but audit should still be normalized by the moderation service. |
+| Image moderation external call | `image_moderation_service` + listener/stage | Must be disabled by default; no external API call until guild opt-in; honor exempt roles/channels; threshold/category flags govern action. |
+| Raid handling/account-age filter | `security_service` | Owns join-window state, slowmode/lockdown/action/alert; fresh repo should make Discord side effects explicit specs. |
+| Cleanup policy delete | `cleanup_cog` stage/policy detection -> `moderation_service.auto_delete` | Cleanup settings are policy; deletion/audit owner is moderation service. |
+| Server logging embeds | `server_logging` | It should never own primary mutations; it subscribes to events/gateway/audit logs and routes according to config. |
+| Role lifecycle create/edit/delete | `RoleLifecycleService` | Must enforce role hierarchy and preview/confirm destructive changes. |
+| Role member assignment/removal for progression | `role_automation` | Separate from role definition lifecycle; tests already enforce no direct cog member role APIs for threshold paths. |
+| Channel lifecycle rename/move/delete/reorder | `ChannelLifecycleService` | Should absorb old channel cog direct mutations in future. |
+| Subsystem create-or-bind resources | `ResourceProvisioningPipeline` | No silent auto-create; confirmation or standing setting required; binding through binding pipeline. |
+| Scalar settings | `SettingsMutationPipeline` | Capability and kill-switch checked before write; emits settings changed. |
+| Resource bindings | `BindingMutationPipeline` | Capability, audit/event/cache invalidation; never direct table writes from views/cogs. |
+| Setup wizard apply | `setup_operations.apply_operations` | Owns draft operation execution and `setup_delegate` actor type; delegates actual mutation to pipelines. |
+| Ticket open/close/config | `ticket_service` / `ticket_mutation` | Keep as domain owner; wiring check advisory says `ticket.opened` subscriber needs confirmation. |
+
+## 6. Admin UX grammar
+
+### Reusable patterns found
+
+- **Preview before mutation:** provisioning preview, setup final review, channel/role lifecycle previews.
+- **Confirmation for irreversible actions:** lifecycle services and ticket confirm views model this; future repo should require `ConfirmationSpec` for ban/delete/role delete/channel delete/bulk cleanup/full setup apply.
+- **Permission/capability re-check in callbacks:** documented in `docs/capability-authority.md`; must be made universal for mutating panels reachable from hubs/help.
+- **Resource picker flows:** channel/role selectors exist in `views/selectors`, logging provision views, setup template/resource flows, role/channel panels.
+- **Create or bind flows:** resource provisioning pipeline and logging provisioning views are the best concrete implementation.
+- **Settings editor flows:** schemas (`SettingSpec`) plus settings views are the canonical future route; many cogs still expose command-specific config.
+- **Diagnostic read-only panels:** diagnostic/platform hubs demonstrate safe read-only UX.
+- **Staff/admin/owner separation:** moderation uses moderator tier grants; settings/provisioning use admin floor + platform owner override; setup-delegate is owner/capability significant; platform diagnostics should be owner/admin classified.
+- **Ephemeral/public behavior:** diagnostic hubs are ephemeral/timeout-based; moderation public logging is opt-in and strips moderator identity; most owner panels should default ephemeral.
+
+### Inconsistencies to eliminate
+
+- Commands, hubs, and setup wizard expose overlapping setup/config paths.
+- Some admin surfaces rely on command decorators while panels rely on invoker locks; callbacks need a single `AdminActionSpec` authority check.
+- Logging settings use legacy channel-id settings and BindingSpecs in parallel; future repo should pick binding rows as route truth and migrate settings as compatibility aliases only.
+- View directories are inconsistent: logging panels live under `cogs/logging/`, tickets use `views/tickets`, no dedicated views exist for automod/security/welcome/counters despite owner-facing settings.
+- Lifecycle result vocabulary exists for channels/roles but not yet for moderation/security/tickets/logging route mutations.
+
+## 7. Hidden dependencies and rebuild hazards
+
+- **Permission semantics:** Discord administrator, bot owner override, target-guild membership, moderator/trusted role tier grants, setup delegate actor type, and raw Discord permissions (`manage_channels`, `manage_roles`, moderation perms) are distinct and must not be collapsed.
+- **Capability strings:** `logging.settings.configure`, `moderation.settings.configure`, `cleanup.policy.configure`, `proof_channel.settings.configure`, XP/help/game capabilities, and empty-capability admin floor all exist.
+- **Settings key names:** legacy KV keys listed in `utils/settings_keys/*` are externally observable migration data; a rebuild needs an import map.
+- **Binding rows:** `subsystem_bindings` is the durable row owner for resource IDs; provisioning binds through the binding pipeline.
+- **Audit payload shapes:** moderation logs/events, settings mutation audit, resource provisioning audit, lifecycle audit, feature flag audit, ticket audit should be formalized before rebuild.
+- **Event names:** `moderation.action_taken`, `audit.action_recorded`, `settings.changed`, binding changed event, `resource.provisioned`, `role.lifecycle_changed`, `security.raid_detected`, `security.account_flagged`, `image_moderation.flagged`, `welcome.member_greeted`, `counters.updated`, `automation.rule_changed`, `ticket.opened`.
+- **Log routing channels:** mod channel, cleanup channel, events/message/member/role channels, public moderation log channel, security alert channel, welcome channel, counter channels.
+- **Discord hierarchy constraints:** bot role position must exceed managed roles; channel/category permissions and slowmode require bot permissions; delete/reorder operations can fail mid-flight.
+- **External moderation API assumptions:** image moderation uses OpenAI moderation endpoint and must not send images unless enabled; endpoint failures should degrade safely and log diagnostic failures.
+- **Per-guild teardown hooks:** setup sessions, bindings, tickets, role menus, counters, logging route state, and automation rules all have guild-scoped persistence; rebuild import/teardown must be explicit.
+- **Persistent panel IDs:** diagnostic views are ephemeral, but tickets/role menus/logging/setup launchers may have persistent custom IDs; a clean repo needs a registry.
+- **Live/owner-gated setup assumptions:** setup delegate and owner-only bootstrap are capability-significant; do not let normal users apply setup drafts.
+
+## 8. Fragmentation and duplication inventory
+
+### Critical rebuild lesson
+
+- **Direct Discord mutations must not live in views/cogs.** Legacy channel/role paths are grandfathered; future repo should require lifecycle/provisioning services for every Discord resource mutation.
+- **Authority cannot be decorator-only.** Hubs/help can make panels reachable without command decorators; mutating callbacks must re-check capability.
+- **Setup apply must be one path.** `quicksetup`, setup wizard, per-cog config, and hub routes should all compile to setup draft operations or mutation specs.
+
+### Important improvement
+
+- Move logging UI from `cogs/logging/*` into `views/logging/*` or a generated settings/bindings panel family.
+- Add first-class `ModerationActionSpec` and `SecurityActionSpec` previews/results matching lifecycle services.
+- Convert public/private log channel IDs from legacy settings into binding specs with compatibility read aliases.
+- Give automod/security/welcome/counters dedicated generated panels instead of command-only/admin-only hidden features.
+
+### Cleanup
+
+- Normalize naming: `ticket` vs `tickets`, `proof_channel` view absence, logging panels under cogs.
+- Replace one-off modals/selects with shared resource picker/settings editor/confirmation primitives.
+- Confirm or remove wiring-map advisory dead subscribers.
+
+### Acceptable specialization
+
+- UX lab remains a non-production design surface.
+- Public moderation logging intentionally differs from private moderator logs by omitting actor identity.
+- Image moderation needs external-call-specific guardrails beyond text automod.
+
+## 9. Future new-repo recommendations
+
+### Foundation primitives
+
+- **`AdminActionSpec`**: name, audience, capability, Discord permission fallback, callback re-check requirement, public/ephemeral policy, audit event. Evidence: command decorators + capability docs + hub-reachable panels.
+- **`ModerationActionSpec`**: action kind (`warn`, `timeout`, `kick`, `ban`, `delete`, `auto_delete`), target, reason policy, DM policy, cleanup policy, hierarchy/permission check, audit payload, log route. Evidence: `moderation_service`, moderation settings keys, message pipeline descriptor.
+- **`ResourceMutationSpec`**: resource kind, operation (`create`, `bind`, `rename`, `move`, `delete`, `reorder`), preview, confirmation, Discord permission requirements, rollback/compensation notes. Evidence: provisioning and lifecycle services.
+- **`AuditEventSpec`**: event name, actor/subject/guild, payload schema, redaction/public projection, subscribers. Evidence: moderation/server_logging/settings/provisioning/lifecycle events.
+- **`SettingsPanelSpec`**: generated editor over `SettingSpec`, widgets, validation, capability, default, help copy, setup-section membership. Evidence: subsystem schemas and settings mutation pipeline.
+- **`BindingSpec`**: canonical resource binding declaration with required kind, fallback route, setup/provisioning hint, migration/import alias. Evidence: subsystem binding docs and provisioning catalogue.
+- **`ConfirmationSpec`**: irreversible/compensatable/reversible classification, challenge text or preview hash, timeout, actor re-check, before-state snapshot requirement. Evidence: lifecycle contracts and setup final review.
+- **`LifecycleResult`**: shared result object for all Discord/server mutations, not just channels/roles. Evidence: `services.lifecycle.contracts`.
+- **`ServerEventRouteSpec`**: passive event category, source (gateway/audit-log/domain event), opt-in flag, route binding, public/private projection, ignore filters. Evidence: server logging v1/v2 keys and docs.
+
+### Recommended shape
+
+Build the fresh repo around a **spec registry + mutation executors + generated panels**:
+
+1. Each subsystem declares settings, bindings, resources, admin actions, log routes, and setup sections.
+2. Hubs render from registries.
+3. Mutations execute only through service-layer owners.
+4. Every mutating UI callback re-checks an `AdminActionSpec`.
+5. Every result emits a typed audit event and returns a typed result object.
+6. Setup wizard compiles drafts to the same specs; it never owns mutation logic.
+
+## 10. Handoff to other mapping sessions
+
+### Platform/UI primitives this session depends on
+
+- Base view invoker locking vs authority re-check.
+- Settings registry and generated settings panels.
+- Binding/provisioning catalogue.
+- Event bus and audit event contracts.
+- Persistent view/custom-id registry.
+- Setup section registry and draft operation rendering.
+- Capability/governance tier resolver.
+
+### Areas that use or should use these patterns
+
+- Economy/community/game features with admin-tunable settings should use `SettingsPanelSpec` and capability checks, not bespoke commands.
+- AI provider/admin controls must remain read-only or capability-gated and should reuse diagnostics/platform panels.
+- Games/community role rewards should route member role assignment through role automation, not direct Discord APIs.
+- Any subsystem that needs a channel should declare a BindingSpec/ResourceRequirement and use provisioning.
+- Public-facing announcements/logs should define `ServerEventRouteSpec` with public/private redaction rules.
+
+## 11. Final verification after report creation
+
+- `PYENV_VERSION=3.10.20 python3.10 scripts/check_docs.py` was attempted after writing this file. If it fails, record exact output in the session/final response; source was not changed to satisfy the checker because the allowed edit is this report only.
+

--- a/docs/analysis/rebuild-discovery/ai-knowledge-data-tooling-map.md
+++ b/docs/analysis/rebuild-discovery/ai-knowledge-data-tooling-map.md
@@ -1,0 +1,402 @@
+# AI, knowledge-data, eval, docs-agent, CI/tooling, and operations rebuild discovery map
+
+> **Status:** `historical` — rebuild-discovery mapping report.
+>
+> Scope: Part 4 of 4 rebuild-discovery mapping for a possible future clean SuperBot repo. This report is a source-grounded design inventory, not approval to rebuild or implement. Source code and merged repo state are treated as higher authority than planning/current-state docs.
+
+## 1. Executive summary
+
+### Strongest ideas to preserve
+
+1. **AI gateway as a reusable safety boundary.** `disbot/core/runtime/ai/gateway.py` centralizes provider selection, fallback, request/payload redaction, tool-result redaction, diagnostics, and degraded replies. Preserve the idea as an `AIProviderGateway` primitive, but redesign the layer boundary so core runtime does not import services.
+2. **Typed AI contracts and task profiles.** `disbot/core/runtime/ai/contracts.py` defines `AITask`, `AIRequestContext`, `AIRequest`, tool specs, tool budgets, answer evidence, and diagnostics. `routing.py` maps tasks to provider/model targets with env overrides. This is exactly the kind of API a fresh repo should keep.
+3. **Natural-language stage with deterministic domain gates.** `disbot/core/runtime/ai/natural_language_stage.py` is large, but the important idea is strong: passive AI is one message-pipeline stage; BTD6/Project Moon/YouTube detection and refusals happen before model calls where deterministic data is insufficient.
+4. **Answer review and preset feedback loop.** `migrations/100_ai_review_log.sql`, `migrations/102_ai_answer_presets.sql`, `utils/db/ai_review_log.py`, `utils/db/ai_presets.py`, `services/ai_review_log_service.py`, `services/ai_preset_service.py`, and `cogs/ai_review_cog.py` confirm a durable loop for redacted answer capture, correction triage, and reusable preset answers.
+5. **Knowledge-domain provenance contracts.** BTD6 is the mature exemplar: source registry, source snapshots, facts, committed data blobs, AI context summaries, view-model services, source health, probes, evals, and admin refresh surfaces all exist. The rebuild should generalize this into `KnowledgeDomainSpec`, `SourceProvenanceSpec`, `IngestionPipeline`, and `ViewModelContextHandle`.
+6. **Repo-native agent tooling.** `scripts/context_map.py`, `scripts/wiring_map.py`, architecture/doc checks, generated agent context packs, workflow routines, and deterministic merge-state helpers make repo navigation executable. Preserve the principle, simplify the implementation.
+7. **GitHub workflow safety patterns.** Code Quality, tool-pin checks, PR conflict/behind checks, CI rerun watchdog, manual BTD6 refresh PRs, dashboard data refresh, DB backups, AI evals, and subproject CI are valuable. A fresh repo should replace PAT-heavy or bespoke automation with GitHub-native features where possible.
+
+### Biggest hallucination/data/provenance risks
+
+- **Provider behavior can be hidden behind env.** `AI_DEFAULT_PROVIDER`, task-specific routing env vars, `AI_FALLBACK_PROVIDER`, and provider-specific API keys mean the same code can behave very differently in production, CI, and local runs.
+- **BTD6 data has multiple provenance tiers.** Official Ninja Kiwi endpoints, committed CSV/JSON, parsed game dumps, wiki-derived formulas, DB facts, and manual strategy rows coexist. The rebuild must require source labels on every answer block and prohibit unlabelled cross-source merges.
+- **Natural-language routing is complex and centralized in one large stage.** This reduces duplicate passive responders but creates a high-risk file where domain routing, model calls, deterministic refusals, conversation memory, and rendering meet.
+- **Generated docs/context packs can drift.** They are useful orientation, but not source of truth. Fresh tooling should make freshness obvious and CI-enforced.
+- **Command-only diagnostics are insufficient.** BTD6 and AI have diagnostics commands/services, but a rebuild should include panels/help routes so operators can see readiness, source health, stale data, and review backlog without memorizing commands.
+
+### Best repo operations ideas
+
+- Deterministic merge/conflict/behind checks using a single helper (`scripts/git_merge_state.py`) shared by workflows.
+- One Code Quality workflow that runs docs, stale-claims, session-card gates, consistency, unit tests, architecture, wiring, and tool-pin style checks.
+- Manual external-data refresh workflows that open reviewable PRs instead of pushing to main.
+- Scheduled/dispatch routines recorded in versioned docs, with explicit token/PAT hazards.
+- SHA-pinned actions plus `scripts/check_tool_pins.py` to keep workflow pins aligned with dev tooling.
+- Generated agent context packs (`docs/agent/generated/*.context.md`) built from a curated manifest.
+
+### What a future repo should simplify or centralize
+
+- Split natural-language routing into small task-profile/domain-router modules instead of one giant stage.
+- Make provider/model routing declarative (`TaskProfile`) rather than scattered between env, settings, routing, and tests.
+- Centralize knowledge-domain data provenance into one schema with mandatory `source_label`, `source_url/key`, freshness, and confidence/trust tier.
+- Use one ingestion runner abstraction for BTD6, Project Moon, YouTube, and future domains.
+- Keep GitHub Actions minimal: Code Quality, data refresh PRs, backups, deploy, and subproject CI; avoid bespoke auto-merge/PAT machinery unless GitHub-native auto-merge cannot satisfy the workflow.
+
+## 2. Source route and verification
+
+### Docs read
+
+Read or sampled the required orientation/current-state/subsystem/operations files: `.claude/CLAUDE.md`, `docs/collaboration-model.md`, `docs/current-state.md`, `docs/current-state/S2-btd6.md`, `docs/current-state/S3-ai-memory.md`, `docs/current-state/S4-docs.md`, `docs/current-state/S5-ops.md`, `docs/AGENT_ORIENTATION.md`, `docs/architecture.md`, `docs/ownership.md`, `docs/runtime_contracts.md`, `docs/repo-navigation-map.md`, `docs/repo-review-map.md`, `docs/ultracode/README.md`, `docs/subsystems/ai.md`, `docs/subsystems/btd6.md`, `docs/subsystems/media-youtube.md`, `docs/decisions/006-btd6-data-provenance-ownership.md`, `docs/decisions/007-media-youtube-ownership.md`, `docs/context-map-tooling.md`, `docs/operations/autonomous-routines.md`, `docs/operations/production-deployment.md`, `docs/agent/README.md`, and `docs/agent/index.yml`.
+
+### Source roots inspected
+
+- AI: `disbot/cogs/ai_cog.py`, `disbot/cogs/ai_review_cog.py`, `disbot/core/runtime/ai/`, `disbot/services/ai*`, `disbot/utils/db/ai*`, `disbot/views/ai/`, AI migrations and tests.
+- BTD6: `disbot/cogs/btd6*.py`, `disbot/cogs/paragon_cog.py`, `disbot/views/btd6/`, `disbot/services/btd6*`, `disbot/utils/db/btd6*`, `data/btd6/`, BTD6 scripts, tests, and evals.
+- Project Moon: `disbot/cogs/project_moon_cog.py`, `disbot/views/projmoon/`, `disbot/services/projmoon_*`, `disbot/data/projmoon/`, `disbot/utils/projmoon/`, tests.
+- Media/YouTube: `disbot/cogs/media_maintenance_cog.py`, `disbot/services/youtube_*`, `disbot/utils/db/youtube_video_cache.py`, `disbot/views/youtube_*`, migration `049_youtube_video_cache.sql`, docs and tests.
+- Tooling/ops: `.github/workflows/`, `.github/dependabot.yml`, `scripts/check_*`, `scripts/context_map.py`, `scripts/wiring_map.py`, `scripts/git_merge_state.py`, `scripts/run_evals.py`, `tools/agent_context/`, `docs/agent/`, `.claude/`, `.sessions/README.md`, `pyproject.toml`, `requirements*.txt`, `.pre-commit-config.yaml`, and subproject CI paths.
+
+### Commands run and results
+
+- `PYENV_VERSION=3.10.20 python3.10 --version` → pass, Python 3.10.20 available only after selecting pyenv version.
+- `python3.10 scripts/context_map.py disbot/cogs/ai_cog.py` initially failed because `python3.10` was not selected and then because `yaml` was missing; after installing PyYAML under `PYENV_VERSION=3.10.20`, it passed and mapped AI cog imports, docs, and tests.
+- `python3.10 scripts/context_map.py disbot/cogs/btd6_cog.py` passed after PyYAML install.
+- `python3.10 scripts/context_map.py disbot/services/btd6_view_model_service.py` passed after PyYAML install.
+- `python3.10 scripts/context_map.py disbot/cogs/project_moon_cog.py` passed after PyYAML install.
+- `python3.10 scripts/context_map.py scripts/context_map.py` returned exit 2: non-`disbot/` files are intentionally not mapped.
+- `python3.10 scripts/wiring_map.py --check` passed with advisory possible-dead-subscriber warnings for `ticket.opened` and governance visibility/cache/cleanup events.
+- `python3.10 scripts/check_architecture.py --mode strict` initially failed on missing `yaml`; after PyYAML install, passed with 0 errors and 49 tracked warnings.
+- `python3.10 scripts/check_tool_pins.py` passed.
+- `gh pr view 1509 ...` could not run because `gh` is not installed in the environment.
+- `python3.10 scripts/check_docs.py --strict` was run after adding this report and passed.
+
+- `python3.10 scripts/btd6_probe.py --help` passed and confirmed the offline probe interface.
+- `python3.10 scripts/btd6_probe.py --route "how much cash do rounds 1-10 give in btd6"` failed before probing because `discord` is not installed in the selected Python environment.
+- `python3.10 scripts/run_evals.py --help` passed and confirmed the `--smoke`, `--btd6`, and `--btd6-only` modes.
+- `python3.10 scripts/run_evals.py --smoke` failed before running the smoke matrix because `discord` is not installed in the selected Python environment.
+
+### Open PR / active gate status
+
+- Live GitHub PR verification was blocked by missing `gh`. No source claim in this report treats PR #1509 as merged truth.
+- Current-state docs identify active BTD6 live retest/menu-layout and AI substrate/consistency-linter queues, but source code remains the authority for this map.
+- `docs/agent/index.yml` still lists AI expansion gates around provider/provenance checks, caching/source-health clarity, behavior/config correctness, and orchestration foundation approval.
+- `docs/operations/production-deployment.md` confirms merge-to-main deploys production, so any future workflow changes must account for merge=deploy.
+
+### Verification limits
+
+- No live Discord, Railway, GitHub settings, secrets, production DB, paid model calls, or external BTD6 dump credentials were used.
+- Several context/doc claims are treated as advisory unless source-backed below.
+- The report maps code architecture; it does not prove production settings, branch protection, required checks, or secret availability.
+
+## 3. AI platform inventory
+
+### Provider abstraction
+
+Confirmed source-backed components:
+
+- `core/runtime/ai/contracts.py`: typed `AITask`, `AIScope`, `AIResponseMode`, `AIRequestContext`, `AIToolSpec`, `AIToolChoice`, `AIToolBudget`, `CalculationEvidence`, `AIAnswerWithEvidence`, `AIRequest`, `AIResponse`, and `AIDiagnosticsSnapshot`.
+- `core/runtime/ai/providers/base.py`: provider protocol and tool-loop helpers.
+- `providers/openai_provider.py` and `providers/anthropic_provider.py`: provider-specific execution with tool-calling support.
+- `providers/openai_moderation.py`: image moderation via OpenAI key.
+- `gateway.py`: registers providers, resolves provider/model routing, redacts request payload/system prompts, wraps tool dispatch, handles fallback/degraded responses, and records diagnostics.
+
+Reusable primitive: **`AIProviderGateway`**. Copy the idea, not the exact file shape; keep provider protocol, redaction, fallback, diagnostics, and tool-dispatch wrapper, but place it in a layer that does not violate architecture boundaries.
+
+### Routing/task profiles
+
+- `routing.py` resolves task-to-provider/model targets, with defaults for OpenAI and Anthropic and env fallback.
+- `feature_flags.py` reads `AI_ENABLED`, `AI_DEFAULT_PROVIDER`, task enablement, tool enablement, server-member lookup, and setup-advisor provider flags.
+- Tests cover routing disjointness and provider behavior (`tests/unit/runtime/ai/test_domain_routing_disjoint.py`, provider tests, task-router tests for Project Moon/YouTube/strategy channel).
+
+Reusable primitive: **`TaskProfile`** with fields for task name, provider preference, model, response mode, tool budget, deterministic grounding requirements, cache policy, and eval suite.
+
+### Natural-language gates
+
+- `natural_language_stage.py` explicitly says the AI cog stays unregistered so this stage is the only passive responder.
+- It detects direct bot mentions, strips mentions, derives `AIScope`, records visible user turns, gathers knowledge/context blocks, builds BTD6/Project Moon constraints/refusals, invokes the gateway, renders registered responses, redacts outbound text, and splits Discord messages.
+- It contains deterministic refusals for BTD6 and Project Moon when data is absent or grounding is unsafe.
+
+Reusable primitive: **`NaturalLanguageRouter`** plus per-domain `KnowledgeRouter` modules. Do not copy the monolith as-is.
+
+### Context gathering
+
+- `services/ai_context_service.py` and `services/ai_instruction_service.py` build base bot/guild/user/system context.
+- `_gather_bot_knowledge_blocks` in `natural_language_stage.py` integrates feature facts, BTD6, Project Moon, and YouTube-style context.
+- `services/btd6_ai_context_service.py`, `services/projmoon_context_service.py`, and `services/youtube_context_service.py` are domain context providers with length/provenance constraints.
+
+Reusable primitive: **`ContextBlock`** with `domain`, `facts`, `source_label`, `freshness`, `max_chars`, and `render()`.
+
+### Review-log loop
+
+- `migrations/100_ai_review_log.sql` creates `ai_review_log` with redacted question/answer/correction fields.
+- `utils/db/ai_review_log.py` provides DB access.
+- `services/ai_review_log_service.py` handles capture/listing/triage behavior.
+- `cogs/ai_review_cog.py` and `views/ai/` provide operator surfaces.
+- `docs/operations/ai-review-backlog-runbook.md` documents the operational loop.
+
+Reusable primitive: **`AnswerReviewLog`**. Preserve redacted storage, correction capture, task/provider metadata, and staff triage states.
+
+### Preset loop
+
+- `migrations/102_ai_answer_presets.sql` creates `ai_answer_presets` with guild/question key/answer fields and optional routed-task provenance.
+- `utils/db/ai_presets.py` is explicit that redaction/normalization happens before DB calls.
+- `services/ai_preset_service.py` and orchestration preset tests confirm presets are used to bypass/reuse answer behavior.
+
+Reusable primitive: **`PresetAnswerStore`** keyed by normalized question, guild/scope, task, locale, and source/provenance metadata.
+
+### Audits/redaction
+
+- `redaction.py` redacts text and JSON-like payloads.
+- `gateway.py` redacts the full payload/system prompt, provider input, tool results, and degraded responses.
+- `services/ai_decision_audit_service.py`, `migrations/039_ai_policy.sql`, and AI policy DB tables provide decision audit history.
+
+Reusable primitive: **`RedactionContract`** with tests proving every request field and tool result crosses the redactor.
+
+### Settings/bindings
+
+- `migrations/039_ai_policy.sql` creates instruction profiles and guild/channel/category/role policy tables.
+- `services/ai_policy_mutation.py`, `services/ai_config_projection_service.py`, `utils/settings_keys/ai.py`, and views/cogs provide settings projection and mutation boundaries.
+- `docs/ai-config-ownership.md` is a binding doc for config ownership.
+
+Reusable primitive: **`AIConfigProjection`**: read-only projection separate from mutation service.
+
+### Diagnostics
+
+- `diagnostics.py` records requests/failures/successes and reports provider/redaction status.
+- `services/ai_readiness_service.py`, `services/ai_introspection_service.py`, and diagnostics providers support readiness and self-knowledge.
+- The rebuild should add a visible diagnostics panel, not only commands.
+
+### Tests/evals
+
+AI tests cover gateway, providers, redaction, prompt injection, natural-language stage, tool orchestration/calling, response rendering, memory, policy, presets, review log, readiness, settings projection, and domain routers. `.github/workflows/ai-evals.yml` manually runs `scripts/run_evals.py` with OpenAI/Anthropic keys and a BTD6 QA suite option.
+
+### Failure modes
+
+- Missing provider SDK/API key degrades behavior.
+- Mis-set provider/model env can route to unregistered providers.
+- Redaction contract expansion risk: new `AIRequest` fields must be covered.
+- Monolithic natural-language stage increases regression risk.
+- Domain routing ambiguity can hallucinate by sending deterministic questions to the model without facts.
+- Review/preset tables rely on normalization before DB calls.
+
+## 4. Knowledge-domain inventory
+
+### BTD6
+
+- **Data sources:** official Ninja Kiwi endpoints/source registry; committed `data/btd6/towers.csv` and `heroes.csv`; parsed game data; wiki-derived formulas for round XP/cash where not in game dump; DB facts/snapshots; staff strategy submissions.
+- **Ingestion/extraction scripts:** `scripts/fetch_btd6_wiki_data.py`, `scripts/parse_gamedata.py`, `scripts/seed_btd6_data.py`, `scripts/upload_btd6_data.py`, `scripts/btd6_probe.py`, `scripts/btd6_patch_diff.py`, `scripts/btd6_gamedata_inventory.py`, `scripts/btd6_decode_inventory_report.py`, and related import/probe scripts.
+- **Committed data:** `data/btd6/README.md`, `heroes.csv`, `towers.csv`, plus generated/parsed fixtures under the data tree where present.
+- **Runtime DB tables:** `btd6_source_registry`, `btd6_source_audit`, `btd6_source_snapshots`, `btd6_facts`, `btd6_patch_notes`, `btd6_strategies`, `btd6_strategy_audit`, `btd6_ingestion_runs`, and `btd6_data_blobs`.
+- **View-model services:** `services/btd6_view_model_service.py` feeds tower/hero/live-events/leaderboard browser views.
+- **Context IDs/handles:** BTD6 AI context summaries carry stable IDs for towers/heroes/events/leaderboards/facts and render length-bounded source-labelled facts.
+- **Answer routing:** natural-language stage and BTD6 grounding services decide deterministic refusal vs grounded AI answer vs panel/browser flow.
+- **Source/provenance labels:** `btd6_ai_context_service.py`, `btd6_source_registry.py`, data migrations, parser comments, and tests assert source labels/freshness.
+- **Evals/probes:** `scripts/run_evals.py`, BTD6 eval suite in `.github/workflows/ai-evals.yml`, `scripts/btd6_probe.py`, many BTD6 unit tests.
+- **UI/browser panels:** `views/btd6/panel.py`, tower/hero/live-events/leaderboard browser views, admin panel, strategy review views.
+- **Admin/ops refresh flows:** `cogs/btd6_ops_cog.py`, `views/btd6/admin_panel.py`, manual `btd6-data-refresh.yml`, seed/upload scripts.
+- **Tests:** extensive services/utils/db/invariant/cog/script tests listed under `tests/unit/services/test_btd6_*`, `tests/unit/utils/test_btd6_*`, `tests/unit/scripts/test_btd6_*`.
+
+### Project Moon
+
+- **Data sources:** committed structural data under `disbot/data/projmoon/`; utility parsing/keyword helpers under `disbot/utils/projmoon/`.
+- **Runtime:** `cogs/project_moon_cog.py`, `services/projmoon_data_service.py`, `services/projmoon_grounding_service.py`, `services/projmoon_context_service.py`, and `views/projmoon/`.
+- **Context/provenance:** `ProjmoonContext` mirrors the BTD6 context pattern and appends honest provenance (`Limbus Company structural data`) to bounded facts.
+- **Routing/tests:** AI natural-language Project Moon tests and task-router tests confirm a deterministic domain route exists.
+- **Rebuild note:** copy the BTD6-style context/provenance idea, but Project Moon should get the same explicit domain spec/ingestion/freshness schema as BTD6.
+
+### Media / YouTube
+
+- **Data sources:** YouTube metadata/transcripts fetched by `youtube_fetch_service.py` and cached in Postgres.
+- **Runtime DB:** `migrations/049_youtube_video_cache.sql`; `utils/db/youtube_video_cache.py` supports get/upsert/purge/stats.
+- **Runtime/services:** `youtube_context_service.py`, `youtube_fetch_service.py`, `youtube_diagnostics.py`, `media_maintenance_cog.py`, `views/youtube_embeds.py`, and `views/youtube_renderers.py`.
+- **Docs/ownership:** `docs/subsystems/media-youtube.md` and decision 007 define ownership.
+- **Tests:** YouTube cache, diagnostics, context, fetch service, and AI task-router tests.
+- **Rebuild note:** preserve transcript/metadata caching and diagnostics, but make cache TTL, transcript source, video ID normalization, and summarization policy explicit in a domain spec.
+
+### Other deterministic knowledge domains
+
+Fishing, games, settings, health diagnostics, and help projections use similar patterns, but they are out of deep scope here. The key rebuild lesson is to make deterministic domains first-class specs instead of ad hoc services.
+
+## 5. BTD6 deep mapping
+
+### Runtime cogs
+
+- `btd6_cog.py`: product subsystem command/panel entrypoint; context map identifies docs and tests.
+- `btd6_events_cog.py`: live events surfaces.
+- `btd6_ops_cog.py`: admin/operator refresh and readiness surfaces.
+- `btd6_reference_cog.py`: reference/browser surfaces.
+- `btd6_strategy_cog.py`: staff strategy submission/review flow.
+- `paragon_cog.py`: paragon calculator and data interactions.
+
+### Ops/admin refresh surfaces
+
+- `views/btd6/admin_panel.py` and `btd6_ops_cog.py` provide in-bot ops surfaces.
+- `.github/workflows/btd6-data-refresh.yml` is manual only, fetches a dump, runs parse/audit/inventory/decode scripts, and opens a reviewable PR rather than pushing to main.
+- `scripts/seed_btd6_data.py` seeds deterministic data into `btd6_data_blobs`; `scripts/upload_btd6_data.py` uploads a manifest/tree to public object storage.
+
+### Data pipeline scripts
+
+- `fetch_btd6_wiki_data.py`: fetches tower/hero data from Bloons wiki API and writes CSV rows.
+- `parse_gamedata.py`: parses game dumps, overlays structured data, audits anchors, builds round XP/cash formulas with source notes, and emits data files.
+- `btd6_gamedata_inventory.py` and `btd6_decode_inventory_report.py`: inventory/decode coverage.
+- `btd6_patch_diff.py`: patch diffing.
+- `btd6_probe.py`: grounding triage for AI answerability.
+- `seed_btd6_data.py` and `upload_btd6_data.py`: runtime data distribution.
+
+### Data freshness model
+
+- `btd6_source_registry.py` classifies source freshness buckets and exposes health/listing/usable-source checks.
+- `btd6_ingestion_runs` and source audit/snapshot tables capture refresh attempts and source history.
+- `btd6_data_blobs.sha256` stores source-file provenance for committed deterministic data.
+- Fresh repo recommendation: define freshness policy once per source in `SourceProvenanceSpec`; avoid each service inventing freshness semantics.
+
+### Context bridge to AI
+
+- `btd6_ai_context_service.py` returns dataclasses like `ActiveEventSummary`, `EventDetailsSummary`, `EntitySummary`, `RestrictionSummary`, `LeaderboardSummary`, `SourceStatusSummary`, and `FactSummary`, each with `render()` and provenance-preserving length caps.
+- Natural-language stage calls BTD6 grounding/refusal functions before model invocation.
+- Tests pin BTD6 grounding injection, answer guidance, context tower stats, fact-store fetch, and source labels.
+
+### Paragon calculator/data
+
+- `paragon_cog.py`, `services/btd6_paragon_*`, paragon tests, and calculator commands handle paragon names, costs, income/effects, ability rosters, elite replies, and stats.
+- Best rebuild idea: calculators should emit `CalculationEvidence` objects usable by both embeds and AI answers.
+
+### Live events/heroes/towers/leaderboards
+
+- View-model service is imported by tower browser, hero browser, live-events, leaderboard browser, and panel views.
+- AI context service exposes current events, event details, tower summary, hero summary, restrictions, leaderboard summary, and source status.
+
+### Known gates / owner-live retest items
+
+- Current-state docs mention BTD6 live retest, menu layout, curated counter lists, decode items, and owner-live verification. These are not treated as merged requirements unless source-backed.
+- Architecture strict check still warns on `views/btd6/admin_panel.py` and `views/btd6/strategy_review.py` direct `discord.ui.View` inheritance; acceptable tracked debt, but fresh repo should start on a base-view primitive.
+
+### Best functions and anti-patterns
+
+- Preserve: source registry freshness, AI context dataclasses with provenance-preserving render, BTD6 probe/evals, manual refresh PR workflow, seed/upload manifest tooling, view-model service for UI browsers.
+- Redesign: monolithic natural-language BTD6 branches; duplicated source labels across scripts/services; split DB/file/cloud data providers behind one data-provider interface.
+- Discard/avoid: hidden “AI knows game facts” paths; unlabelled wiki/game-dump merges; live API requirements in unit/eval paths; command-only diagnostics.
+
+## 6. Repo tooling and operations inventory
+
+| Area | Current files/workflows | Fresh-repo recommendation |
+|---|---|---|
+| CI quality workflow | `.github/workflows/code-quality.yml`, `scripts/check_quality.py`, docs/stale/session/consistency/test/architecture checks | **Copy idea, redesign smaller.** Keep one required quality workflow with named gates and fast/slow split. |
+| Architecture/doc checks | `scripts/check_architecture.py`, `scripts/check_docs.py`, `scripts/check_stale_claims.py`, `scripts/check_consistency.py` | **Copy nearly as-is concept.** Start strict early to avoid migration debt. |
+| Context map/packs | `scripts/context_map.py`, `docs/context-map-tooling.md`, `tools/agent_context/`, `docs/agent/index.yml`, generated packs | **Copy idea.** Make maps work for all repo roots, not just `disbot/`. |
+| Wiring map/event observability | `scripts/wiring_map.py`, EventBus catalogue, tests | **Copy nearly as-is.** Keep dead subscribers advisory and uncatalogued events gated. |
+| Tool pin checks | `scripts/check_tool_pins.py`, `.github/workflows/tool-pins.yml`, SHA-pinned actions | **Copy.** Valuable low-cost supply-chain guard. |
+| Dependabot | `.github/dependabot.yml` | **Copy/simple.** Keep update cadence modest and grouped. |
+| Auto-merge/enabler | `.github/workflows/auto-merge-enabler.yml` | **Replace with GitHub-native auto-merge where possible.** Keep docs of autonomy model. |
+| PR conflict/behind checks | `pr-conflict-guard.yml`, `pr-auto-update.yml`, `scripts/git_merge_state.py`, `scripts/check_pr_mergeable.py` | **Copy helper, simplify workflows.** Prefer branch protection + native auto-update if available. |
+| CI rerun watchdog | `ci-rerun-watchdog.yml`, `scripts/check_ci_coverage.py` | **Keep if flaky/missed CI is real.** Otherwise discard initially. |
+| Dashboard/data refresh | `dashboard-data-refresh.yml`, `scripts/export_dashboard_data.py` | **Copy idea.** Automated generated-data PRs are good; keep narrow. |
+| Backups | `backup-db.yml` | **Copy/redesign for target infra.** Preserve integrity check before artifact upload. |
+| AI eval workflow | `ai-evals.yml`, `scripts/run_evals.py` | **Copy idea.** Separate free/offline deterministic evals from paid provider evals. |
+| BTD6 data refresh | `btd6-data-refresh.yml` | **Copy pattern.** External data refresh must open PR, never push to main. |
+| Botsite/dashboard/design-system CI | `botsite-ci.yml`, `dashboard-ci.yml`, `design-system-ci.yml` | **Keep if subprojects remain.** Otherwise replace with one matrix workflow. |
+| Codex final review | `codex-final-review.yml` | **Discard initially.** Reintroduce only if the same born-red review gap recurs. |
+| Routines | `docs/operations/autonomous-routines.md`, reconciliation trigger | **Preserve as docs-first workflow specs.** Reduce PAT reliance. |
+
+## 7. Best ideas/functions to preserve
+
+| File/function/class/workflow | Problem solved | Value | Disposition | Hidden dependencies |
+|---|---|---|---|---|
+| `core/runtime/ai/gateway.py::AIGateway` | Safe provider execution/fallback/redaction/tool dispatch | One choke point for model IO | Redesign around idea | Provider SDKs, env vars, diagnostics, services imports |
+| `core/runtime/ai/contracts.py` dataclasses/enums | Typed AI boundary | Makes evals/tests/provider code stable | Copy nearly as-is | Task taxonomy must match product domains |
+| `core/runtime/ai/redaction.py` | Scrubs payload/text/tool results | Privacy and review-log safety | Copy with stronger tests | Pattern coverage can be incomplete |
+| `core/runtime/ai/routing.py` | Task-to-provider/model routing | Enables task-specific model policy | Redesign as declarative `TaskProfile` | Env drift, model availability |
+| `services/ai_review_log_service.py` + `utils/db/ai_review_log.py` | Captures answer/correction triage | Self-improving answer loop | Copy idea | Migration 100, redaction before storage |
+| `services/ai_preset_service.py` + `utils/db/ai_presets.py` | Reusable reviewed answers | Reduces repeated hallucinations/cost | Copy idea | Normalized question keys, guild scope |
+| `btd6_ai_context_service.py` render dataclasses | Grounded, bounded source-labelled facts | Domain-safe AI context | Copy pattern | BTD6 DB/provider availability |
+| `btd6_view_model_service.py` | UI browser read model | Separates UI from data plumbing | Copy pattern | Resolver/body coercion/db provider |
+| `btd6_source_registry.py` | Freshness/trust/source health | Provenance and ops visibility | Copy as `SourceProvenanceSpec` | Registered sources and audit tables |
+| `scripts/parse_gamedata.py` | Game dump extraction/audit | Repeatable deterministic data pipeline | Redesign around ingestion framework | Dump availability/licensing |
+| `scripts/btd6_probe.py` | AI grounding triage | Fast answerability debugging | Copy pattern | Corpus expectations and local data |
+| `projmoon_context_service.py::ProjmoonContext` | Small domain context bridge | Proves pattern generalizes | Copy idea | Committed structural data completeness |
+| `youtube_context_service.py` + cache DB | Metadata/transcript cache context | Avoids repeated fetch/model work | Copy idea | YouTube API/transcript limits/TTL |
+| `scripts/context_map.py` | Agent orientation per file | Reduces codebase discovery cost | Copy and generalize | PyYAML, manifest coverage, disbot-only limitation |
+| `scripts/wiring_map.py` | EventBus observability | Finds uncatalogued events | Copy | AST limitations/false positives |
+| `scripts/git_merge_state.py` | Deterministic merge state | Shared workflow truth | Copy | Git availability/fetch depth |
+| `.github/workflows/btd6-data-refresh.yml` | Reviewable external-data refresh | Prevents silent data mutation | Copy pattern | External dump URL, create-PR action |
+| `.github/workflows/backup-db.yml` | Scheduled DB backup with integrity check | Operational safety | Redesign for target infra | DB URL secret, artifact retention |
+| `tools/agent_context/` | Generated context packs | Better agent handoff | Copy | Pack freshness CI |
+
+## 8. Hidden dependencies and rebuild hazards
+
+- **AI provider/env/secrets:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AI_ENABLED`, `AI_DEFAULT_PROVIDER`, `AI_FALLBACK_PROVIDER`, task routing env vars, provider SDK packages, and optional moderation provider.
+- **Review log/preset schemas:** migrations 100 and 102; normalized question keys; guild-scoped rows; redacted question/answer/correction text.
+- **Redaction contracts:** every model input, output, tool argument/result, review row, and preset mutation must pass a single redactor.
+- **Model routing assumptions:** task names in `AITask` must line up with provider/model defaults, settings, evals, and natural-language routers.
+- **Knowledge-domain context IDs:** BTD6 tower/hero/event/leaderboard/fact IDs and Project Moon entry IDs must stay stable across UI, AI, eval fixtures, and DB rows.
+- **Licensing/provenance:** BTD6 game dumps, Ninja Kiwi endpoints, Bloons wiki data, Project Moon structural data, and YouTube transcripts have different provenance and licensing expectations.
+- **Seed/refresh ordering:** source registry before facts; deterministic blobs before postgres/cloud backend; ingestion run/audit before source health; AI evals after data refresh.
+- **Eval fixture assumptions:** BTD6 QA corpus assumes specific data version/source labels and may fail if data updates without golden refresh.
+- **GitHub Actions tokens/PAT:** routines/reconciliation and some PR/status workflows document `ROUTINE_PAT` or status permissions; default `GITHUB_TOKEN` may not trigger external routines.
+- **Generated docs/context freshness:** generated context packs and current-state docs can lag source.
+- **CI required-check assumptions:** auto-merge/enabler workflows assume specific check names and branch protection shape not visible locally.
+- **Dashboard/botsite data pipelines:** generated JSON and subproject CI can drift from bot source if export scripts are not required checks.
+
+## 9. Fragmentation and duplication inventory
+
+### Critical rebuild lesson
+
+- **AI natural-language stage monolith:** domain routing, context gathering, refusals, memory, gateway calls, render dispatch, and review logging should be split into composable routers/task profiles.
+- **BTD6 data providers:** file, Postgres, cloud, parsed dump, wiki, and live endpoint concepts must share one provenance schema.
+- **Workflow PAT complexity:** routine triggers, auto-merge, conflict statuses, and reconciliation can become fragile if dependent on expiring PATs.
+
+### Important improvement
+
+- **Diagnostics split across commands/services/views:** give AI/BTD6/media a common diagnostics panel plus command route.
+- **Context maps limited to `disbot/`:** generalize to scripts, workflows, and subprojects.
+- **Provider routing via env:** expose a clear runtime settings projection with safe defaults and diagnostics.
+
+### Cleanup
+
+- Direct `discord.ui.View` inheritance warnings in BTD6 admin/strategy views and unrelated views should be eliminated in a fresh repo by starting with one base-view library.
+- Generated current-state and planning docs should have automatic stale markers.
+
+### Acceptable specialization
+
+- BTD6-specific parsers/calculators are acceptable because the domain is complex.
+- YouTube cache/diagnostics can remain separate because API/cache behavior differs from static game data.
+- Project Moon keyword/grounding utilities can remain domain-specific if they implement the shared knowledge-domain interfaces.
+
+## 10. Future new-repo recommendations
+
+1. **`AIProviderGateway`** — source evidence: `gateway.py`, provider modules, redaction tests. Centralize provider calls, fallback, diagnostics, and tool result redaction.
+2. **`TaskProfile`** — source evidence: `AITask`, `routing.py`, `feature_flags.py`, AI eval workflow. Declaratively define provider/model/tools/grounding/eval expectations.
+3. **`ContextBlock`** — source evidence: BTD6/Project Moon/YouTube context services. Make domain facts typed, bounded, source-labelled, and freshness-aware.
+4. **`AnswerReviewLog`** — source evidence: migration 100, review log service/cog/tests/runbook. Store redacted answer events and corrections.
+5. **`PresetAnswerStore`** — source evidence: migration 102, preset DB/service/tests. Store reviewed answers keyed by normalized task/question/scope.
+6. **`KnowledgeDomainSpec`** — source evidence: BTD6 subsystem, Project Moon services, media docs. Define commands, panels, data sources, context builder, eval suite, and diagnostics.
+7. **`SourceProvenanceSpec`** — source evidence: BTD6 source registry/freshness/data blobs/source labels. Require source key, trust tier, freshness, license note, and answer label.
+8. **`IngestionPipeline`** — source evidence: BTD6 parse/fetch/seed/upload/refresh workflow and YouTube fetch/cache. Standardize fetch, parse, validate, audit, diff, PR, seed.
+9. **`ViewModelContextHandle`** — source evidence: `btd6_view_model_service.py` and browser views. Use stable handles across UI panels, AI context, and eval fixtures.
+10. **`EvalHarness`** — source evidence: `scripts/run_evals.py`, `.github/workflows/ai-evals.yml`, BTD6 probe/tests. Separate deterministic offline evals from paid provider evals.
+11. **`AgentContextPack`** — source evidence: `docs/agent/index.yml`, `tools/agent_context/`, generated packs, context-map tooling. Generate task-specific orientation from source manifests.
+12. **`RepoQualityGate`** — source evidence: code-quality workflow, architecture/docs/wiring/tool-pin checks. Define required checks as code.
+13. **`WorkflowRoutineSpec`** — source evidence: `docs/operations/autonomous-routines.md`, reconciliation trigger, production deployment docs. Version autonomous routine prompts and their token/permission assumptions.
+
+## 11. Handoff to other mapping sessions
+
+### Needed from Part 1 platform primitives
+
+- Base Discord view/navigation lifecycle (`BaseView`, hub/panel conventions, interaction ack/defer helper).
+- EventBus/catalogue contract and message pipeline stage interface.
+- Settings/bindings/resource requirement schema.
+- Diagnostics provider registry and health snapshot model.
+- Database migration and repository conventions.
+
+### Needed from Part 2 admin/safety dependencies
+
+- Permission tiers and owner/staff gates for AI review, BTD6 ops, media maintenance, and data refresh commands.
+- Audit log mutation contract for AI policy changes, review actions, strategy approval, and source refreshes.
+- Redaction/privacy policy for stored prompts, YouTube transcript snippets, Discord message context, and review corrections.
+- Safety rules for autonomous routines, merge=deploy, rollback, and production verification.
+
+### Needed from Part 3 product/game/community dependencies
+
+- Product-level command/menu taxonomy for where BTD6, Project Moon, media, and AI panels live.
+- Game/community context facts that AI may reference safely.
+- User-facing help copy conventions and browser panel UX patterns.
+- Live verification scripts/checklists for owner-walked BTD6/media/AI answers.

--- a/docs/analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md
+++ b/docs/analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md
@@ -1,0 +1,247 @@
+# Codex rebuild-discovery maps — verified & folded preserve/redesign/drop synthesis (2026-07-02)
+
+> **Status:** `reference` — the single consolidated "one picture" that folds the **4 Codex
+> rebuild-discovery maps** into one verified preserve / redesign / drop artifact + a unified primitive
+> taxonomy + the backward-compat contract. **This is the primary Codex-evidence input to the Fable-5
+> design session.** Every load-bearing claim was re-verified against **live source** by a 4-agent fleet
+> (Q-0120, 2026-07-02): **48 of 59 CONFIRMED, 2 FALSE, 9 PARTIAL** — the §1 corrections are **binding
+> over the raw maps**. Source code + merged PRs win over this file.
+>
+> **Provenance:** authored by the owner's 4 Codex sessions (originally PRs #1630–#1633, **superseded by
+> this consolidation** — their reports are preserved verbatim for drill-down):
+> [platform-ui-runtime](platform-ui-runtime-map.md) · [admin-safety-server](admin-safety-server-map.md) ·
+> [community-economy-games](community-economy-games-map.md) ·
+> [ai-knowledge-data-tooling](ai-knowledge-data-tooling-map.md).
+> Feeds the rebuild launch pad
+> ([`rebuild-ultracode-handoff`](../../planning/rebuild-ultracode-handoff-2026-07-02.md)) and the strategy
+> baseline ([`fresh-rebuild-strategy`](../../planning/fresh-rebuild-strategy-2026-07-02.md) §6).
+
+---
+
+All six spot-checks confirm the maps against live source: `ActionSpec` collides at `services/automation_registry.py:35`; `SettingSpec`/`BindingSpec`/`DomainPanelSpec`/`SubsystemSchema` sit in `subsystem_schema.py`; `multi_channel.py` is genuinely absent; the AI DB module is `utils/db/ai_review.py` (no `ai_review_log.py`); `gateway.py:51` really does `from services import metrics`; and the server hub command is `servermanagement`/`servermenu`/`guildmenu`. The corrections hold. Here is the synthesis body.
+
+## 1. Verification summary — what held vs what didn't
+
+Across the 4 maps, **48 of 59 load-bearing verdicts are CONFIRMED, 2 are FALSE, 9 are PARTIAL.** The confirmed spine is solid: all ~39 platform-seam files exist; the four audited mutation pipelines, EventBus fan-out, lifecycle phase machine, capability seam, help-as-projection chain, health-findings persistence, the economy/XP/karma sole-writer invariants, the AI gateway + typed contracts, and every cited migration/table/script/workflow are real. The corrections below are the only places a Fable designer must **not** take a source map at face value.
+
+| # | Domain | Claim (as written in the map) | Verdict | Correction (source-verified) |
+|---|---|---|---|---|
+| 1 | Platform/UI | `views/selectors/` contains `multi_channel.py` | **FALSE** | Dir has `channel, role, subsystem, multi, multi_role, scope, _resource_helpers` — **no `multi_channel.py`**. Fragmentation point stands; filename is wrong. |
+| 2 | Admin/safety | `BindingSpec` / `LifecycleResult` / `CapabilityDecision` are **new** foundation primitives to build | **FALSE** | All already shipped: `BindingSpec` `subsystem_schema.py:75`, `LifecycleResult` `lifecycle/contracts.py:77`, `CapabilityDecision` `governance/capability.py:57`. **Reuse/extend, never recreate.** |
+| 3 | Platform/UI | `wiring_map` lists `ticket.opened` as a "possible dead subscriber" | PARTIAL | Live subscriber exists: `ticket_cog.py:57 bus.on('ticket.opened',…)`. Advisory is a false positive. But `governance.visibility/cache/cleanup.changed` **are** `EVT_*` constants with no `bus.on` found — real catalogue/subscriber drift. |
+| 4 | Admin/safety | Hub entered via `!server` / `!servermanage` / `!serverpanel` | PARTIAL | Real command is `servermanagement` (aliases `servermenu`, `guildmenu`) at `server_management_cog.py:40-41`. Hub class `ServerManagementHubView` is correct; tokens are wrong. |
+| 5 | Admin/safety | Setup commands are `!setup scan/start/resume/apply` + `!setup-delegate` | PARTIAL | No `!setup` group. Real surface: `setupadvanced`/`advancedsetup`, `setupdescribe`, slash `setup-advanced`/`setup-describe`/`setup-hub`/`setup-depth`, `setup-delegate`. Apply flow exists; command names differ. |
+| 6 | Admin/safety | `image_moderation_service` is the external-call scanner (OpenAI moderation) | PARTIAL | It **explicitly does not** call OpenAI (`image_moderation_service.py:4-6`); the external call lives in `core/runtime/ai/providers/openai_moderation.py`. Attribution is off by one module. |
+| 7 | Community/games | `karma_service.give` guarded by **INV-K** | PARTIAL | INV-K is **overloaded**: `architecture.md:136` = asyncio task-spawn invariant; `ownership.md:36` + `karma_service.py` = karma sole-writer. Karma usage matches ownership.md, but the taxonomy must disambiguate. |
+| 8 | Community/games | `SettleOnceMixin` used by `views/blackjack/pvp_view` | PARTIAL | Class at `utils/terminal_guard.py:44`; real users are `rps/pvp_play`, `creature_battle/challenge`, `games/deathmatch_panel`, `blackjack_state` — **not** `blackjack/pvp_view`, which settles via `game_wager_workflow.settle_pvp`. |
+| 9 | Community/games | A new declarative primitive layer must be **built** (RouteRegistry/Spec-family) | PARTIAL | A **mature declarative layer already exists and was unmentioned**: `subsystem_schema.py` (`SubsystemSchema`, `DomainPanelSpec`, `SettingSpec`, `BindingSpec` + `register`/`get_schema`) used by 10+ modules. RouteRegistry must **extend**, not greenfield. |
+| 10 | AI/knowledge | Answer-review DB module is `utils/db/ai_review_log.py` | PARTIAL | Table (`ai_review_log`, mig 100), service, cog all confirmed — but the Python module is **`utils/db/ai_review.py`** (path cited wrong 4×). Table name is correct; path is not. |
+
+### Primitive-name collisions with existing symbols (the load-bearing callout)
+
+- **`ActionSpec` — HARD COLLISION.** Part 1's proposed UI action primitive collides with the **shipped** `services/automation_registry.py:35 class ActionSpec` (a frozen dataclass of automation `action_kind` metadata, mirroring migration 032 — a genuinely different concept). A rebuild reusing the bare name shadows the automation registry. **Design must rename** (`PanelActionSpec` / `UIActionSpec`) or explicitly unify. Because `ActionSpec` is meant to be shared across all 4 domains, the rename must be resolved **repo-wide before any domain adopts it.**
+- **`SettingSpec` / `BindingSpec` — intentional reuse, not a rename.** Collide with `subsystem_schema.py:109`/`:75`, but the maps treat these as the **same existing types to preserve+fold**. No rename; document that they are the shipped classes.
+- **`LifecycleResult` / `LifecyclePreview` / `StepResult` / `CapabilityDecision` / `ResourceRequirement` / `ProvisioningOption` — already shipped**, at `contracts.py:77/66/56`, `capability.py:57`, `resource_specs.py:79`, `resource_provisioning_catalogue.py:79`. Extend, don't recreate.
+- **`AIGateway`** already exists (`core/runtime/ai/gateway.py:177`); Part 4's `AIProviderGateway` is a **rename-in-place**, and `services/ai_gateway.py:25` re-exports it — the seam split must be preserved.
+- **All other proposed names grep-clean** in `disbot/` (SubsystemManifest, PanelSpec, EmbedFrame, TableSpec, ListSpec, NavigationSpec, SelectorSpec, WorkflowResult, MutationPreview, DiagnosticProviderSpec, ManagedTaskSpec, PanelContext, AdminActionSpec, ModerationActionSpec, SecurityActionSpec, ResourceMutationSpec, ServerEventRouteSpec, ConfirmationSpec, and all Part-3/Part-4 names). Note: `AIConfigProjection`/`RedactionContract`/`KnowledgeDomainSpec` have no class collision but are **behaviorally embodied** by existing `ai_config_projection_service.py`, `redaction.py`, and the in-flight "KnowledgeDomain seam (Slice B)" (`contracts.py:34`, `projmoon_context_service.py:15,113`) — align, don't compete.
+
+## 2. The convergent thesis
+
+All four independent maps describe the **same rebuild**: the codebase already contains the *right* patterns — service-owned audited mutation lanes (`emit_audit_action` fan-out), a publish-accepted `EventBus` with a catalogued event vocabulary, a typed three-lane config schema (`SettingSpec`/`BindingSpec`/`ResourceRequirement`), restart-safe `PersistentView` + capability-recheck-at-callback, help-as-projection, and a single provider-IO choke point (`AIGateway`) — **but those patterns are non-authoritative**: they run in parallel with legacy KV writes, raw `discord.ui.View` subclasses, per-cog permission checks, command-only surfaces, and five divergent result shapes. The rebuild's job is to make **the good pattern the *only* pattern**, and to make it **generated from one declarative source of truth** — a typed `SubsystemManifest`/`RouteRegistry` that owns each subsystem's metadata, capabilities, commands, panels, settings, bindings, resources, events, diagnostics, and help in one place, from which panels, routes, permission gates, and Help are *derived* rather than hand-wired. Crucially, this is **consolidation, not greenfield**: a mature declarative layer (`subsystem_schema.py`, `subsystem_registry.SUBSYSTEMS`, `hub_registry.HUBS`) already exists in fragments — the rebuild unifies them behind one grammar and deletes the divergent duplicates.
+
+## 3. The unified primitive taxonomy
+
+Every proposed declarative primitive, deduplicated across the 4 maps and grouped by layer. **Proposed-by** shows which parts converged on it; **collision** flags clash with a shipped symbol. This is the manifest grammar Fable must define.
+
+### A. Manifest / registry core (the single source of truth)
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **SubsystemManifest** | One typed record per subsystem: metadata, caps, commands, panels, settings, bindings, resources, events, diagnostics, help — folds `SUBSYSTEMS` dict + `SubsystemSchema` + `hub_registry` + `help_catalogue` | P1 (shared to all 4) | Free — but **must extend the shipped `subsystem_schema.py`** |
+| **RouteRegistry** | One typed manifest over `subsystem_registry` + `hub_registry` + Help + settings/panel/permissions/completion; hub discovery + routing facet | P3 | Free — **same concept as SubsystemManifest; reconcile, don't double-define** |
+| **KnowledgeDomainSpec** | Per-knowledge-domain manifest: commands, panels, data sources, context builder, eval suite, diagnostics (BTD6/ProjMoon/YouTube) | P4 | Behaviorally = in-flight "KnowledgeDomain seam (Slice B)" — align |
+
+### B. Config lanes (already shipped — preserve & fold, do not reinvent)
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **SettingSpec** | Scalar/typed setting lane | P1, P2, P3 | **EXISTS** `subsystem_schema.py:109` — reuse |
+| **BindingSpec** | Discord-pointer binding lane | P1, P2 | **EXISTS** `subsystem_schema.py:75` — reuse |
+| **ResourceSpec / ResourceRequirement** | Provisionable Discord resource (preview/apply/link) | P1 | **EXISTS** `resource_specs.py:79` — reuse |
+| **SettingsPanelSpec** | Generated editor over `SettingSpec` (widgets/validation/capability/default/help) | P2 | Free — generator over existing SettingSpec |
+
+### C. UI / panel grammar
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **PanelSpec** | Declarative panel identity/owner/audience/anchor policy/renderer/actions/selectors/nav | P1 | Free |
+| **PanelRuntimeView / GameViewBase / GamePanel** | Spec-driven base view (owner/participant/timeout/response-policy/back-help slots) replacing `BaseView`/`HubView`/raw `discord.ui.View` | P1, P3 | Free |
+| **EmbedFrame / CardRendererSpec** | Safe embed/card renderer with size budgets + style tokens (folds `clamp_embed`, `help_overlay.home_embed_frame`, card/asset manifest) | P1, P3 | Free |
+| **TableSpec / ListSpec / BrowserView** | Bounded table/list with pagination + truncation; shared browser (filter/sort/paginate) | P1, P3 | Free |
+| **NavigationSpec / HubRoute** | Serializable help/home/back/parent routes, persistent custom_ids, public/ephemeral policy, click-time governance recheck | P1, P3 | Free |
+| **SelectorSpec** | Options/pagination/selected/empty-state/callback-result | P1 | Free |
+| **PanelContext** | Explicit bot/guild/actor/channel/interaction-or-anchor/audience — replaces `help_ctx_shim` | P1 | Free |
+| **ActionView / ResultView / ConfirmModal** | Composed UI grammar for action panels, result cards, confirmation modals | P3 | Free |
+
+### D. Action / mutation executors
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **PanelActionSpec** (proposed `ActionSpec`) | Button/modal contract: label/custom_id/capability/defer-mode/handler/result-renderer/audit | P1 (shared) | **⚠ `ActionSpec` COLLIDES** `automation_registry.py:35` — **rename** |
+| **AdminActionSpec** | Admin action: audience/capability/perm-fallback/callback-recheck/ephemeral/audit | P2 | Free |
+| **ModerationActionSpec** | warn/timeout/kick/ban/delete/auto_delete + reason/DM/cleanup/hierarchy/audit/log-route | P2 | Free |
+| **SecurityActionSpec** | raid/account-age side-effects as explicit specs | P2 | Free |
+| **ResourceMutationSpec** | create/bind/rename/move/delete/reorder + preview/confirmation/perm-reqs/rollback | P2 | Free |
+| **GameActionSpec** | mine/dig/explore, begin_cast/commit_catch, catch/collect/work | P3 | Free |
+| **BindingAction** | Executor for binding mutations (`BindingMutationPipeline`) | P1 | Free |
+| **CapabilitySpec** | Declarative capability requirement | P2 | Free — but resolves to **existing `CapabilityDecision`** `capability.py:57` |
+
+### E. Result / preview grammar (collapse the five divergent shapes)
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **WorkflowResult** | Unified mutation result: status/before-after/audit-event-cache flags/warnings/user-message across settings/bindings/provisioning/governance/lifecycle | P1 | Free |
+| **MutationPreview** | Dry-run object for settings bundles/provisioning/lifecycle/setup | P1 | Free |
+| **ConfirmationSpec** | preview/confirm/cancel/apply grammar; irreversible\|compensatable\|reversible, challenge/hash, timeout, actor re-check, before-state snapshot | P1, P2 | Free |
+| **CurrencyMutationResult** | Money-mutation result (from `TreasuryResult` + economy result views) | P3 | Free |
+| _LifecycleResult / LifecyclePreview / StepResult_ | Existing safety vocabulary | (reuse) | **EXIST** `contracts.py:77/66/56` |
+
+### F. Event / audit
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **AuditEventSpec** | Event name/actor/subject/guild/payload schema/redaction/subscribers/persistence-audit behavior | P1, P2 | Free — overlaps `audit_events.py` EVT_ module (behavioral) |
+| **EventSpec** | Event name/payload shape/owner (catalogue entry) | P1 | Free |
+| **ServerEventRouteSpec** | Passive event routing: source (gateway\|audit-log\|domain-event), opt-in, route binding, public/private projection, ignore filters | P2 | Free |
+
+### G. Runtime / diagnostics / tasks
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **DiagnosticProviderSpec** | name/sync-async lane/timeout/status-mapping/audience/redaction | P1 (shared) | Free |
+| **ManagedTaskSpec** | name/subsystem/cancellation prefix/error hook/metrics labels | P1 | Free |
+| **GameSessionPersistencePolicy** | ephemeral \| checkpointed \| authoritative (from `game_state_service`) | P3 | Free |
+
+### H. Economy / progression / games domain specs
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **EconomyLedger** | Audited coin ledger (from `economy_service` + `economy_audit_log`) | P3 | Free — audit-schema overlaps P2 |
+| **ProgressionTrackSpec** | XP/level/title tracks (`xp_service` + `game_xp_service` + mining titles/world_identity) | P3 | Free |
+| **RewardSpec** | daily/work/farm-collect/fishing-drops/mining-harvest | P3 | Free |
+| **ItemCatalogSpec** | mining/fishing/creature/inventory item metadata (coupled namespace) | P3 | Free |
+| **CraftingRecipeSpec + UpgradeTrackSpec** | mining recipes/forge + fishing bait/rod/charm/curio + farm upgrades | P3 | Free |
+| **CollectionDexSpec** | creature dex + fishing log (discovered/undiscovered/filters/completion) | P3 | Free |
+| **ChallengeSession** | participants/escrow/accept-decline-timeout/settle-once/rematch (blackjack/RPS/deathmatch/creature) | P3 | Free |
+| **IdleAccrualSpec** | farm + fishing/mining energy + structures (last_settled_at/rate/capacity/collect txn) | P3 | Free |
+| **LeaderboardSpec** | rank_source/metric/tie_breakers/scope/empty_state/card/privacy | P3 | Free |
+| **CostVector** | shared spend/sink validation across shops/crafting/wagers | P3 | Free |
+
+### I. AI / knowledge / tooling
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **AIProviderGateway** | provider protocol + select/fallback + redaction + diagnostics + tool-dispatch | P4 | Rename of **existing `AIGateway`** `gateway.py:177` |
+| **TaskProfile** | task→provider/model/response-mode/tool-budget/grounding/cache/eval-suite (declarative) | P4 | Free |
+| **ContextBlock** | domain/facts/source_label/freshness/max_chars/render() | P4 | Free |
+| **AnswerReviewLog** | redacted question/answer/correction + task/provider metadata + triage states (mig 100) | P4 | Free |
+| **PresetAnswerStore** | keyed by normalized question + guild/scope + task + locale + provenance (mig 102) | P4 | Free |
+| **SourceProvenanceSpec** | source key/trust tier/freshness/license note/answer label | P4 | Free |
+| **IngestionPipeline** | fetch→parse→validate→audit→diff→PR→seed (shared by BTD6/ProjMoon/YouTube) | P4 | Free |
+| **ViewModelContextHandle** | stable entity handles across UI + AI context + eval fixtures | P4 | Free |
+| **EvalHarness** | separate deterministic offline evals from paid provider evals | P4 | Free — offline provider = `deterministic_provider.py` |
+| **RedactionContract** | test-proven: every request field + tool result crosses the redactor | P4 | Behaviorally = `redaction.py` |
+| **AIConfigProjection** | read-only projection separate from mutation service (mig 039) | P4 | Behaviorally = `ai_config_projection_service.py` |
+| **NaturalLanguageRouter / KnowledgeRouter** | split the monolithic `natural_language_stage` into router + per-domain knowledge modules | P4 | Free |
+
+### J. Ops / workflow (meta-substrate)
+
+| Primitive | Owns | Proposed by | Collision |
+|---|---|---|---|
+| **AgentContextPack** | task-specific orientation generated from source manifests (`tools/agent_context/`) | P4 | Free |
+| **RepoQualityGate** | required checks as code (one `code-quality.yml`, named gates) | P4 | Free |
+| **WorkflowRoutineSpec** | versioned autonomous-routine prompts + token/permission assumptions | P4 | Free |
+
+## 4. Preserve / redesign / drop — unified, by domain
+
+### Platform / UI / runtime
+
+**Preserve** — Four service-owned audited mutation lanes (`SettingsMutationPipeline` `settings_mutation.py:221`, `BindingMutationPipeline` `:154`, `ResourceProvisioningPipeline` `:240`, `GovernanceMutationPipeline` `writes.py:107`), each calling `emit_audit_action`. Authority re-check at callback time (`capability.py:71 actor_holds_capability`) — opening a panel is not authorization. `EventBus` publish-accepted fan-out (`events.py on/off/emit`) + `KNOWN_EVENTS` catalogue + the `audit.action_recorded → server_logging._on_audit_action` wiring (`server_logging.py:1856`). Lifecycle phase machine (7 phases) + `can_accept_commands` admission gate. Managed task registry (`tasks.spawn/cancel_all/cancel_by_prefix`) with diagnostics self-registration. `PersistentView` restart-safe contract (`timeout=None` + static custom_id, re-registered at startup, `persistent_views.py:72`). Interaction helpers `safe_defer/safe_followup/safe_edit/clamp_embed`. `BaseView` invoker-lock + `views.navigation` never-strand-from-Help/hub (`base.py:130`, `nav:help`/`nav:hub:`). Help-as-projection (`build_help_catalogue → project_help → HelpProjection` + `HelpRoute/open_route`). **Three distinct config lanes kept separate** (scalar `SettingSpec`, pointer `BindingSpec`, provisionable `ResourceRequirement`) — must not collapse to one generic config table. Registry-driven `SUBSYSTEMS` + `validate_registry`. Diagnostics registry + composed health snapshot + persistent findings (mig 057). Confirmation-first provisioning (`ProvisioningPreview` + mandatory `confirmed=True`).
+
+**Redesign** — Fold `SUBSYSTEMS` + `SubsystemSchema` + `hub_registry` + `help_catalogue` metadata into one typed **SubsystemManifest**. Ad-hoc embed builders + `clamp_embed` + `home_embed_frame` → one **EmbedFrame**. Repeated defer/auth/mutate/audit/render callbacks → **PanelActionSpec** + **SelectorSpec** + **ConfirmationSpec** executors. Non-serializable navigation closures (`BackTarget`/`chain_back`) → serializable **NavigationSpec** with stable custom_ids + click-time recheck. Ad-hoc diagnostics providers → typed **DiagnosticProviderSpec**. **Five divergent mutation results + three preview shapes → one WorkflowResult / MutationPreview grammar.** `help_ctx_shim` → explicit **PanelContext**. `BaseView` → **PanelRuntimeView**.
+
+**Drop** — Duplicate back buttons / one-off nav where `views.navigation`/`BaseView` already express the contract. Raw `discord.ui.View` subclasses lacking documented+test-pinned lifecycle (13 flagged: `LogChannelSelectView`, `ChannelSettingSelectView`, `_ChannelListPaginatorView`, `NumericPresetsView`, `RoleSettingSelectView`, `SetupLauncherView`, `StrategyReviewView`, `BTD6AdminView`, …). Command-only surfaces with no Help route / hub panel / discoverability metadata. Scattered per-panel permission checks instead of central governance resolution at entry **and** every callback. Direct DB writes from cogs/views and raw SQL outside db owners (`automation_scheduler.py`, `binding_backfill.py` flagged). Treating stale planning docs as truth.
+
+### Admin / safety / server-management
+
+**Preserve** — `SettingsMutationPipeline.set_value` (validation+authority+audit+event+cache-invalidation). `BindingMutationPipeline.set_binding/clear_binding` (`subsystem_bindings` rows + binding-changed events). `ResourceProvisioningPipeline` create-or-bind with **no silent auto-create**, binds through `BindingMutationPipeline`, audits success/fail/decline. `moderation_service` owns warn/timeout/kick/ban/unban/clear + auto_delete, all emit `EVT_MOD_ACTION` identical payload (`:361-629`). `message_pipeline` ordered stages route `ModerationActionDescriptor → auto_delete`; deleted msgs never reach XP. `server_logging` as fail-safe bus subscriber (swallows exceptions, `subscriber_errors` counter). `setup_operations.apply_operations` sole minter of `setup_delegate` actor_type, re-verifies live setup access (`:749/793`, pinned by `test_setup_delegate_actor_boundary`). `actor_holds_capability` central check (target-guild membership, platform-owner override, admin floor, revoke overlay, setup-delegate). `ChannelLifecycleService`/`RoleLifecycleService` preview/apply for destructive ops. `lifecycle/contracts.py` typed `StepResult`/`LifecyclePreview`/`LifecycleResult`. `subsystem_bindings` (mig 022) as durable resource-id owner. Capability-string gates (`logging/moderation.settings.configure`, `cleanup.policy.configure`, `proof_channel.settings.configure`). Read-only diagnostic/platform hubs; `FlagManagerView` as the mutating exception routed through the rollout pipeline.
+
+**Redesign** — Logging UI lives under `cogs/logging/` with **no `views/logging/` dir** → move into a generated settings/bindings panel family. Legacy channel-id logging settings run parallel to `BindingSpec`s → make binding rows the single route-truth, demote settings to compat read-aliases. Moderation & security lack the preview/result vocabulary channels/roles have → add **ModerationActionSpec/SecurityActionSpec** modeled on `lifecycle/contracts.py`. Scattered `has_permissions(administrator=True)`/`guild_permissions`/owner checks → one **AdminActionSpec**/capability resolver re-checked at every mutating callback. One-off selectors/modals → shared resource-picker / settings-editor / confirmation primitives. automod/security/welcome/counters/proof_channel have settings but **no view dir** → generated panels driven by `SettingSpec`.
+
+**Drop** — Direct Discord mutations from cogs/views (`guild.create_*`, `channel.delete`, `member.add_roles`) — grandfather legacy only. Direct legacy-KV writes and direct `subsystem_bindings` writes bypassing audit/event/cache. Duplicate setup paths (quicksetup, wizard, hub panels, per-cog config) → compile to setup-draft operations. Decorator-only authority (hub/help reach a panel without the command decorator). Command-only/admin-only hidden config for automod/security/welcome/counters. Inconsistent destructive confirmations (some preview+confirm, older panels one-shot delete).
+
+### Community / economy / progression / games
+
+**Preserve** — **INV-F** (every coin mutation through `economy_service.credit/debit/transfer/bet_and_settle/refund` → `economy_audit_log` mig 014, AST-enforced). **INV-G** (every XP mutation through `xp_service.award/reset/import_level`; `xp.level_up → community_spotlight` real subscriber `cog:254`). **INV-K/karma** (every grant through `karma_service.give`: no-self, per-pair cooldown, per-giver daily cap; emits `karma.granted`). `audit.action_recorded` shared publisher (import-invisible wiring — preserve by grep, not import graph). `game_wager_workflow.settle_pvp/refund_pvp` escrow/refund seam (blackjack + RPS). `game_state_service.save/load/clear/list_stale` checkpoints (mig 015/018) + TTL + cleanup. Pure engines with no Discord/DB imports (`blackjack_engine`, fishing/mining/creature/farm math+catalog). `SUBSYSTEMS.parent_hub` ↔ `HUBS.primary_children` roster (CI-tested `test_every_hub_primary_children_match_parent_hub_filter`). **The existing declarative layer `subsystem_schema.py`** — build on it. `SettleOnceMixin` (`terminal_guard.py:44`) idempotent settlement.
+
+**Redesign** — Mother-hub navigation via registry discovery (`discover_game_children`/`discover_community_children`) → one **HubRoute** grammar. Fragmented back-nav (`BackToPanelButton` + `attach_back_to_{games,economy,community}_button`) → one route-aware Back/Home/Help/Rules slot set. `BlackjackPanelView` → canonical **GamePanel** composition. `UnifiedInventoryView` + `_group_page_by_rarity` → shared **BrowserView**. `LeaderboardView` `rank_providers` → per-domain **LeaderboardSpec**. `CreatureDexView` → generic **CollectionDexSpec**. `RodRecipeBrowserView` + mining recipes → generic **CraftingRecipeSpec** browser. `farm_workflow` idle accrual → **IdleAccrualSpec**.
+
+**Drop** — Mixed view bases with no shared game/session base (casino poker, `FishingCastView`, solo `BlackjackView` extend raw `discord.ui.View`; hubs use `HubView`/`PersistentView`; browsers use `BaseView`). Per-game reinvented challenge/session lifecycle (accept/decline/timeout/settle-once/stale) duplicated across blackjack/RPS/deathmatch/creature/casino. Inventory UX split from item ownership (generic `utils/db/inventory.py` vs vertical stores). Command-only product surfaces not reachable from panels. In-cog view classes (`SpotlightView`/`GamesView`, `ChainMenuView`) instead of shared primitives. Ad-hoc audit reason strings / event names instead of typed enums.
+
+### AI / knowledge-data / tooling / ops
+
+**Preserve** — `AIGateway` as the single provider-IO choke point (select + fallback + payload/system-prompt/tool-result redaction + degraded reply + diagnostics). Typed AI boundary in `contracts.py` (12 classes). **Invariant: exactly one passive responder** — AI cog stays unregistered so `natural_language_stage` is the sole passive path (`:6`). Answer-review durable loop (`ai_review_log` mig 100 + `utils/db/ai_review.py` + service + cog + `views/ai/panel.py`). Preset reuse loop (`ai_answer_presets` mig 102, redaction/normalization **before** DB). Redaction crossing every model input/output/tool-arg/tool-result and every stored row. BTD6 provenance stack (`btd6_source_registry` freshness/trust/health + `btd6_data_blobs.sha256` + source-labelled render dataclasses with length caps). `btd6_view_model_service` UI read-model. AI config read projection kept separate from mutation seam (mig 039). External-data refresh opens a reviewable PR, never pushes to main. Shared `git_merge_state.py` + one `code-quality.yml` with named gates. Generated agent-context packs from `docs/agent/index.yml` + `context_map.py`.
+
+**Redesign** — Declarative provider/model routing as **TaskProfile** (today split across `routing.py` + `feature_flags.py` + `AI_*` env + settings). Split monolithic `natural_language_stage` into **NaturalLanguageRouter** + per-domain **KnowledgeRouter**. Collapse per-service freshness into one **SourceProvenanceSpec**. One **IngestionPipeline** shared by BTD6/ProjMoon/YouTube. **Relocate `AIGateway` out of `core/` so it stops importing services** (`gateway.py:51 from services import metrics` is the live boundary break). Shared diagnostics panel + help route for AI/BTD6/media (not command-only). Generalize `context_map.py`/`wiring_map.py` beyond `disbot/` (exit-2 on non-disbot today). Stable **ViewModelContextHandle** reused across UI/AI/evals. Give ProjMoon + YouTube the same explicit **KnowledgeDomainSpec** BTD6 effectively has (incl. YouTube cache TTL / transcript source / video-id normalization).
+
+**Drop** — Ungrounded "AI already knows game facts" answer paths (route deterministic questions through facts, not the model). Unlabelled cross-source merges (wiki-derived vs game-dump vs DB). Live external API inside unit/eval paths (evals must run offline/deterministic — use `deterministic_provider.py`). Command-only diagnostics with no operator panel. PAT-heavy/bespoke auto-merge machinery where GitHub-native auto-merge + branch protection suffice. Raw `discord.ui.View` in `views/btd6/admin_panel.py` + `strategy_review.py` (tracked debt). Provider behavior hidden behind env with no runtime settings projection/diagnostics.
+
+## 5. Backward-compat contract (the migration hazard set)
+
+The union of what **breaks persisted state or the Discord routing surface** if the rebuild changes it. This is the cross-domain output the design must freeze before touching a schema.
+
+**1. Persisted `subsystem_registry` keys (rename = data loss).** `SUBSYSTEMS` keys (`admin, server_management, moderation, economy, inventory, treasury, ticket, mining, settings, diagnostic, help, …`) are load-bearing across DB rows, governance policies, help overrides, settings groups, bindings, and capability strings. `HUBS.primary_children` **must equal** `SUBSYSTEMS.parent_hub` filter (CI-tested) — generate one from the other.
+
+**2. Persistent `custom_id` strings = a Discord routing API (must stay verbatim).** All verified: `nav:help`, `nav:hub:<subsystem>`, `help:back`, `help_categories:select`, `settings_hub.{subsystem_select,page_prev,page_next,needs_setup,invalid,missing_bindings,audit,command_access}`, `settings_missing_bindings.back`, `settings_invalid.back`, `settings_subsystem.back_to_hub`/`open_panel`, `settings:back`. `ServerManagementHubView`, `EconomyPanelView`, `MiningHubView`, tickets/role-menus/logging/setup launchers, and `views/ai/` (`panel.py`, `support_report.py` — **unmapped, extract before rebuild**) all carry persistent IDs. **A clean repo needs a central custom_id registry**, and a **versioned scheme** for dynamic game-session IDs (blackjack/RPS/creature).
+
+**3. Event names + payload shapes (the cross-service contract).** All are `EVT_*` constants mirrored in `core/events_catalogue.py`: `moderation.action_taken`, `audit.action_recorded`, `settings.changed`, `resource.provisioned`, `role.lifecycle_changed`, `channel.lifecycle_changed`, `security.raid_detected`, `security.account_flagged`, `image_moderation.flagged`, `welcome.member_greeted`, `counters.updated`, `automation.rule_changed`, `ticket.opened`, `xp.level_up`, `karma.granted`. Payloads are **untyped kwargs**; a result flag like `event_emitted` means *publish-accepted only, not delivered*. **Drift risk:** `governance.visibility/cache/cleanup.changed` are defined `EVT_*` with **no `bus.on` subscriber found**. Freeze these payload shapes: `EVT_MOD_ACTION`/mod_logs, settings-mutation audit, `resource_provisioning_audit` (mig 030), lifecycle audit, feature-flag audit, ticket audit.
+
+**4. DB migrations / tables (ordering-load-bearing).** Fixed numbers own live tables: `022 subsystem_bindings`, `030 resource_provisioning_audit`, `031 setup_session`, `035 setup_draft_operations`, `039 ai_policy` (5 policy tables), `040/041/048/054 BTD6` (incl. `btd6_data_blobs.sha256` provenance), `049 youtube_video_cache`, `057 operational_health_findings`, `069 setup_delegate_actor_type`, `092 guild_treasury`, `098 tickets`, `099 setup_session_essential_anchor`, `100 ai_review_log`, `102 ai_answer_presets`; economy/game set `003/005/014/015/018/019/065`; `019` **dropped `rps_matches`** — RPS state lives in `game_state_service`, **do not port a matches table**. A clean rebuild deriving a smaller schema **must plan a data migration off these**. Seed/refresh ordering: source registry → facts → snapshots → source health; ingestion run/audit before health; evals after data refresh.
+
+**5. Settings keys (externally observable).** Legacy KV keys in `utils/settings_keys/*` (`moderation, cleanup, automod, image_moderation, security, welcome, counters, logging, karma, ai`) are migration data — **a rebuild needs an import/alias map**. `settings_keys` constants are the **only** valid keys into `db.get_setting` (never raw strings). Per-subsystem `cogs/*/schemas.py` keys are a persisted contract (blackjack reads `default_entry_fee`). **Hard semantic invariant: empty `capability_required` in `SettingSpec`/`BindingSpec` means ADMINISTRATOR floor, not anonymous access — must not be reinterpreted.**
+
+**6. Actor types / audit invariants.** `actor_type='setup_delegate'` is minted **only** in `apply_operations` and guarded by `test_setup_delegate_actor_boundary` — payload/actor-type shape is a hard contract. Sole-writer invariants INV-F (coins), INV-G (XP), INV-K (karma) are AST-enforced — every rebuild mutation must go through the audited seam or CI reddens. `subsystem_bindings` rows are durable resource-id persistence; teardown/import must be explicit. Platform-owner bypass exists via `config.is_platform_owner` (`config.py:46`).
+
+**7. AI/knowledge stable identifiers.** `AITask` enum member names must line up with provider/model defaults + settings + eval fixtures + NL routers (rename = multi-surface break). Knowledge context IDs (BTD6 tower/hero/event/leaderboard/fact IDs; ProjMoon entry IDs) must stay stable across UI, AI context, eval fixtures, DB rows. `ai_review_log`/`ai_answer_presets` rows are guild-scoped with **normalized question keys** + redacted question/answer/correction columns — key normalization is a compat contract. BTD6 QA eval corpus assumes a specific data version + source labels — data update without golden refresh reddens evals. `youtube_video_cache` TTL + video-id normalization + transcript-source assumptions.
+
+**8. Env/secrets + CI token assumptions (behavior differs by environment).** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AI_ENABLED`, `AI_DEFAULT_PROVIDER`, `AI_FALLBACK_PROVIDER`, task-routing vars, optional moderation key. **Image moderation must not call OpenAI until guild opt-in**; external call lives in `openai_moderation.py` (honor exempt roles/channels + threshold/category buckets). Routines/reconciliation + some PR-status workflows rely on `ROUTINE_PAT`/elevated perms; default `GITHUB_TOKEN` won't trigger downstream workflows (the auto-merge-enabler recursion-guard class).
+
+**9. Versioned product content.** `data/fishing/fish.json`, `data/creatures/creatures.json`, `data/projmoon/limbus/*.json`, `data/btd6/{towers,heroes}.csv` (**repo root**, not `disbot/data/`) are authoritative content (odds/rewards/entities) — treat schema as **versioned**. Mining inventory doubles as the generic material store for fishing pearls/coral/curios — **item namespace is coupled across games; unifying the catalog must preserve cross-refs.** Restart-safety split: counting/blackjack/RPS in-process state is restart-lossy; only `game_state_service` checkpoints survive — money-safety relies on refund/recovery tests.
+
+## 6. Minimum platform kernel a fresh repo starts with
+
+The ordered foundation all 4 maps imply — build this **before any feature cog**; each layer depends only on those above it.
+
+1. **`utils/` + `utils/db/` + migrations runner.** DB access seam (`asyncpg`-only in `utils/db/`; never `pool.execute()` outside it) + `settings_keys` constants. Nothing else may touch SQL.
+2. **`EventBus` + `KNOWN_EVENTS` catalogue** (`on/off/emit/registered_events/delivery_stats`) with the catalogue as source-of-truth and a catalogue↔subscriber drift check.
+3. **Lifecycle phase machine** (7 phases) + `can_accept_commands` admission gate, and the **managed task registry** (`spawn/cancel_all/cancel_by_prefix`) with diagnostics self-registration (INV: `create_task → tasks.spawn`).
+4. **`governance/capability`** — `actor_holds_capability` + `CapabilityDecision` (target-guild membership, platform-owner override, ADMINISTRATOR floor, revoke overlay, setup-delegate). The single authority seam, re-checked at every callback.
+5. **Audited mutation seam** — `emit_audit_action` fan-out + the **WorkflowResult / MutationPreview / ConfirmationSpec** grammar, so every write is previewable, audited, event-emitting, and cache-invalidating from day one.
+6. **`subsystem_schema` config lanes** (`SettingSpec` / `BindingSpec` / `ResourceRequirement`) + the unified **SubsystemManifest/RouteRegistry** + `validate_registry`, with `HUBS` generated from `SUBSYSTEMS`.
+7. **Discord UI kernel** — `PanelRuntimeView` (restart-safe: `timeout=None` + static custom_id, re-registered at startup) + interaction helpers (`safe_defer/safe_followup/safe_edit`) + **EmbedFrame** + a **central custom_id registry** + **NavigationSpec** (never-strand-from-Help/hub) + **PanelActionSpec/SelectorSpec** executors.
+8. **Help-as-projection** (`build_help_catalogue → project_help → HelpProjection` + `HelpRoute/open_route`) derived from the manifest, and **diagnostics registry + health-findings** persistence (mig 057-equivalent) with audience projection/redaction.
+9. **AIProviderGateway relocated *out of* `core/`** (so core imports no services) + typed `contracts.py` boundary + **RedactionContract** + the offline `deterministic_provider` + **EvalHarness** — before any knowledge domain.
+10. **Repo substrate** — `context_map.py`/`check_architecture.py`/`RepoQualityGate` (one `code-quality.yml`, named gates), **AgentContextPack** generation, and **WorkflowRoutineSpec** — the self-improving-workflow layer that is itself the primary artifact.
+
+## 7. Open questions for the Fable design
+
+1. **The `ActionSpec` rename (blocking, repo-wide).** The UI action primitive collides with shipped `automation_registry.ActionSpec`. Choose one and apply it **before any domain adopts the shared primitive**: `PanelActionSpec`/`UIActionSpec` (rename, keep automation's `ActionSpec`), or a single unified `ActionSpec` grammar covering both UI-button and automation-action semantics (are they really one concept? the maps say no). This decision gates Parts 1–3.
+2. **One manifest vs. split registries.** `SubsystemManifest` (P1), `RouteRegistry` (P3), and `KnowledgeDomainSpec` (P4) are three names for "the one declarative source." Do they unify into a single manifest with facets (metadata / routing / knowledge-domain), or stay as a small family? Either way they **must extend the shipped `subsystem_schema.py` + `subsystem_registry` + `hub_registry`** — not greenfield parallel infra (the P3 PARTIAL correction).
+3. **Legacy-KV vs. `BindingSpec` route-truth.** Logging (and other domains) run channel-id settings **in parallel** with binding rows. Which becomes authoritative in the rebuild, and what is the exact import/alias map that lets old `settings_keys` rows read through the new binding as compat aliases? (Affects the mig-005-style data migration.)
+4. **INV-K disambiguation.** `INV-K` names **two** invariants in source (`architecture.md:136` task-spawn; `ownership.md:36` karma sole-writer). The cross-domain invariant taxonomy must rename one before it becomes a rebuild contract.
+5. **Settings safe-default policy.** The empty-`capability_required`→ADMINISTRATOR-floor rule must survive verbatim. Beyond that: does a freshly-provisioned subsystem default its settings **ON** (discoverable) or **OFF** (opt-in) — and how does that interact with the "no silent auto-create" provisioning invariant and the image-moderation "no external call until opt-in" gate?
+6. **Custom-id versioning scheme.** Static persistent IDs (hubs) vs. dynamic per-session IDs (game challenges) need one scheme that survives restart *and* schema evolution. Include the currently **unmapped `views/ai/` custom_ids** — enumerate them before the rebuild strands an AI panel.
+7. **Where does `AIGateway` live?** It must leave `core/` to stop importing `services` (`gateway.py:51`), while `services/ai_gateway.py` keeps re-exporting the seam. New home: `services/ai/`? A dedicated `ai/` top-level package? This reshapes the layer graph.
+8. **Data migration off fixed migration numbers.** A rebuild deriving a smaller schema must decide: fresh schema + one-time importer from the live `003…102` tables, or carry the numbered chain forward? The `019 drop rps_matches` precedent (state in `game_state_service`, not a table) is the template — which other tables collapse into checkpoints vs. persist?
+9. **Ingestion + eval determinism.** One `IngestionPipeline` for BTD6/ProjMoon/YouTube implies a shared `SourceProvenanceSpec` and a golden-refresh discipline (data bump ⇒ eval-corpus bump). Confirm the offline `deterministic_provider` is the sanctioned eval provider and that no unit/eval path can reach a live API.
+10. **Manifest-generated leaderboard honesty.** `LeaderboardSpec` assumes per-user persisted stats that casino/blackjack/word-chain **don't currently write**. Unified leaderboards need new stat-write seams first — does the rebuild add those writes as part of the game-session primitive (`ChallengeSession`/`GameSessionPersistencePolicy`), or defer honest leaderboards to a later band?

--- a/docs/analysis/rebuild-discovery/community-economy-games-map.md
+++ b/docs/analysis/rebuild-discovery/community-economy-games-map.md
@@ -1,0 +1,423 @@
+# Rebuild discovery map — community, economy, progression, games, and product loops
+
+> **Status:** `historical` — repo-grounded rebuild discovery audit report; source + merged PRs win.  
+> **Audit part:** 3 of 4 — community/economy/progression/games/product loops.  
+> **Date:** 2026-07-02.  
+> **Mode:** repo-grounded rebuild discovery mapping only. No implementation approval. No source edits.  
+> **Allowed output:** this report only.  
+> **Truth order used:** source + merged repo state first; binding docs second; current-state ledgers third; planning/completion/readiness docs as supporting context.
+
+## 1. Executive summary
+
+### Strongest reusable product/game/community ideas
+
+1. **Mother hubs backed by registry metadata.** The current bot has a useful product shape: top-level hubs (`games`, `economy`, `community`, `utility`) plus child subsystems declared in `SUBSYSTEMS.parent_hub` and displayed through `hub_registry.HUBS`. Preserve the idea, but rebuild it as a first-class route graph with one panel grammar, not one-off buttons per cog.
+2. **Audited shared-state writers.** Coins, XP, and karma already have explicit service seams (`economy_service`, `xp_service`, `karma_service`) and invariant tests. This is the most important rebuild foundation: product loops should depend on mutation result objects, not write tables directly.
+3. **Game-specific pure engines plus thin Discord adapters.** Blackjack has `blackjack_engine.py`; fishing/mining/creatures/farm have pure catalog/math modules under `utils/`; creature battle has a service-level simulation. Preserve this split: pure simulation is reusable and testable, while views/cogs should only orchestrate.
+4. **Activity-game progression stack.** Mining/fishing/creatures/farm combine collection, skill/gear growth, unlocks, leaderboards, and repeated short actions. This is the best product depth in the repo and should inform a fresh `ActivityGameSpec` family.
+5. **Collection-first UX.** Fishing catch log, creatures dex, mining inventory/gear/title panels, inventory category browser, and leaderboards prove that SuperBot's strongest user loop is “do a small action → gain a resource/record → view progress → improve odds/output.”
+6. **Shared restart-safety ideas.** `game_state_service` and migrations `015`/`018` give a good checkpoint pattern for persistent pending games. RPS/blackjack use it for tournaments or pending sessions; other games deliberately use persistent per-player progression instead of preserving every ephemeral interaction.
+7. **Visual cards and panels.** Leaderboard cards, mining paper-doll/gear renders, world cards, and compact embeds make progression tangible. Rebuild should treat card rendering as a reusable capability with graceful fallback.
+
+### Best progression loops
+
+- **Daily/recurring economy:** `!daily`, work jobs, balance, shop, peer `give/pay`, and treasury contribution/disbursement are straightforward social currency loops.
+- **Mining:** mine/explore/dig/descent → collect ores/resources → sell/craft/equip/repair/build structures → improve depth/capacity/stats/title → leaderboard/world identity.
+- **Fishing:** cast/reel minigame → catch species/weight/drops → energy/rod/bait/venue/weather/gear affect odds → craft rods/baits/charms/curios/structures → fish log/trophies/leaderboard.
+- **Creatures:** catch → collection/dex → XP/levels → level-normalized PvP → records/leaderboards/rematch.
+- **Farm:** idle eggs accrue while away → collect once → buy chickens/upgrade coop → flock-size leaderboard.
+- **Counting/chain:** channel community challenge loops with persistent channel state and scoreboards.
+- **Competitive games:** blackjack, RPS, deathmatch, and casino provide session/challenge/tournament patterns; strongest reusable pieces are challenge acceptance, set-once settlement, tournament registration, rules buttons, and post-game replay/back navigation.
+
+### Best economy/inventory/collection mechanics
+
+- **Audited `economy_service` methods** (`credit`, `debit`, `transfer`, `bet_and_settle`, `refund`, transaction variants) should become an `EconomyLedger` with typed reasons, actor/context, idempotency, and event emission.
+- **Inventory as an aggregation layer** is useful but currently split: generic `utils/db/inventory.py` plus mining/fishing stores. A rebuild should unify item catalogs, ownership, quantity, rarity, value, use action, crafting, and display metadata.
+- **Crafting recipes** are rich across mining (`recipes.py`, forge/workshop), fishing (`bait`, `rods`, `curios`, charms), and structures. Extract `CraftingRecipeSpec` and `CostVector` primitives.
+- **Collection/dex/logbook** should be common: fish species + best weight, creature dex + elements, mining item categories/titles, curios/cosmetics.
+- **Leaderboards** already aggregate XP, economy, creatures, fishing, farm, counting, and other providers. Rebuild should use `LeaderboardSpec` per domain with ranking key, tie-breakers, empty states, privacy, and card renderer.
+
+### Biggest fragmentation to avoid
+
+- **Panel grammar fragmentation:** hubs use `HubView`, some game panels use custom `discord.ui.View`, some browsers use `BaseView`, and many commands still build custom ephemeral/public behavior.
+- **Inventory fragmentation:** generic inventory, mining inventory, equipment, fishing bait/rod/venue/energy, creature logs, and farm state are separate vertical tables and browsers. That may be fine internally, but the product layer should expose one inventory/collection grammar.
+- **Game session fragmentation:** challenge flows, timeouts, stale-state behavior, persistent checkpoints, and settle-once logic are reimplemented differently in blackjack, RPS, deathmatch, creatures, casino, counting, and chain.
+- **Economy mutation fragmentation risk:** source mostly enforces economy writes through service, but mining/fishing/farm have direct inventory/resource writes and game-specific coin/cost paths. Rebuild should make coin, item, and XP mutation seams equally explicit.
+- **Leaderboards are provider-like but not fully standardized:** several games still cannot join unified leaderboards because they lack per-player persisted stats.
+- **Public/ephemeral and back/help/hub behavior is inconsistent:** good conventions exist, but every new game currently has to rediscover them.
+
+## 2. Source route and verification
+
+### Docs read or sampled
+
+Binding and orientation docs:
+
+- `.claude/CLAUDE.md`
+- `docs/collaboration-model.md`
+- `docs/current-state.md`
+- `docs/current-state/S1-bot.md`
+- `docs/AGENT_ORIENTATION.md`
+- `docs/architecture.md`
+- `docs/ownership.md`
+- `docs/runtime_contracts.md`
+- `docs/repo-navigation-map.md`
+- `docs/repo-review-map.md`
+- `docs/ultracode/README.md`
+- `docs/subsystems/games.md`
+- `docs/planning/feature-completion/README.md`
+- `docs/planning/feature-completion/units/blackjack.md`
+- `docs/planning/production-readiness/*` was searched for relevant game/economy/readiness references.
+
+Key doc facts used:
+
+- Architecture defines services as audited cross-subsystem mutation paths and names INV-F/INV-G for economy/XP sole-writer invariants.
+- Runtime contracts name `economy_audit_log` as durable and in-process counting/blackjack/RPS as expected restart-loss areas, with refunds/recovery for some stakes.
+- Repo navigation maps the cogs/views/services/DB ownership for each subsystem in this report.
+- Completion ledger has every in-scope unit assessed, but none owner-certified as complete as of the repo snapshot.
+- Current-state records recent additions such as karma reaction grants, inventory detail density/sort/filter, fishing rod recipe browser, farm and fishing leaderboard providers, peer economy transfer, creature panel/dex, blackjack PvP bet selector/edge tests, and owner-gated inventory item-action/capability cleanup gaps.
+
+### Source roots inspected
+
+- Cogs: `disbot/cogs/economy_cog.py`, `inventory_cog.py`, `treasury_cog.py`, `xp_cog.py`, `karma_cog.py`, `leaderboard_cog.py`, `community_cog.py`, `community_spotlight_cog.py`, `general_cog.py`, `four_twenty_cog.py`, `games_cog.py`, `blackjack_cog.py`, `casino_cog.py`, `deathmatch_cog.py`, `rps_tournament_cog.py`, `counting_cog.py`, `chain_cog.py`, `mining_cog.py`, `fishing_cog.py`, `creature_cog.py`, `creature_battle_cog.py`, `farm_cog.py`, `help_cog.py`.
+- Views: `disbot/views/economy/`, `treasury/`, `xp/`, `games/`, `blackjack/`, `casino/`, `community/`, `counting/`, `creature/`, `creature_battle/`, `farm/`, `fishing/`, `mining/`, `rps/`.
+- Services: `economy_service.py`, `treasury_service.py`, `xp_service.py`, `karma_service.py`, `blackjack_engine.py`, `blackjack_state.py`, `blackjack_persistence.py`, `mining_workflow.py`, `fishing_workflow.py`, `creature_workflow.py`, `creature_battle_service.py`, `farm_workflow.py`, `game_state_service.py`, `game_xp_service.py`, `chain_service.py`.
+- DB helpers: `disbot/utils/db/economy.py`, `inventory.py`, `treasury.py`, `xp.py`, `karma.py`, and `disbot/utils/db/games/*` for chain/counting/creatures/creature battles/deathmatch/farm/fishing/mining/RPS/game state/game XP.
+- Pure data/math/catalogs: `disbot/utils/mining/*`, `disbot/utils/fishing/*`, `disbot/utils/creatures/*`, `disbot/utils/farm/*`, `disbot/data/fishing/fish.json`, `disbot/data/creatures/creatures.json`.
+- Registries: `disbot/utils/subsystem_registry.py`, `disbot/utils/hub_registry.py`.
+- Tests: relevant `tests/unit/cogs`, `tests/unit/services`, `tests/unit/db`, `tests/unit/invariants`, `tests/unit/utils`, and `tests/unit/views` suites listed by file discovery.
+
+### Commands run and results
+
+- `find /workspace -name AGENTS.md -print` — no `AGENTS.md` files found under `/workspace`.
+- `git status --short` — clean before report creation.
+- `sed -n ...` over the required docs — succeeded; output was large and partially truncated in the terminal transcript, so subsequent targeted `rg`/source reads were used.
+- `gh pr list --state open --limit 20 --json number,title,headRefName,author,url` — failed: `gh: command not found`. Open PR status could not be verified with GitHub CLI from this container.
+- `rg -n "production-readiness|economy|inventory|..." docs/...` — succeeded; found relevant current-state/readiness references.
+- `python3.10 scripts/context_map.py <target>` for all six required targets — failed before execution because `python3.10` is not available on PATH under the active pyenv shim: `pyenv: python3.10: command not found` and it notes version `3.10.20` exists.
+- `~/.pyenv/versions/3.10.20/bin/python scripts/context_map.py <target>` for all six required targets — failed with `ModuleNotFoundError: No module named 'yaml'`.
+- `python3.10 scripts/check_architecture.py --mode strict` — failed for the same pyenv shim issue: `python3.10: command not found`.
+- `python3.10 scripts/check_docs.py` — failed for the same pyenv shim issue: `python3.10: command not found`.
+- `python scripts/check_architecture.py --mode strict` — succeeded as a fallback: 0 errors, 49 tracked warnings.
+- `python scripts/check_docs.py` — initially reported the new report missing a status badge/orphan link; after marking this report `historical`, it passed all checks.
+- `find disbot/cogs disbot/views disbot/services disbot/utils/db ...` — succeeded; produced the scoped file inventory.
+- `rg -n "^(class|def|async def) " ...` — succeeded; produced cogs/views/services function/class inventory.
+- Python AST snippets using default `python` — succeeded for registry extraction where possible.
+
+### Open PR / active gate status
+
+- **Open PRs:** not verified; GitHub CLI is unavailable in this container. Treat PR #1509, if still open, as advisory only per prompt. No source claims in this report depend on PR #1509 being merged.
+- **Completion gate:** all in-scope units are `assessed` in `docs/planning/feature-completion/README.md`; none are owner-certified. That is a product/completion status, not a prohibition on source mapping.
+- **Owner/live gates observed from current-state/certs:** inventory item actions and some content/art/live walkthrough items remain owner-gated; blackjack certification still needs owner decisions/live walkthrough; live Discord verification was not performed.
+- **No active source off-limits gate found** for mapping these lanes. Owner-gated art/content/data is noted as a verification limit, not used as proof.
+
+### Verification limits
+
+- No live Discord or production database access.
+- No GitHub CLI; open PR verification unavailable.
+- Required `context_map.py` and check scripts could not run under requested command because of local Python/pyyaml environment issues.
+- This is a static source/docs audit; UI behavior is inferred from code and tests, not clicked live.
+- Source line numbers are intentionally not embedded in this report because it is a design map; final response will cite changed report lines.
+
+## 3. Product surface inventory
+
+Legend for current state: **Done** = implemented enough to map from source/tests; **Partial** = functional with known gaps/fragmentation; **In-flight/gated** = source/docs name remaining owner/live/content work; **Unclear** = needs live/prod or PR verification.
+
+### Economy and inventory
+
+| Subsystem | Registry key | Parent hub/group | Entry commands | Views/panels/modals/selectors | Services/engines | DB/tables/migrations | Settings | Events/audit | Tests | Current state |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Economy hub/currency | `economy` | top-level hub | `economymenu`, `daily`, `work`, `balance`; current-state also names `give/pay` | `EconomyPanelView`, `attach_back_to_economy_button`, work/shop subviews, job/shop selects, work result view | `economy_service`, `economy_flow_service`, `economy_helpers` | `utils/db/economy.py`; migration `014_economy_audit_log.sql`; core economy balance tables are referenced in architecture/runtime docs | `cogs/economy/schemas.py`; `settings_keys/economy.py` | `economy_audit_log`; service emits balance/audit events; INV-F invariant | `test_economy_service*`, `test_economy_db_txn`, `test_economy_flow_service`, `test_economy_log_channel_pipeline`, view tests | **Done/Partial** — core loop strong; rebuild should preserve audit seam and simplify UI grammar. |
+| Inventory | `inventory` | `economy` | `inventory` | `UnifiedInventoryView`, `_CategoryView`, category/detail pages, sort/filter selects/buttons; no separate `views/inventory/` directory found | Mostly cog/read aggregation; mining/fishing workflow mutate game inventories | `utils/db/inventory.py`; mining/fishing inventory-like tables under `utils/db/games/*` | no dedicated schema found in scoped files | direct inventory DB helpers; owner-gated audit/capability cleanup named in current-state | `test_inventory_display_logic`, `test_economy_inventory_edit`, inventory view/cog tests | **Partial/gated** — browser is rich, actions/audit model not fully unified. |
+| Treasury | `treasury` | `economy` | `treasury` | `views/treasury/menu.py`, `TreasuryMenuView`, `ContributeModal`; Economy treasury button | `treasury_service` | `utils/db/treasury.py`; migration `092_guild_treasury.sql` | no dedicated schema found | transfers member coins into server pool; disbursement gated to managers; should audit via economy/treasury DB | `test_treasury_service`, `test_treasury_cog`, `test_treasury_contribute_modal`, economy treasury button test | **Done/Partial** — good collective economy idea; rebuild needs explicit server-wallet ledger primitive. |
+
+### Progression and community
+
+| Subsystem | Registry key | Parent hub/group | Entry commands | Views/panels/modals/selectors | Services/engines | DB/tables/migrations | Settings | Events/audit | Tests | Current state |
+|---|---|---|---|---|---|---|---|---|---|---|
+| XP & levels | `xp` | `community` | `xpmenu`, `rank` | `views/xp/main_panel.py`, config/import panels, rank view, modals | `xp_service`, `xp_role_sync`, `xp_helpers`, `xp_migration` | `utils/db/xp.py`; migration `003_role_xp_thresholds.sql`; XP tables | `cogs/xp/schemas.py`, `settings_keys/xp.py` | `xp_service.award/import/reset`; `xp.level_up` feeds spotlight; INV-G sole writer | XP cog/listener/service/import/rank tests and invariant | **Done/Partial** — strong general progression seam; needs fresh `ProgressionTrackSpec`. |
+| Karma | `karma` | `community` | `thanks`, `karma` | mostly cog embeds/cards; no `views/karma/` directory found | `karma_service`, `karma_config` | `utils/db/karma.py`; migration `093_karma.sql` | `cogs/karma/schemas.py`, `settings_keys/karma.py`; `karma.reaction_emoji` opt-in | audited `karma_service.give`, cooldown/daily cap/self-protection; reaction source | `test_karma_service`, `test_karma_reaction`, schema tests, INV-K invariant | **Done/Partial** — good social reputation loop; UI less panelized than XP. |
+| Leaderboards | `leaderboard` | `economy` with community cross-link | `leaderboard`, `lb` | `LeaderboardView`, provider select, card rendering | provider/read-only aggregation inside cog/rank providers | reads XP/economy/game DB modules; no single leaderboard table | n/a | read-only | `test_leaderboard_card`, empty states, provider tests in game units | **Done/Partial** — valuable aggregation; some games need persisted per-user stats first. |
+| Community hub | `community` | top-level hub | `community` | `CommunityHubView`, dynamic child buttons, back-to-community helper | hub discovery only | registry driven | n/a | no business mutations | `test_community_hub_view` | **Done** as navigation; rebuild should keep dynamic discovery. |
+| Community spotlight | `community_spotlight` | `community`/activities | `spotlight` | in-cog `SpotlightView`, `GamesView`, `_GameSelect` | read-only rank providers; EventBus `xp.level_up` feed | reads `utils/db/xp.py` and game providers | no dedicated schema found | reacts to XP/rank events | `test_community_spotlight_cog` | **Done/Partial** — good “show active community” idea; panel lives in cog. |
+| General | `general` | `utility` | `generalmenu` | in-cog panel, trivia reveal view, 8-ball modal | content loader only | no scoped DB | content JSON/static | no audit | general cog tests if present | **Done/Partial** — utility/social mini-features, not core rebuild priority. |
+| 420 easter egg | `four_twenty` | `utility` | `420`, `fourtwenty` | `_FourTwentyPanelView`, stage/content | content loader/stage | static content/assets | none | none | not central | **Acceptable specialization**; mention only as reusable content-panel pattern. |
+| Utility hub | `utility` | top-level hub | `utilitymenu`, `myprofile`, `avatar`, `serverinfo`, `ping` | utility/general views if present; general/four_twenty children | mostly cog utilities | no scoped DB | none | none | utility/general tests | **Done/Partial** — out of core scope except profile/status UX. |
+
+### Games hub and competitive/activity games
+
+| Subsystem | Registry key | Parent hub/group | Entry commands | Views/panels/modals/selectors | Services/engines | DB/tables/migrations | Settings | Events/audit | Tests | Current state |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Games hub | `games` | top-level hub | `games` | `GamesHubView`, `_GameHubButton`, no-panel embed, back-to-games helper | registry discovery | registry only | none | no business mutation | `test_games_cog`, `test_games_hub_view`, common/back tests | **Done** as navigation; actionability contract is important. |
+| Blackjack | `blackjack` | `games`/competitive | `blackjack`, `bj` | `BlackjackPanelView`, bet preset/custom modal, challenge opponent/bet pickers, solo/PvP/tournament views, result/replay/back | `blackjack_engine`, `blackjack_state`, `blackjack_persistence`; cog state | `game_state` checkpoints; no dedicated bankroll table; economy audit for coins | `cogs/blackjack/schemas.py` (`default_entry_fee`) | solo via `economy_service`; PvP/tournament via wager/escrow/refund; settle-once tests | engine, solo/PvP/tournament persistence, edge cases, panel stake picker, settle-once, replay | **Done/assessed; not certified** — best competitive-game template; split/insurance/surrender/live owner items remain. |
+| Casino/poker | `casino` | `games`/competitive | `casino`, `poker`, `holdem` | `CasinoHubView`, `PokerLobbyView`, `SeatLobbyView`, `PokerSeatView`, action buttons | in-view poker table/session | in-memory/ephemeral play chips per current-state; no persisted per-player stats | no schema found | no real economy audit; ephemeral chips | `test_casino.py` | **Partial** — fun session pattern, weak rebuild foundation unless formalized. |
+| Deathmatch | `deathmatch` | `games`/competitive | `deathmatch`, `dm` | `DeathmatchPanelView`, bot duel, PvP challenge/result views | cog duel state; mining/equipment stats and wear | `utils/db/games/deathmatch.py`; mining equipment/wear dependencies | `cogs/deathmatch/schemas.py` | gear wear ticks; no default coin staking yet | deathmatch bot/challenge/combat/gear/guild/PvP tests | **Done/Partial** — good gear-dependent combat loop; rebuild should isolate `CombatResolver`. |
+| RPS tournament/PvP | `rps_tournament` | `games`/competitive | `rps` | RPS panel, solo play/replay, PvP challenge/play, registration/move picker | tournament helpers/rules/stage; in-memory + persistence helper | `utils/db/games/rps.py`; migrations `005`, `019`; game_state for pending | `cogs/rps_tournament/schemas.py` | stakes/refunds via economy paths in cog; persistent pending sessions | RPS naming, PvP, pending persistence, tournament persistence/stage, view tests | **Done/Partial** — good challenge/tournament lifecycle; standardize with `ChallengeSession`. |
+| Counting | `counting` | `games`/activities; community cross-link | `count_info`, `counttop`, `countingmenu` | `views/counting/hub_panel.py` with channel/mode selects/toggles/reset/disable/refresh | counting handler/game_logic/parsing/stage/leaderboard | `utils/db/games/counting.py`; migration `005` game PKs | likely counting settings in cog package | channel game events/save outcomes; in-process current state per runtime docs | counting channel/modes/parsing/persistence/leaderboard tests | **Done/Partial** — strong community-channel loop; restart/persistence rules need fresh base. |
+| Word chain | `chain` | `games`/activities; community cross-link | `chainmenu`, `chain` | in-cog `ChainMenuView`, create/delete/limit modals | `chain_service` | `utils/db/games/chain.py`; migration `005` game PKs | none found | service emits mutation events; chain write boundary invariant | chain cog prefix/stage/service/invariant tests | **Done/Partial** — channel game, no per-user leaderboard without new writes. |
+
+### Exploration, collection, and idle games
+
+| Subsystem | Registry key | Parent hub/group | Entry commands | Views/panels/modals/selectors | Services/engines | DB/tables/migrations | Settings | Events/audit | Tests | Current state |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Mining | `mining` | `games`/activities; economy cross-link | `minemenu`, `mine` plus many subcommands | `MiningHubView`, home/market/forge/gear/grid/vault/workshop/skills/titles/recipes/how-to/character/loadout panels, build modal | `mining_workflow`; pure modules for capacity, energy, grid, exploration, rewards, items, recipes, skills, structures, world, titles; renderer | many `utils/db/games/mining*`; migrations `016`, `017`, `060`, `061`, `063`, `066`, `070`, `072`, `073`, `074`, `085`, `086`, `101` | none scoped beyond game settings | direct resource/equipment writes; coin buy/sell through economy; game XP/world identity | extensive mining cog/db/services/utils/views tests and invariant | **Done/Partial** — deepest product loop; also biggest fragmentation source. |
+| Fishing | `fishing` | `games`/activities | `fish`, `fishlog`; current code includes many related commands/buttons | `FishingMenuView`, `FishingCastView`, bait shop, rod shop, rod recipe browser, structures hub, dock/boathouse/fishery/tide pool | `fishing_workflow`; pure modules for fish, bait, rods, energy, venue, weather, weight, rewards, gear, minigame, curios | `utils/db/games/fishing*`; migrations `075`, `076`, `087`, `088`, `091`, `094`, `095`; uses mining inventory for some materials | none found | item/energy/collection writes; economy purchases; game XP | broad fishing workflow/bait/charm/curio/rod/db/utils/view tests | **Done/Partial** — best collection/odds/crafting loop; should become shared `CollectionGameSpec`. |
+| Creatures | `creature` | `games`/activities | `creatures`, `catch`, `dex`, `cbattle`, `cbrecord`, `cbattletop` | `CreatureMenuView`, dex filter/select, challenge select, battle challenge/rematch/render | `creature_workflow`, `creature_battle_service`; pure creature catalog/battle/encounters | `utils/db/games/creatures.py`, `creature_battles.py`; migrations `077`, `082`; data `creatures.json` | none found | collection/PvP record writes; game XP | creature workflow/battle/catalog/menu/challenge/rematch tests | **Done/Partial** — high-value catch+dex+PvP template; needs live owner cert. |
+| Farm | `farm` | `games`/activities | `farm` | `FarmMenuView`, `FarmShopView` | `farm_workflow`; pure farm math/state | `utils/db/games/farm.py`; migration `090_chicken_farm.sql` | none found | idle settle-once collect; economy purchases; leaderboard provider | farm workflow/db/utils/menu tests | **Done/Partial** — cleanest idle accrual model; preserve. |
+| Shared game state | n/a service | used by games | n/a | n/a | `game_state_service`, `game_state_cleanup` | `utils/db/games/game_state.py`; migrations `015`, `018` | TTL constants | checkpoint save/load/clear/list stale; recovery/refund use | `test_game_state_service` | **Done as primitive** — rebuild should formalize session persistence policy. |
+| Shared game XP | n/a service | cross-game | n/a | identity/profile displays | `game_xp_service` | `utils/db/games/game_xp.py`; migration `065_game_xp.sql` | none | `award`, `emit_award_events`, `world_identity` | game XP db/service tests | **Done/Partial** — good cross-game progression primitive. |
+
+### Subsystem registry and help
+
+| Surface | File(s) | Role | Current state |
+|---|---|---|---|
+| Immutable subsystem metadata | `disbot/utils/subsystem_registry.py` | registry key, display name, entry points, visibility, parent hub, hub group, dependencies, capabilities | Strong source of truth; rebuild should make this schema typed/data-driven. |
+| Hub presentation registry | `disbot/utils/hub_registry.py` | top-level hub display/order/children/cross-links | Strong idea; currently separate from route/action specs. |
+| Help catalogue/panels | `disbot/cogs/help_cog.py` and help catalogue services | resolves visible commands, hub panels, back to help | Useful unified discovery layer; rebuild should avoid command-only hidden features. |
+
+## 4. Best ideas/functions/classes to preserve
+
+| Source | Problem solved | User value | Technical value | Rebuild decision | Hidden dependencies |
+|---|---|---|---|---|---|
+| `services/economy_service.credit/debit/transfer/bet_and_settle/refund` | safe coin mutation with audit | trustworthy balances, refunds, wagering | sole writer, transaction variants, audit reasons | **Copy idea, redesign API** as `EconomyLedger`/`CurrencyMutationResult` | DB economy tables, audit log, event bus, invariant tests, reason taxonomy |
+| `services/xp_service.award/import_level/reset` | shared XP mutation and level transitions | consistent rank/progression | sole writer, event emission | **Copy nearly as-is conceptually** into `ProgressionTrackSpec` | XP DB, role sync, level-up events, settings |
+| `services/karma_service.give` | peer reputation with cooldown/caps/self-block | social recognition without spam | audited seam and typed errors | **Copy idea** | karma settings, reaction listener, daily cap/cooldown DB |
+| `services/treasury_service.contribute/disburse` | collective server wallet | community funding/sinks | server-owned balance model | **Redesign around idea** | economy debit/credit, manager permissions, treasury table |
+| `views/economy/main_panel.EconomyPanelView` | central money hub | balance/work/shop/inventory/treasury reachable | persistent hub route | **Redesign around unified hub grammar** | registry, child panels, public/ephemeral choices |
+| `cogs/inventory_cog.UnifiedInventoryView` + `_group_page_by_rarity` | readable mixed inventory browser | large inventory is understandable | pure grouping/sorting helpers | **Copy helper ideas** | item metadata from multiple catalogs; owner-gated actions |
+| `services/blackjack_engine` | pure blackjack math | fair cards/hand values | deterministic unit-tested engine | **Copy nearly as-is** | view/cog game-state; omitted rule decisions |
+| `views/blackjack/solo_view.BlackjackView` and result view | full interactive card loop | hit/stand/double/replay/back | action view + replay pattern | **Redesign around `GameViewBase`** | economy service, timeouts, user authority |
+| `views/blackjack/pvp_view` + `SettleOnceMixin` usage | prevent duplicate settlement | no double payout/loss | idempotent interaction settlement | **Copy idea into `ChallengeSession`** | economy escrow, interaction replay behavior |
+| `views/games/blackjack_panel.BlackjackPanelView` | game-specific landing page | solo/bet/PvP/tournament/rules from one place | reusable panel composition | **Copy pattern, standardize** | games hub back buttons, custom modals |
+| `services/game_state_service.save/load/clear/list_stale` | restart checkpoints for sessions | fewer lost tournaments/pending games | typed-ish JSON state with TTL/version | **Copy idea, strengthen typing** | migrations 015/018, cleanup, recovery code |
+| `services/game_xp_service.award/world_identity` | cross-game identity | global game progression/name/title | reusable game progression | **Copy idea** | game_xp DB, mining titles, profile displays |
+| `services/mining_workflow.mine/explore/dig/craft/buy/sell/equip/save_loadout/build_structure` | deep resource/progression economy | lots to do and optimize | vertical workflow concentrated in service | **Redesign around shared specs** | many mining DB modules, economy, equipment, assets |
+| `utils/mining/grid.py` + `mining_workflow.dig/descend` | deterministic exploration map | spatial mining fantasy | pure seed/grid math | **Copy idea** | guild seed/world DB, depth records |
+| `utils/mining/recipes.py` + recipe browser | crafting visibility | clear next goals | data-driven recipes | **Copy idea as `CraftingRecipeSpec`** | item catalog, inventory source, forge gates |
+| `views/mining/gear_panel` + character render | gear optimization and visual identity | paper-doll/status payoff | renderer fallback, equipment stats | **Redesign around `CardRendererSpec`** | gear assets, Pillow optional, equipment DB |
+| `services/fishing_workflow.begin_cast/commit_catch` | staged cast/reel loop | active minigame with anticipation | separates start parameters from commit | **Copy idea** | energy, bait, rod, weather, venue, gear stats |
+| `utils/fishing/weather/weight/rewards/minigame` | odds modifiers and catch properties | variety and trophy chase | pure math modules | **Copy nearly as-is conceptually** | fish data, balancing docs/tests |
+| `fishing_workflow.craft_bait/craft_pearl_bait/craft_rod/craft_charm/craft_curio` | multiple material sinks | long-term goals beyond selling | repeatable recipes and material consumption | **Extract shared crafting primitive** | mining inventory store, fishing catalogs |
+| `views/fishing/rod_recipe_browser.RodRecipeBrowserView` | live craft progress | users know what to collect next | recipe progress UI | **Copy UX pattern** | eligible-count helpers, fish/material catalogs |
+| `services/creature_workflow.catch` | catch/collect loop | collection progress and random encounters | compact workflow with XP | **Copy idea** | creatures DB/data, game XP |
+| `services/creature_battle_service.build_normalized_team/resolve_pvp` | fair creature PvP | collection can be used competitively | pure normalized battle resolver | **Copy idea** | creature catalog, battle records, challenge UI |
+| `views/creature/menu.CreatureDexView` | filtered collection browser | understand collection gaps | generic dex filter pattern | **Copy as `CollectionDexSpec`** | creature elements/data |
+| `services/farm_workflow.collect/buy_chicken/upgrade_coop` | idle accrual with upgrades | reward for returning | simple settle-once math | **Copy nearly as-is conceptually** | farm DB, economy, time source |
+| `cogs/leaderboard_cog.LeaderboardView` | unified standings | social comparison | provider-like rendering | **Redesign as `LeaderboardSpec`** | per-domain persisted stats, card renderer |
+| `views/games/hub.discover_game_children` / `views/community/hub.discover_community_children` | dynamic hub lists | discoverability | registry-driven UI | **Copy idea** | parent_hub/cross-link contracts |
+| `views/games/common.BackToPanelButton` and hub back helpers | navigation consistency | less dead-end UI | simple reusable component | **Copy and make universal** | panel builder callbacks |
+
+## 5. Game/economy loop extraction and future primitives
+
+### Daily/recurring rewards
+
+- **Current evidence:** economy `daily`, fishing energy regeneration, farm idle egg accrual, XP per message, karma daily caps/cooldowns.
+- **Reusable primitive:** `RewardSpec` with `cadence`, `cooldown`, `cap`, `grant vector`, `audit reason`, and `presentation`.
+- **Fresh-repo target:** recurring rewards should never be ad hoc commands; they should be `RewardClaim` instances with standardized cooldown messaging and audit.
+
+### Work/earn actions
+
+- **Current evidence:** economy work jobs, mining mine/harvest/sell, fishing catches/drops, farm collect, creature catch XP.
+- **Reusable primitive:** `GameActionSpec` (`cost`, `roll`, `rewards`, `state changes`, `cooldown`, `public/private result`).
+- **Fresh-repo target:** every earn action returns a typed result object that views can render consistently.
+
+### Spend/sink actions
+
+- **Current evidence:** shop purchases, mining buy/repair/craft/build/vault upgrade, fishing rods/bait/charms/structures, farm chickens/coops, treasury contributions, blackjack/RPS wagers.
+- **Reusable primitive:** `CostVector` + `EconomyLedger` + `InventoryMutationResult`.
+- **Fresh-repo target:** coin and item spends should share validation, preview, confirmation, and transaction semantics.
+
+### Inventory and item use
+
+- **Current evidence:** `inventory_cog` browser, mining item use/equip/unequip/cook, fishing bait/rod/charms/curios, equipment loadouts.
+- **Reusable primitive:** `ItemCatalogSpec` with item type, rarity, stackability, value, use action, equip slot, source game, display fields.
+- **Fresh-repo target:** separate physical tables may remain, but UI reads from one catalog/index.
+
+### Crafting/upgrades
+
+- **Current evidence:** mining recipes/forge/workshop/structures; fishing bait/pearl bait/rods/charms/curios/structures; farm upgrades.
+- **Reusable primitive:** `CraftingRecipeSpec` and `UpgradeTrackSpec` with requirements, preview, progress, craft result, and failure reasons.
+- **Fresh-repo target:** recipe browsers should be generic and fed by data, not hand-built per game.
+
+### Collection/dex/logbook
+
+- **Current evidence:** fish catch log/species/best weight, creature dex/elements, mining inventory/titles/world identity, curios, farm flock.
+- **Reusable primitive:** `CollectionDexSpec` with discovered/undiscovered, filters, sort, per-entry stats, and completion metrics.
+- **Fresh-repo target:** every collection game gets the same dex, detail page, progress bar, and leaderboard integration.
+
+### Leaderboards
+
+- **Current evidence:** unified leaderboard provider, community spotlight, counting leaderboard, fishing/farm/creature providers, XP/economy standings.
+- **Reusable primitive:** `LeaderboardSpec` with `rank_source`, `metric`, `tie_breakers`, `scope`, `empty_state`, `card_renderer`, `privacy`.
+- **Fresh-repo target:** adding a game leaderboard requires only persisted stats plus a spec.
+
+### PvP challenge flows
+
+- **Current evidence:** blackjack PvP challenge, RPS PvP challenge/move picker, creature battle challenge/rematch, deathmatch challenge, tournament registration.
+- **Reusable primitive:** `ChallengeSession` with participants, stake/escrow, accept/decline/timeout, authority checks, settle-once, rematch, back route.
+- **Fresh-repo target:** one challenge base handles custom IDs, timeouts, persistent checkpoint policy, and duplicate interactions.
+
+### Idle accrual/settle-once flows
+
+- **Current evidence:** farm collect, fishing energy, mining energy, structure effects, cooldown-like work/daily.
+- **Reusable primitive:** `IdleAccrualSpec` with `last_settled_at`, production rate, capacity, modifiers, collect transaction.
+- **Fresh-repo target:** idle games should compute accrual from state at read/collect time, not schedule background grants.
+
+### Pure simulation/math engines
+
+- **Current evidence:** blackjack engine, fishing odds/minigame/weather/weight, mining grid/rewards/energy/capacity, creature battle, farm math.
+- **Reusable primitive:** `GameEngine` modules with no Discord/DB imports and simulation tests.
+- **Fresh-repo target:** every product loop has a pure engine package plus adapter layer.
+
+### Game XP / cross-game progression
+
+- **Current evidence:** `game_xp_service`, mining titles, world identity, game activity awards.
+- **Reusable primitive:** `ProgressionTrackSpec` for global bot XP and per-game XP, with events and unlock hooks.
+- **Fresh-repo target:** avoid hard-coded game names; registry declares progression tracks.
+
+### Persistent vs non-restart-safe state
+
+- **Current evidence:** `game_state_service` checkpoint rows; runtime docs call out in-process counting/blackjack/RPS state; blackjack/RPS have recovery/refund tests for money safety.
+- **Reusable primitive:** `GameSessionPersistencePolicy` (`ephemeral`, `checkpointed`, `authoritative`) with TTL, recovery handler, refund handler.
+- **Fresh-repo target:** every game declares restart behavior before implementation.
+
+### Visual cards/PIL/assets
+
+- **Current evidence:** leaderboard cards, mining gear/character render, world cards, creature/fishing/mining embeds, asset folders.
+- **Reusable primitive:** `CardRendererSpec` with data projection, asset manifest, fallback embed, cache key.
+- **Fresh-repo target:** rendering is optional and tested; missing/corrupt assets degrade gracefully.
+
+## 6. User-facing UI grammar
+
+### Best current UX conventions
+
+- **Actionable hubs:** Games, Economy, and Community hubs discover children from the registry and give buttons, not just command lists.
+- **Game-specific panels:** Blackjack and deathmatch panels are strong: overview, main actions, rules, challenge, and back route are in one place.
+- **Collection browsers:** inventory grouping/sort/filter, creature dex filters, fishing log, mining recipe browser, and rod recipe progress are strong patterns.
+- **Back buttons:** `BackToPanelButton`, `attach_back_to_games_button`, `attach_back_to_economy_button`, and `attach_back_to_community_button` are valuable, even if fragmented.
+- **Result views with replay/rematch:** blackjack replay, RPS replay, creature rematch, and deathmatch result back navigation are good retention loops.
+- **Confirmation/progress views:** treasury contribution modal, blackjack custom bet modals, mining build modal, crafting progress browsers, and challenge accept/decline flows are good patterns.
+- **Rules/how-to affordances:** blackjack rules, mining how-to, creature how-to/dex, fishing menu/rules reduce hidden mechanics.
+
+### Inconsistent or fragmented UX conventions
+
+- **Different base classes:** `PersistentView`, `HubView`, `BaseView`, raw `discord.ui.View`, and in-cog views are mixed without a single game/session base.
+- **Public vs ephemeral:** hubs often edit/respond ephemerally; game sessions may be public; command-only features vary. A rebuild needs a response policy per action type.
+- **Timeout behavior:** solo blackjack 120s, PvP 60s, tournaments configurable, challenge views custom, mining/fishing panels different. Standardize stale-game UX.
+- **Back/help/hub navigation:** multiple attach helpers exist. Rebuild should make `Back`, `Home`, `Help`, and `Rules` route slots universal.
+- **Selectors and pagination:** category selects, type selects, item selects, leaderboards, dex filters, recipe browsers, and shop tables duplicate paging/list logic.
+- **Hidden command-only surfaces:** some deep actions are reachable from panels, others remain command-first or in-cog; completion docs repeatedly identify missing buttons as gaps.
+- **Game state messages:** some games disable controls and show result views; others rely on in-memory objects or command replies.
+
+### Recommended fresh UI grammar
+
+- `HubRoute`: top-level or child hub with registry-backed children, cross-links, and visibility.
+- `GamePanel`: overview + primary actions + collection/progression + rules + back.
+- `ActionView`: a single action session with owner/participant authority, timeout, result renderer.
+- `BrowserView`: shared pagination/filter/sort for inventory, dex, recipes, leaderboards.
+- `ConfirmModal/View`: standardized custom amount/stake/build/contribute flows.
+- `ResultView`: replay/rematch/back/share buttons and disabled stale controls.
+
+## 7. Hidden dependencies and rebuild hazards
+
+1. **Coin sole-writer invariant.** Architecture and tests enforce balance mutation through `economy_service`. A rebuild must preserve this stronger than source does today: no direct table update, no hidden game mint, every mutation reason typed.
+2. **XP sole-writer invariant.** `xp_service` owns shared XP. Game XP is separate; distinguish global XP, per-game XP, and social karma.
+3. **Karma service invariant.** Karma grants include anti-abuse rules; reaction grants must use same service.
+4. **Cross-game economy dependencies.** Mining, fishing, farm, blackjack, RPS, proof-channel-like rewards, and treasury all touch coins differently. Wagers need escrow/refund semantics; shops/crafting need cost vector transactions.
+5. **Inventory fragmentation.** Mining inventory doubles as generic material store for fishing pearls/coral/curios; fishing rods/bait/venue/energy use separate tables; generic inventory browser aggregates views. Rebuild needs explicit catalog ownership and item namespace rules.
+6. **Registry parent-hub assumptions.** `hub_registry.HUBS.primary_children` must match `SUBSYSTEMS.parent_hub`; Help/hubs rely on this roster. Fresh repo should generate one from the other or validate at startup/CI.
+7. **Persistent custom IDs and views.** Persistent hubs/custom IDs must remain stable across restarts. Games with dynamic session IDs need a versioned custom-id scheme.
+8. **Migrations/table schemas.** Relevant migrations include `003`, `005`, `014`, `015`, `016`, `017`, `018`, `019`, `060`, `061`, `063`, `065`, `066`, `070`, `072`, `073`, `074`, `075`, `076`, `077`, `082`, `085`, `086`, `087`, `088`, `090`, `091`, `092`, `093`, `094`, `095`, `101`. A clean rebuild should not blindly port these; derive a smaller schema from primitives.
+9. **Asset paths.** Mining gear/character render and other visual cards depend on assets under `disbot/assets/`; creatures/fishing depend on data JSON. Missing owner art must not block mechanics; use manifests and fallbacks.
+10. **Data files.** `disbot/data/fishing/fish.json` and `disbot/data/creatures/creatures.json` are product content sources. Treat content schema as versioned, not incidental.
+11. **Leaderboard assumptions.** Not every game has per-user persisted stats. Casino, blackjack, and word chain need new stat writes before unified leaderboards are honest.
+12. **Restart-safety decisions.** Some in-memory game sessions are accepted if money-safe; others checkpoint. Rebuild must make this explicit per game and test recovery/refund.
+13. **Rate limits/concurrency locks.** Economy and XP service concurrent tests exist. Challenge settle-once tests exist. Idle collect/crafting should use transaction locks or idempotency.
+14. **Owner-gated art/content/future mechanics.** Inventory item actions, live walkthroughs, some art/content drops, and blackjack rule decisions remain owner/live-gated in docs. Do not infer product completion from source presence.
+15. **Help/actionability contracts.** Games hub children are expected to expose real action buttons. Hidden command-only features degrade product value.
+
+## 8. Fragmentation and duplication inventory
+
+### Critical rebuild lessons
+
+- **Do not duplicate balance mutation paths.** Files: `economy_service.py`, mining/fishing/farm/blackjack/RPS workflows. Lesson: one ledger, typed mutation result, no direct coin writes.
+- **Do not let each game invent challenge/session lifecycle.** Files: blackjack PvP/tournament views, RPS views, deathmatch panel/cog, creature challenge/rematch, casino poker. Lesson: `ChallengeSession` + `GameSessionPersistencePolicy`.
+- **Do not split inventory UX from item ownership.** Files: `inventory_cog.py`, `utils/db/inventory.py`, `utils/db/games/mining*`, `fishing*`, creature/farm stores. Lesson: catalog/index with game-specific storage adapters.
+- **Do not hide product loops behind commands.** Completion docs repeatedly push panels/buttons. Lesson: every registry child needs a `GamePanel`/`HubRoute` route.
+
+### Important improvements
+
+- **Centralize browser/pagination/filtering.** Files: inventory category views, mining recipe/market/gear selectors, fishing rod recipe/bait/structure views, creature dex, leaderboard select.
+- **Centralize stale/timeout UX.** Files: blackjack, RPS, deathmatch, creature, casino, fishing cast. Use standard disabled state + result/reopen action.
+- **Centralize public/ephemeral policy.** Hubs can be private, game sessions often public, admin flows private; make response policy explicit.
+- **Standardize settings/schema exposure.** XP/economy/karma/blackjack/deathmatch/RPS have schemas; many games rely on constants/data only.
+- **Standardize audit event naming.** Economy audit has reason strings; chain has mutation result/events; karma has source. Fresh repo should use event/reason enums.
+
+### Cleanup
+
+- In-cog view classes for community spotlight/general/four_twenty/chain could move behind shared view primitives in a rebuild.
+- Multiple `attach_back_to_*` helpers can become one route-aware back button.
+- Repeated select option formatting, item line rendering, and empty-state embed code can become UI components.
+- Naming drift between command aliases, registry keys, and cogs should be mechanically validated.
+
+### Acceptable specialization
+
+- Blackjack hand rendering and rules are game-specific.
+- Fishing weather/weight/venue/rod math is domain-specific.
+- Mining spatial grid/depth/gear wear is domain-specific.
+- Creature elements/battle normalization is domain-specific.
+- Farm idle math is small enough to stay specialized behind a common idle interface.
+
+## 9. Future new-repo recommendations tied to source evidence
+
+1. **`EconomyLedger`** — based on `economy_service` and `economy_audit_log`. Owns all coin balance mutations, escrow, refunds, transfers, treasury movement, and audit events.
+2. **`CurrencyMutationResult`** — based on `TreasuryResult`, economy service errors, and work/shop result views. Standardizes success/failure/balance delta/new balance/audit id.
+3. **`ProgressionTrackSpec`** — based on `xp_service`, `game_xp_service`, mining titles/world identity, fishing/creature XP. Defines level curve, award actions, unlocks, events.
+4. **`RewardSpec`** — based on daily/work/farm collect/fishing drops/mining harvest. Declares cadence, cooldown, reward roll, cap, and audit.
+5. **`ItemCatalogSpec`** — based on mining items/equipment, fishing fish/bait/rods/curios, creature catalog, inventory browser metadata. Unifies display names, rarity, value, stack/equip/use semantics.
+6. **`CraftingRecipeSpec`** — based on mining recipes, fishing bait/rod/charm/curio recipes, farm upgrades. Supports material progress, craft button eligibility, transaction preview.
+7. **`CollectionDexSpec`** — based on creature dex and fishing log; supports filters, undiscovered states, collection percentage, best record fields.
+8. **`GameActionSpec`** — based on mining `mine/dig/explore`, fishing `begin_cast/commit_catch`, creature `catch`, farm `collect`, economy `work`. Returns typed action results.
+9. **`GameViewBase`** — based on `HubView`, `BaseView`, `PersistentView`, blackjack/RPS/deathmatch custom views. Handles owner/participant checks, response policy, timeout, stale state, back/help/rules slots.
+10. **`ChallengeSession`** — based on blackjack/RPS/deathmatch/creature challenge flows. Handles participant selection, accept/decline, stake/escrow, timeout/refund, settle-once, rematch.
+11. **`IdleAccrualSpec`** — based on farm, fishing/mining energy, structures. Computes elapsed production with capacity and modifier tracks.
+12. **`LeaderboardSpec`** — based on `LeaderboardCog` providers and current-state additions for fishing/farm. Requires rank source, metric, tie-breakers, empty state, display/card fields.
+13. **`CardRendererSpec`** — based on leaderboard cards, mining render, world cards, and embed fallbacks. Declares asset manifest, renderer, fallback, cache/invalidation.
+14. **`GameSessionPersistencePolicy`** — based on `game_state_service` and runtime docs. Every game must declare `ephemeral`, `checkpointed`, or `authoritative`, with recovery/refund tests.
+15. **`RouteRegistry`** — based on `subsystem_registry` + `hub_registry` + Help. One typed manifest should declare key, commands, hub, children, settings, permissions, panel builder, and completion metadata.
+
+## 10. Handoff to other mapping sessions
+
+### Needs from Part 1 — platform/UI primitives
+
+- Final route/hub/view base recommendations for `HubView`, `BaseView`, `PersistentView`, safe interaction helpers, custom-id versioning, and public/ephemeral policy.
+- Help catalogue and registry architecture: whether `subsystem_registry` and `hub_registry` should merge in a clean repo.
+- Standard browser/pagination/select/modal components.
+- Card rendering/asset manifest/fallback policy.
+- Session persistence/custom ID/runtime session conventions.
+
+### Needs from Part 2 — admin/safety dependencies
+
+- Permission/capability model for economy settings, treasury disbursement, counting/chain channel configuration, XP/karma settings, and admin resets.
+- Audit log schema and governance event taxonomy for currency, XP, karma, item grants, treasury, and settings changes.
+- Anti-abuse/rate-limit policy for work/daily/karma/reactions/games.
+- Production migration and rollback rules for user balances/items/game state.
+- Operator diagnostics needed for “lost coins”, “lost XP”, “stuck tournament”, “stale challenge”, and “bad item grant”.
+
+### Needs from Part 4 — AI/data/knowledge dependencies
+
+- Whether AI assistant should summarize or guide user-facing game/product loops without mutating state.
+- Content/data schema recommendations for fish/creatures/items/recipes and how AI can safely explain them.
+- Knowledge-card rendering conventions that should align with game card renderers.
+- Boundaries between AI recommendations and authoritative game mechanics; AI must not invent odds, rewards, or item effects outside versioned data specs.
+
+## 11. Rebuild conclusion
+
+The current bot has enough good product material to justify using it as a design mine for a clean rebuild, but not by copying the repo structure. The highest-value preservation target is the **loop grammar**:
+
+1. hub → panel → action → result → replay/back;
+2. earn → collect → craft/upgrade/equip → improve odds/output;
+3. collection → dex/logbook → leaderboard/social proof;
+4. challenge → accept/escrow → play → settle once → rematch;
+5. idle accrue → settle once → reinvest.
+
+A fresh SuperBot should start from shared primitives for these loops and then plug in mining, fishing, creatures, farm, blackjack, RPS, deathmatch, counting, chain, economy, XP, karma, inventory, treasury, and leaderboards as specs/adapters. That would keep the current bot's strongest user-facing ideas while avoiding the fragmentation that came from organically growing each game and hub separately.

--- a/docs/analysis/rebuild-discovery/platform-ui-runtime-map.md
+++ b/docs/analysis/rebuild-discovery/platform-ui-runtime-map.md
@@ -1,0 +1,570 @@
+# Platform/UI/runtime rebuild discovery map (Part 1 of 4)
+
+> **Status:** `historical` — source-grounded discovery report for a possible future rebuild; source and merged PRs win.
+
+Date: 2026-07-02  
+Scope: core platform, UI grammar, runtime, help/discoverability, settings/bindings/provisioning, diagnostics.  
+Output type: discovery map only. This report does **not** approve a rebuild and does **not** propose source changes.
+
+## 1. Executive summary
+
+### What this bot already does best
+
+- **It has real platform seams, not only feature cogs.** The strongest reusable pieces are `BaseView`/`HubView`, `PersistentView`, `views.navigation`, `core.runtime.interaction_helpers`, `core.runtime.lifecycle`, `core.runtime.tasks`, `core.events.EventBus`, `core.runtime.subsystem_schema`, `utils.subsystem_registry`, governance resolution/mutation services, help catalogue/projection/overlay, typed settings/bindings/resource provisioning, and health diagnostics.
+- **It separates mutation ownership better than most Discord bots.** Scalar settings go through `SettingsMutationPipeline`; bindings through `BindingMutationPipeline`; resources through `ResourceProvisioningPipeline`; governance through `GovernanceMutationPipeline`; help presentation through `help_overlay_mutation`; lifecycle Discord resources through channel/role lifecycle services.
+- **It treats UI as an operational contract.** `BaseView` locks panels to the invoker by default, disables on timeout, and auto-attaches standard Help/back-to-hub navigation when `SUBSYSTEM` is declared. `PersistentView` documents cross-restart requirements. `safe_defer`, `safe_followup`, and `safe_edit` encode the Discord interaction deadline and embed-size limits.
+- **It has discoverability as a projection layer.** Help is no longer only command introspection: `help_catalogue` builds a registry-aware catalogue; `help_projection` applies governance/execution/overlay decisions; `help_overlay` stores guild presentation customizations; Help routes can open command, category, and subsystem panels.
+- **It already contains the vocabulary of a future platform kernel.** Current source effectively proves the need for `SubsystemManifest`, `PanelSpec`, `ActionSpec`, `NavigationSpec`, `SelectorSpec`, `SettingSpec`, `BindingSpec`, `ResourceSpec`, `ConfirmationSpec`, `WorkflowResult`, `MutationPreview`, `AuditEventSpec`, and `DiagnosticProviderSpec`.
+
+### What a future clean repo should preserve
+
+- Preserve **service-owned mutations + audited fan-out**: mutation result objects, authority re-checks at callback execution time, explicit audit/event emission, and cache invalidation hooks.
+- Preserve **Help as projection**, not as scattered command docs: reason-coded display decisions, overlay state, route openers, category/subsystem grouping, and command-to-panel mapping.
+- Preserve **runtime contracts**: lifecycle phases, managed task registry, publish-accepted EventBus semantics, persistent view registration, interaction helper patterns, startup and health diagnostics.
+- Preserve **settings/bindings/resources as distinct lanes**: scalar values, Discord object pointers, and provisionable resources must not collapse into a generic configuration table.
+- Preserve **registry-driven subsystem metadata**: subsystem keys, capabilities, hubs, related subsystems, default channels, visibility tier/mode, and UI priority are architectural data.
+
+### What should be redesigned into central primitives
+
+- Turn today's `SUBSYSTEMS` dict + `SubsystemSchema` into a single typed **`SubsystemManifest`** that owns metadata, capabilities, commands, panels, settings, bindings, resources, diagnostics, audit events, and help entries.
+- Turn ad-hoc embed/view builders into **`PanelSpec` + `EmbedFrame` + `Table/ListSpec`** so panels can be rendered consistently across Discord, control API, docs, and tests.
+- Turn button/select/modal callback patterns into **`ActionSpec`**, **`SelectorSpec`**, and **`ConfirmationSpec`** with standard authority, defer, mutation preview, result rendering, audit, and error handling.
+- Turn navigation into **`NavigationSpec`** with canonical Help/home/back behavior, stack/anchor semantics, persistent custom IDs, and public/ephemeral policy.
+- Turn diagnostics providers into **`DiagnosticProviderSpec`** with audience, sync/async lane, timeout, redaction, status mapping, and ownership metadata.
+- Turn mutation return shapes into **`WorkflowResult` / `MutationPreview`** so settings, bindings, provisioning, governance, setup operations, and lifecycle services all speak one result grammar.
+
+### What should not be carried forward
+
+- Do not carry forward duplicate back buttons and one-off navigation functions where `views.navigation`/`BaseView` can express the contract.
+- Do not carry forward direct `discord.ui.View` subclasses unless their specialized state/lifecycle is documented and test-pinned.
+- Do not carry forward command-only feature surfaces without Help route, hub panel, or settings/discoverability metadata.
+- Do not carry forward scattered permission checks; panel entry and every callback need central governance/capability resolution.
+- Do not carry forward direct DB writes from cogs/views or ad-hoc raw SQL outside db/service owners.
+- Do not copy stale planning docs as truth. This repo has valuable docs, but source + merged PRs remain authoritative.
+
+## 2. Source route and verification
+
+### Binding/current-state docs read
+
+Read or inspected directly:
+
+- `.claude/CLAUDE.md`
+- `docs/collaboration-model.md`
+- `docs/current-state.md`
+- `docs/current-state/S3-ai-memory.md`
+- `docs/current-state/S4-docs.md`
+- `docs/current-state/S5-ops.md`
+- `docs/AGENT_ORIENTATION.md`
+- `docs/architecture.md`
+- `docs/ownership.md`
+- `docs/runtime_contracts.md`
+- `docs/repo-navigation-map.md`
+- `docs/repo-review-map.md`
+- `docs/ultracode/README.md`
+- `docs/subsystems/settings-bindings-provisioning.md`
+- `docs/subsystems/health-diagnostics.md`
+- `docs/help-command-surface-map.md`
+- `docs/building-roadmap/command-integration-standard.md`
+- `docs/building-roadmap/mother-hub-map.md`
+- `docs/setup-platform/` index/content by targeted search
+- `docs/health/` index/content by targeted search
+
+### Source roots inspected
+
+Inspected by direct reads and ripgrep across:
+
+- Runtime/lifecycle: `disbot/bot1.py`, `disbot/config.py`, `disbot/guild_lifecycle.py`, `disbot/healthserver.py`, `disbot/core/runtime/`, `disbot/core/resources/`, `disbot/core/events.py`, `disbot/core/events_catalogue.py`.
+- Governance/capability: `disbot/governance/`, `disbot/services/governance_service.py`, `disbot/services/*governance*`, `disbot/services/*capability*`, `disbot/utils/subsystem_registry.py`, `disbot/utils/hub_registry.py`, `disbot/utils/settings_keys/`.
+- Shared UI/navigation: `disbot/views/base.py`, `disbot/views/navigation.py`, `disbot/views/selectors/`, `disbot/views/settings/`, hub view files found by `rg "class .*Hub|HubView|PersistentView|BaseView" disbot/views disbot/cogs`.
+- Help/discoverability: `disbot/cogs/help_cog.py`, `disbot/cogs/help/`, `disbot/services/help_catalogue.py`, `disbot/services/help_projection.py`, `disbot/services/help_overlay.py`, `disbot/services/help_overlay_mutation.py`.
+- Settings/bindings/provisioning: `disbot/services/settings*`, `disbot/services/binding*`, `disbot/services/resource_provisioning.py`, `disbot/services/lifecycle/`, `disbot/services/channel_lifecycle_service.py`, `disbot/services/role_lifecycle_service.py`, `disbot/views/settings/`.
+- Diagnostics/observability: `disbot/services/diagnostics_service.py`, `disbot/services/health_snapshot_service.py`, `disbot/services/health_findings_service.py`, `disbot/services/health_contracts.py`, tests under `tests/unit/services/`, `tests/unit/runtime/`, `tests/unit/views/`, `tests/unit/help/`, `tests/unit/registry/`, `tests/unit/invariants/` by targeted search.
+
+### Commands run and results
+
+- `find /workspace -name AGENTS.md -print` — passed; no `AGENTS.md` files found under `/workspace`, so no repo-local agent instructions applied.
+- `git status --short` — passed before editing; working tree initially clean.
+- `gh pr list --state open --limit 20` — failed: `gh` is not installed in the container.
+- `curl -s https://api.github.com/repos/menno420/superbot/pulls?state=open&per_page=20 ...` — attempted for open PR verification, but the inline parser failed because `python3.10` was initially not selected by pyenv. Verification limit recorded below.
+- `PYENV_VERSION=3.10.20 python3.10 --version` — passed: `Python 3.10.20`.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/context_map.py disbot/views/base.py` — first failed before installing PyYAML; then passed after `python3.10 -m pip install PyYAML`. Result: `views.base`, review unit `A1 · platform: view-primitives`, 172 importers, 555 transitive dependents, high fan-in.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/context_map.py disbot/views/navigation.py` — first failed before installing PyYAML; then passed. Result: `views.navigation`, review unit `A1 · platform: view-primitives`, 49 importers, 555 transitive dependents, relevant test `tests/unit/views/test_navigation.py`.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/context_map.py disbot/utils/subsystem_registry.py` — first failed before installing PyYAML; then passed. Result: `utils.subsystem_registry`, review unit `A1 · platform: utils`, 31 importers, 555 transitive dependents, relevant test `tests/unit/utils/test_subsystem_registry.py`.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/context_map.py disbot/core/runtime/interaction_router.py` — first failed before installing PyYAML; then passed. Result: `core.runtime.interaction_router`, review unit `A1 · platform: runtime-core`, imported by `utils.subsystem_registry`, 555 transitive dependents.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/wiring_map.py --check` — passed. Advisory possible dead subscribers: `ticket.opened`, `governance.visibility.changed`, `governance.cache.invalidated`, `governance.cleanup.changed`. Final output: `EventBus wiring check passed ✓`.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/check_architecture.py --mode strict` — first failed before installing PyYAML; then passed with `0 error(s), 49 warning(s)`. Warnings include 13 direct-`discord.ui.View` inheritance warnings, 31 known layer-boundary warnings, and 5 raw-SQL warnings.
+
+### Open PR / active gate status
+
+- The GitHub CLI is absent, so open PR verification could not use `gh`.
+- A GitHub REST check was attempted but the first parser invocation failed due to pyenv not exposing `python3.10` until `PYENV_VERSION=3.10.20` was set. Because this task is a repo-local discovery report and no source behavior was changed, I treated open PRs as a verification limit rather than a blocker.
+- Current-state S3/S4/S5 show no active gate making this scope off-limits. They do identify the fresh-rebuild vision as planning/discovery context, not approval to rebuild.
+- PR #1509, if open, was not used as merged truth. This report relies on checked-out source and binding docs.
+
+### Verification limits
+
+- No live Discord bot, production DB, credentials, or provider keys were used.
+- Source was inspected in the current checkout only; unmerged PR source was not incorporated.
+- `check_quality.py --full` was not run because this change is one markdown report and the full suite is expensive; targeted docs/architecture/wiring checks were used instead, with `check_docs.py` run after writing the report if available.
+
+## 3. Platform architecture map
+
+### Runtime lifecycle
+
+- `disbot/bot1.py` is the process entry and wiring hub: it loads extensions, validates registries, registers persistent views, attaches command gating, starts health/control surfaces, and owns shutdown cleanup.
+- `disbot/core/runtime/lifecycle.py` is the canonical process phase machine: `STARTING`, `RUNNING`, `DRAINING`, `SHUTTING_DOWN`, `RESTARTING`, `STOPPED`, `FAILED_STARTUP`. It exposes `can_accept_commands()`, `request_shutdown()`, `request_restart()`, pending intent state, a transition ring buffer, and metrics gauges/histograms.
+- `disbot/core/runtime/tasks.py` centralizes managed background tasks. `spawn()` keeps strong refs, records outcomes, logs errors, supports `cancel_all()` and `cancel_by_prefix()`, and registers a diagnostics provider.
+- `disbot/core/runtime/scope_locks.py`, `session_gc.py`, `message_anchor_manager.py`, `navigation_stack.py`, `live_update_scheduler.py`, and `message_pipeline.py` show a recurring platform need: scoped state, anchors, sessions, locks, and safe slow-path execution should be first-class runtime services in a rebuild.
+
+### EventBus and event catalogue
+
+- `disbot/core/events.py` defines a lightweight in-process async `EventBus` with `on`, `off`, `emit`, `registered_events`, and `delivery_stats`.
+- The bus contract is **publish-accepted**: `emit()` returning means the bus accepted dispatch, not that every subscriber succeeded. Handler failures/timeouts are isolated and observable.
+- `disbot/core/events_catalogue.py` is the known event-name catalogue. Unknown event names warn once and increment metrics instead of crashing runtime.
+- `scripts/wiring_map.py --check` passed, with advisory possible dead subscribers. A future repo should make `AuditEventSpec/EventSpec` part of `SubsystemManifest`, including payload shape and subscriber ownership.
+
+### Persistent views and anchor/session lifecycle
+
+- `disbot/core/runtime/persistent_views.py` defines `PersistentView`, a registry, and the cross-restart contract: `timeout=None`, static `custom_id`s on all components, registration at startup, and no message-local closure state as the only authority.
+- `views.navigation.BackTarget` explicitly warns that stack closures cannot be persisted across restarts; persistent re-registration must rebuild views without `_back_target` and rely on click-time governance rechecks.
+- `message_anchor_manager`, `navigation_stack`, and `session_gc` indicate that the bot already has implicit session/anchor semantics. A clean repo should model anchors and session state centrally, instead of letting each view improvise.
+
+### Interaction helper/defer/edit/followup pattern
+
+- `core.runtime.interaction_helpers.safe_defer()` defers idempotently and returns `False` if the token expired or HTTP failed.
+- `safe_followup()` chooses response vs followup based on whether a response has already happened.
+- `safe_edit()` edits the original/anchor safely; `clamp_embed()` enforces Discord embed component, field-count, and total-size limits before sending.
+- `help_ctx_shim()` demonstrates compatibility debt: many hub builders still expect command `ctx`; Help/interactions need an interaction-shaped opener. A rebuild should pass explicit `PanelContext` rather than shim command contexts.
+
+### Managed task lifecycle
+
+- `core.runtime.tasks.spawn()` is the canonical task creation API and should be preserved conceptually.
+- `cancel_by_prefix()` encodes a useful naming convention (`<subsystem>:<purpose>[:<id>]`) that should become a `TaskSpec`/`ManagedTaskSpec` contract in a future repo.
+- Diagnostics provider registration by the tasks module is a good model: runtime services self-report through `diagnostics_service`.
+
+### Governance/capability resolver
+
+- `disbot/governance/models.py` defines `GovernanceContext`, `VisibilityResult`, `ExecutionResult`, `CleanupPolicy`, `CommandPolicy`, `SubsystemEffectiveState`, snapshots and diffs.
+- `governance.resolver` resolves visibility through scope chain, member tiers, overrides, dependencies, and subsystem state.
+- `governance.execution` resolves command/capability execution and caches capability overrides.
+- `governance.capability.actor_holds_capability()` is consumed by settings/bindings/provisioning mutation pipelines via `SettingSpec.capability_required` and `BindingSpec.capability_required`.
+- `governance.writes.GovernanceMutationPipeline` owns visibility/cleanup/capability-style writes and audit fan-out.
+- Rebuild lesson: never treat opening a panel as authorization. Every action callback must re-resolve capability at execution time.
+
+### Registry/hub metadata
+
+- `utils.subsystem_registry.SUBSYSTEMS` is a platform manifest in dict form. It contains display names, descriptions, emoji, color, visibility tier/mode, category, tags, entry points, default channels, dependencies, cleanup support, UI priority, parent hub, hub group, and capabilities.
+- `validate_registry()` freezes and validates structure, including capability namespace and hub relationships.
+- `utils.hub_registry.HubEntry` adds a more UI-specific hub catalogue with routes, labels, audience tiers, and presentation metadata.
+- Rebuild lesson: merge these into typed manifests rather than split metadata between raw dicts, hub registry, help catalogue, command aliases, and panel code.
+
+### Help projection/discoverability
+
+- `help_catalogue.build_help_catalogue()` builds registry-backed rows for hubs/subsystems and findings.
+- `help_projection.project_help()` and `project_help_with_execution()` apply governance, execution, overlay, and orphaned override decisions into a reason-coded `HelpProjection`.
+- `help_overlay` provides cached guild presentation overlays and `home_embed_frame()` for home-message framing; `help_overlay_mutation` owns audited hide/rename/description/home-message changes.
+- `cogs/help/route.py` provides `HelpRoute`, `HelpOpener`, route resolution, single-command embeds, not-found embeds, and `open_route()`.
+- `cogs/help/panels.py.HelpCategoryView` is a persistent Help category selector.
+
+### Settings/bindings/resource provisioning
+
+- `core.runtime.subsystem_schema` defines `SettingSpec`, `BindingSpec`, `ResourceRequirement`, `DomainPanelSpec`, and `SubsystemSchema`.
+- `settings_resolution` is the typed read path for scalar settings with default/coercion/provenance and diagnostics counters.
+- `settings_mutation.SettingsMutationPipeline` is the central scalar write path: resolves spec, checks authority/capability, coerces/validates, writes, invalidates, audits.
+- `binding_mutation.BindingMutationPipeline` is the central binding write path: validates kind, checks capability/admin floor, writes binding rows, invalidates/audits.
+- `resource_provisioning.ResourceProvisioningPipeline` previews and applies resource creation/reuse through declared resource requirements and binding specs; confirmation is mandatory for mutation.
+- `binding_backfill` maps legacy setting IDs into binding rows with dry-run/apply classification and advisory locks.
+- `views/settings` provides the operator UI grammar for typed settings: hub, subsystem summary, invalid settings, missing bindings, audit, bool toggle, text/number modals, enum select, role/channel selects, numeric presets, reset button, and related domain panels.
+
+### Shared UI primitives
+
+- `BaseView` standardizes invoker restriction, public panels, timeout disabling, error handling, `message` tracking, and standard navigation attachment.
+- `HubView` standardizes hub timeout.
+- `PersistentView` standardizes restart-safe component registration.
+- `views.navigation` centralizes back-button attachment, Help/home/back-to-hub nav IDs, Help navigation attachments, BackTarget composition, component-cap warnings, safe defer/edit, and fallback errors.
+- `views/selectors` centralizes channel/role/subsystem/scope/multi-select helpers, but the architecture warning list still shows duplicate direct select views in settings/channel/list panels.
+
+### Diagnostics/health/observability
+
+- `diagnostics_service` is a synchronous registry: `register`, `unregister`, `snapshot`, `snapshot_all`, `registered_names`, `_reset_for_tests`.
+- `health_contracts` defines `SnapshotStatus`, `FindingSeverity`, `HealthAudience`, `OperationalHealthFinding`, `SubsystemHealth`, `HealthSnapshot`, `HealthSnapshotRequest`, and status derivation.
+- `health_snapshot_service` composes runtime, tasks, diagnostics, errors, consistency, startup, extensions, AI, gateway, database, resource, and health-finding facts. It has cached and async collection lanes, `_safe`/`_safe_async` provider isolation, audience projection, redaction, grouping, and payload serialization.
+- `health_findings_service` owns persistent operational findings: record, list, count, status transitions, retention, and audit event fan-out on transition.
+
+## 4. Best ideas/functions to preserve
+
+| Item | Problem solved | New-repo value | Disposition | Hidden dependencies / migration risks |
+|---|---|---|---|---|
+| `views.base.BaseView` | Standard invoker lock, timeout disable, error handling, nav attach | Essential UI lifecycle baseline | Copy idea; redesign as `PanelRuntimeView` around specs | Depends on `views.navigation`, `config.is_platform_owner`, Discord message edit behavior |
+| `views.base.HubView` | Repeated hub timeout/defaults | Useful hub convention | Copy nearly as-is after spec integration | Hub vs child panels still inconsistent |
+| `views.base.send_panel` | Binds sent message to view for timeout edit | Avoids lost message reference | Copy idea | Only command-context send; interactions need parallel path |
+| `views.base.handle_view_error` | Logs rich context and sends generic ephemeral | Good global error UX | Copy idea | Some specialized views bypass for admin details |
+| `views.navigation.attach_back_button` | Central back button with cap guard/defer/edit/fallback | High-value navigation primitive | Redesign into `NavigationSpec`/`ActionSpec` | Parent builders are closures, cannot persist; custom IDs must be stable |
+| `views.navigation.attach_standard_nav` | Never-stranded Help/back-to-hub controls | Core discoverability contract | Preserve | Requires correct `SUBSYSTEM`, `parent_hub`, Help route availability |
+| `views.navigation.BackTarget` / `chain_back` | Composable ad-hoc back stack without router | Valuable transitional pattern | Redesign into serializable nav stack | Closure state cannot survive restarts |
+| `core.runtime.interaction_helpers.safe_defer` | Avoids Discord 3-second failure | Essential | Copy nearly as-is | Must be universally adopted; modal flows may need variants |
+| `safe_followup` / `safe_edit` | Response/followup/edit routing and token failure handling | Essential | Copy idea | Attachment clearing and ephemeral behavior must be modeled |
+| `clamp_embed` | Prevents Discord embed-limit hard failures | Essential embed frame primitive | Redesign as `EmbedFrame` validator | Discord limits are platform-specific and may change |
+| `core.runtime.persistent_views.PersistentView` | Restart-safe UI component contract | Essential | Copy idea with typed registration metadata | Static `custom_id`s are persisted API; cannot rename casually |
+| `core.runtime.lifecycle` | Process phase/admission/shutdown state | Essential | Copy nearly as-is | Metrics labels, command gating, shutdown semantics |
+| `core.runtime.tasks.spawn` | Strong refs, outcomes, cancellation, diagnostics | Essential | Copy idea as managed task service | Naming convention is informal; make typed |
+| `core.events.EventBus` | In-process fact fan-out with isolation | Valuable | Redesign around typed events | Event names/payload shapes currently stringly typed |
+| `core.events_catalogue.KNOWN_EVENTS` | Event name inventory | Valuable | Redesign as `AuditEventSpec/EventSpec` | Wiring map warnings indicate catalogue/subscriber drift risk |
+| `utils.subsystem_registry.SUBSYSTEMS` | Central subsystem metadata/capabilities | Essential | Redesign as typed `SubsystemManifest` | Keys are persisted across DB, help, routing, settings, governance |
+| `core.runtime.subsystem_schema.SettingSpec` | Typed scalar settings declaration | Essential | Preserve and fold into manifest | `settings_key` constants and KV schema are hidden dependencies |
+| `BindingSpec` | Typed Discord-resource pointer declaration | Essential | Preserve | Binding kind/table assumptions; legacy backfill |
+| `ResourceRequirement` / provisioning specs | Declared resources for preview/apply | Essential | Preserve as `ResourceSpec` | Discord permission/order/idempotency, binding link |
+| `DomainPanelSpec` | Makes non-scalar config discoverable in Settings | Important | Preserve | Discovery-only; mutation authority remains elsewhere |
+| `settings_resolution.resolve_value` | Typed setting read with defaults/provenance | Essential | Copy idea | Consumers rely on declared defaults and coercion shape |
+| `SettingsMutationPipeline` | Central scalar write with auth/audit/cache | Essential | Redesign as `ActionSpec` executor | Direct DB writes must be prohibited; actor type assumptions |
+| `BindingMutationPipeline` | Central binding write with kind/auth/audit | Essential | Redesign as `BindingAction` executor | Discord object kind validation; binding table schema |
+| `ResourceProvisioningPipeline.preview/apply` | Confirmation-first provisioning | Essential | Preserve idea | Needs permission checks, partial failure model, audit and retries |
+| `help_catalogue.build_help_catalogue` | Registry-to-help read model | Essential | Preserve | Depends on subsystem registry, command discovery, aliases |
+| `help_projection.HelpProjection` | Reason-coded help visibility/render model | Essential | Preserve | Overlay/gov/execution state and orphaned overrides |
+| `help_overlay.home_embed_frame` | Central Help home presentation frame | Useful | Redesign as `EmbedFrame` | Default byte-identical tests may pin content |
+| `help_overlay_mutation` | Audited presentation customization | Essential | Preserve lane | DB migration/table and audit event assumptions |
+| `governance.capability.actor_holds_capability` | Capability gate for mutations | Essential | Preserve idea | Empty capability = admin floor in pipelines; do not reinterpret |
+| `governance.writes.GovernanceMutationPipeline` | Sole governance mutation owner | Essential | Preserve | Scope/version/cache/audit semantics |
+| `diagnostics_service.register/snapshot_all` | Lightweight provider registry | Useful | Redesign as typed providers | Sync-only registry; health has async lane separately |
+| `health_snapshot_service.collect_snapshot` | Composed operator health snapshot | Essential | Preserve idea | Redaction, provider isolation, audience gates |
+| `health_findings_service.set_status` | Operator-managed finding lifecycle | Useful | Preserve | Audit event names and DB migration 057 |
+| `ChannelLifecycleService` / `RoleLifecycleService` | Discord resource lifecycle previews/results | Valuable | Preserve | Discord API permissions and idempotency assumptions |
+
+## 5. UI grammar extraction
+
+### Hub panels
+
+Current patterns:
+
+- Hub classes usually extend `HubView` and declare `SUBSYSTEM`, e.g. settings hub, diagnostic platform panel, economy/community/server-management hubs.
+- Hubs typically render an embed plus a view with buttons/selects for child panels.
+- Help can open many hubs through `build_help_menu_view` hooks or route openers.
+- Hub metadata is split across `SUBSYSTEMS`, `hub_registry`, command docs, Help route code, and individual view classes.
+
+Consistent:
+
+- Hub timeout is usually 180 seconds through `HubView`.
+- `BaseView` auto-navigation increasingly ensures Help/back-to-hub controls.
+- Hubs are often invoker-locked unless intentionally public.
+
+Fragmented:
+
+- Some hubs still use direct `discord.ui.View` or bespoke command-context builders.
+- Hub opener return shapes vary: some return `(embed, view)`, some send directly, some require `ctx`, some accept `interaction`.
+
+### Child panels
+
+Current patterns:
+
+- Child panels are usually `BaseView`/`HubView` descendants with back buttons added externally or auto-attached by `SUBSYSTEM`.
+- Settings child panels include `SubsystemSettingsView`, `InvalidSettingsView`, `MissingBindingsView`, `RecentChangesView`.
+- Diagnostic subviews render sections of the health/diagnostics state.
+
+Consistent:
+
+- Increasing use of `safe_defer` + `safe_edit` for in-place transitions.
+- Back buttons rebuild parents at click time, which is correct for governance/state freshness.
+
+Fragmented:
+
+- Parent/back builders are closures and not serializable.
+- Some child panels have custom back buttons (`settings_missing_bindings.back`, `settings_invalid.back`, `settings_subsystem.back_to_hub`) while standard nav uses `nav:*` IDs.
+
+### Persistent panels
+
+Current patterns:
+
+- `PersistentView` is used when controls must survive restarts; Help category selector is an example.
+- Static `custom_id`s are required for every component.
+
+Consistent:
+
+- Contract is well documented in `persistent_views.py`.
+
+Fragmented/hazard:
+
+- Persistent `custom_id` strings are effectively API. They are spread across view code and not centrally inventoried.
+- Closure-backed navigation cannot persist.
+
+### Buttons
+
+Current patterns:
+
+- Buttons encode actions directly in callbacks.
+- Back/help/home buttons use `views.navigation` or local button classes.
+- Destructive/confirmation buttons use custom short-timeout views in several areas.
+
+Consistent:
+
+- `attach_back_button()` handles defer/build/edit/fallback consistently where adopted.
+- `BaseView` handles invoker lock and timeout disable.
+
+Fragmented:
+
+- Button labels, rows, custom IDs, authority checks, and result messages vary by feature.
+- Some buttons still implement direct `interaction.response` calls instead of helper functions.
+
+### Selects
+
+Current patterns:
+
+- Shared selector helpers: `views/selectors/channel.py`, `role.py`, `subsystem.py`, `multi.py`, `multi_channel.py`, `multi_role.py`, `scope.py`.
+- Settings hub uses `_SubsystemSelect` and page buttons for >25 options.
+- Settings editor dispatch uses enum select, role/channel selects, numeric presets, and reset selects.
+
+Consistent:
+
+- Discord 25-option/component limits are recognized.
+- Settings hub paginates actionable groups.
+
+Fragmented:
+
+- There are duplicate direct select views (`LogChannelSelectView`, `ChannelSettingSelectView`, role/channel setting views) flagged by architecture checks.
+- Select option building and empty-state behavior are not yet a single `SelectorSpec`.
+
+### Modals
+
+Current patterns:
+
+- Settings text and number editors use `discord.ui.Modal` (`TextSettingModal`, `NumberSettingModal`).
+- Modal callbacks write through `SettingsMutationPipeline` and refresh parent panels.
+
+Consistent:
+
+- Typed `SettingSpec` controls modal routing.
+
+Fragmented:
+
+- Modal result rendering and parent refresh are per-widget helper functions.
+- Modal validation UX is not expressed as a shared `ActionSpec` result.
+
+### Back/help/home navigation
+
+Current patterns:
+
+- `BaseView` auto-attaches standard Help and back-to-hub controls when `SUBSYSTEM` is set and `STANDARD_NAV` is true.
+- `views.navigation` defines `NAV_HELP_ID`, `NAV_HUB_ID_PREFIX`, `BackTarget`, `attach_back_button`, `chain_back`, and Help attachment forwarding.
+- Legacy local back buttons still exist in Help, settings, games, logging, and admin areas.
+
+Consistent:
+
+- The desired contract is clear: no panel should strand a user away from Help or mother hub.
+
+Fragmented:
+
+- There are several local custom IDs and local back button classes; not all panels express their parent through a central `NavigationSpec`.
+
+### Pagination
+
+Current patterns:
+
+- Settings hub paginates groups past Discord's 25-option cap.
+- Diagnostic and list panels have bespoke pagination or dense embeds.
+- Architecture warnings include `_ChannelListPaginatorView` directly extending `discord.ui.View`.
+
+Consistent:
+
+- Discord limits are known and guarded in several places.
+
+Fragmented:
+
+- No single `PaginatedSelectorSpec` or `ListSpec/TableSpec` owns pagination, empty states, page labels, and bounds.
+
+### Confirmation/destructive flows
+
+Current patterns:
+
+- Resource provisioning requires preview + confirmation before applying.
+- Lifecycle services return preview/result shapes.
+- Destructive admin/setup operations often use local short-timeout confirmation views.
+
+Consistent:
+
+- The provisioning lane has the best preview/confirm/apply/audit pattern.
+
+Fragmented:
+
+- Confirmation UX is not one reusable primitive; button labels, timeout, authority re-check, and audit result rendering differ.
+
+### Error and timeout handling
+
+Current patterns:
+
+- `BaseView.on_error` uses `handle_view_error`.
+- `PersistentView.on_error` also delegates to shared error handling.
+- `safe_defer`/`safe_followup`/`safe_edit` handle token and HTTP failures.
+- `BaseView.on_timeout` disables controls and edits the bound message.
+
+Consistent:
+
+- The platform has a clear error doctrine and logs rich interaction context.
+
+Fragmented:
+
+- Some specialized direct `discord.ui.View` classes bypass shared handling.
+- Channel-management views intentionally expose error type to admins; this should become an explicit error policy, not a divergence.
+
+### Public vs ephemeral behavior
+
+Current patterns:
+
+- `BaseView(public=False)` locks panels to author; `public=True` allows shared panels.
+- Help/settings/admin callbacks often send ephemeral fallback messages.
+- Slash/status parity surfaces are often ephemeral.
+
+Consistent:
+
+- Invoker lock is centralized.
+
+Fragmented:
+
+- Public/ephemeral policy is implicit per call. A future `PanelSpec` should declare visibility, audience, whether the anchor is public, and whether errors/results are ephemeral.
+
+## 6. Future new-repo primitive proposal
+
+| Primitive | What it should mean | Current files proving need |
+|---|---|---|
+| `SubsystemManifest` | Typed manifest for subsystem key, display, category, capabilities, entry points, hubs, panels, settings, bindings, resources, events, diagnostics | `utils/subsystem_registry.py`, `core/runtime/subsystem_schema.py`, `utils/hub_registry.py`, `services/help_catalogue.py`, `governance/*` |
+| `PanelSpec` | Declarative panel identity, owner subsystem, audience, anchor/public policy, renderer, actions, selectors, navigation | `views/base.py`, `views/settings/hub.py`, `views/settings/subsystem_view.py`, `views/diagnostic/platform_panel.py`, hub views |
+| `EmbedFrame` | Safe embed renderer with title/description/fields/footer/image budgets and style tokens | `interaction_helpers.clamp_embed`, `help_overlay.home_embed_frame`, many embed builders |
+| `TableSpec` / `ListSpec` | Bounded table/list rendering with pagination and truncation | diagnostic panels, settings audit/missing/invalid embeds, channel list paginator |
+| `ActionSpec` | Button/modal action contract: label, custom_id, capability, defer mode, handler, result renderer, audit event | `attach_back_button`, settings edit/reset widgets, provisioning apply, governance writes |
+| `NavigationSpec` | Help/home/back/parent/child routes, serializable stack behavior, persistent custom IDs | `views/navigation.py`, `BaseView.SUBSYSTEM`, `parent_hub`, Help routes |
+| `SelectorSpec` | Select menu options, pagination, selected state, empty state, callback result | `views/selectors/*`, settings hub `_SubsystemSelect`, enum/select setting editors |
+| `SettingSpec` | Typed scalar config declaration | `core/runtime/subsystem_schema.py`, `settings_resolution.py`, `settings_mutation.py`, `views/settings/*` |
+| `BindingSpec` | Typed Discord resource pointer declaration | `subsystem_schema.py`, `binding_mutation.py`, `binding_backfill.py`, missing bindings UI |
+| `ResourceSpec` | Provisionable Discord resource requirement with preview/apply/link semantics | `core/runtime/resource_specs.py`, `services/resource_provisioning.py`, lifecycle services |
+| `ConfirmationSpec` | Preview/confirm/cancel/apply grammar for destructive/provisioning flows | `resource_provisioning.py`, `services/lifecycle/contracts.py`, setup/provisioning views |
+| `WorkflowResult` | Common mutation result: status, before/after, audit/event/cache flags, warnings, user message | `SettingsMutationResult`, `BindingMutationResult`, `ProvisioningResult`, `LifecycleResult`, `TransitionResult` |
+| `MutationPreview` | Dry-run/preview object for settings bundles, provisioning, lifecycle/setup operations | `ProvisioningPreview`, `LifecyclePreview`, binding backfill `DryRunSummary`, setup operations |
+| `AuditEventSpec` | Event name, payload shape, owner, persistence/audit behavior | `core/events_catalogue.py`, `services/audit_events`, mutation pipelines, health findings transitions |
+| `DiagnosticProviderSpec` | Provider name, sync/async lane, timeout, status mapping, audience/redaction | `diagnostics_service.py`, `health_contracts.py`, `health_snapshot_service.py` |
+| `ManagedTaskSpec` | Task name, subsystem, cancellation prefix, error hook, metrics labels | `core/runtime/tasks.py`, lifecycle shutdown cleanup |
+| `PanelContext` | Explicit context replacing command-ctx shims: bot, guild, actor, channel, interaction/message anchor, audience | `interaction_helpers.help_ctx_shim`, Help openers, hub builders |
+
+## 7. Hidden dependencies and rebuild hazards
+
+### Persisted subsystem keys
+
+- Keys in `utils.subsystem_registry.SUBSYSTEMS` are used by governance, help projection, settings schemas, bindings, resource requirements, command ledgers, diagnostics, and tests.
+- Examples: `admin`, `server_management`, `moderation`, `economy`, `inventory`, `treasury`, `ticket`, `mining`, `settings`, `diagnostic`, `help` and many more.
+- Hazard: renaming keys breaks DB rows, overlay rows, settings groups, Help overrides, governance policies, and capability strings.
+
+### Persistent `custom_id` strings
+
+Known examples from inspected scope:
+
+- Standard nav: `nav:help`, `nav:hub:<subsystem>`.
+- Help: `help:back`, `help_categories:select`.
+- Settings hub: `settings_hub.subsystem_select`, `settings_hub.page_prev`, `settings_hub.page_next`, `settings_hub.needs_setup`, `settings_hub.invalid`, `settings_hub.missing_bindings`, `settings_hub.audit`, `settings_hub.command_access`.
+- Settings children: `settings_missing_bindings.back`, `settings_invalid.back`, `settings_subsystem.back_to_hub`, `settings:back`, `settings_subsystem.open_panel`, edit/reset selects.
+- Hazard: persistent/restart-safe views and Discord interaction routing depend on stable IDs. A rebuild needs an inventory and compatibility policy.
+
+### Event names and payload shapes
+
+- `core.events_catalogue.KNOWN_EVENTS` and `scripts/wiring_map.py --check` are current safeguards.
+- EventBus payloads are kwargs without a typed schema. Mutation result flags such as `event_emitted` mean publish-accepted only.
+- Hazard: a fresh repo could silently drop subscribers or change payload names unless events are typed and tested.
+
+### DB schema assumptions
+
+- Settings rely on canonical `utils/settings_keys` constants and KV rows.
+- Bindings rely on `subsystem_bindings` semantics and legacy backfill classification.
+- Help overlay relies on its overlay table/migration and cached row model.
+- Health findings rely on migration 057 and finding fingerprint/status retention semantics.
+- Resource provisioning and audit checks rely on audit tables and CHECK constraints widened in later migrations.
+
+### Runtime session/anchor assumptions
+
+- `BaseView.message` must be set for timeout disabling.
+- `safe_edit`/navigation assumes an interaction has an editable original/anchor.
+- `BackTarget` closure stacks are intentionally non-persistent.
+- Persistent views must be re-registered at startup with static custom IDs.
+
+### Governance visibility/capability assumptions
+
+- Visibility and execution are distinct. A subsystem can be shown/hidden separately from command/action capability.
+- Empty `capability_required` in setting/binding specs is treated as administrator floor, not anonymous access.
+- Callback authority must be rechecked at execution time.
+- Platform owner bypass exists via `config.is_platform_owner` and admin helpers.
+
+### Help overlay/customization state
+
+- Overlay can hide/rename/re-describe Help entries and customize home messages.
+- Projection handles orphaned overrides.
+- Hazard: rebuilding Help from command introspection alone loses guild-specific presentation state and operator expectations.
+
+### Test/invariant assumptions
+
+- Architecture checker currently allows warnings but no errors; warning classes are living debt inventory.
+- Wiring map requires event wiring consistency but flags advisory possible dead subscribers.
+- Settings declared-vs-consumed parity and settings reachability guards are documented current-state invariants.
+- BaseView inheritance warnings are an explicit conformance ratchet.
+
+## 8. Fragmentation inventory
+
+### Critical rebuild lesson
+
+- **Metadata split across registries and code.** `SUBSYSTEMS`, `SubsystemSchema`, `hub_registry`, Help route/openers, command decorators, settings views, and docs all contain pieces of one subsystem manifest. Rebuild with `SubsystemManifest` first.
+- **Navigation is partly central, partly local.** `views.navigation` is correct direction, but local back buttons remain in Help/settings/games/logging/admin patterns. Rebuild with serializable `NavigationSpec` and generated standard controls.
+- **Action callbacks are not centrally specified.** Settings widgets, provisioning confirmations, governance buttons, and hub buttons repeat defer/auth/mutate/audit/render code. Rebuild with `ActionSpec` and `WorkflowResult`.
+- **Persistent IDs are not centrally inventoried.** Stable `custom_id`s are spread through source. Rebuild with a custom-id registry and compatibility tests.
+
+### Important improvement
+
+- **Direct `discord.ui.View` inheritance remains.** `check_architecture.py --mode strict` warns on `_DuelView`, `_ChallengeView`, `LogChannelProvisionView`, `LogChannelSelectView`, `_DisabledHelpHookView`, `BTD6AdminView`, `StrategyReviewView`, `_ChannelListPaginatorView`, `ChannelSettingSelectView`, `NumericPresetsView`, `RoleSettingSelectView`, `SetupLauncherView`, `_RankView`. Some are acceptable specialization; some are platform debt.
+- **Layer-boundary warnings remain known debt.** Core imports services in runtime modules; governance imports services; utils imports core/services in DB helpers. A clean repo can avoid much of this by making runtime ports explicit.
+- **Raw SQL warnings remain in service files.** `automation_scheduler.py` and `binding_backfill.py` still contain known raw SQL/pool primitive warnings. A future repo should enforce db-access owners from day one.
+- **Help opener context shims indicate old command-first surfaces.** `help_ctx_shim()` is practical but proves the need for `PanelContext`.
+
+### Cleanup
+
+- Consolidate selector option builders into `SelectorSpec`.
+- Consolidate settings edit parent-refresh helpers.
+- Replace per-panel back button classes with generated navigation controls.
+- Inventory all custom IDs and event names into generated docs/tests.
+- Replace one-off embed/list truncation with `EmbedFrame`/`ListSpec`.
+
+### Acceptable specialization
+
+- Game-state views may extend `discord.ui.View` directly when tightly coupled to gameplay lifecycle, timeout cleanup, or transient challenge state. The current `BaseView` doctrine already allows this if documented.
+- Channel-management views may expose richer admin error details, but that should be an explicit `ErrorPolicy.ADMIN_DIAGNOSTIC` rather than a hidden custom `on_error`.
+- Dense domain panels can keep custom renderers if they still declare `PanelSpec`, `NavigationSpec`, and action metadata.
+
+## 9. Minimum foundation a fresh repo should start with
+
+Before recreating any feature cogs, a clean SuperBot repo should have this platform kernel:
+
+1. **Typed `SubsystemManifest` registry** with stable keys, display metadata, capabilities, command surfaces, panel surfaces, settings, bindings, resources, events, diagnostics, and help entries.
+2. **Governance/capability service** with visibility vs execution separation, member/role tiers, scope chain, callback-time capability checks, cache invalidation, and audited mutation pipeline.
+3. **Runtime lifecycle service** with phases, command admission gate, graceful shutdown/restart intents, managed task registry, metrics, and diagnostics provider.
+4. **Typed EventBus/audit catalogue** with event names, payload schemas, owner, subscriber wiring checks, publish-accepted semantics, delivery stats, and audit fan-out.
+5. **UI platform grammar**: `PanelSpec`, `ActionSpec`, `NavigationSpec`, `SelectorSpec`, `ConfirmationSpec`, `EmbedFrame`, `ListSpec/TableSpec`, `PanelContext`, `WorkflowResult`.
+6. **Discord interaction helpers** for defer/followup/edit, embed/file limits, ephemeral/public policy, timeout/error behavior, and persistent-view registration.
+7. **Help/discoverability projection** from manifests + governance + overlay state, including routes to panels and commands.
+8. **Settings/bindings/resources lanes** with typed read models, mutation pipelines, preview/confirm provisioning, cache invalidation, audit, and tests.
+9. **Diagnostics/health layer** with typed provider specs, cached/async lanes, redaction/audience projection, persistent findings, and startup snapshot.
+10. **Invariants/checkers from day one**: architecture/layering, direct-view conformance, settings declared⇔consumed, event wiring, custom-id uniqueness, command/help reachability, and docs/report path checks.
+
+## 10. Handoff to other mapping sessions
+
+### Admin/safety session should verify
+
+- Whether moderation, automod, cleanup, logging, channel, role, ticket, setup, and server-management panels re-check governance/capability at callback execution time.
+- Which admin/safety views still directly extend `discord.ui.View` for acceptable specialization vs avoidable BaseView debt.
+- Whether destructive admin actions follow preview/confirmation/audit semantics comparable to resource provisioning.
+- Governance event payloads, audit event names, and permission tiers used outside this platform scope.
+
+### Community/games session should verify
+
+- Which game/community hubs can be expressed as `PanelSpec`/`ActionSpec` and which game-state views require direct specialized `discord.ui.View`.
+- Whether economy/inventory/mining/treasury/community panels use service-owned mutations and standard navigation.
+- Any duplicate pagination/select/list patterns in game leaderboards, inventories, shops, matchmaking, and BTD6 browsers that should become `ListSpec`/`SelectorSpec`.
+- Persistent custom IDs and session state in game flows.
+
+### AI/data/tooling session should verify
+
+- AI runtime/tool orchestration manifests that resemble `SubsystemManifest`, `ActionSpec`, or `DiagnosticProviderSpec`.
+- AI-memory substrate assumptions that should plug into EventBus, diagnostics, settings, Help projection, or control-plane manifests.
+- Whether tool catalogues, answerability projections, and data-source freshness metadata can share the same discovery grammar as Help/diagnostics.
+- Static checks that should become mandatory in a fresh repo: architecture, wiring map, settings parity, custom IDs, docs consistency, and CodeGraph coverage.

--- a/docs/ideas/superbot-fresh-rebuild-vision-2026-06-30.md
+++ b/docs/ideas/superbot-fresh-rebuild-vision-2026-06-30.md
@@ -8,6 +8,11 @@
 > reintroduced) — before any work starts. This document exists so the reasoning from a long live
 > conversation isn't lost — mirrors the precedent set by `portable-agent-memory-package-2026-06-12.md`
 > and `autonomous-improvement-loop-vision-2026-06-12.md`.
+>
+> **⚠️ UPDATE 2026-07-02:** the "gated on Fable 5 / not reintroduced" status below is **superseded** —
+> Fable 5 was **redeployed 2026-07-01** (verified live), so that gate is **cleared**. The
+> research-grounded plan that supersedes/extends this vision is
+> [`../planning/fresh-rebuild-strategy-2026-07-02.md`](../planning/fresh-rebuild-strategy-2026-07-02.md).
 
 ## Why this document exists
 
@@ -248,9 +253,10 @@ just a fact fix:
 - The maintainer's own detailed keep/change specification — not started.
 - Extracting `substrate-kit/` into its own repo — available to start now (zero code coupling found),
   independent of the bigger rebuild decision.
-- Re-check the live Claude model picker periodically for Fable 5's actual availability (withdrawn
-  since 2026-06-12, not yet reintroduced as of 2026-06-30) — this is a real, currently-open gate on
-  the maintainer's stated timeline, not a cleared one.
+- Re-check the live Claude model picker periodically for Fable 5's actual availability. **UPDATE
+  2026-07-02: Fable 5 was REDEPLOYED 2026-07-01** (Anthropic, "Redeploying Fable 5"; global on Claude
+  Platform / Code / Cowork, cloud phasing in) — **this gate is now CLEARED**, verified live. The prior
+  "withdrawn since 2026-06-12, not yet reintroduced as of 2026-06-30" status is superseded.
 - The 7 confirmed-safe-to-delete docs from the historical-docs audit (this session) — awaiting the
   maintainer's go-ahead, not yet executed.
 - The 45 condense-candidate docs from the same audit — not yet scoped into a follow-up pass.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -108,9 +108,9 @@ Next action.** Remaining website work has its own durable handoff:
 Owner-directed **planning** thread (not yet an approved build) for a from-scratch SuperBot rebuild
 "designed as one picture," with the current repo as a frozen reference and the substrate-kit finished
 first as its foundation. **Rebuild go/no-go stays owner-gated** (after the Fable design + owner review).
-The source-grounded discovery evidence — 4 Codex maps, verified against shipped source per Q-0120 — is
-being folded into one synthesis artifact this session; the 4 verbatim domain maps live under
-[`analysis/rebuild-discovery/`](../analysis/rebuild-discovery/platform-ui-runtime-map.md).
+The source-grounded discovery evidence — 4 Codex maps, verified against shipped source per Q-0120
+(48/59 load-bearing claims confirmed, the corrections binding) — is folded into one artifact:
+[`analysis/rebuild-discovery/codex-preserve-map-synthesis`](../analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md).
 
 | Plan | Status / gate |
 |---|---|

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -103,6 +103,21 @@ Next action.** Remaining website work has its own durable handoff:
 | [owner-review-inbox-plan](owner-review-inbox-plan-2026-06-17.md) | Phase 1 shipped (#1091 `/reviews`); Phases 2–3 owner-paced |
 | [website-two-site-split-plan](website-two-site-split-plan-2026-06-19.md) | v1 build **code-complete + reviewed** (#1109–#1123); remaining = rollout + the control-API security-review-gated slices → tracked in the next-steps handoff |
 
+### Fresh from-scratch rebuild — cross-cutting planning initiative
+
+Owner-directed **planning** thread (not yet an approved build) for a from-scratch SuperBot rebuild
+"designed as one picture," with the current repo as a frozen reference and the substrate-kit finished
+first as its foundation. **Rebuild go/no-go stays owner-gated** (after the Fable design + owner review).
+The source-grounded discovery evidence — 4 Codex maps, verified against shipped source per Q-0120 — is
+being folded into one synthesis artifact this session; the 4 verbatim domain maps live under
+[`analysis/rebuild-discovery/`](../analysis/rebuild-discovery/platform-ui-runtime-map.md).
+
+| Plan | Status / gate |
+|---|---|
+| [fresh-rebuild-strategy](fresh-rebuild-strategy-2026-07-02.md) | the **verified baseline + end-to-end order** (Phase 0→5 + gates); analysis-grade, **not an approved execution plan** |
+| [simulation-driven-design](simulation-driven-design-2026-07-02.md) | owner-directed **standing rule** — structure (grouping / ordering / layout) is discovered by simulation; the manifest is the search space |
+| [rebuild-ultracode-handoff](rebuild-ultracode-handoff-2026-07-02.md) | **START-HERE launch pad** — paste-ready ultracode session prompts (harvest · finish substrate-kit · golden harness · Fable design) |
+
 ### Horizon backlog drafts (Later / Someday — routed, not stale)
 
 The 2026-06-08 product-growth roadmap drafts are **active as routed backlog** — each is wired into

--- a/docs/planning/fresh-rebuild-strategy-2026-07-02.md
+++ b/docs/planning/fresh-rebuild-strategy-2026-07-02.md
@@ -22,6 +22,15 @@ that plan: the verified state of the world, the corrections the verification for
 approach, and the design principles + memory-package improvements that make "designed, not stitched"
 mechanical rather than aspirational.
 
+> **Fable 5 availability (verified live, 2026-07-02):** Fable 5 launched 2026-06-09, was **withdrawn
+> 2026-06-12**, and was **redeployed 2026-07-01** (Anthropic, "Redeploying Fable 5"; global on the Claude
+> Platform / Claude.ai / Claude Code / Cowork, cloud platforms phasing in). This **clears the "wait for
+> Fable 5" gate** the fresh-rebuild vision doc recorded as open (that doc's "not reintroduced as of
+> 2026-06-30" line is now stale — corrected there). Fable: $10/$50 per M tokens; 1M ctx / 128K out;
+> always-on thinking (effort-controlled `low`→`max`); `refusal` stop-reason + model fallbacks; requires
+> 30-day data retention. *(This session runs on `claude-opus-4-8`; the Fable-specific work is the Phase-2
+> design ultracode, §3.1.)*
+
 ---
 
 ## 1. Verified baseline
@@ -146,34 +155,85 @@ mechanical rather than aspirational.
 
 ---
 
-## 3. The plan-of-plans (phases + gates)
+## 3. End-to-end execution order (from here to a production-ready rebuilt bot)
 
-**Phase 0 — Finish the substrate-kit's adaptive half (buildable now).** Build the nervous system that's
-absent: mode-conditioned behaviors, drift/trigger detection, the reflection buffer + meta-reflection
-miner (forward-injected), the missing 7 contract templates (kills the dangling routes), the remaining
-hooks. This *also* de-risks Phase 1 by proving "design as one picture" on a self-contained kit before
-betting the 237k-line bot on it. It's the generator for the new repo's clean binding docs + router.
+**Critical path:** `[Phase 0 · 0.5 · 1 in parallel]` → **Phase 2 design** → **🔒 owner approval** →
+Phase 3 skeleton → Phase 4 port → Phase 5 cutover → **done.** Token limits are not the binding
+constraint; wall-clock is (see §3.1). Everything up to the owner-approval gate is agent-buildable now.
 
-**Phase 0.5 — Capture the behavioral golden set against the live bot (NEW, must precede any freeze).**
-Stand up a black-box golden-output harness (command-in → embed/DB-out, ephemeral Postgres + a Discord
-driver), snapshot the current bot's observable behavior, reuse the `evals/` corpus. This is the only
-structure-agnostic correctness oracle for the rebuild — and independently a better regression net for
-the current bot (which today only checks internal wiring).
+**Phase 0 — Finish the substrate-kit's adaptive half** *(buildable now).* Build the unbuilt nervous
+system: the three `mode` behaviors, drift/trigger detection, reflection buffer + meta-reflection miner,
+the 7 missing contract templates (kills the dangling routes), the remaining hooks, memory-integrity/
+quarantine + the context budget (§5.2). Ships the namespace-guard as a portable checker (§5.3). Also
+the design-method dry-run + the clean-binding-doc generator. **Gate:** kit green + extractable.
 
-**Phase 1 — The comprehensive design spec (the Fable job; design, not code).** One coherent picture,
-produced against the frozen reference: the redone architecture + layer/ownership/runtime contracts; the
-authoritative settings model (§4); the **central command/symbol namespace** (§4); the functionality
-inventory harvested from the old repo + goldens; the **distilled decision ledger** (§4); the data model;
-the regenerated binding docs. Owner-approved before any Phase-2 code. Fable's sweet spot: long-horizon,
-whole-picture, reason-from-knowledge — run at `xhigh`.
+**Phase 0.5 — Behavioral golden harness against the LIVE bot** *(parallel; must precede any freeze).*
+Black-box goldens (command-in → embed/DB-out, testcontainers Postgres + a Discord driver), reuse the
+`evals/` corpus. The only structure-agnostic rebuild oracle (§1.4), and a current-bot regression win.
+**Can only be captured while the old bot is live.**
 
-**Phase 2 — Execute the rebuild (gated).** Port behavior into the new repo, each slice **red-until-parity
-against the Phase-0.5 goldens**; substrate-kit driving the workflow from day one; old repo stays in
-production until verified parity. ~100 PRs.
+**Phase 1 — Harvest what to keep** *(parallel; feeds the design).* Router distillation → clean decision
+ledger; settings-authority audit → authoritative model; functionality inventory; hidden-dependency /
+backward-compat map. Verified GPT-stream findings folded in (§6). *(Running now as the `rebuild-harvest`
+ultracode → `docs/planning/rebuild-harvest/`.)*
 
-**Gates:** don't freeze the old repo before the goldens exist; don't start Phase-2 code before the design
-is owner-approved; keep the old repo live until parity; extraction-to-own-repo and the rebuild go/no-go
-stay owner decisions.
+**Phase 2 — The comprehensive design spec** *(the Fable job; the decision gate).* One coherent picture:
+redone architecture + contracts; the manifest grammar (§4/§6.1) designed **to be simulated over** (§4);
+the central namespace; the authoritative settings model; the data model + backward-compat contract; the
+control-plane (rulesets + OIDC); the regenerated binding docs. Independent-model review before freeze.
+**🔒 OWNER GATE — the big one:** owner approves the design + the backward-compat contract + the rebuild
+go/no-go. Nothing below starts until this.
+
+**Phase 2.5 — Cold-start proof** *(parallel with Phase 2; gates Phase 3).* Point the finished kit at a
+small throwaway repo; run the substrate-on vs -off A/B (§5.2). Proves the memory system works cold,
+cheaply, before the ~100-PR commitment.
+
+**Phase 3 — New-repo skeleton** *(owner-gated).* Create the repo; bootstrap the substrate-kit → clean
+binding docs + ledger + workflow; build the two spines first — the manifest-grammar runtime engine + the
+namespace registry; wire the control-plane (rulesets + OIDC); wire the golden harness as the acceptance
+gate (red until parity); CI. The spines exist *before* any feature — that's what makes it designed, not stitched.
+
+**Phase 4 — Port slice-by-slice, red-until-parity** *(the ~100-PR bulk).* Per subsystem: declare it in
+the manifest grammar (sim-optimized per §4), implement the service behind the audited seam, green its
+goldens. Order by dependency/risk — core platform + settings + governance first, then economy/moderation,
+then games/AI/BTD6. Migrations honor the backward-compat contract. Old repo = frozen oracle, in production
+throughout.
+
+**Phase 5 — Cutover** *(owner-verified — the end).* Shadow-run until goldens + live checks green →
+migrate data per the contract → flip production (Railway redeploy) → keep the old repo as frozen rollback
+for a bounded window → decommission. **End state: the fully working, production-ready rebuilt bot.**
+
+**Continuous side-track** *(low priority, parallel throughout):* keep the *old* bot healthy while it
+serves production — apply §6.2's safe control-plane toggles + fix prod bugs. The *designed* control-plane
+lands fresh in Phase 3.
+
+**Buildable now vs gated:** Phases 0, 0.5, 1, 2.5 and *drafting* Phase 2 are agent-buildable with no owner
+gate. The one hard gate is **owner approval of the design (Phase 2)** before any new-repo code. Cutover +
+data migration (Phase 5) stay owner-verified. **The two sequencing rules that matter most:** capture the
+goldens (0.5) before the old repo is ever frozen; approve the design (2) before Phase 3.
+
+### 3.1 Model & ultracode allocation
+
+Limits are not the binding constraint (Max ×20); **wall-clock is.** Principle: **spend Fable where
+reasoning is the bottleneck; run the parallel bulk on faster models for throughput, not cost** —
+unlimited *tokens* ≠ unlimited *time*, and a Fable fleet clears fewer items/hour than an Opus/Sonnet
+fleet. Independent review always uses a *different* model than built it (the review-seam pattern; Codex/
+GPT are the natural non-Claude reviewers).
+
+| Phase | Model + effort | Ultracode |
+|---|---|---|
+| 0 — finish kit | Opus 4.8 `xhigh`; Fable for the hard design calls | Opus ultracode |
+| 0.5 — golden harness | Opus/Sonnet fleet, Opus `max` core | Opus ultracode |
+| 1 — harvest/map | Opus + Sonnet fan-out; Fable synthesis; **Codex** parallel cross-check | Opus ultracode *(running)* |
+| 2 — design | **Fable judge-panel** (3 framings) + Opus `max` → synthesize → review by Opus + Codex/GPT | **the Fable ultracode** (clean usage-measurement run) |
+| 2.5 — cold-start | Sonnet runs, Opus interprets | — |
+| 3 — skeleton | Opus 4.8 `xhigh`/`max` on the spines; Sonnet on CI/control-plane | Opus ultracode |
+| 4 — port (~100 PRs) | **Sonnet 5** workhorse; Opus 4.8 escalation for hard subsystems; Haiku for boilerplate | Opus-supervised Sonnet fleet |
+| 5 — cutover | Opus 4.8 `high`; Sonnet for migration scripts | — |
+
+The golden harness (0.5) is what **makes the cheap tiers safe** on the Phase-4 port: red-until-parity
+catches any regression a Sonnet/Haiku agent introduces, so premium models are reserved for design
+(Fable) and the structural spines (Opus).
 
 ---
 
@@ -187,6 +247,12 @@ stay owner decisions.
   registry: panels, actions, settings, bindings, navigation and selectors declared once and *generated*
   by a runtime engine, not hand-coded per cog. Introduced *through* the central namespace so it can't
   recreate the `ActionSpec`-style collision. (§6.1)
+- **Structure is discovered by simulation, not decided by hand.** Any grouping/ordering/layout decision
+  with a measurable objective (commands, buttons/panels, settings, file ordering, AI-answer structure) is
+  run through a simulator that searches for the most efficient arrangement — a standing, first-class step
+  gated by a *sim-reviewed-or-exempt* check. The manifest grammar is what makes this cheap (the manifest
+  *is* the search space), so it must be designed **to be simulated over**. Full rule + guardrails +
+  per-domain mechanisms: [`simulation-driven-design-2026-07-02.md`](simulation-driven-design-2026-07-02.md).
 - **A central command/symbol namespace that reserves names at declaration and fails *before* boot.**
   The single highest-value structural fix — it directly prevents the class that crash-looped production
   twice in three days. (§1.6)
@@ -301,12 +367,13 @@ rebuild decision, from §6.1's hidden-dependency list); **manifest format** — 
 YAML/JSON vs hybrid; **control-plane hardening scope** — which of §6.2's safe GitHub toggles to enable
 on the *current* repo now.
 
-**Recommended immediate sequence (nothing here touches Phase-2 code or freezes the old repo):**
+**Recommended immediate sequence (nothing here touches Phase-3 code or freezes the old repo — full order in §3):**
 1. Finish the substrate-kit adaptive half (**Phase 0**) — first application of the design method.
-2. In parallel, stand up the **Phase-0.5** golden harness against the live bot (also a current-bot win).
-3. Run the **router distillation** + **settings-authority** harvests (buildable now, valuable even if the
-   rebuild slips) — they become raw material for Fable's Phase-1 design.
-4. Hand Fable (`xhigh`) the **Phase-1 design spec** with verified material, not a blank page.
+2. In parallel, stand up the **Phase 0.5** golden harness against the live bot (also a current-bot win).
+3. Run the **Phase 1 harvest** (router distillation + settings-authority + inventory + hidden-deps) —
+   *running now as the `rebuild-harvest` ultracode*; raw material for the design.
+4. Hand **Fable** the **Phase 2 design spec** (judge-panel + cross-model review) with verified material,
+   not a blank page — then the owner-approval gate.
 
 ---
 

--- a/docs/planning/fresh-rebuild-strategy-2026-07-02.md
+++ b/docs/planning/fresh-rebuild-strategy-2026-07-02.md
@@ -1,6 +1,6 @@
 # Fresh-rebuild strategy — verified baseline + plan-of-plans (2026-07-02)
 
-> **Status:** `analysis` — research-grounded strategy, **not an approved execution plan.**
+> **Status:** `plan` — research-grounded strategy (analysis-grade), **not an approved execution plan.**
 > Every quantitative claim below was verified against **live source / tooling on 2026-07-02** by a
 > 7-agent verification fleet, not carried over from prior docs. Where an earlier figure drifted or was
 > wrong, the correction is marked **⚠️**.
@@ -374,6 +374,12 @@ on the *current* repo now.
    *running now as the `rebuild-harvest` ultracode*; raw material for the design.
 4. Hand **Fable** the **Phase 2 design spec** (judge-panel + cross-model review) with verified material,
    not a blank page — then the owner-approval gate.
+
+**Launch pad for the fresh ultracode sessions:**
+[`rebuild-ultracode-handoff-2026-07-02.md`](rebuild-ultracode-handoff-2026-07-02.md) — paste-ready
+session prompts (harvest / finish substrate-kit / golden harness / Fable design) plus the
+verified-baseline TL;DR and the non-negotiable constraints, so a fresh high-core `/effort ultracode`
+session starts without this session's in-memory context.
 
 ---
 

--- a/docs/planning/fresh-rebuild-strategy-2026-07-02.md
+++ b/docs/planning/fresh-rebuild-strategy-2026-07-02.md
@@ -1,0 +1,320 @@
+# Fresh-rebuild strategy — verified baseline + plan-of-plans (2026-07-02)
+
+> **Status:** `analysis` — research-grounded strategy, **not an approved execution plan.**
+> Every quantitative claim below was verified against **live source / tooling on 2026-07-02** by a
+> 7-agent verification fleet, not carried over from prior docs. Where an earlier figure drifted or was
+> wrong, the correction is marked **⚠️**.
+>
+> **Extends** [`../ideas/superbot-fresh-rebuild-vision-2026-06-30.md`](../ideas/superbot-fresh-rebuild-vision-2026-06-30.md)
+> (corrects several of its figures) and sits **above** the approved
+> [`portable-substrate-kit-extraction-2026-06-13.md`](portable-substrate-kit-extraction-2026-06-13.md)
+> + [`portable-agent-substrate-revision-2026-06-13.md`](portable-agent-substrate-revision-2026-06-13.md)
+> plans. §6 **integrates** two external (GPT) research streams (UI/command grammar; GitHub/CI control
+> plane), each verified against source per Q-0120 — corrections and owner-judgment items are marked **⚠️**.
+
+## 0. Purpose
+
+The maintainer's goal: use Fable 5 to produce an **extremely comprehensive plan to rebuild the bot
+from scratch**, with the current repo as a *frozen reference*, designed as one finished picture rather
+than stitched together — and to **finish + extract the portable AI-memory substrate-kit first** so the
+new repo bootstraps a clean workflow from day one. This document is the *trustworthy foundation* for
+that plan: the verified state of the world, the corrections the verification forced, the phased
+approach, and the design principles + memory-package improvements that make "designed, not stitched"
+mechanical rather than aspirational.
+
+---
+
+## 1. Verified baseline
+
+### 1.1 Settings — the good pattern exists but is **not authoritative**
+- **114 distinct setting keys** (17 `utils/settings_keys/` modules); **100 `SettingSpec` declarations**
+  (15 cog `schemas.py`); **~14 keys have no spec at all** (governance, economy log channel, etc.).
+- A genuinely good declarative pipeline exists: `SettingSpec` → `settings_registry` → `resolve_setting`
+  / `SettingsMutationPipeline` (coerce → validate → capability → **DB write + audit in one transaction**).
+  ~100 settings flow through it correctly.
+- **⚠️ But it coexists with a legacy raw-KV path that bypasses all of it:** **40 direct callsites**
+  (24 `get_setting` + 16 `set_setting`) with inline defaults, no validation, no audit — including a
+  read *inside a view* (`disbot/views/setup/sections/moderation.py:408`), a layer violation.
+- **Safe-default-OFF is confirmed real** (`server_logging_config.py:85` `DEFAULT_ENABLED = False`, every
+  category off; AI off via env `AI_ENABLED` + spec `default=False`). The owner's instinct is correct.
+- The clearest "outgrew itself" case: **AI forked its own pipeline** — the same on/off lives as an
+  *env var + a KV scalar + a typed `ai_guild_policy` column*, kept in sync by a projection service,
+  with two independent default declarations.
+- **Implication:** the settings redesign is **"promote the existing registry to the *only* way to
+  declare a setting, and delete every bypass"** — not a greenfield build. In place that means deleting
+  40 callsites + unforking AI's typed store under live traffic (hard); in a rebuild the `SettingSpec`
+  layer is authoritative from commit 1.
+
+### 1.2 The AI-memory substrate-kit — real completion ~**45–55%**, not ~60%
+- **32 files / ~4,024 lines**; **117 tests, all green**; build regenerates cleanly; `--simulate 1`
+  smoke passes. Foundation is solid and **extraction-clean (zero `disbot` imports)**.
+- **⚠️ The "60% built, just finish PR 2 remainder + PR 3" framing is generous.** The split:
+  - **Done (declaration layer):** state backend, config, guardrail, interview + adaptive graduation,
+    5 stances, 7 skills, 3 personas, 2 checkers, render, CLI, single-file bootstrap, stance-guard hook.
+  - **Stubbed:** the three integration **modes** (`observe/guided/active`) — the field is set but its
+    *only read is a status print*; zero behavioral branching. Review seam = a persona prompt that says
+    "wire me up," unwired. Promotion-rights = field only.
+  - **Absent:** drift/staleness/**trigger** detection; the self-maintenance loop; the reflection
+    buffer; the full episodic index; `session_start`/`post_edit`/`stop_check` hooks +
+    `settings.template.json`; mode/stance/skill simulation asserts.
+  - **Templates: 6 of 13**, with **live dangling routes** — the question bank points Q-004/006/008/009/010
+    at `architecture.md`/`ownership.md`/`runtime_contracts.md`/`owner-profile.md` that **do not exist**.
+- **Everything shipped is declarative/static; the entire self-improving "nervous system" is unbuilt.**
+  That is the highest-value half — and the part that most benefits from a proper design pass.
+- Extraction blockers (all known Phase-2 productization): tests live outside the kit (`sys.path` shim),
+  no packaging metadata, no dedicated CI.
+
+### 1.3 Question router — ~**0 genuinely open**; the problem is format + stale decisions
+- **7,874 lines / 67,401 words; 212 contiguous Q-blocks** (Q-0001→Q-0212, zero gaps).
+- **⚠️ "60% unclassified / 11 open" is an artifact, not reality.** A semantic pass finds **~210 decided,
+  ~0 genuinely open**. The impression comes from **four coexisting status formats** (`**Status:**` on only
+  98 of 212; the rest use `**DECISION**`/`**DIRECTED**`/`**ANSWERED**` tokens, an `**Area:**` metadata
+  line, or the abandoned split-header format used by Q-0001–0005).
+- The real defects are exactly the owner's two: **stale decisions never stamped** (Q-0117 establishes the
+  Hermes merge-gate → Q-0176 debates tuning it → Q-0197 kills it; all three still read as live, none
+  cross-referenced) and **decided rules trapped as perpetual "questions"** (Q-0103/Q-0106 are quoted
+  verbatim as binding in CLAUDE.md yet still sit in the router).
+- **10,036 plain-text `Q-NNNN` citations** (212 unique) → in-place renumbering is unsafe. The archive
+  mechanism exists but is a **literal empty placeholder (0 archived blocks)**.
+
+### 1.4 Test suite as a rebuild oracle — **it cannot serve as one as-is** (load-bearing)
+- **11,510 test functions / 1,102 files**, all under `tests/unit/`.
+- **⚠️ The suite is aggressively white-box** and cannot be a frozen *behavioral* oracle for a rewrite:
+  - ~55–60% structural/implementation-coupled (arch/checker/doc meta-tests ~12%; SQL-shape pins asserting
+    literal query text; mock-choreography asserting internal call sequences).
+  - ~20–25% pure-unit portable logic (`utils/`); ~15–20% behavioral (formatters, view renders, and the
+    `evals/` grounding corpus — the one true black-box asset).
+  - **True end-to-end ≈ 0 in CI:** zero tests build a real `asyncpg` pool; every DB test mocks; the 6
+    `*_integration.py` skip whenever `DATABASE_URL` is unset (always). No Discord-gateway harness.
+  - **Transferable to a restructured rebuild: ~20–30% of test *intent*, <10% of test *code*.**
+- **The suite verifies *how SuperBot is built, not what it does.*** Pointed at a from-scratch
+  reimplementation, almost none passes even if behavior is identical.
+- **Consequence (see §3, Phase 0.5):** the correctness oracle must be **built**, not inherited — a
+  black-box golden-output harness (command-in → embed/DB-out) captured against the **live** bot before
+  any freeze. Reuse the `evals/` corpus; discard `invariants/`/`scripts/`/`docs/`/SQL-pins/mock-choreography.
+
+### 1.5 Binding docs & orientation cost — outgrown, and narrating their own history
+- Verified sizes (lines/words): CLAUDE.md 445/5,169 · collaboration-model 248/2,336 · current-state
+  424/6,555 · **AGENT_ORIENTATION 484/3,292 (1.9× its own stated ~250-line cap)** · architecture
+  474/2,637 · ownership 504/6,104 · runtime_contracts 473/2,616 · repo-nav 275/2,865.
+- **Per-session boot read ≈ 25,300 words** (7-doc "any task" set); **~33,600 with the journal.**
+- **≥5 rules that supersede themselves, tombstone retired mechanisms, or drift across docs**, e.g.
+  CLAUDE.md `:173` says "open the PR ready" then `:226` reverses it to "born-red, flip ready last" — a
+  reader obeys the dead instruction 53 lines before learning it's dead; the merge rule threads
+  Q-0084→Q-0123 + five carve-outs; the reconciliation cadence still recites "10 → 20 → 30."
+- **Pattern:** the binding docs **narrate their revision history inline** — "stitched, not designed"
+  applied to the memory system itself. New repo: state each rule cleanly at its current value, keep
+  Q-provenance in a *separate linked ledger*.
+
+### 1.6 Architecture debt — the real debt is **late-binding collisions**, not the warnings
+- **Verified: `0 errors, 49 warnings`** (13 baseview + 31 layer_boundary + 5 raw_sql — exact match).
+  36 grandfathered in `architecture_rules/` YAML; 13 baseview are hard-coded warnings, several
+  legitimate exemptions (game/paginator views). **⚠️ The "956 application files" denominator does not
+  reconcile** (`find disbot -name '*.py'` = 879).
+- **The 49 warnings are managed, contained, ~0-risk debt — not the story.** The real, incident-backed
+  debt:
+  1. **No central command/symbol namespace.** Q-0211 (`give` triple-collision) crash-looped production;
+     **BUG-0030 (`dock`/`sail`) recurred the identical class 2 days later** because the first fix only
+     de-duped cross-cog. Two boot crash-loops from one root cause in three days, both patched reactively.
+     Also Q-0200 (`round_composition` silent name-shadow).
+  2. **God-functions:** `AINaturalLanguageStage.process` cognitive **135 / 869 LOC / MI 11**;
+     `validate_registry` 83 (ironically the boot-abort validator); **533 functions over the complexity
+     threshold**; min MI 9.9.
+  3. **⚠️ Coupling is runtime/lazy, invisible to static tools.** The "essential_setup fan-out ~210"
+     figure **does not verify** (`impact_analysis` = 0 dependents; the subsystem imports lazily in
+     function bodies). No `disbot` file shows large measured fan-out — the true coupling can't be seen
+     by the import graph, which is itself a rebuild risk.
+- **Do not conflate** late-binding registration collisions (the real debt) with layer-boundary warnings
+  (managed debt). Honest nuance: prior consolidation passes (settings #625/#640, `edit_in_place`) found
+  SuperBot *already had* a central spine — the work was "finish and clarify," i.e. drift-accretion, not
+  absence.
+
+---
+
+## 2. What the research changed about the plan (five corrections)
+
+1. **The oracle must be built, not inherited.** The existing 11,510 tests are a regression net for the
+   *current* structure, not a behavioral spec for a rewrite. → new **Phase 0.5** (§3).
+2. **Finishing the substrate-kit is the real work, not mop-up.** Its adaptive/self-improving half is
+   unbuilt; "finish it first" is where the design method gets proven on a safe ~4k-line target.
+3. **The router isn't an open-question backlog** (≈0 open) — it's format-chaos + unstamped stale
+   decisions + decided-rules-trapped-as-questions. "Distill, don't migrate" becomes a concrete triage.
+4. **The bot's real debt is a missing namespace + god-functions + hidden coupling**, not the 49 tracked
+   warnings. The rebuild's structural wins should target *those*.
+5. **The settings problem is enforcement/consolidation of an existing-good pattern**, reframing design
+   move "declarative settings registry" from build → *make-authoritative + delete-bypasses*.
+
+---
+
+## 3. The plan-of-plans (phases + gates)
+
+**Phase 0 — Finish the substrate-kit's adaptive half (buildable now).** Build the nervous system that's
+absent: mode-conditioned behaviors, drift/trigger detection, the reflection buffer + meta-reflection
+miner (forward-injected), the missing 7 contract templates (kills the dangling routes), the remaining
+hooks. This *also* de-risks Phase 1 by proving "design as one picture" on a self-contained kit before
+betting the 237k-line bot on it. It's the generator for the new repo's clean binding docs + router.
+
+**Phase 0.5 — Capture the behavioral golden set against the live bot (NEW, must precede any freeze).**
+Stand up a black-box golden-output harness (command-in → embed/DB-out, ephemeral Postgres + a Discord
+driver), snapshot the current bot's observable behavior, reuse the `evals/` corpus. This is the only
+structure-agnostic correctness oracle for the rebuild — and independently a better regression net for
+the current bot (which today only checks internal wiring).
+
+**Phase 1 — The comprehensive design spec (the Fable job; design, not code).** One coherent picture,
+produced against the frozen reference: the redone architecture + layer/ownership/runtime contracts; the
+authoritative settings model (§4); the **central command/symbol namespace** (§4); the functionality
+inventory harvested from the old repo + goldens; the **distilled decision ledger** (§4); the data model;
+the regenerated binding docs. Owner-approved before any Phase-2 code. Fable's sweet spot: long-horizon,
+whole-picture, reason-from-knowledge — run at `xhigh`.
+
+**Phase 2 — Execute the rebuild (gated).** Port behavior into the new repo, each slice **red-until-parity
+against the Phase-0.5 goldens**; substrate-kit driving the workflow from day one; old repo stays in
+production until verified parity. ~100 PRs.
+
+**Gates:** don't freeze the old repo before the goldens exist; don't start Phase-2 code before the design
+is owner-approved; keep the old repo live until parity; extraction-to-own-repo and the rebuild go/no-go
+stay owner decisions.
+
+---
+
+## 4. Design principles for the new repo ("designed as one picture")
+
+- **One authoritative settings registry.** `SettingSpec` is the *only* way to declare a setting —
+  type/default/scope/validation/capability/UI/audit in one place; **safe-default policy as a field**
+  (features safe-on by default); no raw-KV escape hatch; AI's typed policy folded into the same
+  declaration. (§1.1)
+- **One declarative manifest grammar for the whole UI/command surface** — generalizes the settings
+  registry: panels, actions, settings, bindings, navigation and selectors declared once and *generated*
+  by a runtime engine, not hand-coded per cog. Introduced *through* the central namespace so it can't
+  recreate the `ActionSpec`-style collision. (§6.1)
+- **A central command/symbol namespace that reserves names at declaration and fails *before* boot.**
+  The single highest-value structural fix — it directly prevents the class that crash-looped production
+  twice in three days. (§1.6)
+- **A clean, self-classifying decision ledger** (the distilled router): one status format, machine-
+  parseable, ordered; "promote decided→rule-in-doc" and "retire→stamp superseded" as first-class ops;
+  starts at zero orphaned citations. (§1.3)
+- **Lean, regenerated binding docs with provenance separated from the rule.** State the current rule
+  cleanly; keep the Q-history in a linked ledger; enforce the orientation-cost cap with a checker so it
+  can't silently regrow. (§1.5)
+- **A complexity budget + visible coupling.** Cap god-functions (the AI NL stage is the worst offender);
+  prefer explicit imports so the dependency graph is *real*, not hidden behind lazy function-body imports.
+  (§1.6)
+- **Seam authority as an invariant.** For every audited seam (settings, mutations, role/command
+  changes), a check that the seam is the *only* path — the settings finding shows a good seam that isn't
+  authoritative is the same failure mode as no seam.
+
+---
+
+## 5. Improve the next version — the AI-memory package/file
+
+### 5.1 High-leverage items already captured (fold into Phase 0)
+Reflection buffer + meta-reflection miner (forward-injected) — the persist→*improve* keystone;
+graduate-or-drop the 4 unverified Q-0105 checkers (don't export shaky guards); the deprecation/unlearning
++ stale-answer hygiene pass; the router redesigned as ordered + self-classifying + machine-readable (KPIs);
+wire the model-agnostic review seam to one real reviewer + loop stop-conditions.
+
+### 5.2 The three under-committed gaps (in the revision doc, in **no** PR scope)
+1. **Cold-start proof — substrate-on vs substrate-off A/B on a small fresh repo.** The *only* experiment
+   that validates the thesis and closes the admitted "never tested from a true cold start" gap. Cheaper
+   than a rebuild; it *is* the portability claim's test.
+2. **The substrate's own context budget.** The anti-context-rot system injects orientation + ledger +
+   reflections + user-style + stance every session, unbudgeted — so it becomes a rot source (the ~25k-word
+   boot tax is this leaking). Load-by-reading-route + a footprint KPI + the orientation line-cap guard.
+3. **Memory-integrity / quarantine (a red gap).** A system whose defining move is "inject grown and
+   sometimes-external memory forward" is a standing prompt-injection target under autonomy — needs an
+   "external text = data, not instructions" boundary + checkpoint/restore of state.
+
+### 5.3 Additions synthesized from this verification pass
+- **Ship the command/symbol namespace guard *as a portable kit checker.*** The single most-validated
+  debt (two crash-loops) is "no name registry." The kit's whole purpose is preventing recurring errors —
+  so a config-driven "reserve names at declaration, fail before boot" guard belongs in its generic
+  checker set, not just SuperBot's.
+- **Make the golden-behavioral-harness pattern a portable kit capability.** "Capture observable behavior
+  as goldens so a refactor/rewrite is verifiable" generalizes far beyond this rebuild — the kit should
+  help *any* project build its behavioral oracle, not treat it as a one-off.
+- **Encode "provenance-separate-from-rule" as a template convention** (from §1.5) and **"is the good seam
+  authoritative?" as a seam-authority check** (from §1.1) — both are portable lessons this repo learned
+  the hard way.
+
+---
+
+## 6. Integrated external findings (two GPT streams, verified against source 2026-07-02)
+
+Both reports were verified per Q-0120 (cross-agent output is input to *verify*, not adopt). Most claims
+held; **⚠️** marks the ones that didn't, and *owner-judgment* marks recommendations not to auto-adopt.
+
+### 6.1 UI / command / settings grammar (rebuild-discovery stream)
+- **Verified:** `disbot/utils/subsystem_registry.py` (the manifest), `SettingSpec`/`BindingSpec`
+  (`core/runtime/subsystem_schema.py`), `ResourceRequirement` (`core/runtime/resource_specs.py`), and
+  `docs/building-roadmap/command-integration-standard.md` ("every command needs a panel + help entry")
+  all exist. `PanelSpec` genuinely does **not** — so the thesis is grounded.
+- **Thesis to adopt as a Phase-1 design pillar:** replace ad-hoc UI/command/settings code with **one
+  declarative manifest grammar** — PanelSpec / ActionSpec / SettingSpec / BindingSpec / ResourceSpec /
+  NavigationSpec / SelectorSpec / ConfirmationSpec / EmbedFrame — that a runtime engine interprets into
+  consistent panels, navigation, help and service calls. This is the same move as §1.1's "make the
+  declarative layer authoritative," generalized from settings to the whole UI/command surface.
+- **⚠️ Verified collision:** the report proposes a *new* `ActionSpec`, but `ActionSpec` already exists
+  (`services/automation_registry.py:35`). Introducing the grammar naively recreates the §1.6
+  namespace-collision bug class — so the grammar must be introduced *through* the central symbol
+  namespace, not alongside it.
+- **Preserve (verified consistent with the repo's own contracts):** service-owned mutation + audit
+  fan-out; the subsystem registry; help projection/overlay; BaseView/HubView auto-nav; paginated
+  selects; the settings/binding/resource separation; the event-bus wiring map; the AI review/preset
+  loop; the health-snapshot model.
+- **Migration hazards to model as an explicit backward-compat contract (the "hidden dependencies" a
+  naive rewrite breaks):** persistent `custom_id` strings; subsystem-registry keys (referenced in DB +
+  migrations); event-bus names; DB schemas/enums; audit payload shapes; the `help_overlay`/visibility/
+  cleanup governance tables. See the owner decision in §7.
+
+### 6.2 Control-plane / CI / GitHub settings (platform-optimization stream)
+- **Verified:** all 16 workflows exist as described; **`ROUTINE_PAT` is used by 7 workflows** (the
+  single-point-of-failure the substrate plan already flagged as "PAT-expiry silent failure");
+  `code-quality` is the sole required check; no `CODEOWNERS`.
+- **⚠️ Corrections (caught per Q-0120):** the report claims "no PR/issue templates" — both **exist**
+  (`.github/PULL_REQUEST_TEMPLATE.md` + `ISSUE_TEMPLATE/{bug_report,feature_request,config}`); and
+  "hundreds of stale `claude/*` branches" **does not verify** (local remote shows 1) — needs a live
+  GitHub check before acting.
+- **Adopt-worthy (safe, current-repo wins, independent of the rebuild):** reduce the `ROUTINE_PAT`
+  single-point-of-failure (GitHub App / OIDC); enable secret-scanning + push-protection; add a
+  `CODEOWNERS`; Dependabot security updates; enable auto-delete-head-branches (after the live
+  branch-count check).
+- **Owner-judgment (do NOT auto-adopt — could destabilize the autonomous loop):** making the
+  currently-UNVERIFIED subproject CI + tool-pins *required* checks; requiring branches-up-to-date
+  (would throttle the high-velocity agent pipeline — `pr-auto-update.yml` exists precisely to manage
+  this); requiring signed commits (agents/bots must sign); making Codex/Hermes reviews *required* gates
+  (false positives would block merges). The report itself flags these as needs-review/do-not-do-yet —
+  that judgment is correct.
+- **For the rebuild:** keep the good parts (deterministic `git merge-tree` conflict checks, auto-merge-
+  on-green, self-healing watchers, the routines) but design the new repo's control plane on
+  GitHub-native **rulesets + OIDC from day one**, instead of accreting PAT-powered workarounds — the
+  S5/ops analog of the "authoritative settings" and "declarative grammar" moves.
+
+---
+
+## 7. Open decisions & recommended next steps
+
+**Owner decisions still needed:** published kit name (branding); rebuild go/no-go after the design spec;
+whether cold-start proof needs the full rebuild or a small throwaway target (recommend the latter);
+**backward-compat contract** — does the new bot preserve existing DB tables + persistent `custom_id`s +
+subsystem keys via migrations, migrate only the important data, or start fresh? (the single biggest
+rebuild decision, from §6.1's hidden-dependency list); **manifest format** — Python dataclasses vs
+YAML/JSON vs hybrid; **control-plane hardening scope** — which of §6.2's safe GitHub toggles to enable
+on the *current* repo now.
+
+**Recommended immediate sequence (nothing here touches Phase-2 code or freezes the old repo):**
+1. Finish the substrate-kit adaptive half (**Phase 0**) — first application of the design method.
+2. In parallel, stand up the **Phase-0.5** golden harness against the live bot (also a current-bot win).
+3. Run the **router distillation** + **settings-authority** harvests (buildable now, valuable even if the
+   rebuild slips) — they become raw material for Fable's Phase-1 design.
+4. Hand Fable (`xhigh`) the **Phase-1 design spec** with verified material, not a blank page.
+
+---
+
+## Appendix — verification provenance (2026-07-02)
+
+Seven independent agents verified this baseline against live source/tooling: settings system, substrate-kit
+source state, question router, test-suite oracle viability, binding-doc/orientation cost, architecture debt,
+and the memory-system improvement harvest. Corrections they forced over prior docs are marked **⚠️** inline
+(notably: kit completion ~45–55% not ~60%; router ~0 open not 60% unclassified; the test suite cannot serve
+as a rebuild oracle; the "essential_setup fan-out 210" and "956 files" figures do not verify; the real arch
+debt is late-binding collisions + god-functions, not the 49 warnings).

--- a/docs/planning/rebuild-ultracode-handoff-2026-07-02.md
+++ b/docs/planning/rebuild-ultracode-handoff-2026-07-02.md
@@ -1,0 +1,140 @@
+# Rebuild — ultracode launch pad / handoff (2026-07-02)
+
+> **Status:** `plan` — **START HERE to launch the first ultracode sessions** of the SuperBot rebuild.
+> Written as a self-contained handoff (the planning session that produced it was nearing context
+> compaction). A **fresh ultracode session** provisions a high-core container → the full 16-wide fan-out
+> works (this doc's author ran in a 4-core container capped at 2, which is why the work was slow — start
+> each session below as a *new* `/effort ultracode` session).
+
+## 0. How to use this doc
+Open a **new Claude Code session, set `/effort ultracode`**, and paste one of the prompts in §5. Each is
+self-contained (points at the docs to read, the scope, model, output, constraints). Run the buildable-now
+ones (A, B, C) in parallel as separate sessions; D (the Fable design) runs after the harvest (A) lands.
+
+## 1. Read-first (durable, verified — do not re-derive)
+- **[`fresh-rebuild-strategy-2026-07-02.md`](fresh-rebuild-strategy-2026-07-02.md)** — the verified baseline
+  (§1), the five plan corrections (§2), the **end-to-end order Phase 0→5 + gates (§3)**, the **model &
+  ultracode allocation (§3.1)**, design principles (§4), memory-package improvements (§5), the integrated
+  GPT streams (§6), open owner decisions (§7).
+- **[`simulation-driven-design-2026-07-02.md`](simulation-driven-design-2026-07-02.md)** — the standing rule:
+  structure (grouping/ordering/layout) is discovered by simulation; the manifest is the search space.
+- **[`../../.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md`](../../.sessions/2026-07-02-rebuild-strategy-and-substrate-planning.md)**
+  — this planning session's decisions + context-delta.
+
+## 2. Verified baseline TL;DR (from a 7-agent fleet, source-checked 2026-07-02)
+- **Substrate-kit** is ~**45–55%** done (not ~60%): the declaration layer is built + 117 tests green, but the
+  *self-improving nervous system* (mode behaviors, drift/triggers, reflection buffer, self-maintenance loop,
+  review-seam wiring) is **absent/stubbed**, and **7 of 13 contract templates are missing with live dangling
+  routes**. Zero `disbot` coupling (extraction-clean).
+- **The existing 11,510-test suite CANNOT be the rebuild oracle** — it's white-box (asserts internal SQL/call
+  choreography), <10% transferable. A **black-box golden harness must be built against the live bot first**.
+- **The real bot debt is a missing central command/symbol namespace** (two boot crash-loops in 3 days:
+  Q-0211 `give`, BUG-0030 `dock`/`sail`) + god-functions (`AINaturalLanguageStage.process` cognitive 135) +
+  lazy-import-hidden coupling — **not** the 49 managed arch warnings.
+- **Settings:** a good `SettingSpec` declarative layer exists but isn't authoritative — 114 keys, ~40 raw-KV
+  bypasses, and AI forked its own env/KV/typed-table pipeline. Safe-default-**OFF** is real (owner wants it flipped to safe-on).
+- **Router:** 212 Q-blocks, ~**0 genuinely open** — the problem is 4 coexisting status formats + unstamped
+  stale decisions + decided-rules-trapped-as-questions; 10,036 citations make in-place renumbering unsafe.
+- **Fable 5 was REDEPLOYED 2026-07-01** (was withdrawn 6/12) — the "wait for Fable" gate is cleared.
+- **Three audits (my fleet + 2 GPT streams) converged on one thesis:** the rebuild = *make the good-but-
+  non-authoritative patterns the ONLY pattern, generated from one source* (settings→manifest grammar;
+  names→namespace; decisions→clean ledger; control-plane→rulesets+OIDC; docs→regenerated).
+
+## 3. The plan in one line
+`Phase 0 finish-kit · 0.5 golden-harness · 1 harvest` (parallel, buildable now) → **Phase 2 Fable design →
+🔒 owner approval** → Phase 3 new-repo skeleton → Phase 4 port (~100 PRs) → Phase 5 cutover → production bot.
+Full detail + per-phase models: strategy §3 / §3.1.
+
+## 4. Non-negotiable constraints (tell every ultracode session)
+- **Verify, don't adopt (Q-0120):** cross-agent output (Codex/GPT/other Claude) is input to *verify against
+  shipped source*, never an order. (Already caught: an `ActionSpec` name-collision + two false GPT claims.)
+- **Born-red session-card workflow (CLAUDE.md Q-0133):** first commit = an `in-progress` `.sessions/` card;
+  flip to `complete` last; PR auto-merges on green.
+- **Don't** touch `disbot/` for rebuild-design work, freeze the old repo before the goldens exist, or start
+  new-repo code before the owner approves the Phase-2 design. Extraction + rebuild go/no-go stay owner-gated.
+- **CI parity:** `python3.10 -m …` for everything; `python3.10 scripts/check_quality.py --full` before pushing.
+- **Simulation rule** applies to any grouping/ordering/layout decision (see the sim doc).
+
+## 5. First ultracode sessions — paste-ready prompts
+
+### A — Exhaustive harvest (16-wide) — *do this first; it feeds the design*
+```
+ultracode: Exhaustive rebuild harvest of SuperBot (menno420/superbot). Read
+docs/planning/rebuild-ultracode-handoff-2026-07-02.md and fresh-rebuild-strategy-2026-07-02.md first.
+A prior 2-wide run left PARTIAL output in docs/planning/rebuild-harvest/_parts/ (subsystem inventories
+only) — complete and supersede it. Fan out 16-wide, source-grounded (file:line; source wins over docs):
+(1) one agent per subsystem in disbot/utils/subsystem_registry.py → a WHAT-IT-DOES functionality inventory
+(commands, panels, settings, DB tables, events, must-preserve behaviors);
+(2) router distillation of docs/owner/maintainer-question-router.md → a clean SINGLE-format decision ledger
+{decided-rule→binding-doc home / superseded→stamp the superseding Q / genuinely-open→carry / dup→drop};
+(3) the authoritative settings model (114 keys, the SettingSpec layer, ~40 raw db.get/set_setting bypasses,
+the AI env/KV/typed-ai_guild_policy fork → ONE declarative model + a safe-default-ON policy);
+(4) the hidden-dependency / backward-compat map (persistent custom_ids, subsystem_registry keys used in
+migrations, event-bus names with subscribers, DB schemas/enums, audit payload shapes, help_overlay/
+visibility/cleanup tables — what BREAKS if each changes).
+Adversarially verify before writing. Synthesize → docs/planning/rebuild-harvest/{functionality-inventory,
+decision-ledger,settings-model,migration-contract}.md. Opus xhigh. Born-red session card.
+```
+
+### B — Finish the substrate-kit adaptive half (Phase 0)
+```
+ultracode: Finish the AI-memory substrate-kit's adaptive half (Phase 0). Read
+docs/planning/rebuild-ultracode-handoff-2026-07-02.md, fresh-rebuild-strategy-2026-07-02.md (§1.2/§3/§5),
+and portable-substrate-kit-extraction-2026-06-13.md (approved plan + "RESUME HERE"). Source of truth:
+substrate-kit/src/**, tests/unit/substrate_kit/**. Build the UNBUILT nervous system (verified
+absent/stubbed): the three mode behaviors observe/guided/active (the field is set but nothing reads it);
+drift/staleness/trigger detection; the reflection buffer + meta-reflection miner (forward-injected into
+orientation); the 7 MISSING contract templates (architecture, ownership, runtime_contracts,
+repo-navigation-map, helper-policy, ai-project-workflow, owner-profile — this kills the dangling
+question_bank routes); the remaining hooks (session_start orientation injection, post_edit, stop_check) +
+settings.template.json; memory-integrity/quarantine + a context budget; ship the namespace-guard as a
+portable checker. Regenerate dist/bootstrap.py after ANY src/engine edit; keep zero disbot imports;
+bootstrap stays stdlib-only. Verify: python3.10 -m pytest tests/unit/substrate_kit/ -q; build_bootstrap +
+dist/bootstrap.py --simulate 1; python3.10 scripts/check_quality.py --full. Opus xhigh. Born-red card.
+```
+
+### C — Behavioral golden harness (Phase 0.5) — *capture while the bot is live, before any freeze*
+```
+ultracode: Build the black-box behavioral golden harness against the LIVE SuperBot (Phase 0.5 — the
+rebuild's ONLY viable correctness oracle; the existing 11,510-test suite is white-box, <10% transferable).
+Read docs/planning/rebuild-ultracode-handoff-2026-07-02.md + fresh-rebuild-strategy-2026-07-02.md §1.4/§3.
+Stand up a command-in → embed/DB-out golden-capture harness: ephemeral Postgres (testcontainers) + a
+Discord driver (dpytest or equivalent), reusing tests/evals/ (the one existing black-box asset). Fan out
+16-wide, one agent per subsystem command-surface (use the harvest's functionality-inventory once it lands,
+else disbot/cogs/), snapshotting observable outputs + DB deltas as golden fixtures a rebuilt bot can be
+replayed against (red-until-parity). Deliver a runnable harness + the golden corpus; it doubles as a
+current-bot regression net. Opus xhigh/max on the harness core, Sonnet for per-subsystem capture. Born-red card.
+```
+
+### D — The Fable design spec (Phase 2) — *run AFTER A (harvest) lands; the owner-gate deliverable*
+```
+ultracode (start the session on Claude Fable 5, effort max): Produce the comprehensive from-scratch rebuild
+DESIGN SPEC for SuperBot — the "one picture." DESIGN, NOT CODE. Read fresh-rebuild-strategy-2026-07-02.md
+(all), simulation-driven-design-2026-07-02.md, docs/planning/rebuild-harvest/*.md (the harvest artifacts),
+and the merged Codex "preserve" map. Run it as a JUDGE-PANEL: 3 independent designs from different framings
+(clean-slate-ideal / minimal-migration-risk / manifest-grammar-maximal) + 1 Opus, synthesize best-of, then
+independent review by Opus + a non-Claude model. Produce: redone architecture + layer/ownership/runtime
+contracts; the declarative MANIFEST GRAMMAR (Panel/Action/Setting/Binding/Resource/Nav/Selector) designed
+TO BE SIMULATED OVER; the central command/symbol namespace; the authoritative settings model + safe-default
+policy; the data model + backward-compat contract; the control-plane (GitHub rulesets + OIDC); the
+regenerated binding docs. Do NOT re-open the 10 settled substrate-kit review rounds — verify against source,
+don't re-litigate. Output → docs/planning/rebuild-design-spec-2026-07-xx.md. Owner approves before Phase 3.
+```
+
+> **Also:** the owner is running **4 Codex mapping sessions** (best-ideas-to-preserve, one per domain:
+> AI/knowledge · economy/games · server-mgmt/moderation · platform/UI). When they land, an orchestrator
+> session diffs them against A's functionality inventory, verifies against source (Q-0120), and folds the
+> union into one **preserve / redesign / drop** artifact that feeds D.
+
+## 6. Current in-flight state (as of this handoff)
+- **My 2-wide harvest** (`rebuild-harvest` workflow) is partial: 13 subsystem inventories in
+  `docs/planning/rebuild-harvest/_parts/` (gitignored scratch), no router/settings/deps parts or synthesized
+  artifacts yet. **Session A supersedes it 16-wide** — don't wait on it.
+- **4 Codex mapping sessions** running on the owner's side (independent cloud compute, truly parallel).
+- **Committed + pushed** on branch `claude/substrate-kit-planning-review-3a1jkf`: the strategy doc, the
+  simulation-driven-design doc, this handoff, the session log, and the Fable-status fixes in the vision doc.
+
+## 7. Model & ultracode allocation (quick ref — full table in strategy §3.1)
+Fable where reasoning is the bottleneck (the Phase-2 design, session D); Opus `xhigh` for the builds
+(A/B/C); Sonnet for wide fan-out / the Phase-4 port; independent review always a *different* model than
+built it. The golden harness (C) is what makes cheap-tier porting safe later (red-until-parity).

--- a/docs/planning/rebuild-ultracode-handoff-2026-07-02.md
+++ b/docs/planning/rebuild-ultracode-handoff-2026-07-02.md
@@ -106,33 +106,47 @@ replayed against (red-until-parity). Deliver a runnable harness + the golden cor
 current-bot regression net. Opus xhigh/max on the harness core, Sonnet for per-subsystem capture. Born-red card.
 ```
 
-### D — The Fable design spec (Phase 2) — *run AFTER A (harvest) lands; the owner-gate deliverable*
+### D — The Fable design spec (Phase 2) — *its main input (the Codex preserve map) has LANDED; run it now (owner-gate deliverable)*
 ```
 ultracode (start the session on Claude Fable 5, effort max): Produce the comprehensive from-scratch rebuild
-DESIGN SPEC for SuperBot — the "one picture." DESIGN, NOT CODE. Read fresh-rebuild-strategy-2026-07-02.md
-(all), simulation-driven-design-2026-07-02.md, docs/planning/rebuild-harvest/*.md (the harvest artifacts),
-and the merged Codex "preserve" map. Run it as a JUDGE-PANEL: 3 independent designs from different framings
-(clean-slate-ideal / minimal-migration-risk / manifest-grammar-maximal) + 1 Opus, synthesize best-of, then
-independent review by Opus + a non-Claude model. Produce: redone architecture + layer/ownership/runtime
-contracts; the declarative MANIFEST GRAMMAR (Panel/Action/Setting/Binding/Resource/Nav/Selector) designed
-TO BE SIMULATED OVER; the central command/symbol namespace; the authoritative settings model + safe-default
-policy; the data model + backward-compat contract; the control-plane (GitHub rulesets + OIDC); the
-regenerated binding docs. Do NOT re-open the 10 settled substrate-kit review rounds — verify against source,
-don't re-litigate. Output → docs/planning/rebuild-design-spec-2026-07-xx.md. Owner approves before Phase 3.
+DESIGN SPEC for SuperBot — the "one picture." DESIGN, NOT CODE. Read (all) fresh-rebuild-strategy-2026-07-02.md,
+simulation-driven-design-2026-07-02.md, and — your primary evidence — the VERIFIED Codex preserve map
+docs/analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md (its §1 corrections are BINDING;
+drill into the 4 raw domain maps in that folder as needed). Run it as a JUDGE-PANEL: 3 independent designs
+from different framings (clean-slate-ideal / minimal-migration-risk / manifest-grammar-maximal) + 1 Opus,
+synthesize best-of, then independent review by Opus + a non-Claude model. Produce: redone architecture +
+layer/ownership/runtime contracts; the declarative MANIFEST GRAMMAR (Subsystem/Panel/Action/Setting/Binding/
+Resource/Nav/Selector) designed TO BE SIMULATED OVER; the central command/symbol namespace; the authoritative
+settings model + safe-default-ON policy; the data model + backward-compat contract (the map's §5 hazard set);
+the control-plane (GitHub rulesets + OIDC); the regenerated binding docs.
+VERIFIED CONSTRAINTS FROM THE MAP (do not re-derive, do not violate):
+ (1) RENAME the proposed `ActionSpec` — it HARD-COLLIDES with the shipped services/automation_registry.py:35
+     class ActionSpec; resolve repo-wide (PanelActionSpec/UIActionSpec) before any domain adopts it.
+ (2) EXTEND, never recreate, the already-shipped types: SettingSpec/BindingSpec (subsystem_schema.py),
+     CapabilityDecision (governance/capability.py), LifecycleResult/StepResult (lifecycle/contracts.py),
+     ResourceRequirement (resource_specs.py), AIGateway (core/runtime/ai/gateway.py, re-exported via
+     services/ai_gateway.py — preserve that seam split). The manifest grammar CONSOLIDATES the mature-but-
+     fragmented subsystem_schema.py + subsystem_registry.SUBSYSTEMS + hub_registry.HUBS — it is not greenfield.
+ (3) Honor the §5 backward-compat contract: persisted subsystem_registry keys, persistent custom_id strings,
+     catalogued event names/payloads, DB migrations/tables, settings keys, audit payload shapes.
+Do NOT re-open the 10 settled substrate-kit review rounds — verify against source, don't re-litigate.
+Output → docs/planning/rebuild-design-spec-2026-07-xx.md. Owner approves before Phase 3.
 ```
 
-> **Also:** the owner is running **4 Codex mapping sessions** (best-ideas-to-preserve, one per domain:
-> AI/knowledge · economy/games · server-mgmt/moderation · platform/UI). When they land, an orchestrator
-> session diffs them against A's functionality inventory, verifies against source (Q-0120), and folds the
-> union into one **preserve / redesign / drop** artifact that feeds D.
+> **The Codex preserve map is DONE (2026-07-02).** The owner's 4 Codex mapping sessions (platform/UI ·
+> admin/safety/server · economy/games · AI/knowledge) landed as PRs #1630–#1633; a verify-and-fold workflow
+> checked their load-bearing claims against source (Q-0120 — **48/59 confirmed, 2 false, 9 partial**) and
+> folded them into **[`codex-preserve-map-synthesis-2026-07-02.md`](../analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md)**.
+> This is D's primary input — the separate 16-wide harvest (A) is now **optional**, not a blocker for D.
 
 ## 6. Current in-flight state (as of this handoff)
-- **My 2-wide harvest** (`rebuild-harvest` workflow) is partial: 13 subsystem inventories in
-  `docs/planning/rebuild-harvest/_parts/` (gitignored scratch), no router/settings/deps parts or synthesized
-  artifacts yet. **Session A supersedes it 16-wide** — don't wait on it.
-- **4 Codex mapping sessions** running on the owner's side (independent cloud compute, truly parallel).
+- **The Codex preserve map is folded and verified** → `docs/analysis/rebuild-discovery/` (synthesis +
+  4 raw domain maps). D can run now; A (the 16-wide harvest) is optional additional depth, not a gate.
+- **My 2-wide harvest** (`rebuild-harvest` workflow) was partial (gitignored `_parts/` scratch) and is
+  **superseded** — the Codex maps cover the same functionality-inventory ground. Don't wait on it.
 - **Committed + pushed** on branch `claude/substrate-kit-planning-review-3a1jkf`: the strategy doc, the
-  simulation-driven-design doc, this handoff, the session log, and the Fable-status fixes in the vision doc.
+  simulation-driven-design doc, this handoff, the session log, the Fable-status fixes in the vision doc,
+  and the verified Codex synthesis + 4 preserved maps.
 
 ## 7. Model & ultracode allocation (quick ref — full table in strategy §3.1)
 Fable where reasoning is the bottleneck (the Phase-2 design, session D); Opus `xhigh` for the builds

--- a/docs/planning/simulation-driven-design-2026-07-02.md
+++ b/docs/planning/simulation-driven-design-2026-07-02.md
@@ -1,0 +1,76 @@
+# Simulation-driven design — structure is discovered, not decided (2026-07-02)
+
+> **Status:** `plan` — **owner-directed standing rule** (owner, in-session, 2026-07-02; this doc is the
+> provenance). Feeds the Phase-2 rebuild design and is a candidate **portable substrate-kit capability**.
+> Companion to [`fresh-rebuild-strategy-2026-07-02.md`](fresh-rebuild-strategy-2026-07-02.md) §4.
+
+## The rule
+
+Any design decision with **(a) a combinatorial arrangement** and **(b) a measurable objective** —
+*grouping, ordering, layout* — is decided by running it through a **simulator that searches the space
+and returns the empirically-best arrangement**, not by intuition or an agent "just deciding." This is a
+**standing, first-class step** for every existing and new feature, gated by a *sim-reviewed-or-exempt*
+check before the feature is called done — not an occasional trick.
+
+**Origin — already proven in-repo** (this generalizes three one-offs into a rule):
+- The **BTD6 menu-layout simulator** (#1617 — owner picked Layout B off it).
+- The **reaction-roles slim-builder layout-sim** (#1612/#1613/#1615 — after the 14-button builder felt dense).
+- `tools/sim/claim_layout_sim.py` — measured **98% vs 0% conflict** and *decided* the per-file claim architecture.
+
+## Why the rebuild unlocks it (the manifest synergy)
+
+The rule is only cheap when structure is **declarative data**. The rebuild's manifest grammar
+(Panel/Action/Setting/Binding/… specs — strategy §4/§6.1) makes panels, commands, and settings *data*,
+so a simulator can reorder/regroup and score candidates mechanically. **The manifest is the search
+space; the simulator is the search.** Hand-coded structure can't be optimized this way; a manifest can.
+Design-by-simulation and the manifest grammar are two halves of one mechanism — so **the manifest must
+be designed *to be simulated over* from day one** (a Phase-2 design requirement).
+
+## Guardrails (the rule fails without these)
+
+1. **Trigger threshold.** Simulate decisions with a *real* combinatorial space + measurable objective
+   (a 12-button hub, a 40-setting group, the module tree). Not a 2-button panel. The rule must state
+   *when* it applies, or it drowns everything in ceremony.
+2. **Explicit, data-grounded objective — the hard part.** A simulator is only as good as its cost
+   function; a *guessed* objective produces a **confidently-wrong** layout. Ground the weights in real
+   signal (usage frequency, co-occurrence, the call graph), not vibes. **This is the one way it fails.**
+3. **Keep the simulator.** It operates on the manifest, so it's re-runnable; when a feature changes,
+   *re-optimize* instead of re-guess. This is what makes it a standing practice, not a one-off.
+4. **Deterministic + auditable.** The sim is deterministic and records *why* the winning arrangement
+   won (matches the repo's observability/auditability principle).
+
+## Per-domain mechanisms
+
+| Domain | The sim optimizes | Objective (minimize) | Engine status |
+|---|---|---|---|
+| **Buttons / panels** | row & sub-panel layout under Discord's 5-row / 25-component cap | clicks-to-action + group cohesion + safe destructive placement | ✅ **built** (BTD6 Layout B; reaction-roles slim builder) |
+| **Commands** | hub/category grouping + help order + names | navigation depth + semantic cohesion + **zero collisions** | ⚙️ manifest-driven; the namespace guard is the collision half |
+| **Settings** | settings-hub grouping + order + primary-vs-advanced | co-edit distance + dependency order + edit frequency | ⚙️ manifest-driven (feeds off the harvest settings model) |
+| **File ordering** | module/dir clustering — where code lives | cross-boundary coupling ↓ / cohesion ↑, within the layer rules | ✅ **engine exists** — CodeGraph community detection |
+| **AI answers** | info ordering/grouping in a response | reader cost (lead-with-the-outcome) + fact grouping | ⚙️ eval-driven (`evals/` corpus); fuzzier, rubric-scored |
+| *(general)* | any arrangement with a measurable objective | the stated objective | build when the trigger threshold is met |
+
+## File-ordering simulator — already has an answer today
+
+CodeGraph community detection on the call/import graph **is** the file-ordering simulator's engine, and
+it already reports **`drift: 48%` / `modularity: 0.4712` / 2148 communities** in every session-start
+banner — i.e. the current file grouping is ~48% off the graph-optimal clustering. `mcp__codegraph__communities`
+gives the per-module detail (which files' graph-community disagrees with their directory). **This is the
+rule working today with zero new tooling** — the file-ordering pass can run first, as the proof of concept.
+
+## Where it lives
+
+- **Phase-2 rebuild design:** a core principle + a **sim-reviewed-or-exempt gate** before a feature is
+  done; the manifest grammar designed to be simulated over.
+- **Portable substrate-kit capability:** the kit ships the design-simulator scaffold + the rule — same
+  "the memory system discovers the right structure" family as the namespace-guard and golden-harness
+  (strategy §5.3).
+- **Current repo:** an owner-directed rule (this doc is the provenance; for binding-`CLAUDE.md` promotion
+  it would still be routed as a rule proposal per the working agreement).
+
+## Next
+
+- Fold into the **Phase-2 design brief** as a core requirement (manifest designed to be simulated over).
+- Build the per-domain simulators as the manifest grammar lands (buttons/commands/settings from the
+  manifest; AI-answers from the eval corpus).
+- Run the **file-ordering sim** (CodeGraph communities) as the first concrete pass — the engine exists.


### PR DESCRIPTION
## Summary

Docs-only, owner-directed planning session for the SuperBot from-scratch rebuild. Two parts:

**(1) The planning foundation** — a trustworthy, source-verified baseline + plan-of-plans + the ultracode launch pad:
- **`docs/planning/fresh-rebuild-strategy-2026-07-02.md`** — 7-agent-verified baseline (settings, substrate-kit real state, router, test-suite oracle viability, binding-doc rot, architecture debt), the end-to-end order (Phase 0→5 + gates), model/ultracode allocation, and two verified external GPT streams.
- **`docs/planning/simulation-driven-design-2026-07-02.md`** — owner-directed standing rule: structure (grouping/ordering/layout) is discovered by simulation; the manifest is the search space.
- **`docs/planning/rebuild-ultracode-handoff-2026-07-02.md`** — paste-ready ultracode session prompts for the first waves (harvest / finish substrate-kit / golden harness / **Fable design**).
- Corrected the stale Fable-5 status in the vision doc (redeployed 2026-07-01).

**(2) The verified Codex preserve-map fold** (this session's follow-up wave):
- Preserves the **4 Codex rebuild-discovery maps** verbatim under `docs/analysis/rebuild-discovery/` (platform-UI-runtime · admin-safety-server · community-economy-games · AI-knowledge-tooling) — the `.md` reports only, dropping the stale `dashboard.json` each Codex branch also carried.
- A verify-and-fold workflow re-checked their load-bearing claims against **shipped source** (Q-0120): **48/59 CONFIRMED, 2 FALSE, 9 PARTIAL** → folded into **`docs/analysis/rebuild-discovery/codex-preserve-map-synthesis-2026-07-02.md`** (unified preserve/redesign/drop + primitive taxonomy + backward-compat contract). This is the primary evidence input to the Fable design session.
- **Key verified catches:** the proposed `ActionSpec` **hard-collides** with the shipped `services/automation_registry.py:35 class ActionSpec` (design must rename repo-wide); `BindingSpec`/`LifecycleResult`/`CapabilityDecision` are **already shipped** (extend, don't recreate); `views/selectors/multi_channel.py` doesn't exist; several command tokens and module paths corrected.

**Supersedes PRs #1630–#1633** (the 4 Codex maps) — their reports live here + in the synthesis.

**CI fixes folded in:** an invalid `analysis` badge + orphan handoff doc (`check_docs`), then a previously-masked `test_check_plan_homing` failure (the 3 new plans are now homed via a `docs/planning/README.md` subsection).

## Linked plan

Extends [`docs/ideas/superbot-fresh-rebuild-vision-2026-06-30.md`](../blob/main/docs/ideas/superbot-fresh-rebuild-vision-2026-06-30.md); sits above the approved `portable-substrate-kit-extraction-2026-06-13.md` plan.

## Type of change

- [x] Documentation

## Checks

- [x] Docs-only — no `disbot/` / runtime / behavior changes; no Python touched
- [x] Codex map claims verified against shipped source (Q-0120), not adopted wholesale
- [x] No secrets, tokens, or credentials added
- [x] `check_quality.py --full` run locally (plan-homing + check_docs green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGBEHsXQ4nTozYzQQBfhLT