### PR TITLE
docs(rebuild): presets-for-text and multi-select-default in the grammar spec

### DIFF
--- a/.sessions/2026-07-02-daily-review-brainstorm.md
+++ b/.sessions/2026-07-02-daily-review-brainstorm.md
@@ -1,0 +1,85 @@
+# 2026-07-02 — Daily review + architecture brainstorm ahead of the rebuild gate
+
+> **Status:** `complete` — ready to merge (Q-0133). Docs-only session; no `disbot/` changes.
+> `check_docs --strict` ✓.
+
+**Branch:** `claude/daily-review-brainstorm-rcyar3` (synced to `main` @ #1657 before this commit).
+
+## What I'm about to do (intentions — as declared born-red)
+
+Owner asked for a plain-language review of everything shipped/decided today (13 sessions, the
+rebuild-strategy → design-spec → linchpin-validation → substrate-kit-finalize → retention-policy →
+Railway-ops → HQ-guild arc), a brainstorm of anything forgotten, and specific thinking on unifying
+the bot's memory/context systems. Follow-up turned into two concrete architecture decisions the
+owner wants folded into the rebuild spec before Phase 3: (1) presets-with-custom-escape-hatch
+generalized to every text-valued setting, not just numeric ones; (2) multi-select promoted from a
+bot-code convention (Q-0205) to a rebuild-grammar compile rule. Owner also asked that all useful
+findings from the conversation get durably documented, not just left in chat.
+
+## What shipped
+
+1. **Research-only synthesis** (4 parallel agents) of today's session logs, `current-state.md` +
+   planning docs, the substrate-kit vs. existing `docs/agent/` context-compiler overlap, and the
+   idea backlog — delivered to the owner as a plain-language summary (not written to a file; the
+   session logs it summarizes are already the durable record).
+2. **Q-0215** (router): generalizes Q-0070's already-decided "presets everywhere, manual entry
+   always available" posture into the rebuild grammar — new `SettingSpec.preset_kind` field
+   (§2.5), a compile rule that `str`-typed specs with presets must declare `preset_kind="text"`.
+3. **Q-0216** (router): promotes Q-0205's "multi-select is the preferred idiom" from a per-PR bot
+   convention into a `SelectorSpec` compile-time default (§2.4) — `max_values` defaults to a
+   binding's declared multiplicity instead of Discord's single-select default.
+4. Both folded into `docs/planning/rebuild-design-spec-2026-07-02.md` (top-of-doc addendum + the
+   two section edits) with cross-references to their precedent Q-numbers, so the spec doesn't
+   silently re-decide something already settled.
+5. Verified the developer-website question the owner raised ("finish the website first?") is
+   **already correctly tracked** — `current-state.md` S5/Next-candidates already carries the
+   website rollout as a separate, non-blocking ops item, and the design spec §6 already requires a
+   versioned control-API contract before the interaction runtime lands. No doc drift found; no
+   edit needed there.
+
+## Context delta
+
+- Two owner-raised "new" architecture questions turned out to both already have an owner-decided
+  posture on the books (Q-0070, Q-0205) that simply hadn't been carried into the *new* rebuild
+  grammar yet. The pattern worth naming: when the owner raises a UX principle during rebuild
+  planning, check the router for prior art before treating it as a fresh decision — the rebuild
+  spec is a **consolidation** of standing decisions as much as it is new design, and it's easy for
+  a verbatim-ported field (like the shipped numeric-only `presets`) to quietly under-carry a
+  broader posture that was already settled for the old code.
+
+## 🛠 Friction → guard
+
+None new. The existing router-search-before-deciding habit (used here manually) is the guard; no
+checker gap surfaced this session.
+
+## 💡 Session idea (Q-0089)
+
+An idea worth having: a small `check_router_precedent.py`-style grep helper that, given a proposed
+new Q-number's topic keywords, surfaces prior router entries with textual overlap (e.g. "preset",
+"multi-select") before a new decision is recorded — would have made today's "is this already
+decided?" check (which I did by hand) a 5-second command instead of reading two full research-agent
+reports. Small, deferred — not built this session.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session (`#1657`, review-recent-session) — hadn't read its log in detail before this one
+started since this branch was cut independently; nothing to flag against it specifically. General
+observation across today's 13-session arc: the design spec's "Revision" addendum pattern (a dated
+callout at the top of the doc summarizing what changed and why) is a genuinely good convention this
+session reused directly — it makes a 150KB+ living document skimmable without re-reading it end to
+end. Worth keeping as the default way to layer late-arriving decisions onto any long-lived planning
+doc, not just this one.
+
+## 📤 Run report
+
+- **Did:** reviewed today's full session arc for the owner in plain language, researched two
+  owner-raised architecture questions against the design spec + current bot code, folded both
+  into the rebuild grammar as compile rules with router provenance.
+- **Outcome:** shipped (docs-only).
+- **Run type:** `manual` (owner-directed, live conversation).
+- **⚑ Owner decisions needed:** none new — Q-0215/Q-0216 record decisions the owner already made
+  live in this conversation.
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** none (every doc change traces to an explicit owner ask this session).
+- **↪ Next:** design-spec owner gate (Phase 3 start) still pending; Phase 2.5 cold-start A/B test
+  for substrate-kit still not run.

--- a/docs/owner/claims/claude-daily-review-brainstorm-rcyar3.md
+++ b/docs/owner/claims/claude-daily-review-brainstorm-rcyar3.md
@@ -1,0 +1,4 @@
+- `claude/daily-review-brainstorm-rcyar3` · docs-only: fold two owner architecture decisions
+  (presets-for-text-settings, multi-select-by-default) into the rebuild design spec + router ·
+  `docs/planning/rebuild-design-spec-2026-07-02.md`, `docs/owner/maintainer-question-router.md`,
+  `.sessions/2026-07-02-daily-review-brainstorm.md` · 2026-07-02

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7949,3 +7949,55 @@ setting to 400 days). Homes: `docs/planning/railway-setup-plan-2026-07-02.md` (p
 **Homes:** the retention plan (policy + PR specs, updated same session) ·
 `docs/planning/fresh-rebuild-strategy-2026-07-02.md` §5.2 slot (context-economy engine) ·
 orientation-cost-reduction plan Workstream D (superseded by decision 3).
+
+### Q-0215 — DIRECTED: generalize presets-plus-manual-entry from numeric-only to every settings class in the rebuild grammar (2026-07-02)
+
+> **Context.** A daily-review/brainstorm session asked the owner to re-confirm an architectural
+> gap before Phase 3 starts: "every text-based function should have presets you can choose from —
+> you should never have to write something yourself, but a custom-input option should exist
+> wherever useful." Research showed this exact posture was **already decided** as Q-0070
+> (2026-06-10) — presets + preset-then-edit + always-available manual entry, for *every* setting
+> class including authored text (DM templates, AI instruction bodies) — but the rebuild design
+> spec (`rebuild-design-spec-2026-07-02.md` §2.5) had only carried the shipped **numeric**-presets
+> mechanism forward verbatim, without generalizing it in the grammar itself. The owner confirmed
+> the posture stands and asked for it to be folded into the spec rather than left as a
+> settings-audit-only convention.
+
+**Decision:** `SettingSpec` gains a `preset_kind: enum {none, numeric, text} = none` field (§2.5).
+`text` extends the shipped numeric-presets UX (pick a preset, edit from it, or write your own) to
+any `str`-typed setting. Compile rule: a `str`-typed spec with a non-empty `presets` tuple must
+declare `preset_kind="text"`, and manual entry can never be the *only* path removed by a preset
+list — the grammar enforces Q-0070's three-requirement posture mechanically instead of relying on
+each port remembering it.
+
+**Scope boundary:** this decides the **grammar primitive** only — it does not re-open Q-0070's
+deferred "AI-suggested template/preset advisor" idea
+(`docs/ideas/settings-presets-and-ai-template-advisor.md`), which stays captured-only behind the
+AI per-exposure gates.
+
+**Homes:** `docs/planning/rebuild-design-spec-2026-07-02.md` §2.5 (new field + compile rule) and
+top-of-doc addendum; supersedes nothing — extends Q-0070's already-decided posture into the new
+repo's grammar.
+
+### Q-0216 — DIRECTED: multi-select promoted from bot-code convention to a rebuild-grammar compile rule (2026-07-02)
+
+> **Context.** Same brainstorm session, second architectural question: "multi-select menus should
+> also be the standard wherever possible." Research found this was **already owner-directed** for
+> the current bot as Q-0205 (2026-06-24) — "multi-select is the preferred idiom for 'pick which of
+> these to turn on'" — and applied in specific PRs (Essential Setup logging-channel step, the
+> block-spam toggle row), but never promoted into the rebuild's manifest grammar as a default rule
+> new ported/generated selectors would inherit automatically. Current-bot count at the time of
+> research: ~125 `Select` menus, only ~20 genuinely multi-select (~5:1 single-select-by-default),
+> confirming the gap is real, not just a preference already satisfied everywhere.
+
+**Decision:** `SelectorSpec` (§2.4) gets a compile-time default rule: when a selector's `on_select`
+target is a `BindingSpec` with `multiplicity > 1`, or otherwise backs a "pick which of these apply"
+choice, `max_values` defaults to that multiplicity (or full option count for unbounded pick-many)
+instead of Discord's single-select default. A single-select override requires explicit
+justification — the grammar treats "one at a time" as the exception for a naturally multi-valued
+choice, not the default. Scalar pickers (channel/role/member selectors backing a true
+single-value `SettingSpec` or a `multiplicity=1` binding) are unaffected.
+
+**Homes:** `docs/planning/rebuild-design-spec-2026-07-02.md` §2.4 (new compile rule) and
+top-of-doc addendum; extends Q-0205's already-directed idiom from the current codebase into the
+new repo's grammar as a mechanical default rather than a per-PR judgment call.

--- a/docs/planning/rebuild-design-spec-2026-07-02.md
+++ b/docs/planning/rebuild-design-spec-2026-07-02.md
@@ -54,6 +54,15 @@
 > that — §7; this document argues its case to the owner on purpose), a fixed per-subsystem
 > "manifest budget" (§2.9's ratchet already enforces the same thing without an arbitrary number),
 > and compile-time Discord component caps (already specified, §2.3).
+>
+> **Addendum (2026-07-02, owner architecture-brainstorm session):** two grammar gaps the owner
+> flagged before code starts, both folded in as compile rules rather than left as conventions:
+> **(1)** `SettingSpec`'s preset mechanism was ported verbatim in numeric-only form (§2.5) even
+> though Q-0070 already decided presets-plus-manual-entry applies to *every* setting class,
+> including authored text — closed via a `preset_kind` field (§2.5, Q-0215); **(2)** multi-select
+> was Q-0205's owner-directed idiom for the *current* bot but was never promoted into the rebuild
+> grammar as a compile-time default — closed via a `SelectorSpec` multiplicity-inference rule
+> (§2.4, Q-0216). Both are additive, no other section changes.
 
 ---
 
@@ -633,6 +642,16 @@ enum, entity}` (S), `options_source: static tuple | ProviderRef` (S), `placehold
 `audience_tier` (S — the §2.2 two-lane authority model), `usage_weight` (O). Placement lives in the
 owning `PanelSpec.layout` (A).
 
+**Multi-select-by-default compile rule (Q-0205's "pick which of these to turn on" idiom,
+promoted from bot-code convention to rebuild grammar, Q-0216):** when a `SelectorSpec`'s
+`on_select` target is a `BindingSpec` with `multiplicity > 1`, or a `str`-typed set/list
+"pick which apply" choice, `max_values` must default to that multiplicity (or the full option
+count for an unbounded pick-many) rather than the Discord-default `1`. A single-select
+(`max_values=1`) requires an explicit, justified override — the grammar treats "one at a time"
+as the exception for a naturally multi-valued choice, not the default. Genuinely single-valued
+selections (channel/role/member pickers backing a scalar `SettingSpec` or a `multiplicity=1`
+binding) are unaffected and stay single-select.
+
 ### 2.5 SettingSpec · BindingSpec · ResourceRequirement — the extended shipped types
 
 **Binding constraint 2, executed literally: these are the shipped classes**, carried into `sb/spec/`
@@ -660,6 +679,7 @@ treated by the mutation pipelines as the administrator floor, NOT "no auth"*). A
 | `panel_order` | `int = 0` | **A** | Order within its group. |
 | `edit_weight`, `co_edit_group` | `float = 1.0`, `str = ""` | O | Seed data for the settings-grouping sim: neutral-prior weight, optional seed pair-group — measured pairwise telemetry overrides both (§2.10.4). |
 | `depends_on` | `tuple[str,...] = ()` | O | Dependency-order constraint for grouping. |
+| `preset_kind` | `enum {none, numeric, text} = none` | S | **Generalizes the shipped `presets` field to authored-text settings (Q-0070, folded in Q-0215).** `numeric` is the shipped numeric-presets behavior, unchanged. `text` extends the same preset-then-edit-then-manual UX to any `str`-typed spec (DM templates, AI instruction bodies, embed copy): the editor renders `presets` as selectable starting points, each openable into a pre-filled override modal, plus an always-present "write your own" entry — never a preset-only editor. Compile rule: a `str`-typed `SettingSpec` with a non-empty `presets` tuple must declare `preset_kind="text"` (or the compiler flags it as decorative/inert data); manual entry can never be disabled by a preset list. |
 
 **SettingGroupSpec / HubGroupSpec — groups are declared; the sim only assigns.** A settings-hub
 group and a hub sub-group render user-visible headers, and copy is semantic (§2.0) — so group


### PR DESCRIPTION
## Summary
- Daily review + architecture brainstorm session ahead of the rebuild's Phase-3 gate.
- Two owner-raised UX principles for the rebuild grammar turned out to already be owner-decided for the current bot (Q-0070 presets-everywhere, Q-0205 multi-select-preferred) but hadn't been carried into the new manifest grammar yet — folded in as compile rules with provenance.
- Verified the developer-website question the owner raised is already correctly tracked as a separate, non-blocking ops item; no drift found, no edit needed.

## Changes
- **`docs/owner/maintainer-question-router.md`**: records Q-0215 (presets generalized from numeric-only to every settings class) and Q-0216 (multi-select promoted from bot-code convention to a rebuild-grammar compile rule).
- **`docs/planning/rebuild-design-spec-2026-07-02.md`**: top-of-doc addendum + `SettingSpec.preset_kind` field (§2.5) + `SelectorSpec` multiplicity-inference compile rule (§2.4).
- **`.sessions/2026-07-02-daily-review-brainstorm.md`**: session log (Q-0089/Q-0102/Q-0104 enders included).
- **`docs/owner/claims/claude-daily-review-brainstorm-rcyar3.md`**: lane claim (removed at session close).

## Test plan
- [x] `python3.10 scripts/check_docs.py --strict` — passes
- [x] `python3.10 scripts/check_architecture.py --mode strict` — exit 0, no new violations (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXjiFBHw9Yu3LQBSefYyvk


---
_Generated by [Claude Code](https://claude.ai/code/session_01DXjiFBHw9Yu3LQBSefYyvk)_