### PR TITLE
docs: add 2026-07-02 repo-grounded work summary

### DIFF
--- a/docs/analysis/today-work-summary-2026-07-02.md
+++ b/docs/analysis/today-work-summary-2026-07-02.md
@@ -1,0 +1,208 @@
+# 2026-07-02 SuperBot Work Summary
+
+> **Status:** `historical` — repo-grounded work-summary report for 2026-07-02.
+
+## Verification limits
+
+- GitHub live state was queried through the public GitHub REST API because `gh` is not installed in this container.
+- The latest live default branch is `main`; live `main` SHA at query time was `87997562484a1cb65052c84a970f84cd5e7fd510`.
+- The local checkout is on branch `work` at the same commit (`87997562484a1cb65052c84a970f84cd5e7fd510`), but no `origin/main` ref is configured locally, so remote-main comparison used the GitHub API plus local `HEAD`.
+- I did not rerun the full heavy verification suite; this report distinguishes GitHub check status, PR/session-local claims, and recommended reruns.
+
+## 1. Executive summary
+
+2026-07-02 was a rebuild-planning and AI-memory-substrate day, with one important runtime-adjacent ops thread and several dashboard refreshes.
+
+The largest shipped outcome was PR #1649: the in-repo `substrate-kit` moved from planning surface to a packaged, stdlib-only, one-step-adopt substrate with source modules, generated `dist/bootstrap.py`, hooks, checkers, a context-economy engine, AgentContextPack generation, templates, and a large unit-test surface. This did **not** implement Phase-3 rebuild code in `disbot/`; it produced the memory substrate and its proof surface.
+
+The second major outcome was PR #1639: the linchpin validation package for the rebuild design. It added the golden behavioral replay harness under `parity/`, grammar-expressiveness spike artifacts, a go/no-go validation document, and a CI workflow for parity replay. The recorded verdict is “GO with amendments,” but the rebuild itself remains owner-gated.
+
+The day also produced the Phase-2 rebuild design spec and revisions, fresh-rebuild strategy/handoff docs, a memory-retention/context-economy plan with owner decisions Q-0214, Railway/admin-guild operational updates, and the 32nd Q-0107 reconciliation pass. The most important remaining gate is unchanged: **no Phase-3 new-repo code before owner approval of the rebuild design spec and its backward-compatibility contract.** A Phase-2.5 cold-start substrate-on/off A/B is still called out as gating Phase 3, and standalone extraction/publishing of `substrate-kit` remains owner-gated.
+
+The main likely forgotten item is docs drift introduced by timing: PR #1652’s reconciliation pass merged before PR #1649, so S4 still lists memory-retention/context-economy implementation as next even though #1649 shipped the kit-native context-economy engine. That is an important docs-cleanup follow-up, not a runtime blocker.
+
+## 2. Verified timeline
+
+| Time (UTC) | PR | Status | Size | Primary deliverable | Evidence |
+| --- | ---: | --- | ---: | --- | --- |
+| 04:26 | #1629 `chore(dashboard): refresh generated data` | merged | 1 file, +4/-4 | Dashboard data refresh. | GitHub API PR list; local merge commit `61db0ef`. |
+| 05:19 | #1634 `docs(planning): rebuild strategy + simulation rule + ultracode launch pad + verified Codex preserve-map fold` | merged | 12 files, +2693/-3 | Fresh rebuild strategy, simulation-driven design rule, ultracode handoff, preserved Codex discovery maps. | GitHub API PR files; local merge commit `b526127`. |
+| 07:15 | #1635 `docs(planning): rebuild design spec — the "one picture" (owner-gate deliverable)` | merged | 10 files, +1754/-2 | Initial Phase-2 design spec and owner-gate framing. | GitHub API PR files; local merge commit `60714ab`. |
+| 09:35 | #1636 `chore(dashboard): refresh generated data` | merged | 1 file, +29/-21 | Dashboard data refresh. | GitHub API PR list; local merge commit `8f89df5`. |
+| 10:16 | #1637 `docs(planning): design-spec revision — plain-language summary + external GPT review round folded in` | merged | 6 files, +404/-7 | Design-spec revision with plain-language summary and external review findings. | GitHub API PR files; local merge commit `a8b2a8b`. |
+| 10:32 | #1638 `docs(ops): Railway token-capability audit + new-project setup plan/roadmap` | merged | 6 files, +345/-3 | Railway token audit and setup plan. | GitHub API PR files; local merge commit `a5ecdc6`. |
+| 10:58 | #1640 `docs(ops): Railway full-automation grant (Q-0213) + R-now hygiene executed via API` | merged | 9 files, +264/-31 | Railway automation grant, workflow/ops doc updates, router decision. | GitHub API PR files; local merge commit `00308ae`. |
+| 11:06 | #1641 `docs(ideas): five captures from the 2026-07-02 session arc` | merged | 7 files, +271/-0 | Idea harvest from the session arc. | GitHub API PR files; local merge commit `b5dd07a`. |
+| 11:10 | #1642 `docs(rebuild): parallel-execution schedule + AI-memory system as the K0 start-gate` | merged | 4 files, +303/-14 | Rebuild execution schedule; AI-memory system elevated as K0 start gate. | GitHub API PR files; local merge commit `3e895b4`. |
+| 11:37 | #1644 `docs(ideas)+ops: admin/logging-guild architecture capture + Railway alerts webhook restored` | merged | 5 files, +185/-1 | Admin/logging guild architecture idea and Railway alerts webhook restoration docs. | GitHub API PR files; local merge commit `d367162`. |
+| 12:11 | #1645 `docs(ops): HQ guild live — Railway alerts moved to Superbot Admin + invite-defaults fix + cutover-token confirmation` | merged | 3 files, +101/-1 | HQ guild live/cutover confirmation. | GitHub API PR files; local merge commit `2e83306`. |
+| 12:24 | #1643 `Memory retention & deletion policy: design brainstorm, hard limits, retention simulator` | merged | 10 files, +1249/-1 | Retention/context-economy plan and simulator. | GitHub API PR files; local merge commit `af8b8f2`. |
+| 12:25 | #1647 `Record owner decisions Q-0214: the four structural retention choices` | merged | 4 files, +60/-9 | Q-0214 owner decisions folded into retention/orientation docs. | GitHub API PR files; local merge commit `66079a6`. |
+| 12:27 | #1646 `chore(dashboard): refresh generated data` | merged | 1 file, +133/-61 | Dashboard data refresh. | GitHub API PR list; local merge commit `ea41ede`. |
+| 12:56 | #1648 `Substrate-finalization launch prep: design-spec ledger refinements + handoff §B extension + repo pointers` | merged | 7 files, +130/-21 | Handoff §5.B extension and pointers into S3/roadmap/design spec. | GitHub API PR files; local merge commit `b18fc8f`. |
+| 14:15 | #1639 `Rebuild linchpin validation: golden behavioral harness ... + go/no-go` | merged | 507 files, +61332/-11 | Golden behavioral harness, grammar spike, validation verdict, parity workflow. | GitHub API PR files; local merge commit `43a7ea7`. |
+| 16:22 | #1650 `chore(dashboard): refresh generated data` | merged | 1 file, +29/-21 | Dashboard data refresh. | GitHub API PR list; local merge commit `8fa70db`. |
+| 16:39 | #1652 `docs: thirty-second Q-0107 reconciliation pass (band-#1650)` | merged | 10 files, +528/-95 | Reconciliation pass, current-state updates, dashboard/botsite export. | GitHub API PR files; local merge commit `d999590`. |
+| 17:30 | #1649 `Finalize the AI-memory substrate ...` | merged | 78 files, +16147/-348 | Finalized in-repo `substrate-kit`, generated bootstrap, tests, docs/session closeout. | GitHub API PR files; local merge commit `8799756`. |
+
+Closed but unmerged PRs updated today: #1630, #1631, #1632, and #1633 were the four rebuild-discovery map PRs that were superseded by/folded into #1634 rather than merged individually.
+
+Open PRs after today’s merges: #1509 plus dependabot PRs #1555–#1560. None of these should be folded into this report or any substrate/rebuild follow-up.
+
+## 3. Main shipped outcomes
+
+### Rebuild design/spec work
+
+- **Actually shipped:** Phase-2 design spec docs, revisions, strategy, ultracode handoff, and execution schedule were merged through #1634, #1635, #1637, #1642, and #1648.
+- **Documented/planned only:** Phase-3 implementation remains unstarted/gated. The design spec explicitly frames itself as an owner-gate artifact awaiting owner approval before Phase-3 work.
+- **Verified by tests/tooling:** GitHub checks for these docs PRs reported success for CodeQL, code-quality, Analyze (python), and flag-conflicts.
+- **Claimed but not independently re-verified here:** The quality of Fable-5/adversarial-review findings and exact design correctness were not re-adjudicated in this session.
+
+### Linchpin validation/golden harness work
+
+- **Actually shipped:** #1639 added `parity/`, `parity/COVERAGE.md`, many golden trace fixtures, grammar-spike artifacts, a parity replay workflow, and the validation report.
+- **Documented/planned only:** The report’s go/no-go recommendation is evidence for owner review, not approval to start Phase 3.
+- **Verified by tests/tooling:** GitHub checks on #1639 were green for CodeQL, flag-conflicts, code-quality, and Analyze (python). The PR/session claims a 465-golden harness with 459/459 gating replay green and grammar fit improving from 73% to 85% with amendments; those claims should be rerun locally before treating them as release evidence.
+- **Claimed but not independently re-verified here:** I did not rerun parity replay or grammar-spike commands.
+
+### AI-memory substrate/substrate-kit work
+
+- **Actually shipped:** #1649 added/updated `substrate-kit/` source, templates, README, `pyproject.toml`, generated `dist/bootstrap.py`, and test coverage under `tests/unit/substrate_kit/`.
+- **Documented/planned only:** Standalone extraction/publishing remains owner-gated; the README states `substrate-kit` is a placeholder published name awaiting owner choice.
+- **Verified by tests/tooling:** GitHub checks on #1649 were green for CodeQL, Analyze (python), code-quality, and flag-conflicts. README/session state claims scratch-repo adopt proof and 117→399 kit tests.
+- **Claimed but not independently re-verified here:** I did not rerun `python3.10 -m pytest tests/unit/substrate_kit`, bootstrap/adopt smoke, or full quality/architecture gates.
+
+### Memory retention/context-economy work
+
+- **Actually shipped:** #1643/#1647/#1648 shipped the plan, owner decisions Q-0214, and simulator; #1649 shipped a kit-native context-economy engine with classes, gauges, triple-filter deletion logic, tombstones, harvest tables, and simulator/calibration commands.
+- **Documented/planned only:** Applying retention deletion to SuperBot itself is not yet done; the first real prune remains a separate, owner-visible/routine-owned follow-up.
+- **Verified by tests/tooling:** PR checks were green; #1649 added unit tests for economy behavior.
+- **Claimed but not independently re-verified here:** I did not run the simulator or a dry-run retention actuator locally.
+
+### docs/current-state/reconciliation work
+
+- **Actually shipped:** #1652 performed the 32nd Q-0107 reconciliation pass and refreshed current-state/dashboard/botsite exports; #1649 later updated S3 after that reconciliation.
+- **Documented/planned only:** S4’s next-action retention row appears stale after #1649 because #1652 merged before #1649.
+- **Verified by tests/tooling:** #1652 had green CodeQL, flag-conflicts, dashboard-tests, Analyze (python), enable-auto-merge, botsite-tests, and code-quality checks.
+- **Claimed but not independently re-verified here:** I did not rerun `scripts/check_docs.py` or current-state ledger checkers.
+
+### Ops/admin guild/Railway/webhook work
+
+- **Actually shipped:** #1638, #1640, #1644, and #1645 documented Railway audit/setup, full-automation grant, webhook restoration, admin/logging guild architecture, HQ guild live, and alert-feed migration.
+- **Documented/planned only:** Some live-bot/Hermes/credentialed actions remain gated by owner credentials/VPS write scope.
+- **Verified by tests/tooling:** PR checks were green; session logs record API/hygiene actions.
+- **Claimed but not independently re-verified here:** I did not inspect Railway or Discord live state.
+
+### Dashboard/generated data refreshes
+
+- **Actually shipped:** #1629, #1636, #1646, #1650, and #1652 touched generated dashboard/botsite data.
+- **Documented/planned only:** None; these were generated-data refreshes.
+- **Verified by tests/tooling:** Dashboard PRs had green dashboard-tests/code-quality; #1652 also had green botsite-tests.
+- **Claimed but not independently re-verified here:** I did not rerun dashboard export or botsite build locally.
+
+## 4. What PR #1649 actually changed
+
+PR #1649 changed 78 files (+16147/-348). The changed-file list and working tree show these substrate-kit additions and updates:
+
+- **New/changed engine modules:** `src/engine/adopt.py`, `cli.py`, `contextpack.py`, `ledger.py`, `render.py`, `lib/` modules (`atomicio`, `config`, `guardrail`, `modes`, `state`), interview modules, stances, skills, agents, loop modules (`episodes`, `kpis`, `maintenance`, `reflections`, `review_seam`, `triggers`), and economy modules (`engine`, `harvest`, `simulator`).
+- **Hooks:** `session_start.py`, `post_edit.py`, `stop_check.py`, `stance_guard.py`, and `settings.py`. The README states these are staged under `.substrate/` and are not written live to `.claude/` unless explicitly requested.
+- **Checkers:** docs hygiene, session-log completeness, decisions-ledger/stamp discipline, namespace/shadowing guard, seam-authority fences, and orientation budget are wired through `check --strict`.
+- **Templates:** 16 content templates under `src/engine/templates/`, including `CONSTITUTION.md`, `CLAUDE.md`, `AGENT_ORIENTATION.md`, current-state, ownership, runtime contracts, question-router, decisions, ideas README, and project workflow templates.
+- **Packaging/bootstrap/adopt flow:** `dist/bootstrap.py` is the generated single-file stdlib distribution; `src/build_bootstrap.py` builds it; `pyproject.toml` provides pip-installable form; `README.md` documents `python3 bootstrap.py adopt` as the one-step adoption path. The CLI guardrail was hardened so the generated bootstrap can adopt an external repo rather than refusing everything outside the source tree.
+- **Context economy:** `src/engine/economy/engine.py` implements class taxonomy, gauges, inbound-reference scanning, triple-filter harvest/window/reference deletion, tombstone shards, and issue-body output. `harvest.py` parses and renders harvest tables. `simulator.py` provides calibration/search support.
+- **Ledger/stamp discipline:** `ledger.py` implements `[D-NNNN]` decisions, machine-readable `supersedes:`, append/check commands, and stamp-discipline checks; README documents this as an enforcing checker category.
+- **AgentContextPack:** `contextpack.py` and CLI wiring generate/load pack indexes so agents can receive scoped context packs instead of relying only on hand-maintained orientation prose.
+- **Tests added/changed:** `tests/unit/substrate_kit/` was expanded heavily across adopt/bootstrap, CLI, checks, economy, hooks, interview, ledger, loop, modes, render, skills/agents, and contextpack behavior. S3 records the kit-test surface as 117→399 tests and scratch-repo proof; this report did not rerun them.
+- **Docs/session updates:** `.sessions/2026-07-02-ultracode-memory-substrate-finalize.md`, `docs/current-state/S3-ai-memory.md`, and `docs/planning/rebuild-ultracode-handoff-2026-07-02.md` were updated to mark handoff §5.B done and record remaining gates.
+
+## 5. Verification and CI evidence
+
+### Live/default branch evidence
+
+- GitHub API reported default branch: `main`.
+- GitHub API reported latest `main` SHA: `87997562484a1cb65052c84a970f84cd5e7fd510`.
+- Local `HEAD` is `87997562484a1cb65052c84a970f84cd5e7fd510` on branch `work`.
+
+### GitHub Actions/check status observed
+
+- #1649: CodeQL success, Analyze (python) success, code-quality success, flag-conflicts success.
+- #1652: CodeQL success, flag-conflicts success, dashboard-tests success, Analyze (python) success, enable-auto-merge success, botsite-tests success, code-quality success.
+- #1639: CodeQL success, flag-conflicts success, code-quality success, Analyze (python) success.
+- Main docs/ops PRs today also showed green CodeQL/code-quality/Analyze/flag-conflicts checks in the GitHub API data.
+
+### Missing check visibility / claims requiring rerun
+
+- PR bodies/session logs claim local full-quality and substrate-kit test runs, but the GitHub API check-runs do not expose those exact local commands as separate check names.
+- The full architecture check and substrate-kit unit suite should be rerun locally before a rebuild approval package is treated as mechanically verified.
+- Scratch-repo bootstrap/adopt proof is documented but should be repeated in a clean temp directory after the final #1649 merge SHA.
+
+### Recommended verification commands
+
+```bash
+python3.10 scripts/check_quality.py --full
+python3.10 scripts/check_architecture.py --mode strict
+python3.10 -m pytest tests/unit/substrate_kit
+tmpdir=$(mktemp -d); cp substrate-kit/dist/bootstrap.py "$tmpdir/bootstrap.py"; (cd "$tmpdir" && python3 bootstrap.py adopt && python3 bootstrap.py check --strict)
+python3 substrate-kit/src/build_bootstrap.py && git diff --exit-code substrate-kit/dist/bootstrap.py
+python3 scripts/check_docs.py --strict
+python3 scripts/check_current_state_ledger.py
+```
+
+## 6. Current gates and blocked scope
+
+- **Phase-3 rebuild implementation remains blocked.** The design spec is explicitly an owner-gate artifact; approving it means ratifying the design, backward-compat contract, and go/no-go. This report does not approve the rebuild.
+- **Phase-2.5 cold-start substrate-on/off A/B still gates Phase 3.** S3 states the A/B remains after #1649 and is an offline proof before Phase 3.
+- **Standalone extraction/publishing of `substrate-kit` remains owner-gated.** The README says `substrate-kit` is a placeholder name and the published name is the owner’s extraction decision.
+- **Live-bot/Hermes/credentialed gates remain.** S3 still tags Hermes bug-triage write-side work as gated on VPS write scope, and ops/Railway/Discord live-state claims should not be treated as reverified without credentials.
+- **Open PRs not to fold in:** #1509 and dependabot #1555–#1560 were open after today’s merges and are outside this report.
+
+## 7. Things that may have been forgotten
+
+| Item | Classification | Finding | Suggested handling |
+| --- | --- | --- | --- |
+| S4 next-action row still says “Memory retention & context economy — implementation-ready” after #1649 shipped the kit-native context-economy engine. | Important improvement | Likely stale because #1652 merged before #1649. | Mini current-state pass: mark kit-native context-economy shipped in S3, re-scope S4 row to SuperBot retention application/first dry-run prune only. |
+| `docs/current-state.md` vs S3/S4 timing drift. | Important improvement | Hub delegates to per-sector files; S3 knows #1649 is done, S4 still points at retention implementation. | Run docs/current-state consistency check and edit only docs if drift confirmed. |
+| Reconciliation pass happened before #1649. | Cleanup | #1652 band-#1650 did not include #1649’s final merged state. | Either wait for next cadence or do a tiny follow-up reconciliation note if owner wants same-day current-state precision. |
+| Stale handoff text may still contain completed §5.B launch instructions. | Cleanup | `rebuild-ultracode-handoff-2026-07-02.md` was updated by #1649, but stale imperative text should be checked before next agent follows it blindly. | Search the handoff for “run/finalize next” language and stamp superseded paragraphs if present. |
+| Open questions/router entries after Q-0214 and #1649. | Cleanup | Q-0214 decisions were recorded, but router/archive stamping should be checked after #1649 in case §5.B decisions superseded entries. | Run/router-specific docs check or manual search for Q-0214/Q-0215 unresolved lines. |
+| TODO/PLACEHOLDER in substrate-kit. | False alarm / cleanup | `rg` found `_PLACEHOLDER_ANSWERS` and template-placeholder regexes, not obvious unfinished TODO/FIXME markers. | No blocker; do a targeted TODO/FIXME audit before extraction. |
+| Dangling docs routes/templates. | Important improvement | #1649 claims complete template set and killed dangling question-bank routes; not independently reverified. | Run `python3 bootstrap.py adopt`, `ask`, `render`, and `check --strict` in a scratch repo. |
+| README/pyproject/package metadata claims obsolete. | Cleanup | README says placeholder package name is owner-gated, which appears current; verify `pyproject.toml` classifiers/entry point before extraction. | Package-metadata review only when owner approves standalone extraction. |
+| Dashboard/current-state freshness after #1649. | Cleanup | Latest dashboard refresh was #1650/#1652 before #1649; S3 changed after the refresh. | Run dashboard export in next docs-only pass if dashboard should reflect #1649 immediately. |
+| Active gates conflicting with next work. | Critical blocker if ignored | Phase-3 new-repo code, standalone publishing, and live credential work are gated. | Keep next work to verification/docs/cold-start proof unless owner explicitly approves gates. |
+
+## 8. Recommended next steps
+
+1. **Immediate verification (highest priority, no design approval implied).** Run the substrate-kit unit suite, full quality, strict architecture, docs/current-state checkers, and a clean scratch-repo `bootstrap.py adopt` smoke at commit `8799756`.
+2. **Docs cleanup mini-pass.** Fix S4/S3 drift caused by #1652 preceding #1649; update S4’s retention row to distinguish “kit engine shipped” from “SuperBot retention actuator/prune not applied.” Refresh dashboard/botsite data if required.
+3. **Phase-2.5 cold-start A/B.** In fresh scratch repos, run agent-like sessions with and without the substrate, collect orientation cost, missed context, question escalation, and adoption friction, and produce an owner-readable evidence note. This is still a Phase-3 gate.
+4. **Owner review package for rebuild design approval.** Package the design spec, linchpin validation report, grammar amendments, golden-harness proof, substrate-kit cold-start A/B, and explicit “what approval means” checklist. Do **not** approve inside the package.
+5. **Substrate-kit extraction decision.** Ask owner whether to keep in-repo, extract to standalone repo, rename package, and publish. Only after owner decision should metadata, package name, CI, and distribution docs be finalized.
+6. **Next session destinations.** Prefer docs-only verification/cleanup or Phase-2.5 proof. Do not start new-repo Phase-3 implementation until owner approves.
+
+## 9. Suggested follow-up prompts
+
+1. “Run a verification-only pass at commit `8799756`: execute substrate-kit unit tests, full quality, strict architecture, docs/current-state checkers, and a scratch-repo bootstrap/adopt smoke. Produce a short evidence report; do not change runtime code.”
+2. “Perform a docs-only mini reconciliation after PR #1649: fix S3/S4/current-state/dashboard drift, especially the S4 retention/context-economy next-action row. Do not touch runtime code.”
+3. “Design and run the Phase-2.5 cold-start substrate-on/off A/B in scratch repos using `substrate-kit/dist/bootstrap.py`; collect metrics and write an owner-review evidence note. Do not approve Phase 3.”
+4. “Prepare the owner review packet for the rebuild design gate: summarize spec §10.2 approval items, #1639 linchpin evidence, #1649 substrate proof, remaining risks, and explicit owner decisions required.”
+
+## 10. Evidence appendix
+
+| Evidence | What was inspected |
+| --- | --- |
+| GitHub API `/repos/menno420/superbot` | Default branch, live latest `main` SHA, repo pushed time. |
+| GitHub API `/pulls?state=all&sort=updated&direction=desc` plus per-PR `/files`, `/commits`, `/check-runs` | PRs created/updated/merged on 2026-07-02, changed-file counts, additions/deletions, check statuses. |
+| `git log --since='2026-07-02 00:00:00' --until='2026-07-03 00:00:00' --all` | Local chronological commit/merge timeline for the day. |
+| `docs/current-state.md` | Hub state, live-source warning, reconciliation marker/current-state delegation. |
+| `docs/current-state/S3-ai-memory.md` | #1649 shipped substrate summary and remaining gates. |
+| `docs/current-state/S4-docs.md` | #1652 reconciliation state and stale retention/context-economy next-action row. |
+| `docs/planning/rebuild-design-spec-2026-07-02.md` | Owner-gate status, approval scope, no Phase-3-before-approval framing. |
+| `docs/planning/rebuild-linchpin-validation-2026-07-02.md` | Golden-harness/grammar-spike validation and go/no-go recommendation framing. |
+| `docs/planning/fresh-rebuild-strategy-2026-07-02.md` | Phase sequencing and Phase-2.5/Phase-3 gates. |
+| `docs/planning/rebuild-ultracode-handoff-2026-07-02.md` | §5.B substrate-finalization handoff and updates. |
+| `docs/planning/memory-retention-and-context-economy-plan-2026-07-02.md` | Q-0214 owner decisions, retention windows, simulator, substrate-kit landing plan. |
+| `.sessions/2026-07-02-*.md` | Session provenance for design spec, Railway/admin work, retention, linchpin validation, reconciliation, and substrate finalization. |
+| `substrate-kit/README.md` | Adopt flow, features, packaging/extraction note, hooks/checkers/economy claims. |
+| `substrate-kit/src/engine/**` and `substrate-kit/dist/bootstrap.py` | Source modules, generated bootstrap, hooks, economy, checkers, templates, CLI surface. |
+| `tests/unit/substrate_kit/**` | Test surface added for substrate-kit behavior. |


### PR DESCRIPTION
### Motivation

- Provide the owner with a single, repo-grounded factual reconstruction of all meaningful work performed on 2026-07-02 to make what landed, what is pending, and next steps explicit and verifiable.
- Capture session provenance, PR-level evidence, and recommended verification steps so follow-ups are traceable and owner-gated decisions remain visible.

### Description

- Add a single documentation report at `docs/analysis/today-work-summary-2026-07-02.md` that includes an executive summary, a verified chronological timeline of the day’s PRs/commits, grouped shipped outcomes by area, a file-verified review of what PR #1649 changed, CI/verification evidence, current gates, likely forgotten items, prioritized next steps, suggested follow-up prompts, and an evidence appendix.
- Include a short "verification limits" section and a `> **Status:** 'historical'` badge to satisfy repo doc conventions and `check_docs.py` expectations.
- This PR is documentation-only and does not modify runtime code, tests, configs, workflows, generated dashboard data, or repo settings.

### Testing

- Ran `git diff --check`, which reported no issues.
- Ran `python3 scripts/check_docs.py --strict` after adding the required `Status` badge, and the checker passed.
- No unit or integration test suites were altered by this change; the report lists recommended verification commands (for example `python3.10 -m pytest tests/unit/substrate_kit` and `python3.10 scripts/check_quality.py --full`) that are suggested to be executed by the owner or maintainers for deeper verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46a29e04008322a347df982a31d7b1)