### PR TITLE
Prepare new-bot capability-audit substrate (7-lane fleet + Fable 5 capstone)

### DIFF
--- a/.sessions/2026-07-02-grammar-audit-prep.md
+++ b/.sessions/2026-07-02-grammar-audit-prep.md
@@ -1,0 +1,73 @@
+# 2026-07-02 — Prepare the repo for the new-bot capability audit (fleet substrate)
+
+> **Status:** `complete`
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #1660 (opening)
+> **Session type:** prep/orchestration — "prepare the repo for 2 Opus + 1 Sonnet ultracode + Codex/deep-research to create the final mapping audit, then a Fable 5 final review"
+
+## What happened
+
+Built the full substrate for a multi-agent **new-bot capability audit** under
+`docs/analysis/rebuild-discovery/new-bot-capability-audit/`. The owner's vision, assembled across the
+session: the next bot is built from **one unified, dependency-ordered, best-in-class plan** (foundations
+→ core management → features; each layer production-grade before the next; every function must outperform
+any other bot). To earn that plan, a fleet runs every capability through **MAP → RECONSIDER → SIMULATE →
+OPTIMIZE → BENCHMARK** across **three axes**: what we have (43 subsystems), what we planned
+(plans/ideas), and what the ecosystem has that we don't (known Discord bots).
+
+### The substrate (docs-only, read-only — no runtime/new-repo code)
+
+- **`BRIEF.md`** — the binding contract: 3-axis mandate, 5 verbs, the end-goal (unified plan / build order
+  / production-grade / outperform), per-capability schema, guardrails, exit bar, grammar spine.
+- **`PARTITION.md`** — **7 lanes**: A–D (43 subsystems, Axis 1), E (plans/ideas, Axis 2), F (ecosystem,
+  Axis 3), **G (L0 foundations — bootstrap / dynamic cog-loader / lean main.py / helper-util arch)** +
+  model→lane matching.
+- **`HANDOFF-PROMPTS.md`** — copy-paste startup prompts for all 7 lanes + the Fable 5 capstone + launch order.
+- **`FINAL-REVIEW-HANDOFF.md`** — the capstone spec: verify-then-rule (grammar GO/GO-with-amendments/NO-GO)
+  + the unified build plan (corpus + dependency-layered order + per-capability done-definition + outperform target).
+- **`README.md`** + **`ground-truth/`** (271 commands + 43 subsystems dumped) + **`lanes/`** (A–D pre-filled
+  with extracted surface inventories; E/G scaffolds) + **`findings/`**.
+
+### The fleet maps to the owner's plan
+
+2 Opus 4.8 ultracode (B, C) · 1 Sonnet 5 ultracode (A) · a few Codex/deep-research (D, E, F, G) → Fable 5
+capstone. Lanes fire in parallel (A–D + G file-disjoint; E/F cross-cutting), then the capstone.
+
+## ⚑ Self-initiated
+
+All owner-directed (the prep + fleet design were requested across the session). Self-initiated **within**
+that direction: (1) ran a **43-agent scaffold Workflow** (~2.0M subagent tokens, 0 errors) to pre-extract
+every subsystem's surface-unit inventory so the fleet spends its budget on judgment, not re-deriving facts;
+(2) the 7-lane structure + the Lane G foundations lane (surfaced a partition gap — the runtime skeleton
+isn't a "subsystem"); (3) the "extract-mechanically-then-judge" + one-shared-schema-so-outputs-compose
+shape (the composition lesson from the prior Codex-review session). Flagged for owner/Hermes review.
+
+## 💡 Session idea
+
+**A reusable "fleet-substrate" skill for large multi-agent audits.** This session's shape — ground-truth
+dump → shared contract/schema → disjoint partition → pre-filled scaffolds → per-lane handoff prompts →
+capstone synthesis — is generic: any big audit (security sweep, dependency migration, doc reconciliation
+at scale) wants exactly this. Codify it as a `/fleet-audit` skill that takes a target + partition axis and
+emits the substrate, so future audits start from a template instead of hand-building it. Grounded in what
+I just built by hand; dedup-checked against `docs/ideas/` (nearest is the ultracode coordinator tooling,
+which is execution-side, not substrate-authoring).
+
+## ⟲ Previous-session review
+
+The previous session (Codex-PR review + hub/S4 drift fix) correctly ran a one-fact-one-home sweep and
+verified cross-agent claims before acting — good discipline. The recurring drift it fixed (hub ▶Next-action
+row contradicting its sector doc) has now bitten **twice** (#1653 and the Codex-review session). **System
+improvement:** a small checker that cross-validates each `current-state.md` hub ▶Next-action row against
+its sector doc's stated next-action would catch this class mechanically instead of relying on an external
+reviewer to spot it — the "enforce, don't exhort" (Q-0132) response to a twice-seen drift.
+
+## 📊 Telemetry
+
+- PR #1660 · new-bot-capability-audit substrate: 7 lanes + capstone + ground truth + handoff prompts
+- 43-agent inventory Workflow: 43/43 subsystems, 0 errors, ~2.0M subagent tokens, 271 surface units mapped
+- Docs-only; `check_docs --strict` green (badges + reachability); zero runtime code
+- Dir named `new-bot-capability-audit/` (owner-approved rename from `grammar-completeness/`)
+
+## Doc audit (Q-0104)
+
+`check_docs --strict` green · new substrate reachable from its README · ledger unaffected (docs-only) ·
+claim released at close.

--- a/.sessions/2026-07-02-grammar-audit-prep.md
+++ b/.sessions/2026-07-02-grammar-audit-prep.md
@@ -1,7 +1,7 @@
 # 2026-07-02 — Prepare the repo for the new-bot capability audit (fleet substrate)
 
 > **Status:** `complete`
-> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #1660 (opening)
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #1661 (opening)
 > **Session type:** prep/orchestration — "prepare the repo for 2 Opus + 1 Sonnet ultracode + Codex/deep-research to create the final mapping audit, then a Fable 5 final review"
 
 ## What happened
@@ -62,7 +62,7 @@ reviewer to spot it — the "enforce, don't exhort" (Q-0132) response to a twice
 
 ## 📊 Telemetry
 
-- PR #1660 · new-bot-capability-audit substrate: 7 lanes + capstone + ground truth + handoff prompts
+- PR #1661 · new-bot-capability-audit substrate: 7 lanes + capstone + ground truth + handoff prompts
 - 43-agent inventory Workflow: 43/43 subsystems, 0 errors, ~2.0M subagent tokens, 271 surface units mapped
 - Docs-only; `check_docs --strict` green (badges + reachability); zero runtime code
 - Dir named `new-bot-capability-audit/` (owner-approved rename from `grammar-completeness/`)

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
@@ -1,0 +1,150 @@
+# New-bot capability audit — shared brief (the contract every lane agent works to)
+
+> **Status:** `reference` — the binding contract for the parallel new-bot capability audit (the
+> new-bot-capability-audit pass is its technical spine).
+> **Prepared:** 2026-07-02 (Opus 4.8) as the substrate for a fleet of independently-launched agents.
+
+## The mandate — reconsider and optimize the whole intended surface (owner, 2026-07-02)
+
+This is **not a passive map.** After these sessions, **every capability intended for the new bot** —
+every command and the behavior behind it, plus the planned/ideated features (`docs/planning/`,
+`docs/ideas/`) meant to land in the rebuild — must be **mapped → reconsidered → simulated → optimized**:
+
+1. **MAP** — inventory the capability and its units (the grammar-fit layer below).
+2. **RECONSIDER** — should it exist as-is? verdict: **keep · improve · merge · drop · redesign**. Nothing
+   is grandfathered in just because it ships today.
+3. **SIMULATE** — express it in the §2 manifest and run it through the simulation substrate (the §2.10
+   manifest simulator / write-surface derivation, `tools/grammar_spike/measure.py`, and the `parity/`
+   golden behavioral harness) to check the *reconsidered* form actually reproduces the intended behavior.
+4. **OPTIMIZE** — deep-reason: **is this the most optimal form?** If not, propose the concrete better
+   version — and, where feasible, simulate the alternative to show it wins.
+5. **BENCHMARK** — review the domain against **known Discord bots and their full feature sets** (MEE6,
+   Carl-bot, Dyno, Dank Memer, Ticket Tool, YAGPDB, Arcane, Tatsu, ProBot, Mudae, and any others that
+   fit the domain). Catalog what **they** do that **we don't**. This is deep-research work (Lane F).
+
+**The three scope axes** (nothing intended for the new bot falls outside them):
+
+- **Axis 1 — what we have** (the 43 subsystems, Lanes A–D): map → reconsider → simulate → optimize.
+- **Axis 2 — what we planned** (`docs/planning/` + `docs/ideas/`, Lane E): reconsider each for the new bot.
+- **Axis 3 — what the ecosystem has that we don't** (Lane F, deep-research vs known bots): catalog the
+  gaps. **These are NOT commitments to build** — they are *documented known options*. The bar is
+  "known and clearly documented," so a future session can pull from a rich menu instead of rediscovering.
+
+**The deliverable is a capability corpus, not a verdict page.** The owner's goal is a repo *overflowing
+with useful, well-documented data the next bot can use* — every capability (ours + planned + ecosystem)
+captured with: what it is · do we have it · is it optimal · the better form · which bots have it · should
+the new bot have it. Filterable, durable, and honest about what's a real gap vs. a deliberate omission.
+
+**Granularity (bounded so it's actionable):** the unit of analysis is the **capability** (a command +
+its handler/service logic), not each of the ~21k Python functions — "function" here means the behavior
+behind a capability. The per-capability output is a *recommendation* backed by grammar-fit + simulation
++ reasoning + ecosystem comparison — never just a tier label.
+
+## The end goal — one unified, ordered, best-in-class build plan (owner, 2026-07-02)
+
+Everything above serves one outcome: **the next bot is built from a single comprehensive unified plan,
+not speculation or trial-and-error** — so every function works the same way and the whole feels like one
+coherent picture (which is exactly what the §2 manifest grammar enforces: one pattern, generated). The
+audit's ultimate product (assembled by the capstone) is therefore not a menu but **THE build plan**, with:
+
+- **A logical build order.** Foundations first → the core bot-management + server-management functions →
+  then features. The capstone sequences every kept/improved/added capability into dependency layers.
+- **Production-grade, done-before-next.** Each layer is **100% complete and operational at production
+  grade** before the next begins — the plan states, per capability, what "done" means (the acceptance
+  tests / the `parity/` golden it must pass), not just "build it."
+- **The outperform bar (standard rule).** Every capability we keep or build must **outperform the best
+  equivalent in any other bot.** This is where Axis 3 (Lane F) earns its keep: for each capability, name
+  the best-in-class competitor and the concrete way ours beats it (or the deliberate reason it needn't).
+
+So each lane's per-capability recommendation carries forward into the plan as: *its dependency layer · its
+production-grade done-definition · its outperform target.* Keep those three in view while you audit.
+
+## The grammar spine — the future-proofing bet
+
+The rebuild's entire wager is the **declarative §2 manifest grammar**: one typed `SubsystemManifest`
+per subsystem, from which commands, panels, settings, events, and help are **generated** — "no
+hand-written views layer." That bet only holds if ~**80%+ of every subsystem's real surface** expresses
+as **tier-1/2 declarations** rather than **tier-3 escape-hatch code**. Enough tier-3 and the rebuild
+re-inherits the fragmentation it set out to kill — i.e. *it needs re-rebuilding in a year.* Avoiding
+that is the **dominant constraint** (owner, 2026-07-02): get the design durable, not fast.
+
+**The gap this audit closes:** the grammar spike ([`RESULTS.md`](../../../../tools/grammar_spike/RESULTS.md))
+measured fit on **3 of 43 subsystems** (karma 80→87%, logging 79→97%, blackjack **44%**) → **73%
+as-written, 85% with six amendments.** "85% is a floor" is currently an *assumption* ("most subsystems
+are karma/logging-shaped"). The named danger zone — **stateful games (~44%), gateway-event listeners,
+`wait_for` wizards, scheduled loops, voice** — is **unmeasured across the other 40 subsystems.** That
+untested surface *is* the future-proofing risk. This audit turns "probably a floor" into a **measured
+fact across all 43** and produces the complete amendment list.
+
+## The method — replicate the spike, at scale
+
+The worked example already exists; **do not reinvent it, extend it**:
+
+- **The grammar:** [`tools/grammar_spike/spec.py`](../../../../tools/grammar_spike/spec.py) — the §2
+  manifest prototype (frozen dataclasses; every field tagged **S**emantic / **A**rrangement /
+  **O**bjective; behavior behind `HandlerRef`/`PanelRef`, never inline). Canonical spec:
+  [`docs/planning/rebuild-design-spec-2026-07-02.md`](../../../planning/rebuild-design-spec-2026-07-02.md) §2.
+- **The worked manifests:** [`tools/grammar_spike/manifests/`](../../../../tools/grammar_spike/manifests/)
+  `karma.py` · `blackjack.py` · `server_logging.py` — each subsystem expressed AS a manifest. **Your
+  output for each assigned subsystem is a manifest sketch + a unit ledger in this exact shape.**
+- **The tier semantics + measure:** [`tools/grammar_spike/measure.py`](../../../../tools/grammar_spike/measure.py)
+  and its docstring define **tier-1** (pure kernel declaration, generated) / **tier-2** (declaration +
+  a registered thin handler/provider ref) / **tier-3** (bespoke logic — the escape hatch the grammar
+  can't remove).
+- **The six existing amendments** (fit gaps the spike already found; extend this list, don't repeat it):
+  **G-1** `GatewayListenerSpec` (no gateway-listener primitive in §2 — every event-driven feature is
+  tier-3 without it) · **G-2** list-valued settings + add/remove workflows · **G-3**
+  `AnnouncementRouteSpec` · **G-4** `CommandSpec.cooldown` · **G-5** declarative validator bounds ·
+  **G-6** per-kind command namespaces (prefix/slash disjoint).
+
+## What each lane agent produces (the output schema — so all outputs compose)
+
+For **each subsystem in your lane**, write one section into your lane file
+(`lanes/lane-<X>-<name>.md`) with these parts, in this order:
+
+1. **Surface-unit ledger** — a table with the spike's columns. Start from the pre-extracted inventory
+   in your lane file (commands from the ground-truth dump + the unit-kind checklist); **verify and
+   complete it against source** — every unit kind must be covered:
+   `command · panel · setting · listener · event · store · game · help`.
+
+   | Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+   |---|---|---|---|---|---|
+
+2. **Manifest sketch** — the subsystem expressed in the §2 grammar (Python-ish, spike style). It need
+   not import/run; it must show *where each unit lands* (which Spec, which field role, which handler ref).
+
+3. **Tier-3 findings → amendments** — for every tier-3 unit: is it (a) a **grammar gap** → propose a
+   named amendment `G-<n>` (or reuse G-1…G-6), or (b) a **legitimate deliberate escape hatch** (thin
+   domain logic that *should* stay code)? State which, with the one-line reason.
+
+4. **Fit numbers** — `units total`, `tier-1/2 count`, `fit % as-written`, `fit % with amendments`
+   (mirror the RESULTS.md table for your subsystem).
+
+5. **Structural-gap flags** — explicitly note if the subsystem uses any of the danger-zone patterns
+   (stateful game loop · gateway/`@bot.event`/`bus.on` listener · `wait_for` wizard · scheduled loop ·
+   voice) and whether the grammar (with amendments) can express it or it needs a new primitive family.
+
+## Hard rules (guardrails)
+
+- **Read-only. No runtime code, no `disbot/` edits, no new-repo code.** This is discovery. Output is
+  docs only, under this directory.
+- **Verify every tier-3 claim against shipped source (Q-0120).** The prior Codex preserve-maps got
+  command names/paths wrong 4× — a "needs tier-3" verdict that's really "I didn't see the tier-2 form"
+  poisons the amendment list. Cite `file:line`. When unsure, mark `⚠ unverified` rather than assert.
+- **Cover the whole subsystem, not just its commands.** Panels, settings, listeners, events, stores,
+  and help are where the grammar actually strains (commands are the easy 80%).
+- **Stay in your lane** (see `PARTITION.md`) — subsystems are assigned disjointly so lanes never
+  collide. If you finish early, do a *verify* pass on an adjacent lane's tier-3 findings, don't re-audit.
+
+## Exit bar — when the design is "durable enough to start building"
+
+The final review (see `FINAL-REVIEW-HANDOFF.md`) declares GO when, **across all 43 subsystems**:
+1. Tier-1/2 fit is **measured** (not extrapolated) and clears the spec's **80%** bar — or the shortfall
+   is a named, bounded set of amendments the owner accepts;
+2. **Every tier-3 unit** is dispositioned: grammar-amendment **or** documented deliberate escape hatch;
+3. The **structural danger-zone patterns** (stateful games, gateway listeners, wizards, loops, voice)
+   each have a design answer (a primitive family or an accepted escape hatch);
+4. The consolidated **amendment list G-1…G-N** is folded into the design spec — a docs pass, no redesign.
+
+Miss any of these and the verdict is **GO-with-amendments** (name them) or **NO-GO** (the grammar needs
+a structural rethink before build) — never a soft "looks fine."

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/FINAL-REVIEW-HANDOFF.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/FINAL-REVIEW-HANDOFF.md
@@ -1,0 +1,97 @@
+# Final review handoff — the Fable 5 capstone
+
+> **Status:** `reference`. This is the startup context for the **final Fable 5 session** (ultracode or
+> normal) that turns the four lanes' findings into one durable go/no-go on the rebuild grammar.
+
+## Your input (the whole substrate — all three axes)
+
+- **The contract:** [`BRIEF.md`](./BRIEF.md) (mandate, method, schema, exit bar) + [`PARTITION.md`](./PARTITION.md).
+- **Axis 1 — what we have:** `lanes/lane-A-governance.md` · `lane-B-economy.md` · `lane-C-games.md` ·
+  `lane-D-knowledge-platform.md` (the 43 subsystems) + `lanes/lane-G-foundations.md` (the **L0 runtime
+  skeleton** — bootstrap / cog-loader / env-config / `main.py` / helper-util architecture). Each: unit
+  ledger + manifest sketch + tier-3 dispositions + fit numbers + structural-gap flags + reconsider/
+  optimize recommendations. **L0 (Lane G) leads the build order — read it first.**
+- **Axis 2 — what we planned:** `lanes/lane-E-plans-ideas.md` — the forward-capability ledger.
+- **Axis 3 — what the ecosystem has:** `findings/ecosystem-benchmark.md` — the known-Discord-bot
+  capability-gap catalog + any other Codex / deep-research addenda in `findings/`.
+- **The baseline:** [`tools/grammar_spike/RESULTS.md`](../../../../tools/grammar_spike/RESULTS.md) (the
+  3-subsystem spike this extends) and the design spec §2 + §10.1 risk 5.
+
+## Your job — synthesize + adversarially verify, then rule
+
+1. **Verify before you trust (Q-0120).** The lanes are independent-agent output, including other
+   providers. **Do not average their numbers blindly.** Spot-check the highest-leverage tier-3 verdicts
+   against source (the ones that would force a new primitive family). The spike caught cross-agent maps
+   mis-reading source 4× — a wrong "needs tier-3" inflates the amendment list; a wrong "tier-2 is fine"
+   hides a real gap. Down-weight `⚠ unverified` rows; re-derive the disputed ones.
+
+2. **Compute the real all-43 fit.** Aggregate the per-subsystem unit ledgers into one table (mirror
+   RESULTS.md, 43 rows + overall), **as-written vs. with-amendments**. This is the number that replaces
+   "85% is probably a floor" with a measured fact. Weight honestly — note if the mean is carried by a
+   few high-fit CRUD subsystems while the stateful cluster drags.
+
+3. **Consolidate the amendment list.** Merge every lane's proposed `G-<n>` into one deduplicated set
+   (G-1…G-6 already exist — extend, don't renumber them). For each: what it adds, which subsystems need
+   it, and whether it's a **soft** spec note or a **structural** new primitive family. Flag any amendment
+   that implies real §2 redesign (not just a docs pass) — those are the durability-critical ones.
+
+4. **Answer the structural danger zones.** For each of stateful-games / gateway-listeners / `wait_for`
+   wizards / scheduled-loops / voice: does the grammar (with amendments) express it, or does it stay a
+   documented escape hatch, or does it need a new family? A subsystem class with *no* clean answer is a
+   NO-GO signal — that is exactly the "needs re-rebuilding in a year" failure.
+
+5. **Per-subsystem preserve / redesign / drop disposition.** One line each (fold with the existing
+   [preserve-map synthesis](../codex-preserve-map-synthesis-2026-07-02.md) — this audit is its grammar
+   layer).
+
+## The verdict (the deliverable)
+
+One of three, with the evidence behind it — never a soft "looks fine":
+
+- **GO** — measured all-43 tier-1/2 fit clears 80% (or the shortfall is a bounded, owner-accepted
+  amendment set), every tier-3 is dispositioned, every structural danger zone has a design answer, and
+  the consolidated amendments are a **docs pass** into the spec (no redesign). → build can start.
+- **GO-with-amendments** — as above but the amendment set is non-trivial; name them and their spec
+  edits; build starts after the (bounded) spec pass.
+- **NO-GO** — a subsystem class has no clean grammar answer, or fit is structurally low on a large
+  cluster. Name the specific primitive-family redesign needed before build. Better a NO-GO now than a
+  re-rebuild in a year — that is the whole point of this pass.
+
+Write the verdict + the aggregated fit table + the consolidated amendment list to
+`findings/FINAL-REVIEW.md`, and open the design-spec amendment PR (or a plan for it) it implies. This
+review is the gate between "planning/discovery" and "creating the new repo" — treat it as owner-facing
+go/no-go evidence, and hand the owner the explicit "what approval means" checklist.
+
+## The unified build plan (the second — and ultimate — deliverable)
+
+The grammar verdict answers *"can we build it durably?"* The owner's ultimate ask is bigger: **the next
+bot must be built from ONE comprehensive unified plan, in a logical order, each layer production-grade
+before the next, every function outperforming the best equivalent in any other bot.** So fold Axis 1
+(kept/improved), **Axis 2 (Lane E, planned)**, and **Axis 3 (Lane F, ecosystem)** into a single ordered
+build plan → `findings/NEW-BOT-BUILD-PLAN.md`. It has three parts:
+
+**1. The capability corpus** — every capability, with its disposition:
+- **KEEP** (optimal as-is) · **IMPROVE** (the better form, simulated where possible) · **MERGE** · **DROP**
+  (Axis 1) · **ADD-from-plans** (Axis 2) · **ADD-from-ecosystem** (Axis 3 strong-fit) · **DEFERRED /
+  known-options** (documented, not scheduled — the "known and clearly documented" menu).
+
+**2. The build order (the part the owner cares most about).** Sequence every KEEP/IMPROVE/ADD into
+**dependency layers**, foundations first:
+- **L0 Foundations** — the kernel/grammar, state/db, config lanes, audit seam, permission/capability
+  model, the manifest+simulator itself.
+- **L1 Core management** — bot-management + server-management functions (setup/provisioning, roles,
+  channels, moderation, logging) — the operator's control plane.
+- **L2+ Features** — everything domain (economy, games, knowledge, community …), each depending only on
+  layers already complete.
+Each item lists its **dependencies** (what must be 100% done first). No item may sit in a layer above
+an unbuilt dependency.
+
+**3. Per-capability acceptance — done-before-next + outperform.** For every buildable item, state:
+- **Production-grade "done"** = the concrete acceptance bar (which `parity/` golden it passes, tests,
+  operational criteria) — a layer is not "done" until every item in it clears this.
+- **Outperform target** = the best-in-class competitor (from Lane F) and the specific way ours must beat
+  it (or the deliberate reason parity is enough).
+
+Keep it **rich, filterable, honest** (deliberate omissions labeled *why*). This is both the "repo
+overflowing with useful data the next bot can use" corpus **and** the singular ordered plan the owner
+builds from — it outlives this review and is the thing the first build session picks up.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/HANDOFF-PROMPTS.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/HANDOFF-PROMPTS.md
@@ -1,0 +1,239 @@
+# Handoff prompts — copy-paste to launch each planned session
+
+> **Status:** `reference`. One ready-to-paste startup prompt per planned agent. Launch the four lanes in
+> parallel (they're file-disjoint), then the Fable 5 capstone once they've landed. Each prompt is
+> self-contained; the agent reads the shared contract from the repo.
+
+---
+
+## Lane A — Governance & Safety  → **Sonnet 5 ultracode**
+
+```
+You are Sonnet 5 running an ULTRACODE session in the menno420/superbot repo. You are Lane A of a 4-lane
+parallel new-bot-capability-audit audit: measure whether the rebuild's §2 manifest grammar can express every
+subsystem as tier-1/2 declarations (vs tier-3 escape-hatch code). This is the future-proofing gate before
+the new-repo build — the spike measured 3 of 43 subsystems; you measure yours.
+
+READ FIRST, in order:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md         (the binding contract: method, output schema, guardrails, exit bar)
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md      (confirm your lane)
+3. docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-A-governance.md  (your workspace — surface-unit inventories pre-filled, tier columns blank)
+4. tools/grammar_spike/  — the method you replicate: spec.py (the §2 grammar), manifests/{karma,blackjack,server_logging}.py (worked examples), measure.py + RESULTS.md (tier semantics + output format)
+
+YOUR SUBSYSTEMS: admin, server_management, moderation, automod, image_moderation, security, cleanup, role, channel, welcome, ticket
+
+DO, per subsystem: (1) verify + complete its unit ledger against source (fix/add units, cite file:line) and fill BOTH tier columns (as-written / with-amendments) with a one-line rationale, covering all unit kinds (command/panel/setting/listener/event/store/game/help); (2) write the §2 manifest sketch (spike style) showing where each unit lands; (3) disposition every tier-3 — grammar-gap → propose/reuse an amendment G-<n>, OR legitimate escape hatch (with reason); (4) fit numbers (units total, tier-1/2 count, fit% as-written, fit% with-amendments); (5) flag structural patterns (esp. the setup/provisioning wait_for wizards).
+
+ULTRACODE: you may fan out one sub-agent per subsystem, then synthesize + adversarially verify their tier-3 verdicts against source before writing your lane file.
+
+RULES: READ-ONLY — no disbot/ edits, no runtime or new-repo code, docs only. Verify every tier-3 against shipped source and cite file:line (a wrong "needs tier-3" poisons the amendment list); mark "⚠ unverified" rather than assert. Stay in Lane A only.
+
+OUTPUT: write the completed docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-A-governance.md and open a PR for it (file-disjoint from the other lanes). Follow the repo's session workflow (.claude/CLAUDE.md — born-red session card, PR, enders).
+```
+
+---
+
+## Lane B — Economy & Character-sim  → **Opus 4.8 ultracode**
+
+```
+You are Opus 4.8 running an ULTRACODE session in the menno420/superbot repo. You are Lane B of a 4-lane
+parallel new-bot-capability-audit audit: measure whether the rebuild's §2 manifest grammar can express every
+subsystem as tier-1/2 declarations (vs tier-3 escape-hatch code). Future-proofing gate before the new-repo
+build — the spike measured 3 of 43 subsystems; you measure yours. Your lane holds the DEEP-STATE
+subsystems (mining/creature/farm) — a primary tier-3 pressure point; probe it hard.
+
+READ FIRST, in order:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md
+3. docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-B-economy.md
+4. tools/grammar_spike/  (spec.py, manifests/*, measure.py, RESULTS.md — the method + tier semantics)
+
+YOUR SUBSYSTEMS: economy, inventory, treasury, mining, fishing, creature, farm, xp, casino, four_twenty, counters
+
+DO, per subsystem: (1) verify + complete its unit ledger against source (cite file:line) and fill BOTH tier columns with a one-line rationale, all unit kinds (command/panel/setting/listener/event/store/game/help); (2) write the §2 manifest sketch; (3) disposition every tier-3 → amendment G-<n> or documented escape hatch; (4) fit numbers; (5) flag structural patterns — especially deep persistent state (mining grid, creature battles, farm growth), transactional multi-write mutations, and leaderboards/records. Where the grammar can't hold persistent game state, say so precisely and propose the primitive family it would need.
+
+ULTRACODE: fan out one sub-agent per subsystem, then synthesize + adversarially verify tier-3 verdicts against source before writing your lane file.
+
+RULES: READ-ONLY — docs only, no disbot/ or new-repo code. Verify tier-3 against source, cite file:line, "⚠ unverified" when unsure. Stay in Lane B.
+
+OUTPUT: write docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-B-economy.md and open a PR. Follow the repo session workflow (.claude/CLAUDE.md).
+```
+
+---
+
+## Lane C — Games & Community  → **Opus 4.8 ultracode**
+
+```
+You are Opus 4.8 running an ULTRACODE session in the menno420/superbot repo. You are Lane C of a 4-lane
+parallel new-bot-capability-audit audit. This is the HARDEST grammar-fit lane: blackjack measured only 44% in
+the spike, and your lane is the stateful game loops (turn/round state machines, wait_for interaction loops,
+timers). It most directly tests whether the grammar needs a GAME-STATE primitive family — likely a new
+amendment. blackjack + karma already have spike manifests; calibrate against them.
+
+READ FIRST, in order:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md
+3. docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-C-games.md
+4. tools/grammar_spike/  (spec.py, manifests/{blackjack,karma,server_logging}.py, measure.py, RESULTS.md)
+
+YOUR SUBSYSTEMS: games, blackjack, deathmatch, rps_tournament, counting, chain, leaderboard, community, community_spotlight, karma
+
+DO, per subsystem: (1) verify + complete its unit ledger (cite file:line), fill BOTH tier columns with a one-line rationale, all unit kinds; (2) §2 manifest sketch; (3) disposition every tier-3 → amendment or escape hatch; (4) fit numbers; (5) flag structural patterns — especially stateful game loops, wait_for loops, and timers. Be explicit about whether the grammar (with amendments) can express a full game turn/round loop or whether that is an irreducible tier-3 handler — this is the lane's central finding.
+
+ULTRACODE: fan out one sub-agent per subsystem, then synthesize + adversarially verify against source.
+
+RULES: READ-ONLY — docs only. Verify tier-3 against source, cite file:line, "⚠ unverified" when unsure. Stay in Lane C.
+
+OUTPUT: write docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-C-games.md and open a PR. Follow the repo session workflow (.claude/CLAUDE.md).
+```
+
+---
+
+## Lane D — Knowledge, AI & Platform  → **Codex / deep-research**
+
+```
+You are auditing Lane D of a 4-lane parallel new-bot-capability-audit audit in the menno420/superbot repo:
+measure whether the rebuild's §2 manifest grammar can express every subsystem as tier-1/2 declarations (vs
+tier-3 escape-hatch code) — the future-proofing gate before the new-repo build. The spike measured 3 of 43
+subsystems; you measure yours. Your lane mixes the easy generated-panel payoff (logging ~97%, settings)
+with the NOVEL AI/knowledge-domain shape the spike never touched — that is where your value is highest.
+
+READ FIRST, in order:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md         (the binding contract — follow its schema exactly so your output composes with the other lanes)
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md
+3. docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-D-knowledge-platform.md
+4. tools/grammar_spike/  (spec.py = the §2 grammar; manifests/server_logging.py = the closest worked example; measure.py + RESULTS.md = tier semantics + output format)
+
+YOUR SUBSYSTEMS: ai, btd6, project_moon, help, settings, logging, diagnostic, ux_lab, utility, general, proof_channel
+
+DO, per subsystem: (1) verify + complete its unit ledger against source (cite file:line), fill BOTH tier columns (as-written / with-amendments) with a one-line rationale, all unit kinds (command/panel/setting/listener/event/store/game/help); (2) write the §2 manifest sketch; (3) disposition every tier-3 → amendment G-<n> or documented escape hatch; (4) fit numbers; (5) flag structural patterns. For the AI/knowledge subsystems, assess whether a KnowledgeDomainSpec (commands + data sources + context builder + eval suite + diagnostics) is expressible declaratively or needs a new family. A deep-research agent may add external patterns (how comparable bots structure knowledge-domain/config surfaces) as a note in findings/ — clearly labeled as external, not repo source.
+
+RULES: READ-ONLY — docs only, no runtime/new-repo code. Verify every tier-3 against shipped source and cite file:line (the earlier Codex maps mis-read source 4× — do not repeat that); mark "⚠ unverified" rather than assert. Stay in Lane D.
+
+OUTPUT: write your completed lane file docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-D-knowledge-platform.md (and any external-research note under findings/), then open a PR.
+```
+
+---
+
+## Lane E — Plans & Ideas (Axis 2)  → **Codex / Opus**
+
+```
+You are auditing Lane E — Plans & Ideas (Axis 2) — of the new-bot capability audit in menno420/superbot.
+Goal: reconsider everything PLANNED or IDEATED for the new bot — does it still belong, is it optimal, how
+to improve it — so the forward surface is as considered as the shipped one.
+
+READ FIRST:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md   (the mandate + per-capability schema)
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md   (your lane)
+3. docs/planning/*.md (active plans — SKIP any badged `historical`) + docs/ideas/*.md + docs/ideas/README.md + docs/roadmap.md
+
+DO, per plan/idea meant for the new bot: (1) reconsider — keep / improve / merge / drop / redesign; (2) express its target capability in the §2 grammar (tools/grammar_spike/spec.py); (3) note whether an Axis-1 subsystem already covers it (avoid double-counting with Lanes A–D); (4) deep-reason optimality + propose the better form. Output a forward-capability ledger: what the new bot should ADD that isn't shipped, each with its optimal form and why.
+
+RULES: READ-ONLY, docs only. Verify against source; cite the plan/idea file. Do not re-audit shipped subsystems (that's A–D). Stay in Lane E.
+
+OUTPUT: write docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-E-plans-ideas.md and open a PR. Follow the repo session workflow (.claude/CLAUDE.md).
+```
+
+---
+
+## Lane F — Ecosystem benchmark (Axis 3)  → **deep-research**
+
+```
+You are running Lane F — Ecosystem benchmark (Axis 3) — of the new-bot capability audit in
+menno420/superbot. Goal: review our bot against KNOWN Discord bots and catalog what THEY do that WE
+don't — a documented known-options corpus for the next bot. This is NOT a build list; the bar is "known
+and clearly documented" so a future session pulls from a rich menu instead of rediscovering.
+
+READ FIRST:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md   (the mandate — Axis 3)
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/ground-truth/command-surface.json  (our 271 commands)
+3. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md  (our domains) + the Axis-1 lane files as they land (our current capabilities per domain)
+
+DO: for each of our domains (moderation/safety, economy/currency, games, leveling/XP, tickets, welcome/
+greeter, reaction-roles, logging, music/voice, utility, knowledge/AI, fun/social), web-research the
+leading bots in that domain — MEE6, Carl-bot, Dyno, Dank Memer, Ticket Tool, YAGPDB, Arcane, Tatsu,
+ProBot, Mudae, Sapphire, and domain-fit others. Catalog their feature/command sets, diff against ours,
+and document EVERY capability they have that we don't: what it is · which bot(s) · would it fit our
+declarative §2 design · fit verdict (**strong fit** / **maybe** / **deliberate omission** + reason).
+CITE sources (URLs/docs). Be thorough — "a lot is still missing"; find it.
+
+ALSO — the OUTPERFORM bar (owner's standard rule): for the capabilities we DO share with these bots,
+identify the **best-in-class** implementation (which bot does it best and how) so ours can be specced to
+BEAT it, not just match it. Note the concrete edge to target (speed, UX, depth, reliability). This feeds
+the build plan's per-capability "outperform target."
+
+RULES: this is a KNOWN-OPTIONS corpus — nothing here is auto-scheduled to build. Label external facts as
+external (not repo source). Be honest about deliberate omissions and why.
+
+OUTPUT: write docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/ecosystem-benchmark.md as a
+filterable capability-gap catalog (group by domain; sortable by fit verdict) and open a PR. Make it rich
+— the explicit goal is a repo overflowing with useful data the next bot can use.
+```
+
+---
+
+## Lane G — Foundations & Runtime Skeleton, L0 (Axis 1)  → **Opus 4.8 / Codex**
+
+```
+You are auditing Lane G — Foundations & Runtime Skeleton (L0) — of the new-bot capability audit in
+menno420/superbot. This is the SUBSTRATE under all 43 subsystems and the FIRST thing the new bot builds
+(foundations first) — the highest-leverage lane. Owner directive: "we already do this, but there's room
+for improvement" — so audit, reconsider, and design the OPTIMAL foundation.
+
+READ FIRST:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md   (mandate + per-capability schema)
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md   (Lane G)
+3. disbot/bot1.py (the bot skeleton + extension loader) · disbot/core/ (kernel/runtime) · disbot/utils/ (helpers) · docs/helper-policy.md · docs/architecture.md
+
+DO — audit + reconsider + optimize + benchmark the L0 substrate:
+- main.py / bootstrap: is it LEAN + functional? what belongs in it vs. what should be extracted.
+- Dynamic cog discovery + auto-load: the skeleton must find and load EVERY cog dynamically with NO hardcoded initial-extensions list. Audit how we do it today, reconsider, and design the optimal auto-discovery (folder-scan / entry-point / manifest-driven) — with failure isolation (one bad cog can't down the bot) and load-order/dependency handling.
+- Env + config: loading, validation, secrets, per-environment — the config lanes' foundation.
+- Helper / util architecture: every applicable function in its PROPER helper/util home (align to docs/helper-policy.md); flag mis-homed functions and the ideal layering.
+- Kernel / runtime: the engine the §2 manifest generates into.
+Benchmark against best-in-class bot skeletons (discord.py cog-loader patterns, large open-source bots). For each foundation piece: reconsider verdict + optimal form (simulated where feasible) + production-grade done-definition + outperform target.
+
+RULES: READ-ONLY, docs only, no runtime/new-repo code. Cite file:line; verify vs source; "⚠ unverified" when unsure.
+
+OUTPUT: write docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-G-foundations.md and open a PR. This lane feeds the build plan's L0 layer directly — it's the first thing the first build session picks up.
+```
+
+---
+
+## Capstone — final review  → **Fable 5 (ultracode or normal)**
+
+```
+You are Fable 5 running the CAPSTONE review of the new-bot-capability-audit audit in the menno420/superbot
+repo. Four independent lanes (2 Opus + 1 Sonnet ultracode + Codex/deep-research) have measured whether the
+rebuild's §2 manifest grammar can express all 43 subsystems as tier-1/2 declarations. Turn their findings
+into one durable go/no-go — this is the gate between "planning/discovery" and "creating the new repo."
+
+READ FIRST:
+1. docs/analysis/rebuild-discovery/new-bot-capability-audit/FINAL-REVIEW-HANDOFF.md   (your full spec — follow it)
+2. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
+3. All four docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-*.md + anything in findings/
+4. tools/grammar_spike/RESULTS.md  (the 3-subsystem baseline you extend)
+
+DO: (1) VERIFY before trusting — spot-check the highest-leverage tier-3 verdicts against source; do not average lane numbers blindly (Q-0120 — the spike caught cross-agent maps mis-reading source 4×); down-weight "⚠ unverified" rows and re-derive disputed ones. (2) Compute the measured all-43 tier-1/2 fit (as-written vs with-amendments; 43 rows + overall; note if the mean is carried by high-fit CRUD subsystems while the stateful cluster drags). (3) Consolidate the amendment list (extend G-1…G-6, dedup; mark each soft-spec-note vs structural-new-family). (4) Answer each structural danger zone (stateful games / gateway listeners / wait_for wizards / scheduled loops / voice) — expressible, documented escape hatch, or needs a new family. (5) Per-subsystem preserve/redesign/drop disposition (fold with ../codex-preserve-map-synthesis-2026-07-02.md).
+
+RULE THE VERDICT: GO / GO-with-amendments / NO-GO — with evidence, never a soft "looks fine." A subsystem class with no clean grammar answer is a NO-GO — that is exactly the "needs re-rebuilding in a year" failure this whole pass exists to catch.
+
+THEN ASSEMBLE THE UNIFIED BUILD PLAN (Lanes E + F too) — the owner's ultimate ask: the next bot is built from ONE comprehensive plan, in a logical order, each layer production-grade before the next, every function outperforming the best equivalent in any other bot. Fold Axis-1 (keep/improve/merge/drop), Axis-2 (Lane E, planned), and Axis-3 (Lane F, ecosystem strong-fit) into: (1) the capability corpus (each item's disposition + deferred known-options); (2) the BUILD ORDER — dependency layers, foundations first: L0 foundations (kernel/grammar/state/config/audit/permission) → L1 core bot+server management (setup, roles, channels, moderation, logging) → L2+ features; each item lists its dependencies, nothing above an unbuilt dependency; (3) per-capability acceptance — the production-grade "done" definition (which parity/ golden + tests it passes) AND the outperform target (the best-in-class competitor from Lane F and how ours beats it).
+
+OUTPUT: findings/FINAL-REVIEW.md (grammar verdict + aggregated fit table + amendments + dispositions) AND findings/NEW-BOT-BUILD-PLAN.md (the corpus + dependency-layered build order + per-capability done-definition + outperform target). Open the design-spec amendment PR (or a plan) the verdict implies, plus the owner "what approval means" checklist. READ-ONLY on runtime; docs only.
+```
+
+---
+
+## Launch order
+
+1. Fire **Lanes A–D + G in parallel** (Axis-1: A–D are file-disjoint by subsystem; G reads the
+   foundation across `bot1.py`/`core`/`utils` — disjoint from the subsystem cogs → clean PRs).
+2. Fire **Lane E** (Axis 2 — plans/ideas) and **Lane F** (Axis 3 — ecosystem benchmark) alongside; they
+   reference the A–D/G output and can refine as it lands (or run just after).
+3. Once all seven land, fire the **Fable 5 capstone** — it reads all lanes + findings/ and produces the
+   grammar go/no-go + the **unified, dependency-ordered, best-in-class build plan**.
+
+The seven lanes map to your fleet: **2 Opus 4.8** (B, C — or move one to **G**, the highest-leverage
+foundation lane) · **1 Sonnet 5** (A) · **a few Codex / deep-research** (D, E, F, G). Each lane's
+amendments, optimality findings, ecosystem gaps, and L0 foundation design are the capstone's raw material.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/PARTITION.md
@@ -1,0 +1,103 @@
+# Partition — 43 subsystems × 4 disjoint lanes
+
+> **Status:** `reference`. Lanes are **file-disjoint**: each subsystem is audited by exactly one lane,
+> so parallel agents never collide and outputs merge cleanly. Assign one agent (or agent-team) per lane.
+
+## Model → lane (suggested — strongest reasoning on the hardest grammar-fit lanes)
+
+The spike showed fit collapses on **stateful game loops** (blackjack 44%) and event-driven surfaces,
+and holds on CRUD/config (logging 97%). Put the deepest reasoners where the grammar strains most:
+
+| Lane | Domain / axis | Scope | Expected difficulty | Suggested agent |
+|---|---|---:|---|---|
+| **A** | Governance & Safety (Axis 1) | 11 subsystems | Medium (moderation/CRUD, capability-gated) | **Sonnet 5 ultracode** |
+| **B** | Economy & Character-sim (Axis 1) | 11 subsystems | **Hard** (deep persistent state) | **Opus 4.8 ultracode** |
+| **C** | Games & Community (Axis 1) | 10 subsystems | **Hardest** (blackjack 44% + stateful loops) | **Opus 4.8 ultracode** |
+| **D** | Knowledge, AI & Platform (Axis 1) | 11 subsystems | Mixed (logging easy; AI-domain novel) | **Codex / deep-research** |
+| **E** | Plans & Ideas (Axis 2) | `docs/planning/` + `docs/ideas/` | Medium (doc reasoning) | **Codex / Opus** |
+| **F** | Ecosystem benchmark (Axis 3) | known Discord bots ↔ our domains | Open-ended (web research) | **deep-research** |
+| **G** | Foundations & Runtime Skeleton (L0) | bootstrap · cog-loader · env/config · `main.py` · helper/util arch | **Hard + highest-leverage** (everything depends on it) | **Opus 4.8 / Codex** |
+
+Lanes **A–D** cover Axis 1 (what we have); **E** covers Axis 2 (what we planned); **F** covers Axis 3
+(what the ecosystem has that we don't). A–D are file-disjoint by subsystem; E and F are cross-cutting
+research lanes that reference A–D's output. The 3 spike-worked manifests
+(`tools/grammar_spike/manifests/`) are shared calibration for all Axis-1 lanes.
+
+## Lane A — Governance & Safety (→ Sonnet 5)
+
+`admin` · `server_management` · `moderation` · `automod` · `image_moderation` · `security` · `cleanup` ·
+`role` · `channel` · `welcome` · `ticket`
+
+Watch for: capability/permission gates as declarations vs. code; the setup/provisioning wizards
+(`wait_for` danger-zone); audit-seam mutations (should be tier-2 handler refs).
+
+## Lane B — Economy & Character-sim (→ Opus 4.8 #1)
+
+`economy` · `inventory` · `treasury` · `mining` · `fishing` · `creature` · `farm` · `xp` · `casino` ·
+`four_twenty` · `counters`
+
+Watch for: **deep persistent state** (mining grid, creature battles, farm growth) — the tier-3 pressure
+point; transactional multi-write mutations; leaderboards/records (LeaderboardSpec vocabulary).
+
+## Lane C — Games & Community (→ Opus 4.8 #2)
+
+`games` · `blackjack` · `deathmatch` · `rps_tournament` · `counting` · `chain` · `leaderboard` ·
+`community` · `community_spotlight` · `karma`
+
+Watch for: **stateful game loops** (the 44% zone) — turn/round state machines, `wait_for` interaction
+loops, timers. This lane most directly tests whether the grammar needs a **game-state primitive family**
+(likely a new amendment). `blackjack` + `karma` already have spike manifests — calibrate against them.
+
+## Lane D — Knowledge, AI & Platform (→ Codex / deep-research)
+
+`ai` · `btd6` · `project_moon` · `help` · `settings` · `logging` · `diagnostic` · `ux_lab` · `utility` ·
+`general` · `proof_channel`
+
+Watch for: the **AI/knowledge-domain** shape (KnowledgeDomainSpec — commands + data sources + context
+builder + eval suite; the spike never touched this) — deep-research value here; `settings`/`logging` are
+the generated-panel payoff (should be near-100% fit — confirm); diagnostics as declarative providers.
+
+## Lane E — Plans & Ideas, Axis 2 (→ Codex / Opus)
+
+Everything **planned or ideated** for the new bot: `docs/planning/*.md` (active plans, not `historical`)
++ `docs/ideas/*.md` (the idea backlog) + the roadmap horizons. For each item: does it still belong in the
+new bot? reconsider (keep/improve/merge/drop/redesign), express its target capability in the §2 grammar,
+and note whether it's **already covered** by an Axis-1 subsystem (so it's not double-counted). Output: a
+forward-capability ledger — what the new bot should add that isn't shipped yet, with the optimal form.
+
+## Lane F — Ecosystem benchmark, Axis 3 (→ deep-research)
+
+Review our domains against **known Discord bots and their full feature sets** — MEE6, Carl-bot, Dyno,
+Dank Memer, Ticket Tool, YAGPDB, Arcane, Tatsu, ProBot, Mudae, and any domain-fit others (web-research
+their feature/command docs). Per domain (align to the A–D groupings): catalog what they do that **we
+don't**, with a one-line "what it is + which bot(s) + would it fit our design." **Not a build list —**
+a *documented known-options corpus* (owner: "known and clearly documented," integrate later). Flag each
+gap as: **strong fit** (the new bot should likely have it) · **maybe** · **deliberate omission** (why we
+skip it). Cite sources. This is where the repo gets "overflowing with useful data the next bot can use."
+
+## Lane G — Foundations & Runtime Skeleton, L0 (→ Opus 4.8 / Codex)
+
+The substrate **under** all 43 subsystems — the L0 layer the build order builds *first*, so it is the
+highest-leverage lane. Audit + reconsider + optimize + benchmark (owner directive 2026-07-02 — "we
+already do this, but there's room for improvement"):
+
+- **Bootstrap / `main.py`** — is it **lean and functional**? What belongs in it vs. extracted.
+- **Dynamic cog discovery + auto-load** — the skeleton must **find and load every cog dynamically, with
+  NO hardcoded initial-extensions list**. Audit how we do it today (`disbot/bot1.py` + the loader),
+  reconsider, and design the optimal auto-discovery (folder-scan / entry-point / manifest-driven).
+- **Env + config** — loading, validation, secrets, per-environment; the config lanes' foundation.
+- **Helper / util architecture** — every applicable function in its **proper** helper/util home (align to
+  `docs/helper-policy.md`); flag mis-homed functions and the ideal layering.
+- **Kernel / runtime** — the engine that the manifest generates *into* (the §2 grammar's host).
+
+Benchmark against best-in-class bot skeletons (discord.py cog-loader patterns, large open-source bots).
+Output feeds the build plan's **L0 layer** directly — with its production-grade done-definition and the
+outperform bar. This lane is not subsystem-partitioned; it reads across `disbot/bot1.py`, `disbot/core/`,
+`disbot/utils/`, and the extension/loader path.
+
+## Coverage guarantee
+
+**Axis 1:** 11 + 11 + 10 + 11 = **43** = every subsystem in `disbot/utils/subsystem_registry.py::SUBSYSTEMS`.
+Cross-check your lane's command counts against `ground-truth/command-surface.json`; if a subsystem spans
+multiple cogs (e.g. `btd6` → `btd6_*_cog.py`), audit all of them. **Axis 2:** every non-`historical`
+plan + every idea file. **Axis 3:** every domain has at least one comparable known bot benchmarked.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/README.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/README.md
@@ -1,0 +1,65 @@
+# New-bot capability audit — the fleet substrate
+
+> **Status:** `reference`. Prepared 2026-07-02 as the shared foundation for a multi-agent audit that
+> **maps, reconsiders, simulates, optimizes, and ecosystem-benchmarks every capability intended for the
+> new bot** — so the rebuild is durable *and* the repo becomes a rich reference corpus the next bot can
+> draw from. The new-bot-capability-audit pass is its technical spine. Read [`BRIEF.md`](./BRIEF.md) first.
+
+## The mandate (owner, 2026-07-02) — three axes, five verbs
+
+Every capability meant for the new bot gets **MAP → RECONSIDER → SIMULATE → OPTIMIZE → BENCHMARK**, across:
+
+- **Axis 1 — what we have** (43 subsystems) → reconsider + optimize (Lanes A–D)
+- **Axis 2 — what we planned** (`docs/planning/` + `docs/ideas/`) → reconsider for the new bot (Lane E)
+- **Axis 3 — what the ecosystem has that we don't** (known Discord bots) → catalog + document (Lane F)
+
+The durability question ("can the §2 grammar express it all?") is the spine; the goal is the **capability
+corpus** — is it optimal, what's missing, what should the next bot be.
+
+## The pipeline
+
+```
+   [PREP — this dir]                 [FLEET — 6 lanes]                        [CAPSTONE]
+   ground truth + contract    A–D  Axis 1  2× Opus + 1× Sonnet ultracode
+   + partition + scaffolds ─► E    Axis 2  Codex/Opus (plans/ideas)      ─►  final Fable 5:
+   + handoff prompts          F    Axis 3  deep-research (ecosystem)          verdict + corpus/roadmap
+```
+
+1. **PREP (this directory).** Ground-truth dumps, the shared mandate/method/schema contract, the
+   partition, per-lane scaffolds (Axis-1 surface inventories pre-extracted), and copy-paste
+   [handoff prompts](./HANDOFF-PROMPTS.md) for every session.
+2. **FLEET.** Six lanes (see [`PARTITION.md`](./PARTITION.md)): A–D audit the shipped subsystems, E the
+   planned/ideated surface, F benchmarks against known bots. Each writes its lane file / findings.
+3. **CAPSTONE.** A final Fable 5 session ([`FINAL-REVIEW-HANDOFF.md`](./FINAL-REVIEW-HANDOFF.md)) verifies
+   the findings against source, rules the grammar **GO / GO-with-amendments / NO-GO**, and produces the
+   **prioritized new-bot capability roadmap** (keep/improve/merge/drop/add + deferred known-options).
+
+## Files
+
+| File | What |
+|---|---|
+| [`BRIEF.md`](./BRIEF.md) | The binding contract: the 3-axis mandate, method, per-capability schema, guardrails, exit bar. |
+| [`PARTITION.md`](./PARTITION.md) | 43 subsystems × Lanes A–D + E (plans/ideas) + F (ecosystem) + G (L0 foundations) + model→lane. |
+| [`HANDOFF-PROMPTS.md`](./HANDOFF-PROMPTS.md) | Copy-paste startup prompts for all 7 lanes + the capstone. |
+| [`FINAL-REVIEW-HANDOFF.md`](./FINAL-REVIEW-HANDOFF.md) | Startup context for the capstone Fable 5 review. |
+| `ground-truth/command-surface.json` | All 271 commands (name/aliases/kind/perm/cog/line). |
+| `ground-truth/subsystems.json` | The 43 subsystems + capabilities/entry_points/hub. |
+| Axis-1 lanes: [`A`](./lanes/lane-A-governance.md) · [`B`](./lanes/lane-B-economy.md) · [`C`](./lanes/lane-C-games.md) · [`D`](./lanes/lane-D-knowledge-platform.md) | **Pre-filled** surface inventories (271 units extracted), judgment columns blank — the fleet completes them. |
+| [`lanes/lane-E-plans-ideas.md`](./lanes/lane-E-plans-ideas.md) | Axis-2 forward-capability ledger (Lane E agent fills). |
+| [`lanes/lane-G-foundations.md`](./lanes/lane-G-foundations.md) | **L0** foundations / runtime-skeleton audit (Lane G agent fills). |
+| [`findings/`](./findings/README.md) | Lane F ecosystem benchmark + the capstone's `FINAL-REVIEW.md` + `NEW-BOT-BUILD-PLAN.md`. |
+
+## Why this shape (the lessons baked in)
+
+- **Extract mechanically, judge with agents.** Ground-truth inventories are a script/scaffold job; the
+  fleet spends its budget on reconsider/optimize/benchmark, not re-deriving facts.
+- **One schema so N reviews compose, not overlap.** Every lane (any provider) fills the same shape →
+  the capstone merges instead of reconciling divergent prose.
+- **Provider diversity as verification.** The capstone verifies cross-agent verdicts against source
+  (Q-0120) — the spike already caught cross-agent maps mis-reading source 4×.
+- **Disjoint lanes.** Axis-1 lanes are file-disjoint by subsystem; E and F are cross-cutting research
+  lanes that reference A–D.
+
+This extends [`../codex-preserve-map-synthesis-2026-07-02.md`](../codex-preserve-map-synthesis-2026-07-02.md)
+(the structural preserve-map) with its grammar-expressiveness + optimization + ecosystem layers, and the
+[grammar spike](../../../../tools/grammar_spike/RESULTS.md) (3 subsystems → all 43 + planned + ecosystem).

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/README.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/README.md
@@ -1,0 +1,13 @@
+# findings/ — where the fleet's research + the capstone deliverables land
+
+> **Status:** `reference`. Home for the cross-cutting research lanes + the capstone outputs.
+
+- `ecosystem-benchmark.md` — **Lane F** (Axis 3): the known-Discord-bot capability-gap catalog +
+  outperform targets. Any other Codex / deep-research addenda also land here (labeled external).
+- `FINAL-REVIEW.md` — **capstone** deliverable 1: the grammar GO / GO-with-amendments / NO-GO verdict +
+  the aggregated all-43 fit table + the consolidated amendment list.
+- `NEW-BOT-BUILD-PLAN.md` — **capstone** deliverable 2: the corpus + the dependency-layered build order
+  (L0 foundations → L1 core management → L2+ features) + each capability's production-grade done-definition
+  + outperform target. This is the singular plan the first build session picks up.
+
+See [`../FINAL-REVIEW-HANDOFF.md`](../FINAL-REVIEW-HANDOFF.md) for the capstone spec.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/ground-truth/command-surface.json
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/ground-truth/command-surface.json
@@ -1,0 +1,2381 @@
+[
+  {
+    "name": "adminmenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 38
+  },
+  {
+    "name": "admin",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 57
+  },
+  {
+    "name": "serverstats",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 77
+  },
+  {
+    "name": "cog",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 99
+  },
+  {
+    "name": "loadall",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 126
+  },
+  {
+    "name": "unloadall",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 149
+  },
+  {
+    "name": "coglist",
+    "aliases": [
+      "cogs",
+      "listcogs",
+      "cogslist"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 182
+  },
+  {
+    "name": "syncslash",
+    "aliases": [
+      "syncs"
+    ],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 200
+  },
+  {
+    "name": "slashes",
+    "aliases": [
+      "slashlist"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 297
+  },
+  {
+    "name": "restart",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 367
+  },
+  {
+    "name": "loglevel",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/admin_cog.py",
+    "lineno": 395
+  },
+  {
+    "name": "ai",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/ai_cog.py",
+    "lineno": 367
+  },
+  {
+    "name": "aimenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/ai_cog.py",
+    "lineno": 519
+  },
+  {
+    "name": "aimenu",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/ai_cog.py",
+    "lineno": 777
+  },
+  {
+    "name": "aireview",
+    "aliases": [],
+    "kind": "group",
+    "perm": "manage_guild",
+    "cog_file": "cogs/ai_review_cog.py",
+    "lineno": 174
+  },
+  {
+    "name": "automod",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/automod_cog.py",
+    "lineno": 119
+  },
+  {
+    "name": "blackjack",
+    "aliases": [
+      "bj"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/blackjack_cog.py",
+    "lineno": 432
+  },
+  {
+    "name": "bjtournament",
+    "aliases": [
+      "bjtourn"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/blackjack_cog.py",
+    "lineno": 518
+  },
+  {
+    "name": "bjstart",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/blackjack_cog.py",
+    "lineno": 579
+  },
+  {
+    "name": "bjstatus",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/blackjack_cog.py",
+    "lineno": 590
+  },
+  {
+    "name": "btd6menu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/btd6_cog.py",
+    "lineno": 172
+  },
+  {
+    "name": "btd6menu",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/btd6_cog.py",
+    "lineno": 183
+  },
+  {
+    "name": "btd6events",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/btd6_events_cog.py",
+    "lineno": 44
+  },
+  {
+    "name": "btd6ops",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/btd6_ops_cog.py",
+    "lineno": 48
+  },
+  {
+    "name": "btd6ref",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/btd6_reference_cog.py",
+    "lineno": 43
+  },
+  {
+    "name": "btd6strat",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/btd6_strategy_cog.py",
+    "lineno": 45
+  },
+  {
+    "name": "casino",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/casino_cog.py",
+    "lineno": 41
+  },
+  {
+    "name": "poker",
+    "aliases": [
+      "holdem"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/casino_cog.py",
+    "lineno": 47
+  },
+  {
+    "name": "chain",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/chain_cog.py",
+    "lineno": 70
+  },
+  {
+    "name": "chainmenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/chain_cog.py",
+    "lineno": 255
+  },
+  {
+    "name": "channelmenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 196
+  },
+  {
+    "name": "set",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 214
+  },
+  {
+    "name": "evt",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 237
+  },
+  {
+    "name": "create",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 282
+  },
+  {
+    "name": "bulkdelete",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 333
+  },
+  {
+    "name": "del",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 384
+  },
+  {
+    "name": "list",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 409
+  },
+  {
+    "name": "clone",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 441
+  },
+  {
+    "name": "move",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 474
+  },
+  {
+    "name": "lock",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 500
+  },
+  {
+    "name": "unlock",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 516
+  },
+  {
+    "name": "channelinfo",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 535
+  },
+  {
+    "name": "rename",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 574
+  },
+  {
+    "name": "slowmode",
+    "aliases": [
+      "slow"
+    ],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 606
+  },
+  {
+    "name": "topic",
+    "aliases": [
+      "settopic"
+    ],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 646
+  },
+  {
+    "name": "permissions",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 677
+  },
+  {
+    "name": "bulkcreate",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "admin",
+    "cog_file": "cogs/channel_cog.py",
+    "lineno": 708
+  },
+  {
+    "name": "cleanuphistory",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_messages",
+    "cog_file": "cogs/cleanup_cog.py",
+    "lineno": 325
+  },
+  {
+    "name": "word",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/cleanup_cog.py",
+    "lineno": 488
+  },
+  {
+    "name": "wordmenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/cleanup_cog.py",
+    "lineno": 554
+  },
+  {
+    "name": "cleanup",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/cleanup_cog.py",
+    "lineno": 563
+  },
+  {
+    "name": "community",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/community_cog.py",
+    "lineno": 42
+  },
+  {
+    "name": "community",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/community_cog.py",
+    "lineno": 59
+  },
+  {
+    "name": "spotlight",
+    "aliases": [
+      "activity"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/community_spotlight_cog.py",
+    "lineno": 304
+  },
+  {
+    "name": "counters",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/counters_cog.py",
+    "lineno": 159
+  },
+  {
+    "name": "counterpreset",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/counters_cog.py",
+    "lineno": 173
+  },
+  {
+    "name": "counters",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "manage_guild",
+    "cog_file": "cogs/counters_cog.py",
+    "lineno": 227
+  },
+  {
+    "name": "countingmenu",
+    "aliases": [
+      "cm"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 181
+  },
+  {
+    "name": "start_match",
+    "aliases": [
+      "sm"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 198
+  },
+  {
+    "name": "end_match",
+    "aliases": [
+      "em"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 385
+  },
+  {
+    "name": "reset_count",
+    "aliases": [
+      "rc"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 434
+  },
+  {
+    "name": "toggle_turns",
+    "aliases": [
+      "tt"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 489
+  },
+  {
+    "name": "count_info",
+    "aliases": [
+      "ci"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 518
+  },
+  {
+    "name": "counttop",
+    "aliases": [
+      "ct",
+      "counting_top"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 573
+  },
+  {
+    "name": "count_rules",
+    "aliases": [
+      "cr"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 605
+  },
+  {
+    "name": "set_skip_numbers",
+    "aliases": [
+      "ssn"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 637
+  },
+  {
+    "name": "toggle_reset_on_wrong_count",
+    "aliases": [
+      "trwc"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/counting_cog.py",
+    "lineno": 688
+  },
+  {
+    "name": "cbattle",
+    "aliases": [
+      "creaturebattle"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_battle_cog.py",
+    "lineno": 73
+  },
+  {
+    "name": "cbrecord",
+    "aliases": [
+      "battlerecord"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_battle_cog.py",
+    "lineno": 90
+  },
+  {
+    "name": "cbattletop",
+    "aliases": [
+      "pvptop",
+      "battletop"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_battle_cog.py",
+    "lineno": 97
+  },
+  {
+    "name": "catch",
+    "aliases": [
+      "hunt"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_cog.py",
+    "lineno": 59
+  },
+  {
+    "name": "creatures",
+    "aliases": [
+      "creaturemenu",
+      "pets"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_cog.py",
+    "lineno": 70
+  },
+  {
+    "name": "dex",
+    "aliases": [
+      "collection"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_cog.py",
+    "lineno": 79
+  },
+  {
+    "name": "dextop",
+    "aliases": [
+      "topcatchers"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/creature_cog.py",
+    "lineno": 86
+  },
+  {
+    "name": "dm_challenge",
+    "aliases": [
+      "deathmatch",
+      "challenge",
+      "dm"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/deathmatch_cog.py",
+    "lineno": 445
+  },
+  {
+    "name": "dm_help",
+    "aliases": [
+      "deathmatch_help"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/deathmatch_cog.py",
+    "lineno": 498
+  },
+  {
+    "name": "platform",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic/platform_group.py",
+    "lineno": 112
+  },
+  {
+    "name": "diagnostics",
+    "aliases": [
+      "diag"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 57
+  },
+  {
+    "name": "lifecycle",
+    "aliases": [
+      "lc"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 64
+  },
+  {
+    "name": "platform",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 116
+  },
+  {
+    "name": "list_commands_detailed",
+    "aliases": [
+      "listcmds"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 137
+  },
+  {
+    "name": "find_command",
+    "aliases": [
+      "findcmd"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 148
+  },
+  {
+    "name": "validate_json_files",
+    "aliases": [
+      "validatejson"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 183
+  },
+  {
+    "name": "check_database",
+    "aliases": [
+      "checkdb"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 190
+  },
+  {
+    "name": "diagnostic_bot_status",
+    "aliases": [
+      "diag_status"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 201
+  },
+  {
+    "name": "latency",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 208
+  },
+  {
+    "name": "system_info",
+    "aliases": [
+      "sysinfo"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 220
+  },
+  {
+    "name": "query_logs",
+    "aliases": [
+      "querylogs"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 231
+  },
+  {
+    "name": "recent_errors",
+    "aliases": [
+      "errors"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 238
+  },
+  {
+    "name": "test_notification",
+    "aliases": [
+      "testnotify"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/diagnostic_cog.py",
+    "lineno": 245
+  },
+  {
+    "name": "economymenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 66
+  },
+  {
+    "name": "economy",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 85
+  },
+  {
+    "name": "daily",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 218
+  },
+  {
+    "name": "work",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 284
+  },
+  {
+    "name": "shop",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 326
+  },
+  {
+    "name": "balance",
+    "aliases": [
+      "bal",
+      "wallet"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 335
+  },
+  {
+    "name": "setlogchannel",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 353
+  },
+  {
+    "name": "joblist",
+    "aliases": [
+      "jobs"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/economy_cog.py",
+    "lineno": 365
+  },
+  {
+    "name": "farm",
+    "aliases": [
+      "chickenfarm",
+      "coop"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/farm_cog.py",
+    "lineno": 44
+  },
+  {
+    "name": "fish",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 76
+  },
+  {
+    "name": "fishing",
+    "aliases": [
+      "fishmenu"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 87
+  },
+  {
+    "name": "forecast",
+    "aliases": [
+      "fishforecast",
+      "fishingweather"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 98
+  },
+  {
+    "name": "sail",
+    "aliases": [
+      "setsail"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 117
+  },
+  {
+    "name": "fishlog",
+    "aliases": [
+      "fishdex"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 131
+  },
+  {
+    "name": "fishtop",
+    "aliases": [
+      "topfishers"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 145
+  },
+  {
+    "name": "trophies",
+    "aliases": [
+      "bigfish",
+      "fishtrophy"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 172
+  },
+  {
+    "name": "rod",
+    "aliases": [
+      "rodshop",
+      "buyrod"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 197
+  },
+  {
+    "name": "bait",
+    "aliases": [
+      "baitshop",
+      "buybait"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 208
+  },
+  {
+    "name": "craftbait",
+    "aliases": [
+      "baitcraft"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 222
+  },
+  {
+    "name": "craftcharm",
+    "aliases": [
+      "charmcraft"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 246
+  },
+  {
+    "name": "craftrod",
+    "aliases": [
+      "rodcraft"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 272
+  },
+  {
+    "name": "rodrecipes",
+    "aliases": [
+      "rodrecipe",
+      "rrecipes"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 283
+  },
+  {
+    "name": "craftpearl",
+    "aliases": [
+      "pearlcraft"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 289
+  },
+  {
+    "name": "curios",
+    "aliases": [
+      "curio",
+      "carvings"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 319
+  },
+  {
+    "name": "tidepool",
+    "aliases": [
+      "reef",
+      "tidepools"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 350
+  },
+  {
+    "name": "dock",
+    "aliases": [
+      "pier",
+      "fishingdock"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 362
+  },
+  {
+    "name": "boathouse",
+    "aliases": [
+      "moorings",
+      "boat"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 374
+  },
+  {
+    "name": "fishery",
+    "aliases": [
+      "hatchery",
+      "fishfarm"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 386
+  },
+  {
+    "name": "craftcurio",
+    "aliases": [
+      "carve",
+      "curiocraft"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/fishing_cog.py",
+    "lineno": 399
+  },
+  {
+    "name": "420",
+    "aliases": [
+      "fourtwenty",
+      "fourtwenty420"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/four_twenty_cog.py",
+    "lineno": 186
+  },
+  {
+    "name": "games",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/games_cog.py",
+    "lineno": 39
+  },
+  {
+    "name": "world",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/games_cog.py",
+    "lineno": 45
+  },
+  {
+    "name": "worldcard",
+    "aliases": [
+      "mystats"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/games_cog.py",
+    "lineno": 59
+  },
+  {
+    "name": "games",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/games_cog.py",
+    "lineno": 84
+  },
+  {
+    "name": "generalmenu",
+    "aliases": [
+      "gmenu"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 87
+  },
+  {
+    "name": "fact",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 113
+  },
+  {
+    "name": "joke",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 125
+  },
+  {
+    "name": "quote",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 137
+  },
+  {
+    "name": "trivia",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 152
+  },
+  {
+    "name": "motivate",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 171
+  },
+  {
+    "name": "eightball",
+    "aliases": [
+      "8ball"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 184
+  },
+  {
+    "name": "greet",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/general_cog.py",
+    "lineno": 191
+  },
+  {
+    "name": "help",
+    "aliases": [
+      "hilfe"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/help_cog.py",
+    "lineno": 284
+  },
+  {
+    "name": "help",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/help_cog.py",
+    "lineno": 370
+  },
+  {
+    "name": "bugreport",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/hermes_cog.py",
+    "lineno": 107
+  },
+  {
+    "name": "dispatch",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/hermes_cog.py",
+    "lineno": 170
+  },
+  {
+    "name": "imagemod",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/image_moderation_cog.py",
+    "lineno": 123
+  },
+  {
+    "name": "inventory",
+    "aliases": [
+      "inv"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/inventory_cog.py",
+    "lineno": 563
+  },
+  {
+    "name": "thanks",
+    "aliases": [
+      "rep",
+      "thank"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/karma_cog.py",
+    "lineno": 210
+  },
+  {
+    "name": "karma",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/karma_cog.py",
+    "lineno": 225
+  },
+  {
+    "name": "karma",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/karma_cog.py",
+    "lineno": 254
+  },
+  {
+    "name": "leaderboard",
+    "aliases": [
+      "lb",
+      "rankings",
+      "minelb",
+      "miningleaderboard",
+      "fishlb",
+      "dm_leaderboard",
+      "dm_lb",
+      "rpslb",
+      "farmlb",
+      "countlb",
+      "counting_leaderboard"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/leaderboard_cog.py",
+    "lineno": 216
+  },
+  {
+    "name": "logging",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/logging_cog.py",
+    "lineno": 315
+  },
+  {
+    "name": "minemenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 57
+  },
+  {
+    "name": "mine",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 91
+  },
+  {
+    "name": "fastmine",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 102
+  },
+  {
+    "name": "chop",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 118
+  },
+  {
+    "name": "mineinv",
+    "aliases": [
+      "mineinventory"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 137
+  },
+  {
+    "name": "minestats",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 150
+  },
+  {
+    "name": "build",
+    "aliases": [
+      "craft"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 193
+  },
+  {
+    "name": "buildlist",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 209
+  },
+  {
+    "name": "buildable",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 240
+  },
+  {
+    "name": "explore",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 265
+  },
+  {
+    "name": "use",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 281
+  },
+  {
+    "name": "cook",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 292
+  },
+  {
+    "name": "equip",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 315
+  },
+  {
+    "name": "unequip",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 326
+  },
+  {
+    "name": "gear",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 338
+  },
+  {
+    "name": "loadout",
+    "aliases": [
+      "loadouts"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 361
+  },
+  {
+    "name": "character",
+    "aliases": [
+      "profile",
+      "char"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 411
+  },
+  {
+    "name": "descend",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 441
+  },
+  {
+    "name": "ascend",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 458
+  },
+  {
+    "name": "mineworld",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 474
+  },
+  {
+    "name": "sell",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 501
+  },
+  {
+    "name": "sellall",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 516
+  },
+  {
+    "name": "buy",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 522
+  },
+  {
+    "name": "market",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 535
+  },
+  {
+    "name": "vault",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 571
+  },
+  {
+    "name": "stash",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 585
+  },
+  {
+    "name": "unstash",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 605
+  },
+  {
+    "name": "vaultupgrade",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 625
+  },
+  {
+    "name": "skills",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 637
+  },
+  {
+    "name": "skill",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 651
+  },
+  {
+    "name": "titles",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 674
+  },
+  {
+    "name": "forge",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 690
+  },
+  {
+    "name": "home",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 706
+  },
+  {
+    "name": "workshop",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 722
+  },
+  {
+    "name": "repair",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 735
+  },
+  {
+    "name": "quickcraft",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 750
+  },
+  {
+    "name": "reset_inventory",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/mining_cog.py",
+    "lineno": 758
+  },
+  {
+    "name": "modmenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 79
+  },
+  {
+    "name": "moderation",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "moderate_members",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 98
+  },
+  {
+    "name": "warn",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 128
+  },
+  {
+    "name": "timeout",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 155
+  },
+  {
+    "name": "kick",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 181
+  },
+  {
+    "name": "ban",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 213
+  },
+  {
+    "name": "unban",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 246
+  },
+  {
+    "name": "clearwarnings",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 277
+  },
+  {
+    "name": "modlogs",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/moderation_cog.py",
+    "lineno": 292
+  },
+  {
+    "name": "paragon",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/paragon_cog.py",
+    "lineno": 27
+  },
+  {
+    "name": "pm",
+    "aliases": [
+      "limbus",
+      "projectmoon"
+    ],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/project_moon_cog.py",
+    "lineno": 79
+  },
+  {
+    "name": "pm",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/project_moon_cog.py",
+    "lineno": 179
+  },
+  {
+    "name": "+prize",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_channels",
+    "cog_file": "cogs/proof_channel_cog.py",
+    "lineno": 121
+  },
+  {
+    "name": "-prize",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_channels",
+    "cog_file": "cogs/proof_channel_cog.py",
+    "lineno": 138
+  },
+  {
+    "name": "prizestatus",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_channels",
+    "cog_file": "cogs/proof_channel_cog.py",
+    "lineno": 152
+  },
+  {
+    "name": "prizemenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_channels",
+    "cog_file": "cogs/proof_channel_cog.py",
+    "lineno": 169
+  },
+  {
+    "name": "timedprize",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_channels",
+    "cog_file": "cogs/proof_channel_cog.py",
+    "lineno": 184
+  },
+  {
+    "name": "setup",
+    "aliases": [
+      "quicksetup",
+      "essentialsetup"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/quicksetup_cog.py",
+    "lineno": 34
+  },
+  {
+    "name": "setup",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/quicksetup_cog.py",
+    "lineno": 47
+  },
+  {
+    "name": "roles",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 355
+  },
+  {
+    "name": "rolesettings",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 371
+  },
+  {
+    "name": "roleinfo",
+    "aliases": [
+      "ri"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 381
+  },
+  {
+    "name": "rolemenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 419
+  },
+  {
+    "name": "rolecreator",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 429
+  },
+  {
+    "name": "assignroles",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 439
+  },
+  {
+    "name": "createrole",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 450
+  },
+  {
+    "name": "deleterole",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 489
+  },
+  {
+    "name": "setrole",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 510
+  },
+  {
+    "name": "unsetrole",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 543
+  },
+  {
+    "name": "debugroles",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 573
+  },
+  {
+    "name": "refreshmembers",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 584
+  },
+  {
+    "name": "reactroles",
+    "aliases": [
+      "reaktionsrollen"
+    ],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 653
+  },
+  {
+    "name": "removereactrole",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 691
+  },
+  {
+    "name": "listreactroles",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_cog.py",
+    "lineno": 711
+  },
+  {
+    "name": "temprole",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_roles",
+    "cog_file": "cogs/role_grants_cog.py",
+    "lineno": 65
+  },
+  {
+    "name": "temproles",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/role_grants_cog.py",
+    "lineno": 108
+  },
+  {
+    "name": "rpsregister",
+    "aliases": [
+      "rpsreg"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 199
+  },
+  {
+    "name": "rpsstart",
+    "aliases": [
+      "rpsbegin"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 369
+  },
+  {
+    "name": "rpsbot",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 411
+  },
+  {
+    "name": "rpsmatchup",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 424
+  },
+  {
+    "name": "rpshelp",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 724
+  },
+  {
+    "name": "rpssettings",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 741
+  },
+  {
+    "name": "rps",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/rps_tournament_cog.py",
+    "lineno": 772
+  },
+  {
+    "name": "security",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/security_cog.py",
+    "lineno": 115
+  },
+  {
+    "name": "servermanagement",
+    "aliases": [
+      "servermenu",
+      "guildmenu"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/server_management_cog.py",
+    "lineno": 45
+  },
+  {
+    "name": "server-management",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/server_management_cog.py",
+    "lineno": 80
+  },
+  {
+    "name": "settings",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/settings_cog.py",
+    "lineno": 127
+  },
+  {
+    "name": "settings",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/settings_cog.py",
+    "lineno": 200
+  },
+  {
+    "name": "setupadvanced",
+    "aliases": [
+      "advancedsetup"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 88
+  },
+  {
+    "name": "setup-advanced",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 114
+  },
+  {
+    "name": "setupdescribe",
+    "aliases": [
+      "describesetup"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 128
+  },
+  {
+    "name": "setup-describe",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 155
+  },
+  {
+    "name": "setup-hub",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 173
+  },
+  {
+    "name": "setup-depth",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 241
+  },
+  {
+    "name": "setup-skip",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 320
+  },
+  {
+    "name": "setup-unskip",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 343
+  },
+  {
+    "name": "setup-reset",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 419
+  },
+  {
+    "name": "setup-delegate",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 493
+  },
+  {
+    "name": "setup-undelegate",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 522
+  },
+  {
+    "name": "setup-status",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/setup_cog.py",
+    "lineno": 546
+  },
+  {
+    "name": "starboard",
+    "aliases": [],
+    "kind": "group",
+    "perm": "manage_guild",
+    "cog_file": "cogs/starboard_cog.py",
+    "lineno": 153
+  },
+  {
+    "name": "ticket",
+    "aliases": [],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/ticket_cog.py",
+    "lineno": 135
+  },
+  {
+    "name": "ticketpanel",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/ticket_cog.py",
+    "lineno": 238
+  },
+  {
+    "name": "ticketsetup",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/ticket_cog.py",
+    "lineno": 245
+  },
+  {
+    "name": "ticketlimit",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/ticket_cog.py",
+    "lineno": 277
+  },
+  {
+    "name": "ticketblacklist",
+    "aliases": [],
+    "kind": "group",
+    "perm": "manage_guild",
+    "cog_file": "cogs/ticket_cog.py",
+    "lineno": 289
+  },
+  {
+    "name": "treasury",
+    "aliases": [
+      "bank",
+      "pool"
+    ],
+    "kind": "group",
+    "perm": "member",
+    "cog_file": "cogs/treasury_cog.py",
+    "lineno": 47
+  },
+  {
+    "name": "utilitymenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 82
+  },
+  {
+    "name": "utility",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 99
+  },
+  {
+    "name": "myprofile",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 116
+  },
+  {
+    "name": "myprofile",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 135
+  },
+  {
+    "name": "clear",
+    "aliases": [
+      "purge"
+    ],
+    "kind": "prefix",
+    "perm": "manage_messages",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 162
+  },
+  {
+    "name": "info",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 181
+  },
+  {
+    "name": "serverinfo",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 251
+  },
+  {
+    "name": "userinfo",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 260
+  },
+  {
+    "name": "avatar",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 269
+  },
+  {
+    "name": "remind",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 277
+  },
+  {
+    "name": "invite",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "create_invite",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 292
+  },
+  {
+    "name": "poll",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 298
+  },
+  {
+    "name": "ping",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 316
+  },
+  {
+    "name": "botinfo",
+    "aliases": [
+      "about"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 334
+  },
+  {
+    "name": "membercount",
+    "aliases": [
+      "members"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/utility_cog.py",
+    "lineno": 374
+  },
+  {
+    "name": "uxlab",
+    "aliases": [
+      "interfacelab"
+    ],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/ux_lab_cog.py",
+    "lineno": 57
+  },
+  {
+    "name": "uxlab",
+    "aliases": [],
+    "kind": "slash",
+    "perm": "admin",
+    "cog_file": "cogs/ux_lab_cog.py",
+    "lineno": 68
+  },
+  {
+    "name": "welcome",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "manage_guild",
+    "cog_file": "cogs/welcome_cog.py",
+    "lineno": 162
+  },
+  {
+    "name": "xpmenu",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/xp_cog.py",
+    "lineno": 92
+  },
+  {
+    "name": "rank",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/xp_cog.py",
+    "lineno": 120
+  },
+  {
+    "name": "givexp",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/xp_cog.py",
+    "lineno": 179
+  },
+  {
+    "name": "resetxp",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/xp_cog.py",
+    "lineno": 197
+  },
+  {
+    "name": "xpconfig",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/xp_cog.py",
+    "lineno": 210
+  },
+  {
+    "name": "xpimport",
+    "aliases": [],
+    "kind": "prefix",
+    "perm": "member",
+    "cog_file": "cogs/xp_cog.py",
+    "lineno": 218
+  }
+]

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/ground-truth/subsystems.json
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/ground-truth/subsystems.json
@@ -1,0 +1,528 @@
+{
+  "admin": {
+    "visibility_tier": "administrator",
+    "parent_hub": null,
+    "capabilities": [
+      "admin.cog.load",
+      "admin.cog.unload",
+      "admin.cog.reload",
+      "admin.server.stats"
+    ],
+    "entry_points": [
+      "adminmenu"
+    ]
+  },
+  "server_management": {
+    "visibility_tier": "administrator",
+    "parent_hub": "admin",
+    "capabilities": [],
+    "entry_points": [
+      "servermanagement"
+    ]
+  },
+  "moderation": {
+    "visibility_tier": "moderator",
+    "parent_hub": null,
+    "capabilities": [
+      "moderation.warn.apply",
+      "moderation.timeout.apply",
+      "moderation.kick.apply",
+      "moderation.ban.apply",
+      "moderation.ban.remove",
+      "moderation.log.view",
+      "moderation.settings.configure"
+    ],
+    "entry_points": [
+      "modmenu",
+      "warn",
+      "timeout",
+      "kick",
+      "ban",
+      "unban"
+    ]
+  },
+  "economy": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "economy.currency.view",
+      "economy.currency.earn",
+      "economy.shop.browse",
+      "economy.shop.buy",
+      "economy.settings.configure"
+    ],
+    "entry_points": [
+      "economymenu",
+      "daily",
+      "work",
+      "balance"
+    ]
+  },
+  "inventory": {
+    "visibility_tier": "user",
+    "parent_hub": "economy",
+    "capabilities": [
+      "inventory.item.view",
+      "inventory.item.use",
+      "inventory.craft.recipe"
+    ],
+    "entry_points": [
+      "inventory"
+    ]
+  },
+  "treasury": {
+    "visibility_tier": "user",
+    "parent_hub": "economy",
+    "capabilities": [
+      "treasury.pool.view",
+      "treasury.pool.contribute",
+      "treasury.pool.disburse"
+    ],
+    "entry_points": [
+      "treasury"
+    ]
+  },
+  "ticket": {
+    "visibility_tier": "user",
+    "parent_hub": "community",
+    "capabilities": [
+      "ticket.ticket.open",
+      "ticket.ticket.manage",
+      "ticket.config.update"
+    ],
+    "entry_points": [
+      "ticket"
+    ]
+  },
+  "mining": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "mining.resource.mine",
+      "mining.resource.view"
+    ],
+    "entry_points": [
+      "minemenu",
+      "mine"
+    ]
+  },
+  "fishing": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "fishing.catch.fish",
+      "fishing.collection.view"
+    ],
+    "entry_points": [
+      "fish",
+      "fishlog"
+    ]
+  },
+  "creature": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "creature.catch.creature",
+      "creature.collection.view"
+    ],
+    "entry_points": [
+      "creatures",
+      "catch",
+      "dex",
+      "cbattle",
+      "cbrecord",
+      "cbattletop"
+    ]
+  },
+  "farm": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "farm.egg.collect",
+      "farm.coop.manage"
+    ],
+    "entry_points": [
+      "farm"
+    ]
+  },
+  "xp": {
+    "visibility_tier": "user",
+    "parent_hub": "community",
+    "capabilities": [
+      "xp.rank.view",
+      "xp.leaderboard.view",
+      "xp.settings.configure"
+    ],
+    "entry_points": [
+      "xpmenu",
+      "rank"
+    ]
+  },
+  "karma": {
+    "visibility_tier": "user",
+    "parent_hub": "community",
+    "capabilities": [
+      "karma.card.view",
+      "karma.grant.give",
+      "karma.settings.configure"
+    ],
+    "entry_points": [
+      "thanks",
+      "karma"
+    ]
+  },
+  "role": {
+    "visibility_tier": "administrator",
+    "parent_hub": "community",
+    "capabilities": [
+      "role.settings.configure",
+      "role.threshold.configure",
+      "role.assignment.manage",
+      "role.reaction.manage"
+    ],
+    "entry_points": [
+      "rolemenu"
+    ]
+  },
+  "channel": {
+    "visibility_tier": "administrator",
+    "parent_hub": "admin",
+    "capabilities": [
+      "channel.create.text",
+      "channel.create.voice",
+      "channel.delete.any",
+      "channel.restrict.apply",
+      "channel.visibility.configure"
+    ],
+    "entry_points": [
+      "channelmenu"
+    ]
+  },
+  "cleanup": {
+    "visibility_tier": "administrator",
+    "parent_hub": "moderation",
+    "capabilities": [
+      "cleanup.word.add",
+      "cleanup.word.remove",
+      "cleanup.history.scan",
+      "cleanup.policy.configure"
+    ],
+    "entry_points": [
+      "cleanup",
+      "wordmenu",
+      "cleanuphistory"
+    ]
+  },
+  "automod": {
+    "visibility_tier": "administrator",
+    "parent_hub": "moderation",
+    "capabilities": [
+      "automod.settings.configure"
+    ],
+    "entry_points": [
+      "automod"
+    ]
+  },
+  "image_moderation": {
+    "visibility_tier": "administrator",
+    "parent_hub": "moderation",
+    "capabilities": [
+      "image_moderation.settings.configure"
+    ],
+    "entry_points": [
+      "imagemod"
+    ]
+  },
+  "games": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "games.hub.view"
+    ],
+    "entry_points": [
+      "games"
+    ]
+  },
+  "community": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "community.hub.view"
+    ],
+    "entry_points": [
+      "community"
+    ]
+  },
+  "community_spotlight": {
+    "visibility_tier": "user",
+    "parent_hub": "community",
+    "capabilities": [
+      "community_spotlight.dashboard.view"
+    ],
+    "entry_points": [
+      "spotlight"
+    ]
+  },
+  "welcome": {
+    "visibility_tier": "administrator",
+    "parent_hub": "community",
+    "capabilities": [
+      "welcome.settings.configure"
+    ],
+    "entry_points": [
+      "welcome"
+    ]
+  },
+  "counters": {
+    "visibility_tier": "administrator",
+    "parent_hub": "community",
+    "capabilities": [
+      "counters.settings.configure"
+    ],
+    "entry_points": [
+      "counters"
+    ]
+  },
+  "security": {
+    "visibility_tier": "administrator",
+    "parent_hub": "moderation",
+    "capabilities": [
+      "security.settings.configure"
+    ],
+    "entry_points": [
+      "security"
+    ]
+  },
+  "blackjack": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "blackjack.game.play",
+      "blackjack.tournament.manage"
+    ],
+    "entry_points": [
+      "blackjack",
+      "bj"
+    ]
+  },
+  "casino": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "casino.game.play"
+    ],
+    "entry_points": [
+      "casino",
+      "poker",
+      "holdem"
+    ]
+  },
+  "btd6": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "btd6.query.ask",
+      "btd6.strategy.view",
+      "btd6.diagnostics.view",
+      "btd6.settings.configure"
+    ],
+    "entry_points": [
+      "btd6",
+      "btd6menu"
+    ]
+  },
+  "project_moon": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "project_moon.lookup.view"
+    ],
+    "entry_points": [
+      "pm",
+      "limbus"
+    ]
+  },
+  "deathmatch": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "deathmatch.game.challenge",
+      "deathmatch.stat.view"
+    ],
+    "entry_points": [
+      "deathmatch",
+      "dm"
+    ]
+  },
+  "rps_tournament": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "rps_tournament.game.join",
+      "rps_tournament.tournament.manage"
+    ],
+    "entry_points": [
+      "rps"
+    ]
+  },
+  "counting": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "counting.game.play",
+      "counting.game.configure"
+    ],
+    "entry_points": [
+      "count_info",
+      "counttop",
+      "countingmenu"
+    ]
+  },
+  "chain": {
+    "visibility_tier": "user",
+    "parent_hub": "games",
+    "capabilities": [
+      "chain.game.play",
+      "chain.game.configure"
+    ],
+    "entry_points": [
+      "chainmenu",
+      "chain"
+    ]
+  },
+  "leaderboard": {
+    "visibility_tier": "user",
+    "parent_hub": "economy",
+    "capabilities": [
+      "leaderboard.xp.view",
+      "leaderboard.economy.view"
+    ],
+    "entry_points": [
+      "leaderboard",
+      "lb"
+    ]
+  },
+  "proof_channel": {
+    "visibility_tier": "staff",
+    "parent_hub": "moderation",
+    "capabilities": [
+      "proof_channel.access.grant",
+      "proof_channel.access.revoke",
+      "proof_channel.access.timed",
+      "proof_channel.settings.configure"
+    ],
+    "entry_points": [
+      "prizemenu",
+      "prizestatus",
+      "timedprize"
+    ]
+  },
+  "utility": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "utility.info.server",
+      "utility.info.user",
+      "utility.tool.ping"
+    ],
+    "entry_points": [
+      "utilitymenu",
+      "myprofile",
+      "avatar",
+      "serverinfo",
+      "ping"
+    ]
+  },
+  "general": {
+    "visibility_tier": "user",
+    "parent_hub": "utility",
+    "capabilities": [
+      "general.info.view",
+      "general.community.interact"
+    ],
+    "entry_points": [
+      "generalmenu"
+    ]
+  },
+  "four_twenty": {
+    "visibility_tier": "user",
+    "parent_hub": "utility",
+    "capabilities": [
+      "four_twenty.panel.view"
+    ],
+    "entry_points": [
+      "420",
+      "fourtwenty"
+    ]
+  },
+  "help": {
+    "visibility_tier": "user",
+    "parent_hub": null,
+    "capabilities": [
+      "help.menu.view",
+      "help.settings.configure"
+    ],
+    "entry_points": [
+      "help"
+    ]
+  },
+  "diagnostic": {
+    "visibility_tier": "administrator",
+    "parent_hub": "admin",
+    "capabilities": [
+      "diagnostic.health.view",
+      "diagnostic.latency.check"
+    ],
+    "entry_points": [
+      "diagnostics",
+      "latency",
+      "platform"
+    ]
+  },
+  "ux_lab": {
+    "visibility_tier": "administrator",
+    "parent_hub": "admin",
+    "capabilities": [],
+    "entry_points": [
+      "uxlab"
+    ]
+  },
+  "ai": {
+    "visibility_tier": "administrator",
+    "parent_hub": "admin",
+    "capabilities": [
+      "ai.platform.view",
+      "ai.diagnostics.view",
+      "ai.provider.view",
+      "ai.routing.view",
+      "ai.settings.configure",
+      "ai.settings.view"
+    ],
+    "entry_points": [
+      "ai",
+      "aimenu"
+    ]
+  },
+  "settings": {
+    "visibility_tier": "administrator",
+    "parent_hub": "admin",
+    "capabilities": [
+      "settings.manager.view"
+    ],
+    "entry_points": [
+      "settings"
+    ]
+  },
+  "logging": {
+    "visibility_tier": "administrator",
+    "parent_hub": "moderation",
+    "capabilities": [
+      "logging.settings.configure",
+      "logging.channel.bind",
+      "logging.channel.create"
+    ],
+    "entry_points": [
+      "logging"
+    ]
+  }
+}

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-A-governance.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-A-governance.md
@@ -1,0 +1,448 @@
+# Lane A — Governance & Safety (Axis 1)
+
+> **Status:** `reference` — this lane's workspace. The surface-unit inventories below are **pre-extracted** (facts only, tier columns blank). The Lane A agent **verifies + completes them against source**, fills BOTH tier columns, writes each subsystem's §2 manifest sketch, dispositions tier-3s, and adds reconsider/optimize recommendations — per [`../BRIEF.md`](../BRIEF.md). Treat the inventory as a starting scaffold, not ground truth.
+
+**Subsystems:** admin, server_management, moderation, automod, image_moderation, security, cleanup, role, channel, welcome, ticket
+
+**Method:** [`../BRIEF.md`](../BRIEF.md) · [`../PARTITION.md`](../PARTITION.md) · `tools/grammar_spike/` · `../ground-truth/command-surface.json`.
+
+---
+
+### admin
+_cogs: disbot/cogs/admin_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !adminmenu | command | cogs/admin_cog.py:36 | | | |
+| /admin | command | cogs/admin_cog.py:51 | | | |
+| !serverstats | command | cogs/admin_cog.py:75 | | | |
+| !cog | command | cogs/admin_cog.py:97 | | | |
+| !loadall | command | cogs/admin_cog.py:124 | | | |
+| !unloadall | command | cogs/admin_cog.py:147 | | | |
+| !coglist (aliases: cogs, listcogs, cogslist) | command | cogs/admin_cog.py:174 | | | |
+| !syncslash (alias: syncs) | command | cogs/admin_cog.py:198 | | | |
+| !slashes (alias: slashlist) | command | cogs/admin_cog.py:295 | | | |
+| !restart | command | cogs/admin_cog.py:365 | | | |
+| !loglevel | command | cogs/admin_cog.py:393 | | | |
+| _AdminPanelView | panel | cogs/admin_cog.py:467 | | | |
+| Stats button | panel | cogs/admin_cog.py:496 | | | |
+| Cog List button | panel | cogs/admin_cog.py:516 | | | |
+| Reload All button | panel | cogs/admin_cog.py:534 | | | |
+| Log Level button (opens modal) | panel | cogs/admin_cog.py:561 | | | |
+| Settings button (navigates to settings panel) | panel | cogs/admin_cog.py:575 | | | |
+| Channels/AI/Platform/Diagnostics/UX Lab/Logging/Cleanup/Help nav buttons | panel | cogs/admin_cog.py:585-673 | | | |
+| Overview back button | panel | cogs/admin_cog.py:699 | | | |
+| _LogLevelModal | panel | cogs/admin_cog.py:763 | | | |
+| on_ready startup message | listener | cogs/admin_cog.py:409 | | | |
+| build_help_menu_view (help-menu direct-nav hook returning admin panel) | help | cogs/admin_cog.py:43 | | | |
+
+**Unit kinds present:** command, panel, listener, help
+**Structural-pattern flags:** gateway listener (`@commands.Cog.listener()` on_ready at line 409); modal wizard-lite (`_LogLevelModal`, a single-step `discord.ui.Modal`, not a multi-step wait_for wizard); no `bus.on`/EventBus subscription, no `emit_audit_action` calls, no owned DB tables/settings keys found in this cog — it is primarily a navigation hub delegating to other subsystems' panels (settings, channels, AI, platform, diagnostics, logging, cleanup, help) via nav buttons; no scheduled `@tasks.loop`; no voice.
+
+---
+
+### server_management
+_cogs: disbot/cogs/server_management_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !servermanagement (aliases: servermenu, guildmenu) | command | disbot/cogs/server_management_cog.py:45 | | | |
+| /server-management | command | disbot/cogs/server_management_cog.py:80 | | | |
+| ServerManagementHubView | panel/view | disbot/views/server_management/hub.py:117 | | | |
+| 🛡️ Moderation button (routes to moderation cog panel) | panel/view | disbot/views/server_management/hub.py:174-185 | | | |
+| 📺 Channels button (routes to channels cog panel) | panel/view | disbot/views/server_management/hub.py:187-198 | | | |
+| 🎭 Roles button (routes to roles cog panel) | panel/view | disbot/views/server_management/hub.py:200-211 | | | |
+| 🧹 Cleanup button (routes to cleanup cog panel) | panel/view | disbot/views/server_management/hub.py:213-224 | | | |
+| 🧩 Setup button (opens setup wizard) | panel/view | disbot/views/server_management/hub.py:226-243 | | | |
+| 🔓 Access Map button (opens AccessMapView) | panel/view | disbot/views/server_management/hub.py:245-277 | | | |
+| 👁 Help Preview button (opens HelpPreviewView) | panel/view | disbot/views/server_management/hub.py:279-311 | | | |
+| ✏️ Help editor button (opens HelpEditorHomeView) | panel/view | disbot/views/server_management/hub.py:313-345 | | | |
+| 🔄 Refresh button (re-renders hub status) | panel/view | disbot/views/server_management/hub.py:347-355+ (body truncated, ⚠ unverified past line 355) | | | |
+| AccessMapView (read-only access-decision subpanel) | panel/view | disbot/views/server_management/access_map.py:363 | | | |
+| HelpPreviewView (read-only help-preview subpanel) | panel/view | disbot/views/server_management/access_map.py:401 | | | |
+| build_help_menu_view hook (help-menu direct-nav entry to hub) | help | disbot/cogs/server_management_cog.py:59-71 | | | |
+| SUBSYSTEMS["server_management"] registry entry (display/tags/entry_points, capabilities empty) | setting | disbot/utils/subsystem_registry.py:94-118 | | | |
+
+**Unit kinds present:** command, panel/view, help (no dedicated setting, listener, event, or store unit found and owned by this subsystem — it is a routing-only hub with `capabilities: []` per subsystem_registry.py:118, and no table/migration or `bus.on`/`bus.emit`/`emit_audit_action` call was found under `disbot/cogs/server_management_cog.py`, `disbot/views/server_management/`, or `disbot/services/server_management_hub.py`).
+
+**Structural-pattern flags:** none obvious for its own code (no `@bot.event`, no `bus.on`/`bus.emit`, no `wait_for` wizard, no scheduled loop, no voice) — it is a thin PersistentView routing hub that delegates via `interaction.client.get_cog(...).build_help_menu_view` to other subsystems' cogs (moderation, channels, roles, cleanup, setup), which may themselves carry those patterns but are out of scope here.
+
+---
+
+### moderation
+_cogs: disbot/cogs/moderation_cog.py, disbot/cogs/moderation/__init__.py, disbot/cogs/moderation/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !modmenu | command | disbot/cogs/moderation_cog.py:79 | | | |
+| /moderation | command | disbot/cogs/moderation_cog.py:98 | | | |
+| !warn | command | disbot/cogs/moderation_cog.py:128 | | | |
+| !timeout | command | disbot/cogs/moderation_cog.py:155 | | | |
+| !kick | command | disbot/cogs/moderation_cog.py:181 | | | |
+| !ban | command | disbot/cogs/moderation_cog.py:213 | | | |
+| !unban | command | disbot/cogs/moderation_cog.py:246 | | | |
+| !clearwarnings | command | disbot/cogs/moderation_cog.py:277 | | | |
+| !modlogs | command | disbot/cogs/moderation_cog.py:292 | | | |
+| ModPanelView | panel | disbot/views/moderation/main_panel.py:36 | | | |
+| warn_btn (mod:warn) | panel | disbot/views/moderation/main_panel.py:63-70 | | | |
+| timeout_btn (mod:timeout) | panel | disbot/views/moderation/main_panel.py:72-79 | | | |
+| kick_btn (mod:kick) | panel | disbot/views/moderation/main_panel.py:81-88 | | | |
+| ban_btn (mod:ban) | panel | disbot/views/moderation/main_panel.py:90-97 | | | |
+| unban_btn (mod:unban) | panel | disbot/views/moderation/main_panel.py:99-106 | | | |
+| modlogs_btn (mod:logs) | panel | disbot/views/moderation/main_panel.py:108-116 | | | |
+| clearwarnings button (mod: clear warnings) | panel | disbot/views/moderation/main_panel.py:117+ | | | |
+| _WarnModal | panel | disbot/views/moderation/modals.py:48 | | | |
+| _TimeoutModal | panel | disbot/views/moderation/modals.py:95 | | | |
+| _KickModal | panel | disbot/views/moderation/modals.py:160 | | | |
+| _BanModal | panel | disbot/views/moderation/modals.py:215 | | | |
+| _UnbanModal | panel | disbot/views/moderation/modals.py:271 | | | |
+| _ModLogsModal | panel | disbot/views/moderation/modals.py:313 | | | |
+| _ClearWarningsModal | panel | disbot/views/moderation/modals.py:349 | | | |
+| WARN_THRESHOLD | setting | disbot/cogs/moderation/schemas.py:193 | | | |
+| WARN_TIMEOUT_MINS | setting | disbot/cogs/moderation/schemas.py:205 | | | |
+| MOD_WARN_ESCALATION_ACTION | setting | disbot/cogs/moderation/schemas.py:217 | | | |
+| MOD_DM_ON_ACTION | setting | disbot/cogs/moderation/schemas.py:234 | | | |
+| MOD_DM_ACTIONS | setting | disbot/cogs/moderation/schemas.py:248 | | | |
+| MOD_DM_TEMPLATE | setting | disbot/cogs/moderation/schemas.py:263 | | | |
+| MOD_REQUIRE_REASON | setting | disbot/cogs/moderation/schemas.py:276 | | | |
+| MOD_BAN_DELETE_MESSAGE_DAYS | setting | disbot/cogs/moderation/schemas.py:289 | | | |
+| MOD_MAX_TIMEOUT_MINUTES | setting | disbot/cogs/moderation/schemas.py:303 | | | |
+| MOD_POST_ACTION_CLEANUP | setting | disbot/cogs/moderation/schemas.py:320 | | | |
+| MOD_POST_ACTION_CLEANUP_LIMIT | setting | disbot/cogs/moderation/schemas.py:335 | | | |
+| MOD_PUBLIC_LOG_ACTIONS | setting | disbot/cogs/moderation/schemas.py:352 | | | |
+| MOD_PUBLIC_LOG_CHANNEL | setting | disbot/cogs/moderation/schemas.py:367 | | | |
+| MODERATOR_TIER_ROLE_ID | setting | disbot/cogs/moderation/schemas.py:390 | | | |
+| TRUSTED_TIER_ROLE_ID | setting | disbot/cogs/moderation/schemas.py:405 | | | |
+| EVT_MOD_ACTION (moderation.action_taken) | event | disbot/services/moderation_service.py:88,226 | | | |
+| audit.action_recorded (emit_audit_action) | event | disbot/services/moderation_service.py:213 | | | |
+| mod_logs table | store | disbot/utils/db/migrations.py:257; disbot/utils/db/moderation.py:44,66 | | | |
+| warnings store (get/add/clear_warning) | store | disbot/utils/db/moderation.py:12,20,32 | | | |
+| moderation_service.warn | service-fn | disbot/services/moderation_service.py:361 | | | |
+| moderation_service.timeout | service-fn | disbot/services/moderation_service.py:446 | | | |
+| moderation_service.kick | service-fn | disbot/services/moderation_service.py:484 | | | |
+| moderation_service.ban | service-fn | disbot/services/moderation_service.py:530 | | | |
+| moderation_service.unban | service-fn | disbot/services/moderation_service.py:587 | | | |
+| moderation_service.clear_warnings | service-fn | disbot/services/moderation_service.py:605 | | | |
+| server_logging._on_moderation_action (bus.on EVT_MOD_ACTION) | listener | disbot/services/server_logging.py:1854 | | | |
+| server_logging._on_moderation_action_public (bus.on EVT_MOD_ACTION) | listener | disbot/services/server_logging.py:1855 | | | |
+
+**Unit kinds present:** command, panel (view+buttons+modals), setting, event, store, service-fn, listener (external subscriber)
+
+**Structural-pattern flags:** gateway listener via EventBus (`bus.on(EVT_MOD_ACTION, ...)` consumed externally in server_logging.py, not within this cog itself — cross-subsystem wiring, verified only by grep since neither CodeGraph nor Grimp would connect emitter→subscriber); persistent panel view (`ModPanelView(PersistentView)`) with modal-based wizard-lite interactions (each button opens a `discord.ui.Modal`, not a multi-step `wait_for` wizard). No scheduled loop, no voice, no stateful game loop obvious in this subsystem's own files. ⚠ unverified: whether `!modlogs`/`_ModLogsModal` and `!clearwarnings`/`_ClearWarningsModal` are wired 1:1 with matching capability strings — not fully cross-checked against `subsystem_registry.py` capability list beyond what's quoted above.
+
+
+---
+
+### automod
+_cogs: disbot/cogs/automod_cog.py, disbot/cogs/automod/listener.py, disbot/cogs/automod/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !automod | command | disbot/cogs/automod_cog.py:119 | | | |
+| build_help_menu_view (help-dropdown hook, HubView) | panel/view | disbot/cogs/automod_cog.py:124 | | | |
+| AutomodStage (message_pipeline stage, order=5) | listener | disbot/cogs/automod_cog.py:37 | | | |
+| cog_load registers pipeline stage + schema | listener | disbot/cogs/automod_cog.py:59 | | | |
+| cog_unload unregisters pipeline stage | listener | disbot/cogs/automod_cog.py:66 | | | |
+| process_message (per-message evaluate+act) | listener | disbot/cogs/automod/listener.py:28 | | | |
+| bus.emit("automod.rule_triggered") | event | disbot/cogs/automod/listener.py:114 | | | |
+| setting: enabled (master switch) | setting | disbot/cogs/automod/schemas.py:115 | | | |
+| setting: spam_enabled | setting | disbot/cogs/automod/schemas.py:128 | | | |
+| setting: invites_enabled | setting | disbot/cogs/automod/schemas.py:137 | | | |
+| setting: caps_enabled | setting | disbot/cogs/automod/schemas.py:146 | | | |
+| setting: mentions_enabled | setting | disbot/cogs/automod/schemas.py:155 | | | |
+| setting: spam_count | setting | disbot/cogs/automod/schemas.py:164 | | | |
+| setting: spam_window_seconds | setting | disbot/cogs/automod/schemas.py:178 | | | |
+| setting: caps_percent | setting | disbot/cogs/automod/schemas.py:189 | | | |
+| setting: mentions_count | setting | disbot/cogs/automod/schemas.py:203 | | | |
+| setting: exempt_roles | setting | disbot/cogs/automod/schemas.py:214 | | | |
+| setting: exempt_channels | setting | disbot/cogs/automod/schemas.py:226 | | | |
+| capability: automod.settings.configure | setting | disbot/utils/subsystem_registry.py:539 | | | |
+
+**Unit kinds present:** command, panel, listener, event, setting
+**Structural-pattern flags:** message-pipeline stage listener (not @bot.event/bus.on directly — registered via core.runtime.message_pipeline.register, order=5, fail-open); emits one advisory bus event (automod.rule_triggered); no dedicated DB table/store (uses legacy scalar guild-settings KV, no migration); no wizard/wait_for, no scheduled loop, no voice. Otherwise none obvious.
+
+---
+
+### image_moderation
+_cogs: disbot/cogs/image_moderation_cog.py, disbot/cogs/image_moderation/listener.py, disbot/cogs/image_moderation/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !imagemod | command | cogs/image_moderation_cog.py:123 | | | |
+| build_help_menu_view (help-dropdown hook) | help | cogs/image_moderation_cog.py:128 | | | |
+| ImageModerationStage (message-pipeline stage, order=25) | listener | cogs/image_moderation_cog.py:41-54 | | | |
+| cog_load registers pipeline stage + schema | listener | cogs/image_moderation_cog.py:63-68 | | | |
+| cog_unload unregisters pipeline stage | listener | cogs/image_moderation_cog.py:70-73 | | | |
+| process_message (scan attachments → act) | listener | cogs/image_moderation/listener.py:52-109 | | | |
+| bus.emit("image_moderation.flagged") | event | cogs/image_moderation/listener.py:184-191 | | | |
+| setting: enabled (master switch) | setting | cogs/image_moderation/schemas.py:96-108 | | | |
+| setting: sexual_enabled | setting | cogs/image_moderation/schemas.py:109-117 | | | |
+| setting: violence_enabled | setting | cogs/image_moderation/schemas.py:118-126 | | | |
+| setting: harassment_enabled | setting | cogs/image_moderation/schemas.py:127-135 | | | |
+| setting: hate_enabled | setting | cogs/image_moderation/schemas.py:136-144 | | | |
+| setting: threshold_percent | setting | cogs/image_moderation/schemas.py:145-158 | | | |
+| setting: exempt_roles | setting | cogs/image_moderation/schemas.py:159-170 | | | |
+| setting: exempt_channels | setting | cogs/image_moderation/schemas.py:171-182 | | | |
+| SubsystemSchema registration (IMAGE_MODERATION_CONFIG_SCHEMA) | setting | cogs/image_moderation/schemas.py:186-197 | | | |
+| store: no dedicated table — uses legacy scalar guild-settings KV table (⚠ unverified table name, no migration file found) | store | disbot/services/image_moderation_config.py (load_policy) | | | |
+
+**Unit kinds present:** command, help, listener, event, setting, store
+**Structural-pattern flags:** none obvious — no @bot.event/bus.on listener registration (stage is invoked synchronously via message_pipeline, not EventBus subscription), no wait_for wizard, no scheduled loop, no voice, no dedicated panel/view (help hook reuses generic HubView with a read-only embed).
+
+
+---
+
+### security
+_cogs: disbot/cogs/security_cog.py, disbot/cogs/security/schemas.py, disbot/cogs/security/__init__.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !security | command | disbot/cogs/security_cog.py:108 | | | |
+| on_member_join | listener | disbot/cogs/security_cog.py:46 | | | |
+| cog_load (register_schemas) | listener/setup-hook | disbot/cogs/security_cog.py:39 | | | |
+| build_help_menu_view | panel/help-hook | disbot/cogs/security_cog.py:120 | | | |
+| _policy_embed | panel (status embed) | disbot/cogs/security_cog.py:57 | | | |
+| security.enabled | setting | disbot/cogs/security/schemas.py:97 | | | |
+| security.alert_channel | setting | disbot/cogs/security/schemas.py:108 | | | |
+| security.raid_enabled | setting | disbot/cogs/security/schemas.py:120 | | | |
+| security.raid_join_count | setting | disbot/cogs/security/schemas.py:128 | | | |
+| security.raid_window_seconds | setting | disbot/cogs/security/schemas.py:139 | | | |
+| security.raid_slowmode_channel | setting | disbot/cogs/security/schemas.py:150 | | | |
+| security.raid_slowmode_seconds | setting | disbot/cogs/security/schemas.py:161 | | | |
+| security.raid_lockdown_seconds | setting | disbot/cogs/security/schemas.py:172 | | | |
+| security.age_enabled | setting | disbot/cogs/security/schemas.py:184 | | | |
+| security.age_min_days | setting | disbot/cogs/security/schemas.py:192 | | | |
+| security.age_action | setting | disbot/cogs/security/schemas.py:202 | | | |
+| security.raid_detected | event | disbot/services/security_service.py:45 | | | |
+| security.account_flagged | event | disbot/services/security_service.py:46 | | | |
+| SUBSYSTEMS["security"] entry (capability security.settings.configure) | setting-registry entry | disbot/utils/subsystem_registry.py:705 | | | |
+
+**Unit kinds present:** command, listener, panel, setting, event, setting-registry entry
+**Structural-pattern flags:** gateway (@commands.Cog.listener on_member_join, member-join screening) listener; scheduled/delayed lockdown-lift via asyncio (services/security_service.py `_hold_then_lift`/`_clear_lock_after`, timer not a cron loop); no stateful game loop, no wait_for wizard, no voice. No dedicated DB table/store — settings are legacy scalar KV only (schema comment confirms "no migration").
+
+
+---
+
+### cleanup
+_cogs: disbot/cogs/cleanup_cog.py, disbot/cogs/cleanup/panel.py, disbot/cogs/cleanup/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !cleanuphistory | command | cogs/cleanup_cog.py:325 | | | |
+| !word (group, invoke_without_command) | command | cogs/cleanup_cog.py:488 | | | |
+| !word add | command | cogs/cleanup_cog.py:502 | | | |
+| !word remove | command | cogs/cleanup_cog.py:521 | | | |
+| !word list | command | cogs/cleanup_cog.py:540 | | | |
+| !wordmenu | command | cogs/cleanup_cog.py:554 | | | |
+| !cleanup | command | cogs/cleanup_cog.py:563 | | | |
+| on_guild_remove | listener | cogs/cleanup_cog.py:317 (@commands.Cog.listener) | | | purges cleanup state on guild removal ⚠ unverified detail |
+| CleanupStage (message-pipeline stage) | listener | cogs/cleanup_cog.py:97 | | | auto-mod tier stage order=10, runs remove_unwanted_message |
+| _WordMenuView | panel | cogs/cleanup_cog.py:638 | | | HubView for word-list add/remove/menu |
+| _AddWordModal | panel | cogs/cleanup_cog.py:592 | | | modal collecting a prohibited word to add |
+| _RemoveWordModal | panel | cogs/cleanup_cog.py:615 | | | modal collecting a prohibited word to remove |
+| _ScanHistoryModal | panel | cogs/cleanup_cog.py:710 | | | modal for channel-history scan params |
+| CleanupPanelView | panel | cogs/cleanup/panel.py:122 | | | HubView entry panel for cleanup subsystem |
+| CleanupPolicyPanelView | panel | views/cleanup/policy_panel.py:702 | | | HubView for per-scope cleanup-level policy config |
+| _CustomLevelView | panel | views/cleanup/policy_panel.py:448 | | | BaseView for custom cleanup-level configuration |
+| _ConfirmApplyView | panel | views/cleanup/policy_panel.py:541 | | | BaseView confirming policy apply |
+| _ScopeSelect / _CategoryPickSelect / _ChannelPickSelect / _LevelSelect / _DeleteAfterSelect / _CustomYesNoSelect / _RemoveSelect | panel (select components) | views/cleanup/policy_panel.py:233,271,294,317,386,410,640 | | | scope/category/channel/level/delete-after/remove select widgets inside policy panel |
+| _CustomPreviewButton | panel | views/cleanup/policy_panel.py:435 | | | button previewing a custom cleanup level |
+| cleanup_spam_window_seconds | setting | utils/settings_keys/cleanup.py:20 | | | scalar KV setting: !cleanuphistory duplicate-message window (default 15s) |
+| cleanup capabilities (cleanup.word.add / cleanup.word.remove / cleanup.history.scan / cleanup.policy.configure) | setting | utils/subsystem_registry.py:509-514 | | | declared capability list in SUBSYSTEMS["cleanup"] |
+| cleanup_policies (table) | store | migrations/004_governance_tables.sql:24 | | | per-scope cleanup behavior overrides, governance-owned |
+| cleanup_policies.policy_version (column) | store | migrations/058_cleanup_policy_version.sql:29 | | | additive version marker, behavior-neutral |
+| wordfilter_config (table) | store | migrations/097_wordfilter_strict.sql:27 | | | prohibited-word list + strict-mode config, ⚠ unverified column detail |
+| governance/cleanup.py resolver | event/other | governance/cleanup.py | | | resolves effective cleanup policy per scope ⚠ unverified — not read in full |
+
+**Unit kinds present:** command, panel, setting, listener, store
+**Structural-pattern flags:** gateway listener (`@commands.Cog.listener` on_guild_remove; `CleanupStage` message-pipeline hook acting like an inline gateway filter); wizard-style modal chain (`_AddWordModal`/`_RemoveWordModal`/`_ScanHistoryModal`) but no `wait_for`-based wizard found; no stateful game loop; no scheduled loop found; no voice.
+
+---
+
+### role
+_cogs: disbot/cogs/role_cog.py, disbot/cogs/role_grants_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !roles | command | disbot/cogs/role_cog.py:354 | | | |
+| !rolesettings | command | disbot/cogs/role_cog.py:369 | | | |
+| !roleinfo | command | disbot/cogs/role_cog.py:375 | | | |
+| !rolemenu | command | disbot/cogs/role_cog.py:414 | | | |
+| !rolecreator | command | disbot/cogs/role_cog.py:423 | | | |
+| !assignroles | command | disbot/cogs/role_cog.py:433 | | | |
+| !createrole | command | disbot/cogs/role_cog.py:444 | | | |
+| !deleterole | command | disbot/cogs/role_cog.py:483 | | | |
+| !setrole | command | disbot/cogs/role_cog.py:504 | | | |
+| !unsetrole | command | disbot/cogs/role_cog.py:537 | | | |
+| !debugroles | command | disbot/cogs/role_cog.py:567 | | | |
+| !refreshmembers | command | disbot/cogs/role_cog.py:578 | | | |
+| !reactroles (alias !reaktionsrollen) | command | disbot/cogs/role_cog.py:651 | | | |
+| !removereactrole | command | disbot/cogs/role_cog.py:689 | | | |
+| !listreactroles | command | disbot/cogs/role_cog.py:709 | | | |
+| !temprole | command | disbot/cogs/role_grants_cog.py:63 | | | |
+| !temproles | command | disbot/cogs/role_grants_cog.py:106 | | | |
+| RoleHubView | panel | disbot/views/roles/main_panel.py:11 | | | |
+| ManagementPanel (+ _EditRolePickView/_DeleteRolesView/_ConfirmDeleteView) | panel | disbot/views/roles/management_panel.py:18 | | | |
+| RoleCreatePanel / RoleAutomationView | panel | disbot/views/roles/creation_panel.py:63,312 | | | |
+| DiagnosticsPanel | panel | disbot/views/roles/diagnostics_panel.py:36 | | | |
+| RoleExemptionsPanel | panel | disbot/views/roles/exemptions_panel.py:23 | | | |
+| ReactionRolesPanel (+ _AddSourceView/_BindEmotesView/_AfterBindView) | panel | disbot/views/roles/reaction_panel.py:48 | | | |
+| RoleMenuListView / RoleMenuBuilder (+ sub-pick views) | panel | disbot/views/roles/role_menu_builder.py:94,449 | | | |
+| RoleMenuView (persistent published menu) | panel | disbot/views/roles/role_menu_view.py:232 | | | |
+| TimeRolesPanel (+ _TempRolesView/_TimeRolePickView) | panel | disbot/views/roles/time_roles_panel.py:31 | | | |
+| XpRolesPanel (+ _XpRolePickView) | panel | disbot/views/roles/xp_roles_panel.py:23 | | | |
+| RolePackView (+ _BulkColourView/_PerRoleColourView) | panel | disbot/views/roles/_role_pack_flow.py:66 | | | |
+| setting: time_roles_stack | setting | disbot/cogs/role/schemas.py:34 | | | |
+| setting: xp_roles_stack | setting | disbot/cogs/role/schemas.py:46 | | | |
+| setting: reaction_roles_enabled | setting | disbot/cogs/role/schemas.py:58 | | | |
+| role_check (24h loop, time/XP auto-assignment) | scheduled loop | disbot/cogs/role_cog.py:284 | | | |
+| _sweep_loop (temp-role expiry sweep) | scheduled loop | disbot/cogs/role_grants_cog.py:42 | | | |
+| on_raw_reaction_add (reaction-role grant) | listener | disbot/cogs/role_cog.py:591 | | | |
+| on_raw_reaction_remove (reaction-role revoke) | listener | disbot/cogs/role_cog.py:616 | | | |
+| on_member_join (tenure/xp role backfill check) | listener | disbot/cogs/role_cog.py:731 | | | |
+| emit_audit_action (role grant/revoke, automation) | event | disbot/services/role_automation.py:660,684,747,799,856,900 | | | |
+| emit_audit_action (reaction role bind/remove) | event | disbot/services/reaction_role_service.py:865,891,919 | | | |
+| store: role_thresholds (tenure/XP thresholds) | store | disbot/utils/db/roles.py:19-149 | | | |
+| store: role_automation_exemptions | store | disbot/utils/db/roles.py:160 ⚠ unverified table name from docstring | | | |
+| store: reaction_roles | store | disbot/utils/db/roles.py:201-260 | | | |
+| store: reaction role message modes | store | disbot/utils/db/roles.py:262-303 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, store, scheduled loop
+**Structural-pattern flags:** scheduled loop (role_check 24h, temp-role sweep loop); gateway listener (on_raw_reaction_add/remove, on_member_join) driving role grant/revoke; no stateful game loop, no wait_for wizard observed, no voice.
+
+
+---
+
+### channel
+_cogs: disbot/cogs/channel_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !channelmenu | command | disbot/cogs/channel_cog.py:192 | | | |
+| !set | command | disbot/cogs/channel_cog.py:210 | | | |
+| !evt | command | disbot/cogs/channel_cog.py:233 | | | |
+| !create | command | disbot/cogs/channel_cog.py:278 | | | |
+| !bulkdelete | command | disbot/cogs/channel_cog.py:329 | | | |
+| !del | command | disbot/cogs/channel_cog.py:380 | | | |
+| !list | command | disbot/cogs/channel_cog.py:405 | | | |
+| !clone | command | disbot/cogs/channel_cog.py:437 | | | |
+| !move | command | disbot/cogs/channel_cog.py:470 | | | |
+| !lock | command | disbot/cogs/channel_cog.py:498 | | | |
+| !unlock | command | disbot/cogs/channel_cog.py:514 | | | |
+| !channelinfo | command | disbot/cogs/channel_cog.py:531 | | | |
+| !rename | command | disbot/cogs/channel_cog.py:570 | | | |
+| !slowmode | command | disbot/cogs/channel_cog.py:598 | | | |
+| !topic | command | disbot/cogs/channel_cog.py:641 | | | |
+| !permissions | command | disbot/cogs/channel_cog.py:673 | | | |
+| !bulkcreate | command | disbot/cogs/channel_cog.py:704 | | | |
+| _ChannelManagerView (main hub panel) | panel/view | disbot/views/channels/main_panel.py:22 | | | HubView subclass, entry point for !channelmenu |
+| _CreateSubView | panel/view | disbot/views/channels/create_panel.py:41 | | | BaseView subclass for channel creation flow |
+| _DeleteSubView | panel/view | disbot/views/channels/delete_panel.py:38 | | | BaseView subclass for channel deletion flow |
+| _DeleteConfirmView | panel/view | disbot/views/channels/delete_panel.py:178 | | | BaseView confirmation sub-panel for delete |
+| _ChannelListPaginatorView | panel/view | disbot/views/channels/list_panel.py:118 | | | ⚠ extends discord.ui.View directly, not BaseView (documented exception) |
+| _MoveSubView | panel/view | disbot/views/channels/move_panel.py:80 | | | BaseView subclass for move-channel flow |
+| _RestrictSubView | panel/view | disbot/views/channels/restrict_panel.py:34 | | | BaseView subclass for access-restriction flow |
+| _VisibilitySubView | panel/view | disbot/views/channels/visibility_panel.py:39 | | | BaseView subclass for visibility toggle flow |
+| _SubsystemToggleView | panel/view | disbot/views/channels/visibility_panel.py:181 | | | BaseView subclass toggling subsystem visibility |
+| channel.create.text | capability/setting | disbot/utils/subsystem_registry.py:485 | | | SUBSYSTEMS["channel"] capability entry |
+| channel.create.voice | capability/setting | disbot/utils/subsystem_registry.py:486 | | | SUBSYSTEMS["channel"] capability entry |
+| channel.delete.any | capability/setting | disbot/utils/subsystem_registry.py:487 | | | SUBSYSTEMS["channel"] capability entry |
+| channel.restrict.apply | capability/setting | disbot/utils/subsystem_registry.py:488 | | | SUBSYSTEMS["channel"] capability entry |
+| channel.visibility.configure | capability/setting | disbot/utils/subsystem_registry.py:489 | | | SUBSYSTEMS["channel"] capability entry |
+| entry_point: channelmenu | setting (registry) | disbot/utils/subsystem_registry.py:474 | | | entry_points list for subsystem registry card |
+
+**Unit kinds present:** command, panel, setting (capability/registry entry)
+**Structural-pattern flags:** none obvious — no `@bot.event`/`bus.on` listener, no `bus.emit`/`emit_audit_action` call found in channel_cog.py or disbot/views/channels/*, no `wait_for` wizard, no scheduled loop, no voice handling, and no dedicated `*_mutation.py` or DB table found under `utils/db/` for this subsystem (⚠ unverified — no channel-specific store/settings-key module located; channel commands appear to act directly on Discord guild objects rather than through a persisted store).
+
+
+---
+
+### welcome
+_cogs: disbot/cogs/welcome_cog.py, disbot/cogs/welcome/schemas.py (services: disbot/services/welcome_service.py, disbot/services/welcome_config.py)_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !welcome | command | disbot/cogs/welcome_cog.py:162 | | | |
+| on_member_join | listener | disbot/cogs/welcome_cog.py:47 | | | |
+| on_member_remove | listener | disbot/cogs/welcome_cog.py:56 | | | |
+| welcome.member_greeted | event | disbot/services/welcome_service.py:267-271 (EVT_WELCOME_MEMBER_GREETED, emitted from handle_member_join) | | | |
+| build_help_menu_view (help-dropdown hook, read-only policy embed) | panel/view | disbot/cogs/welcome_cog.py:167-185 | | | |
+| _policy_embed (policy summary embed builder used by !welcome and help view) | panel/view | disbot/cogs/welcome_cog.py:66-153 | | | |
+| enabled (master switch) | setting | disbot/cogs/welcome/schemas.py:145-155 (WELCOME_ENABLED) | | | |
+| join_enabled | setting | disbot/cogs/welcome/schemas.py:156-163 (WELCOME_JOIN_ENABLED) | | | |
+| leave_enabled | setting | disbot/cogs/welcome/schemas.py:164-171 (WELCOME_LEAVE_ENABLED) | | | |
+| channel | setting | disbot/cogs/welcome/schemas.py:172-183 (WELCOME_CHANNEL) | | | |
+| join_message | setting | disbot/cogs/welcome/schemas.py:184-195 (WELCOME_JOIN_MESSAGE) | | | |
+| leave_message | setting | disbot/cogs/welcome/schemas.py:196-207 (WELCOME_LEAVE_MESSAGE) | | | |
+| entry_role | setting | disbot/cogs/welcome/schemas.py:208-219 (WELCOME_ENTRY_ROLE) | | | |
+| card_enabled | setting | disbot/cogs/welcome/schemas.py:220-230 (WELCOME_CARD_ENABLED) | | | |
+| dm_enabled | setting | disbot/cogs/welcome/schemas.py:231-242 (WELCOME_DM_ENABLED) | | | |
+| dm_message | setting | disbot/cogs/welcome/schemas.py:243-254 (WELCOME_DM_MESSAGE) | | | |
+| min_account_age_days | setting | disbot/cogs/welcome/schemas.py:255-267 (WELCOME_MIN_ACCOUNT_AGE_DAYS) | | | |
+| delete_after_seconds | setting | disbot/cogs/welcome/schemas.py:268-279 (WELCOME_DELETE_AFTER_SECONDS) | | | |
+| register_schemas (registers WELCOME_CONFIG_SCHEMA on cog_load) | setting (registration) | disbot/cogs/welcome_cog.py:39-42 | | | |
+| entry-role grant (via moderation's audited role path, per schema hint) | ⚠ unverified capability | disbot/cogs/welcome/schemas.py:213-215 (hint text only; grant call not located in this pass) | | | |
+| welcome subsystem registry entry (entry_points, capability tag "welcome.settings.configure") | subsystem-registry | disbot/utils/subsystem_registry.py:649-668 | | | |
+| store: no dedicated welcome table found — all settings are scalar guild-settings KV (legacy `settings` table), not a migration-owned table | store | ⚠ unverified — grep of disbot/utils/db and migrations found no welcome-specific table | | | |
+
+**Unit kinds present:** command, panel/view, setting, listener, event, subsystem-registry entry. No dedicated `store` (table) or `help_catalogue` entries found for welcome.
+
+**Structural-pattern flags:** gateway/listener pattern (`@commands.Cog.listener()` on `on_member_join`/`on_member_remove`, `discord.py` event dispatch) — no stateful game loop, no `wait_for` wizard, no scheduled loop, no voice.
+
+---
+
+### ticket
+_cogs: disbot/cogs/ticket_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !ticket | command (group) | disbot/cogs/ticket_cog.py:135 | | | |
+| !ticket new (aliases: open, create) | command (subcommand) | disbot/cogs/ticket_cog.py:141 | | | |
+| !ticket close | command (subcommand) | disbot/cogs/ticket_cog.py:155 | | | |
+| !ticket claim | command (subcommand) | disbot/cogs/ticket_cog.py:179 | | | |
+| !ticket add | command (subcommand) | disbot/cogs/ticket_cog.py:195 | | | |
+| !ticket remove | command (subcommand) | disbot/cogs/ticket_cog.py:211 | | | |
+| !ticketpanel | command (prefix) | disbot/cogs/ticket_cog.py:238 | | | |
+| !ticketsetup | command (prefix) | disbot/cogs/ticket_cog.py:245 | | | |
+| !ticketlimit | command (prefix) | disbot/cogs/ticket_cog.py:277 | | | |
+| !ticketblacklist | command (group) | disbot/cogs/ticket_cog.py:289 | | | |
+| !ticketblacklist add | command (subcommand) | disbot/cogs/ticket_cog.py:294 | | | |
+| !ticketblacklist remove | command (subcommand) | disbot/cogs/ticket_cog.py:310 | | | |
+| TicketLauncherView | panel/view | disbot/views/tickets/launcher.py:19 | | | |
+| post_launcher() | panel/view | disbot/views/tickets/launcher.py:42 | | | |
+| TicketControlView | panel/view | disbot/views/tickets/control.py:63 | | | |
+| build_control_view() | panel/view | disbot/views/tickets/control.py:144 | | | |
+| TicketCloseModal | panel/view (modal) | disbot/views/tickets/control.py:24 | | | |
+| TicketConfirmView | panel/view | disbot/views/tickets/confirm.py:22 | | | |
+| TicketOpenModal | panel/view (modal) | disbot/views/tickets/_shared.py:72 | | | |
+| TicketHubView | panel/view | disbot/views/tickets/hub.py:63 | | | |
+| open_ticket_hub() | panel/view | disbot/views/tickets/hub.py:137 | | | |
+| TicketConfigPanelView | panel/view | disbot/views/tickets/config_panel.py:123 | | | |
+| open_ticket_config_panel() | panel/view | disbot/views/tickets/config_panel.py:268 | | | |
+| _StaffRoleSelect | panel/view (component) | disbot/views/tickets/config_panel.py:88 | | | |
+| _LogChannelSelect | panel/view (component) | disbot/views/tickets/config_panel.py:105 | | | |
+| build_help_menu_view() | help | disbot/cogs/ticket_cog.py:329 | | | |
+| ticket.ticket.open (capability/entry) | setting | disbot/utils/subsystem_registry.py:254 | | | |
+| ticket.ticket.manage (capability) | setting | disbot/utils/subsystem_registry.py:255 | | | |
+| ticket.config.update (capability) | setting | disbot/utils/subsystem_registry.py:256 | | | |
+| ticket_config row (staff_role/log_channel/max_open/ping_staff/enabled) | setting | disbot/utils/db/tickets.py:44 | | | |
+| bus.on("ticket.opened") → _on_ticket_opened | listener | disbot/cogs/ticket_cog.py:57 | | | |
+| bus.on("ticket.open_requested") → _on_ticket_open_requested | listener | disbot/cogs/ticket_cog.py:58 | | | |
+| bus.emit("ticket.opened") | event | disbot/services/ticket_mutation.py:200 | | | |
+| bus.emit("ticket.closed") | event | disbot/services/ticket_mutation.py:331 | | | |
+| bus.emit("ticket.open_requested") (from AI tool) | event | disbot/services/ai_tools.py:2494 | | | |
+| emit_audit_action mutation_type="open" | event | disbot/services/ticket_mutation.py:194 | | | |
+| emit_audit_action mutation_type="claim" | event | disbot/services/ticket_mutation.py:289 | | | |
+| emit_audit_action mutation_type="close" | event | disbot/services/ticket_mutation.py:326 | | | |
+| emit_audit_action mutation_type="add_participant" | event | disbot/services/ticket_mutation.py:422 | | | |
+| emit_audit_action mutation_type="remove_participant" | event | disbot/services/ticket_mutation.py:448 | | | |
+| emit_audit_action mutation_type="config" | event | disbot/services/ticket_mutation.py:562 | | | |
+| emit_audit_action mutation_type="blacklist" | event | disbot/services/ticket_mutation.py:593 | | | |
+| ticket_config table | store | disbot/migrations/098_tickets.sql:23 | | | |
+| tickets table | store | disbot/migrations/098_tickets.sql:46 | | | |
+| ticket_blacklist table | store | disbot/migrations/098_tickets.sql:78 | | | |
+| ticket_* CRUD functions (get_config/upsert_config/create/get/get_by_channel/count_open_for_user/list_for_user/list_open/set_claim/close/is_blacklisted/add_blacklist/remove_blacklist) | store | disbot/utils/db/tickets.py:28 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, store, help
+
+**Structural-pattern flags:** gateway/bus.on listener present (`bus.on("ticket.opened")`, `bus.on("ticket.open_requested")` in `TicketCog.cog_load`, disbot/cogs/ticket_cog.py:57-58); no stateful game loop, no wait_for wizard, no scheduled loop, no voice.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-B-economy.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-B-economy.md
@@ -1,0 +1,395 @@
+# Lane B — Economy & Character-sim (Axis 1)
+
+> **Status:** `reference` — this lane's workspace. The surface-unit inventories below are **pre-extracted** (facts only, tier columns blank). The Lane B agent **verifies + completes them against source**, fills BOTH tier columns, writes each subsystem's §2 manifest sketch, dispositions tier-3s, and adds reconsider/optimize recommendations — per [`../BRIEF.md`](../BRIEF.md). Treat the inventory as a starting scaffold, not ground truth.
+
+**Subsystems:** economy, inventory, treasury, mining, fishing, creature, farm, xp, casino, four_twenty, counters
+
+**Method:** [`../BRIEF.md`](../BRIEF.md) · [`../PARTITION.md`](../PARTITION.md) · `tools/grammar_spike/` · `../ground-truth/command-surface.json`.
+
+---
+
+### economy
+_cogs: disbot/cogs/economy_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !economymenu | command | disbot/cogs/economy_cog.py:66 | | | |
+| /economy | command | disbot/cogs/economy_cog.py:85 | | | |
+| !daily | command | disbot/cogs/economy_cog.py:218 | | | |
+| !work | command | disbot/cogs/economy_cog.py:284 | | | |
+| !shop | command | disbot/cogs/economy_cog.py:326 | | | |
+| !balance (bal, wallet) | command | disbot/cogs/economy_cog.py:335 | | | |
+| !setlogchannel | command | disbot/cogs/economy_cog.py:353 | | | |
+| !joblist (jobs) | command | disbot/cogs/economy_cog.py:365 | | | |
+| EconomyPanelView | panel | disbot/views/economy/main_panel.py:43 | | | |
+| _ShopView | panel | disbot/views/economy/shop_panel.py:28 | | | |
+| _ShopSubView | panel | disbot/views/economy/shop_panel.py:125 | | | |
+| _WorkView | panel | disbot/views/economy/work_panel.py:38 | | | |
+| _WorkSubView | panel | disbot/views/economy/work_panel.py:174 | | | |
+| _WorkResultView | panel | disbot/views/economy/work_panel.py:207 | | | |
+| economy.log_channel (binding) | setting | disbot/core/runtime/config_arbitration.py:579 | | | |
+| capabilities: economy.currency.view/earn, shop.browse/buy, settings.configure | setting | disbot/utils/subsystem_registry.py:166-172 | | | |
+| on_ready (ensure economy-log channel) | listener | disbot/cogs/economy_cog.py:100 | | | |
+| on_guild_join (ensure economy-log channel) | listener | disbot/cogs/economy_cog.py:106 | | | |
+| bus.emit(EVT_BALANCE_CHANGED) x5 | event | disbot/services/economy_service.py:81,118,270,278,319 | | | |
+| table: economy (coins/streak/last_daily/last_worked) | store | disbot/utils/db/economy.py:224-296 | | | |
+| table: xp (coins column, level, work pay) | store | disbot/utils/db/economy.py:25-210 | | | |
+| table: job_progress (times_worked per job) | store | disbot/utils/db/economy.py:308-327 | | | |
+| table: economy_audit_log | store | disbot/utils/db/economy.py:88-187 | | | |
+| help entry — economy hub via build_help_menu_view | help | disbot/cogs/economy_cog.py:73 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, store, help
+**Structural-pattern flags:** gateway listener (`@commands.Cog.listener()` on `on_ready`/`on_guild_join` for auto-provisioning the economy-log channel); no wait_for wizard, no scheduled loop, no voice; persistent panel view (`EconomyPanelView` via `panel_manager`) with cooldown-gated sub-flows (daily/work).
+
+---
+
+### inventory
+_cogs: disbot/cogs/inventory_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !inventory (alias !inv) | command | disbot/cogs/inventory_cog.py:562 | | | |
+| _CategoryView | panel/view | disbot/cogs/inventory_cog.py:271 | | | |
+| UnifiedInventoryView (hub) | panel/view | disbot/cogs/inventory_cog.py:465 | | | |
+| build_help_menu_view | panel/view (help-menu builder) | disbot/cogs/inventory_cog.py:574 | | | |
+| send_panel usage (inventory hub) | panel/send | disbot/cogs/inventory_cog.py:572 | | | |
+| inventory.item.view (capability) | setting/capability | disbot/utils/subsystem_registry.py:193 | | | |
+| inventory.item.use (capability) | setting/capability | disbot/utils/subsystem_registry.py:194 | | | |
+| inventory.craft.recipe (capability) | setting/capability | disbot/utils/subsystem_registry.py:195 | | | |
+| inventory table | store | disbot/utils/db/migrations.py:234 | | | |
+| get_inventory | store/helper | disbot/utils/db/inventory.py:13 | | | |
+| add_item | store/helper | disbot/utils/db/inventory.py:21 | | | |
+| try_grant_unique_item | store/helper | disbot/utils/db/inventory.py:39 | | | |
+| has_item | store/helper | disbot/utils/db/inventory.py:69 | | | |
+
+**Unit kinds present:** command, panel/view, setting (registry capability), store (table + db helpers)
+**Structural-pattern flags:** none obvious — no @bot.event/bus.on listener, no wait_for wizard, no scheduled loop, no voice found in disbot/cogs/inventory_cog.py; ⚠ unverified whether bus.emit/emit_audit_action is called elsewhere (e.g. economy_cog/mining_cog) for inventory-owned events — not found directly in inventory_cog.py or utils/db/inventory.py.
+
+---
+
+### treasury
+_cogs: disbot/cogs/treasury_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !treasury (aliases: bank, pool) | command | disbot/cogs/treasury_cog.py:42-50 | | | |
+| !treasury contribute (aliases: donate, deposit) | command | disbot/cogs/treasury_cog.py:52-59 | | | |
+| !treasury grant (aliases: disburse, payout) | command | disbot/cogs/treasury_cog.py:61-80 | | | |
+| build_help_menu_view (Help-menu hook) | command-adjacent/help | disbot/cogs/treasury_cog.py:84-89 | | | |
+| TreasuryView | panel/view | disbot/views/treasury/menu.py:76-120 | | | |
+| TreasuryView.contribute_btn ("Contribute" button) | panel/view | disbot/views/treasury/menu.py:102-112 | | | |
+| TreasuryView.refresh_btn ("Refresh" button) | panel/view | disbot/views/treasury/menu.py:114-120 | | | |
+| _ContributeModal | panel/view | disbot/views/treasury/menu.py:123-158 | | | |
+| Economy hub "🏛️ Treasury" button (economy:treasury) | panel/view (entry point) | disbot/views/economy/main_panel.py:292-308 | | | |
+| treasury.pool.view / treasury.pool.contribute / treasury.pool.disburse capabilities | setting/registry | disbot/utils/subsystem_registry.py:206-229 | | | |
+| guild_treasury table | store | disbot/migrations/092_guild_treasury.sql:15-19 | | | |
+| get_treasury / credit_treasury / try_debit_treasury (CRUD primitives) | store | disbot/utils/db/treasury.py:24-88 | | | |
+| treasury_service.contribute (audited write) | event/mutation | disbot/services/treasury_service.py:70-118 | | | |
+| treasury_service.disburse (audited write) | event/mutation | disbot/services/treasury_service.py:121-181 | | | |
+| bus.emit(economy_service.EVT_BALANCE_CHANGED, reason=treasury:contribute) | event | disbot/services/treasury_service.py:104-111 | | | |
+| bus.emit(economy_service.EVT_BALANCE_CHANGED, reason=treasury:disburse) | event | disbot/services/treasury_service.py:167-174 | | | |
+
+**Unit kinds present:** command, panel/view, setting (capability registry, no user-facing settings_keys found), store, event (mutation-emitted, reused economy event name — treasury has no event of its own), help (Help-menu hook). No dedicated `listener` (`@bot.event`/`bus.on`) found for this subsystem — it only emits, does not subscribe.
+
+**Structural-pattern flags:** none obvious (no stateful game loop, no gateway/listener subscription, no wait_for wizard, no scheduled loop, no voice). Treasury is a straightforward panel+modal+audited-mutation subsystem; note it reuses economy's `EVT_BALANCE_CHANGED` event rather than emitting its own event name, and has no `settings_registry`/`db.get_setting` entries — only `subsystem_registry.py` capability strings.
+
+---
+
+### mining
+_cogs: disbot/cogs/mining_cog.py (Discord plumbing only); domain in disbot/services/mining_workflow.py; UI in disbot/views/mining/*_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !minemenu | command | disbot/cogs/mining_cog.py:57 | | | |
+| !mine | command | disbot/cogs/mining_cog.py:91 | | | |
+| !fastmine | command | disbot/cogs/mining_cog.py:102 | | | |
+| !chop | command | disbot/cogs/mining_cog.py:118 | | | |
+| !mineinv (aliases: mineinventory) | command | disbot/cogs/mining_cog.py:137 | | | |
+| !minestats | command | disbot/cogs/mining_cog.py:150 | | | |
+| !build (alias: craft) | command | disbot/cogs/mining_cog.py:193 | | | |
+| !buildlist | command | disbot/cogs/mining_cog.py:209 | | | |
+| !buildable | command | disbot/cogs/mining_cog.py:240 | | | |
+| !explore | command | disbot/cogs/mining_cog.py:265 | | | |
+| !use | command | disbot/cogs/mining_cog.py:281 | | | |
+| !cook | command | disbot/cogs/mining_cog.py:292 | | | |
+| !equip | command | disbot/cogs/mining_cog.py:315 | | | |
+| !unequip | command | disbot/cogs/mining_cog.py:326 | | | |
+| !gear | command | disbot/cogs/mining_cog.py:338 | | | |
+| !loadout (alias: loadouts) | command | disbot/cogs/mining_cog.py:361 | | | |
+| !character (aliases: profile, char) | command | disbot/cogs/mining_cog.py:411 | | | |
+| !descend | command | disbot/cogs/mining_cog.py:441 | | | |
+| !ascend | command | disbot/cogs/mining_cog.py:458 | | | |
+| !mineworld | command | disbot/cogs/mining_cog.py:474 | | | |
+| !sell | command | disbot/cogs/mining_cog.py:501 | | | |
+| !sellall | command | disbot/cogs/mining_cog.py:516 | | | |
+| !buy | command | disbot/cogs/mining_cog.py:522 | | | |
+| !market | command | disbot/cogs/mining_cog.py:535 | | | |
+| !vault | command | disbot/cogs/mining_cog.py:571 | | | |
+| !stash | command | disbot/cogs/mining_cog.py:585 | | | |
+| !unstash | command | disbot/cogs/mining_cog.py:605 | | | |
+| !vaultupgrade | command | disbot/cogs/mining_cog.py:625 | | | |
+| !skills | command | disbot/cogs/mining_cog.py:637 | | | |
+| !skill | command | disbot/cogs/mining_cog.py:651 | | | |
+| !titles | command | disbot/cogs/mining_cog.py:674 | | | |
+| !forge | command | disbot/cogs/mining_cog.py:690 | | | |
+| !home | command | disbot/cogs/mining_cog.py:706 | | | |
+| !workshop | command | disbot/cogs/mining_cog.py:722 | | | |
+| !repair | command | disbot/cogs/mining_cog.py:736 | | | |
+| !quickcraft | command | disbot/cogs/mining_cog.py:750 | | | |
+| !reset_inventory (admin) | command | disbot/cogs/mining_cog.py:758 | | | |
+| MiningHubView (PersistentView, @register) | panel | disbot/views/mining/main_panel.py:146-147 | | | |
+| MineGridView (BaseView) | panel | disbot/views/mining/grid_mine_view.py:84 | | | |
+| MiningCharacterHubView (HubView) | panel | disbot/views/mining/character_hub.py:91 | | | |
+| MiningForgeView (HubView) | panel | disbot/views/mining/forge_panel.py:76 | | | |
+| MiningGearView (HubView) | panel | disbot/views/mining/gear_panel.py:358 | | | |
+| MiningLoadoutView (HubView) | panel | disbot/views/mining/gear_panel.py:621 | | | |
+| MiningHomeView (HubView) | panel | disbot/views/mining/home_panel.py:72 | | | |
+| MiningHowToView (HubView) | panel | disbot/views/mining/how_to_panel.py:50 | | | |
+| MiningMarketView (HubView) | panel | disbot/views/mining/market_panel.py:271 | | | |
+| MiningRecipeBrowserView (HubView) | panel | disbot/views/mining/recipe_browser.py:240 | | | |
+| MiningSkillsView (HubView) | panel | disbot/views/mining/skills_panel.py:65 | | | |
+| MiningRespecView (HubView) | panel | disbot/views/mining/skills_panel.py:206 | | | |
+| MiningTitlesView (HubView) | panel | disbot/views/mining/titles_panel.py:108 | | | |
+| MiningVaultView (HubView) | panel | disbot/views/mining/vault_panel.py:153 | | | |
+| MiningWorkshopHubView (HubView) | panel | disbot/views/mining/workshop_hub.py:41 | | | |
+| MiningWorkshopView (HubView) | panel | disbot/views/mining/workshop_panel.py:159 | | | |
+| capability: mining.resource.mine | setting | disbot/utils/subsystem_registry.py:279 | | | |
+| capability: mining.resource.view | setting | disbot/utils/subsystem_registry.py:280 | | | |
+| entry_points: minemenu, mine | setting | disbot/utils/subsystem_registry.py:269 | | | |
+| dependency: economy (hard dep) | setting | disbot/utils/subsystem_registry.py:271 | | | |
+| EVT_BALANCE_CHANGED (repair coin spend) | event | disbot/services/mining_workflow.py:258 | | | |
+| EVT_BALANCE_CHANGED (_emit_balance helper) | event | disbot/services/mining_workflow.py:533 | | | |
+| store: mining_inventory | store | disbot/utils/db/games/mining.py:32 | | | |
+| store: mining_equipment | store | disbot/utils/db/games/mining_equipment.py:45 | | | |
+| store: mining_gear_wear | store | disbot/utils/db/games/mining_gear_wear.py:53 | | | |
+| store: mining_player_state (pos, depth, equipped_title, last_broken_item) | store | disbot/utils/db/games/mining_player_state.py:48 | | | |
+| store: mining_world (grid seed) | store | disbot/utils/db/games/mining_grid.py:93 | | | |
+| store: mining_loadout_presets | store | disbot/utils/db/games/mining_loadout.py:45 | | | |
+| store: mining_structures | store | disbot/utils/db/games/mining_structures.py:26 | | | |
+| store: mining_vault | store | disbot/utils/db/games/mining_vault.py:25 | | | |
+| store: player_skills (shared, mining-consumed) | store | disbot/utils/db/games/player_skills.py:25 | | | |
+| cog_check: guild-only gate | ⚠ unverified — structural, not a listener | disbot/cogs/mining_cog.py:47 | | | |
+
+**Unit kinds present:** command, panel, setting, event, store
+**Structural-pattern flags:** wait_for wizard likely inside modals (e.g. `_BuildModal` referenced in module docstring, disbot/cogs/mining_cog.py:8) — ⚠ unverified, not directly confirmed by grep; grid navigation (MineGridView) is a stateful roam/interact loop via persistent buttons, not a `@bot.event`/`bus.on` listener or scheduled loop. No `@bot.event`, `Cog.listener`, or `bus.on` found in mining files (mining only emits `bus.emit(EVT_BALANCE_CHANGED)`, it does not subscribe). No scheduled task loop or voice usage found.
+
+
+---
+
+### fishing
+_cogs: disbot/cogs/fishing_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !fish | command | disbot/cogs/fishing_cog.py:76 | | | |
+| !fishing (fishmenu) | command | disbot/cogs/fishing_cog.py:87 | | | |
+| !forecast (fishforecast, fishingweather) | command | disbot/cogs/fishing_cog.py:98 | | | |
+| !sail (setsail) | command | disbot/cogs/fishing_cog.py:117 | | | |
+| !fishlog (fishdex) | command | disbot/cogs/fishing_cog.py:131 | | | |
+| !fishtop (topfishers) | command | disbot/cogs/fishing_cog.py:145 | | | |
+| !trophies (bigfish, fishtrophy) | command | disbot/cogs/fishing_cog.py:172 | | | |
+| !rod (rodshop, buyrod) | command | disbot/cogs/fishing_cog.py:197 | | | |
+| !bait (baitshop, buybait) | command | disbot/cogs/fishing_cog.py:208 | | | |
+| !craftbait (baitcraft) | command | disbot/cogs/fishing_cog.py:222 | | | |
+| !craftcharm (charmcraft) | command | disbot/cogs/fishing_cog.py:246 | | | |
+| !craftrod (rodcraft) | command | disbot/cogs/fishing_cog.py:272 | | | |
+| !rodrecipes (rodrecipe, rrecipes) | command | disbot/cogs/fishing_cog.py:283 | | | |
+| !craftpearl (pearlcraft) | command | disbot/cogs/fishing_cog.py:289 | | | |
+| !curios (curio, carvings) | command | disbot/cogs/fishing_cog.py:319 | | | |
+| !tidepool (reef, tidepools) | command | disbot/cogs/fishing_cog.py:350 | | | |
+| !dock (pier, fishingdock) | command | disbot/cogs/fishing_cog.py:362 | | | |
+| !boathouse (moorings, boat) | command | disbot/cogs/fishing_cog.py:374 | | | |
+| !fishery (hatchery, fishfarm) | command | disbot/cogs/fishing_cog.py:386 | | | |
+| !craftcurio (carve, curiocraft) | command | disbot/cogs/fishing_cog.py:399 | | | |
+| build_help_menu_view (help-menu hook) | help | disbot/cogs/fishing_cog.py:423 | | | |
+| FishingMenuView | panel/view | disbot/views/fishing/menu.py:203 | | | |
+| FishingCastView | panel/view | disbot/views/fishing/cast_view.py:142 | | | |
+| _FishingDoneView | panel/view | disbot/views/fishing/cast_view.py:545 | | | |
+| RodShopView | panel/view | disbot/views/fishing/rod_shop.py:89 | | | |
+| BaitShopView | panel/view | disbot/views/fishing/bait_shop.py:209 | | | |
+| RodRecipeBrowserView | panel/view | disbot/views/fishing/rod_recipe_browser.py:104 | | | |
+| TidePoolView | panel/view | disbot/views/fishing/tide_pool.py:84 | | | |
+| DockView | panel/view | disbot/views/fishing/dock.py:80 | | | |
+| BoathouseView | panel/view | disbot/views/fishing/boathouse.py:81 | | | |
+| FisheryView | panel/view | disbot/views/fishing/fishery.py:82 | | | |
+| StructuresView (⚠ unverified — not entry-linked from cog commands) | panel/view | disbot/views/fishing/structures_hub.py:93 | | | |
+| capability: fishing.catch.fish | setting/capability | disbot/utils/subsystem_registry.py:313 | | | |
+| capability: fishing.collection.view | setting/capability | disbot/utils/subsystem_registry.py:314 | | | |
+| entry_points [fish, fishlog] (registry) | setting | disbot/utils/subsystem_registry.py:299 | | | |
+| event: economy_service.EVT_BALANCE_CHANGED (rod purchase) | event | disbot/services/fishing_workflow.py:644 | | | |
+| event: economy_service.EVT_BALANCE_CHANGED (bait purchase) | event | disbot/services/fishing_workflow.py:723 | | | |
+| store: fishing_catch_log | store | disbot/migrations/075_fishing_catch_log.sql:10 | | | |
+| store: fishing_rod | store | disbot/migrations/087_fishing_rod.sql:12 | | | |
+| store: fishing_energy | store | disbot/migrations/088_fishing_energy.sql:14 | | | |
+| store: fishing_bait | store | disbot/migrations/091_fishing_bait.sql:16 | | | |
+| store: fishing_venue | store | disbot/migrations/094_fishing_venue.sql:12 | | | |
+
+**Unit kinds present:** command, panel/view, help, setting/capability, event, store
+
+**Structural-pattern flags:** wait_for wizard (FishingCastView bite/reel timing, disbot/views/fishing/cast_view.py) — no @bot.event/bus.on listener found in fishing_cog.py or fishing_workflow.py (⚠ unverified: only bus.emit calls confirmed, no bus.on subscriber found in fishing files); no scheduled loop or voice usage found.
+
+
+---
+
+### creature
+_cogs: disbot/cogs/creature_cog.py, disbot/cogs/creature_battle_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !catch (alias hunt) | command | disbot/cogs/creature_cog.py:58 | | | |
+| !creatures (alias creaturemenu, pets) | command | disbot/cogs/creature_cog.py:69 | | | |
+| !dex (alias collection) | command | disbot/cogs/creature_cog.py:78 | | | |
+| !dextop (alias topcatchers) | command | disbot/cogs/creature_cog.py:85 | | | |
+| !cbattle (alias creaturebattle) | command | disbot/cogs/creature_battle_cog.py:72 | | | |
+| !cbrecord (alias battlerecord) | command | disbot/cogs/creature_battle_cog.py:89 | | | |
+| !cbattletop (alias pvptop, battletop) | command | disbot/cogs/creature_battle_cog.py:96 | | | |
+| CreatureMenuView | panel | disbot/views/creature/menu.py:60 | | | |
+| CreatureDexView | panel | disbot/views/creature/menu.py:184 | | | |
+| CreatureChallengeSelectView | panel | disbot/views/creature/menu.py:213 | | | |
+| CreatureBattleChallengeView | panel | disbot/views/creature_battle/challenge.py:30 | | | |
+| CreatureRematchView | panel | disbot/views/creature_battle/rematch.py:28 | | | |
+| build_help_menu_view (creature_cog) | help | disbot/cogs/creature_cog.py:98 | | | |
+| build_help_menu_view (creature_battle_cog) | help | disbot/cogs/creature_battle_cog.py:50 | | | |
+| creature_collection_log table | store | disbot/migrations/077_creature_collection_log.sql:1 | | | ⚠ unverified line num, file exists |
+| creature_battle_record table | store | disbot/migrations/082_creature_battle_record.sql:1 | | | ⚠ unverified line num, file exists |
+| SUBSYSTEMS["creature"] capabilities/entry_points | setting | disbot/utils/subsystem_registry.py:324 | | | registry entry, no discrete settings_keys found |
+
+**Unit kinds present:** command, panel, help, store, setting (registry entry only — no `settings_keys`/`db.get_setting` usage found)
+**Structural-pattern flags:** wait_for-style challenge/accept view (CreatureBattleChallengeView) acting as a PvP challenge wizard; no @bot.event/bus.on listeners, no @tasks.loop scheduled loop, no voice usage, no audited emit_audit_action call (comment in creature_battle_service.py explicitly notes writes are not audit-emitted) — otherwise none obvious.
+
+---
+
+### farm
+_cogs: disbot/cogs/farm_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !farm (aliases: chickenfarm, coop) | command | disbot/cogs/farm_cog.py:43-44 | | | |
+| build_help_menu_view (Help hub hook) | help | disbot/cogs/farm_cog.py:51-56 | | | |
+| Explore-world "farm" entry (_register_farm_world / WorldEntry) | listener | disbot/cogs/farm_cog.py:59-98 | | | |
+| FarmMenuView | panel/view | disbot/views/farm/menu.py:164 | | | |
+| FarmMenuView.collect_btn (🥚 Collect) | panel/view | disbot/views/farm/menu.py:197-207 | | | |
+| FarmMenuView.shop_btn (🛒 Shop) | panel/view | disbot/views/farm/menu.py:209-219 | | | |
+| FarmMenuView.refresh_btn (🔄 Refresh) | panel/view | disbot/views/farm/menu.py:221-227 | | | |
+| FarmShopView | panel/view | disbot/views/farm/menu.py:230 | | | |
+| FarmShopView.buy_btn (🐔 Buy hen) | panel/view | disbot/views/farm/menu.py:253-260 | | | |
+| FarmShopView.upgrade_btn (🏠 Upgrade coop) | panel/view | disbot/views/farm/menu.py:267-273 | | | |
+| FarmShopView.back_btn (◀ Back) | panel/view | disbot/views/farm/menu.py:275-296 | | | |
+| SUBSYSTEMS["farm"] capabilities (farm.egg.collect, farm.coop.manage) | setting | disbot/utils/subsystem_registry.py:364-386 | | | |
+| economy_service.EVT_BALANCE_CHANGED emit on collect | event | disbot/services/farm_workflow.py:158-165 | | | |
+| economy_service.EVT_BALANCE_CHANGED emit on buy_chicken | event | disbot/services/farm_workflow.py:235-242 | | | |
+| economy_service.EVT_BALANCE_CHANGED emit on upgrade_coop | event | disbot/services/farm_workflow.py:296-303 | | | |
+| chicken_farm table (per user+guild flock/coop/egg-accrual state) | store | disbot/migrations/090_chicken_farm.sql:12-19 | | | |
+| get_chicken_farm / set_chicken_farm CRUD | store | disbot/utils/db/games/farm.py:42,97 | | | |
+
+**Unit kinds present:** command, panel, listener (world-hub registration), help, setting, event, store
+
+**Structural-pattern flags:** none obvious (no `@bot.event`/`bus.on` listeners, no `wait_for` wizard, no scheduled loop/ticker — idle accrual is pure `settle()` math computed on read per ADR-001/002 — no voice usage).
+
+
+---
+
+### xp
+_cogs: disbot/cogs/xp_cog.py, disbot/cogs/xp/listener.py, disbot/cogs/xp/stage.py, disbot/cogs/xp/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !xpmenu | command | disbot/cogs/xp_cog.py:92 | | | |
+| !rank | command | disbot/cogs/xp_cog.py:120 | | | |
+| !givexp | command | disbot/cogs/xp_cog.py:179 | | | |
+| !resetxp | command | disbot/cogs/xp_cog.py:197 | | | |
+| !xpconfig | command | disbot/cogs/xp_cog.py:210 | | | |
+| !xpimport | command | disbot/cogs/xp_cog.py:218 | | | |
+| _XpHubView | panel | disbot/views/xp/main_panel.py:17 | | | |
+| XpConfigView | panel | disbot/views/xp/config_panel.py:22 | | | |
+| XpImportView | panel | disbot/views/xp/import_panel.py:30 | | | |
+| XpImportSetupView | panel | disbot/views/xp/import_panel.py:213 | | | |
+| _RankView | panel | disbot/views/xp/rank_view.py:19 | | | |
+| _GiveXpModal | panel | disbot/views/xp/modals.py:208 | | | |
+| _ResetXpModal | panel | disbot/views/xp/modals.py:251 | | | |
+| _XpRangeModal | panel | disbot/views/xp/modals.py:290 | | | |
+| _XpCooldownModal | panel | disbot/views/xp/modals.py:333 | | | |
+| _XpChannelModal | panel | disbot/views/xp/modals.py:360 | | | |
+| xp_min | setting | disbot/cogs/xp/schemas.py:75 | | | |
+| xp_max | setting | disbot/cogs/xp/schemas.py:84 | | | |
+| xp_cooldown | setting | disbot/cogs/xp/schemas.py:93 | | | |
+| announce_channel (binding) | setting | disbot/cogs/xp/schemas.py:58 | | | |
+| on_message listener (handle_message via stage pipeline) | listener | disbot/cogs/xp/listener.py:93 | | | |
+| MessagePipelineStage.process (xp stage wrapper) | listener | disbot/cogs/xp/stage.py:35 | | | |
+| EVT_XP_AWARDED emit | event | disbot/services/xp_service.py:126 | | | |
+| EVT_LEVEL_UP emit | event | disbot/services/xp_service.py:136 | | | |
+| EVT_XP_RESET emit | event | disbot/services/xp_service.py:239 | | | |
+| audit.action_recorded (emit_audit_action, xp reset) | event | disbot/services/xp_service.py:247 | | | |
+| xp table (user_id, guild_id, xp, level, messages, last_xp) | store | disbot/utils/db/xp.py:76 | | | |
+| xp threshold role migration ⚠ unverified (may belong to role subsystem) | store | disbot/migrations/003_role_xp_thresholds.sql:1 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, store
+**Structural-pattern flags:** gateway listener (on_message via MessagePipelineStage, effectively a `@bot.event`-style hook) present; no stateful game loop, no wait_for wizard beyond modals, no scheduled loop, no voice.
+
+
+---
+
+### casino
+_cogs: disbot/cogs/casino_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !casino | command | disbot/cogs/casino_cog.py:41 | | | |
+| !poker (alias !holdem) | command | disbot/cogs/casino_cog.py:47 | | | |
+| build_help_menu_view (help-menu hook) | help | disbot/cogs/casino_cog.py:67 | | | |
+| CasinoHubView | panel/view | disbot/views/casino/hub.py:50 | | | |
+| build_casino_hub_panel | panel | disbot/views/casino/hub.py:118 | | | |
+| build_casino_hub_embed | panel | disbot/views/casino/hub.py:23 | | | |
+| PokerLobbyView | panel/view | disbot/views/casino/poker_table.py:566 | | | |
+| SeatLobbyView | panel/view | disbot/views/casino/poker_table.py:606 | | | |
+| PokerEndView | panel/view | disbot/views/casino/poker_table.py:626 | | | |
+| PokerSeatView | panel/view | disbot/views/casino/poker_table.py:685 | | | |
+
+**Unit kinds present:** command, panel/view, help
+**Structural-pattern flags:** stateful game loop (in-memory `_tables` dict keyed by channel_id, `PokerTable` class managing multi-seat live state, disbot/views/casino/poker_table.py:62-109); no listener/bus.on, no bus.emit/audit events found, no settings_registry entries found, no DB store/migration table found (ephemeral play-chips, not persisted) — otherwise none obvious (no wait_for wizard, no scheduled loop, no voice).
+
+
+---
+
+### four_twenty
+_cogs: disbot/cogs/four_twenty_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !420 (aliases fourtwenty, fourtwenty420) | command | disbot/cogs/four_twenty_cog.py:186 | | | |
+| four_twenty.panel.view (_FourTwentyPanelView) | panel/view | disbot/cogs/four_twenty_cog.py:204 | | | |
+| wisdom_btn button | panel/view | disbot/cogs/four_twenty_cog.py:218 | | | |
+| fact_btn button | panel/view | disbot/cogs/four_twenty_cog.py:232 | | | |
+| overview_btn button | panel/view | disbot/cogs/four_twenty_cog.py:246 | | | |
+| FourTwentyStage (message_pipeline stage, registered in cog_load) | listener | disbot/cogs/four_twenty_cog.py:107 | | | |
+| build_help_menu_view (help-menu direct-navigation hook) | help | disbot/cogs/four_twenty_cog.py:195 | | | |
+| SUBSYSTEMS["four_twenty"] registry entry (capabilities/entry_points) | setting | disbot/utils/subsystem_registry.py:1031 | | | |
+
+**Unit kinds present:** command, panel/view, listener, help, setting (registry entry only — no db.get_setting keys, no store tables, no bus.emit events found; subsystem is observe-only/stateless per module docstring).
+
+**Structural-pattern flags:** listener via message-pipeline stage (`FourTwentyStage`, registered/unregistered in `cog_load`/`cog_unload`, not a raw `@bot.event`/`bus.on`) — no stateful game loop, no wait_for wizard, no scheduled loop, no voice. No `emit_audit_action`/`bus.emit` calls found (⚠ unverified beyond docstring claim "nothing here writes to the DB or mutates economy/XP").
+
+---
+
+### counters
+_cogs: disbot/cogs/counters_cog.py (+ disbot/cogs/counters/schemas.py, disbot/cogs/counters/__init__.py)_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !counters | command | disbot/cogs/counters_cog.py:159 | | | |
+| !counterpreset | command | disbot/cogs/counters_cog.py:173 | | | |
+| /counters | command | disbot/cogs/counters_cog.py:227 | | | |
+| _counter_sync_loop | scheduled loop | disbot/cogs/counters_cog.py:57 | | | |
+| _before_counter_sync_loop (before_loop hook) | listener | disbot/cogs/counters_cog.py:84 | | | |
+| cog_load (registers schema, starts loop) | listener | disbot/cogs/counters_cog.py:44 | | | |
+| cog_unload (cancels loop) | listener | disbot/cogs/counters_cog.py:51 | | | |
+| build_help_menu_view (help-menu direct-nav hook) | help | disbot/cogs/counters_cog.py:238 | | | |
+| counters.updated (bus.emit event) | event | disbot/services/counter_service.py:130 | | | |
+| enabled (master switch) | setting | disbot/cogs/counters/schemas.py:88 | | | |
+| total_channel / humans_channel / bots_channel (channel bindings) | setting | disbot/cogs/counters/schemas.py:99 | | | |
+| total_template / humans_template / bots_template (name templates) | setting | disbot/cogs/counters/schemas.py:128 | | | |
+| counters.settings.configure (capability gate) | setting | disbot/cogs/counters/schemas.py:44 | | | |
+
+**Unit kinds present:** command, scheduled loop, listener, help, event, setting
+
+**Structural-pattern flags:** scheduled loop (`@tasks.loop`, `_counter_sync_loop`, 10-min cadence) driving Discord channel renames; no persistent discord.ui.View/panel (status is a plain embed reused via HubView from the help menu); no dedicated DB table — config is guild-settings KV only (SubsystemSchema-declared); no gateway/@bot.event, no wait_for wizard, no voice.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-C-games.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-C-games.md
@@ -1,0 +1,344 @@
+# Lane C — Games & Community (Axis 1)
+
+> **Status:** `reference` — this lane's workspace. The surface-unit inventories below are **pre-extracted** (facts only, tier columns blank). The Lane C agent **verifies + completes them against source**, fills BOTH tier columns, writes each subsystem's §2 manifest sketch, dispositions tier-3s, and adds reconsider/optimize recommendations — per [`../BRIEF.md`](../BRIEF.md). Treat the inventory as a starting scaffold, not ground truth.
+
+**Subsystems:** games, blackjack, deathmatch, rps_tournament, counting, chain, leaderboard, community, community_spotlight, karma
+
+**Method:** [`../BRIEF.md`](../BRIEF.md) · [`../PARTITION.md`](../PARTITION.md) · `tools/grammar_spike/` · `../ground-truth/command-surface.json`.
+
+---
+
+### games
+_cogs: disbot/cogs/games_cog.py, disbot/cogs/blackjack_cog.py, disbot/cogs/rps_tournament_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !games | command | disbot/cogs/games_cog.py:39 | | | |
+| !world | command | disbot/cogs/games_cog.py:45 | | | |
+| !worldcard (alias !mystats) | command | disbot/cogs/games_cog.py:59 | | | |
+| /games (slash) | command | disbot/cogs/games_cog.py:84 | | | |
+| !blackjack (alias !bj) | command | disbot/cogs/blackjack_cog.py:432 | | | |
+| !bjtournament (alias !bjtourn) | command | disbot/cogs/blackjack_cog.py:518 | | | |
+| !bjstart | command | disbot/cogs/blackjack_cog.py:579 | | | |
+| !bjstatus | command | disbot/cogs/blackjack_cog.py:590 | | | |
+| !rpsregister (alias !rpsreg) | command | disbot/cogs/rps_tournament_cog.py:199 | | | |
+| !rpsstart (alias !rpsbegin) | command | disbot/cogs/rps_tournament_cog.py:369 | | | |
+| !rpsbot | command | disbot/cogs/rps_tournament_cog.py:411 | | | |
+| !rpsmatchup | command | disbot/cogs/rps_tournament_cog.py:424 | | | |
+| !rpshelp | command | disbot/cogs/rps_tournament_cog.py:723 | | | |
+| !rpssettings | command | disbot/cogs/rps_tournament_cog.py:741 | | | |
+| !rps | command | disbot/cogs/rps_tournament_cog.py:772 | | | |
+| build_help_menu_view hook | help | disbot/cogs/games_cog.py:73 | | | |
+| GamesHubView | panel/view | disbot/views/games/hub.py:304 | | | |
+| ExploreWorldHubView | panel/view | disbot/views/explore/world_hub.py:243 | | | |
+| _GameHubButton | panel/view | disbot/views/games/hub.py:269 | | | |
+| games/blackjack_panel.py hub-child panel | panel/view | disbot/views/games/blackjack_panel.py:1 | | | |
+| games/rps_panel.py hub-child panel | panel/view | disbot/views/games/rps_panel.py:1 | | | |
+| games/deathmatch_panel.py hub-child panel | panel/view | disbot/views/games/deathmatch_panel.py:1 | | | |
+| BlackjackView (solo) | panel/view | disbot/views/blackjack/solo_view.py:38 | | | |
+| _BlackjackSoloResultView | panel/view | disbot/views/blackjack/solo_view.py:245 | | | |
+| _ChallengeView (blackjack pvp) | panel/view | disbot/views/blackjack/pvp_view.py:31 | | | |
+| _TournRegistrationView (blackjack) | panel/view | disbot/views/blackjack/tournament_views.py:42 | | | |
+| _TournBlackjackView | panel/view | disbot/views/blackjack/tournament_views.py:67 | | | |
+| _RpsView (solo) | panel/view | disbot/views/rps/solo_play.py:37 | | | |
+| _RpsSoloResultView | panel/view | disbot/views/rps/solo_play.py:141 | | | |
+| _RpsMovePickerView | panel/view | disbot/views/rps/move_picker.py:12 | | | |
+| _RpsPvpChallengeView | panel/view | disbot/views/rps/pvp_challenge.py:28 | | | |
+| _RpsPvpPlayView | panel/view | disbot/views/rps/pvp_play.py:72 | | | |
+| _RpsPvpResultView | panel/view | disbot/views/rps/pvp_play.py:30 | | | |
+| _RpsRegistrationView | panel/view | disbot/views/rps/registration.py:15 | | | |
+| ACTIVE_TOURNAMENT | setting | disbot/utils/settings_keys/games.py:12 | | | |
+| RPS_DEFAULT_ENTRY_FEE | setting | disbot/utils/settings_keys/games.py:16 | | | |
+| BLACKJACK_DEFAULT_ENTRY_FEE | setting | disbot/utils/settings_keys/games.py:20 | | | |
+| DEATHMATCH_TURN_TIMEOUT | setting | disbot/utils/settings_keys/games.py:25 | | | |
+| BlackjackCog.on_guild_remove | listener | disbot/cogs/blackjack_cog.py:298 | | | |
+| BlackjackCog.on_raw_reaction_add (bj tournament reg) | listener | disbot/cogs/blackjack_cog.py:410 | | | |
+| RpsTournamentCog.on_guild_remove | listener | disbot/cogs/rps_tournament_cog.py:183 | | | |
+| RpsTournamentCog.on_reaction_add (rps registration) | listener | disbot/cogs/rps_tournament_cog.py:534 | | | |
+| game_wager_workflow.recover_escrow (blackjack pvp escrow refund on guild remove) | event | disbot/cogs/blackjack_cog.py:365 | | | |
+| game_wager_workflow.recover_escrow (rps pvp escrow refund on guild remove) | event | disbot/cogs/rps_tournament_cog.py:190 | | | |
+| game_state rows (generic per-subsystem state store, used by blackjack solo/pvp/tournament) | store | disbot/services/game_state_service.py:48 | | | |
+| rps_players table | store | disbot/utils/db/migrations.py:291 | | | |
+| ⚠ unverified: rps_matches table (noted dropped in migration 019 per comment) | store | disbot/utils/db/games/rps.py:17 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, store, help
+**Structural-pattern flags:** stateful game loop (blackjack/RPS solo, pvp, tournament state machines) · gateway listener (`on_guild_remove`, `on_raw_reaction_add`, `on_reaction_add`) · reaction-based registration wizard (RPS/blackjack tournament sign-up via reactions, not `wait_for`) · ADR-002 declares this game state intentionally not-restart-safe (best-effort recovery on cog_load, e.g. `_cleanup_orphaned_tournaments`); no scheduled `tasks.loop` or voice usage found in these three cog files.
+
+---
+
+### blackjack
+_cogs: disbot/cogs/blackjack_cog.py (+ disbot/cogs/blackjack/{schemas,_state,_persistence,actions}.py, disbot/views/blackjack/*, disbot/views/games/blackjack_panel.py)_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !blackjack / !bj | command | disbot/cogs/blackjack_cog.py:431 | | | |
+| !bjtournament / !bjtourn | command | disbot/cogs/blackjack_cog.py:516 | | | |
+| !bjstart | command | disbot/cogs/blackjack_cog.py:577 | | | |
+| !bjstatus | command | disbot/cogs/blackjack_cog.py:589 | | | |
+| build_help_menu_view (hub direct-nav hook) | help | disbot/cogs/blackjack_cog.py:101 | | | |
+| BlackjackPanelView | panel/view | disbot/views/games/blackjack_panel.py:586 | | | |
+| _BlackjackBetPresetView | panel/view | disbot/views/games/blackjack_panel.py:185 | | | |
+| _BlackjackChallengeSelectView | panel/view | disbot/views/games/blackjack_panel.py:307 | | | |
+| _BlackjackChallengeBetView | panel/view | disbot/views/games/blackjack_panel.py:371 | | | |
+| _BlackjackTournamentSubView | panel/view | disbot/views/games/blackjack_panel.py:496 | | | |
+| BlackjackView (solo game board) | panel/view | disbot/views/blackjack/solo_view.py:38 | | | |
+| _BlackjackSoloResultView | panel/view | disbot/views/blackjack/solo_view.py:245 | | | |
+| _ChallengeView (PvP challenge accept) | panel/view | disbot/views/blackjack/pvp_view.py:31 | | | |
+| _TournRegistrationView | panel/view | disbot/views/blackjack/tournament_views.py:42 | | | |
+| _TournBlackjackView | panel/view | disbot/views/blackjack/tournament_views.py:67 | | | |
+| default_entry_fee | setting | disbot/cogs/blackjack/schemas.py:29 | | | |
+| on_guild_remove (departed-guild cleanup + refunds) | listener | disbot/cogs/blackjack_cog.py:298 | | | |
+| on_raw_reaction_add (✅ tournament registration) | listener | disbot/cogs/blackjack_cog.py:410 | | | |
+| cog_load recovery tasks (solo/pvp/escrow/tournament) | listener | disbot/cogs/blackjack_cog.py:123 | | | |
+| game_state store (shared table, subsystem keys BLACKJACK_SOLO/PVP/TOURNAMENT) | store | disbot/migrations/015_game_state.sql:1 ⚠ unverified line | | | |
+| blackjack.game.play / blackjack.tournament.manage capabilities | setting | disbot/utils/subsystem_registry.py:747 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, store, help (no dedicated `event`/emit_audit_action call found directly in blackjack cog — economy_service.credit/refund and game_wager_workflow handle audit emission downstream; ⚠ unverified whether blackjack itself emits audit events directly).
+
+**Structural-pattern flags:** stateful game loop (solo/PvP/tournament in-memory dict state `_active`/`_pvp`/`_tournaments`); gateway listener (`on_guild_remove`, `on_raw_reaction_add`); scheduled/timer task (tournament auto-start `asyncio.sleep` + `tasks.spawn`); no `wait_for` wizard or voice usage observed.
+
+
+---
+
+### deathmatch
+_cogs: disbot/cogs/deathmatch_cog.py, disbot/views/games/deathmatch_panel.py, disbot/cogs/deathmatch/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !dm_challenge (aliases: deathmatch, challenge, dm) | command | disbot/cogs/deathmatch_cog.py:445 | | | |
+| !dm_help (alias: deathmatch_help) | command | disbot/cogs/deathmatch_cog.py:498 | | | |
+| challenge_error | listener (command error handler) | disbot/cogs/deathmatch_cog.py:486 | | | |
+| Deathmatch.cog_load (registers settings schema) | listener (cog lifecycle) | disbot/cogs/deathmatch_cog.py:411 | | | |
+| _DuelView | panel/view | disbot/cogs/deathmatch_cog.py:94 | | | |
+| _DuelView.btn_attack | panel/view control | disbot/cogs/deathmatch_cog.py:193 | | | |
+| _DuelView.btn_defend | panel/view control | disbot/cogs/deathmatch_cog.py:204 | | | |
+| _DuelView.on_timeout | panel/view lifecycle | disbot/cogs/deathmatch_cog.py:151 | | | |
+| _ChallengeView | panel/view | disbot/cogs/deathmatch_cog.py:274 | | | |
+| _ChallengeView.btn_accept | panel/view control | disbot/cogs/deathmatch_cog.py:329 | | | |
+| _ChallengeView.btn_decline | panel/view control | disbot/cogs/deathmatch_cog.py:385 | | | |
+| DeathmatchPanelView | panel/view (hub) | disbot/views/games/deathmatch_panel.py:603 | | | |
+| DeathmatchPanelView.btn_fight_bot | panel/view control | disbot/views/games/deathmatch_panel.py:616 | | | |
+| DeathmatchPanelView.btn_challenge | panel/view control | disbot/views/games/deathmatch_panel.py:644 | | | |
+| DeathmatchPanelView.btn_rules | panel/view control | disbot/views/games/deathmatch_panel.py:660 | | | |
+| _BotDuelView | panel/view | disbot/views/games/deathmatch_panel.py:192 | | | |
+| _BotDuelResultView | panel/view (result/rematch) | disbot/views/games/deathmatch_panel.py:347 | | | |
+| _PvpDuelResultView | panel/view (result/rematch) | disbot/views/games/deathmatch_panel.py:391 | | | |
+| _DeathmatchChallengeSelectView | panel/view | disbot/views/games/deathmatch_panel.py:493 | | | |
+| _DeathmatchOpponentSelect | panel/view (UserSelect) | disbot/views/games/deathmatch_panel.py:500 | | | |
+| turn_timeout | setting | disbot/cogs/deathmatch/schemas.py:32 | | | |
+| deathmatch.game.challenge | setting/capability | disbot/utils/subsystem_registry.py:858 | | | |
+| deathmatch.stat.view | setting/capability | disbot/utils/subsystem_registry.py:859 | | | |
+| deathmatch_stats | store (table) | disbot/utils/db/migrations.py:313 | | | |
+| update_deathmatch | store (mutation fn) | disbot/utils/db/games/deathmatch.py (⚠ unverified line) | | | |
+| get_deathmatch_leaderboard | store (query fn) | disbot/utils/db/games/deathmatch.py (⚠ unverified line) | | | |
+| get_deathmatch_stats | store (query fn) | disbot/utils/db/games/deathmatch.py (⚠ unverified line) | | | |
+| !leaderboard deathmatch | help/reference (cross-cog leaderboard arg) | disbot/cogs/leaderboard_cog.py:217 | | | |
+| deathmatch registry entry | help/registry entry (entry_points: deathmatch, dm) | disbot/utils/subsystem_registry.py:838 | | | |
+
+**Unit kinds present:** command, listener, panel/view, setting, store, help/reference
+
+**Structural-pattern flags:** stateful game loop (in-memory `active_duels` turn-based duel state machine in `Deathmatch` cog); gateway-adjacent view timeouts (`on_timeout` in `_DuelView`/`_ChallengeView`, discord.ui.View timeout, not `@bot.event`); no `wait_for` wizard, no scheduled loop, no voice usage observed.
+
+
+---
+
+### rps_tournament
+_cogs: cogs/rps_tournament_cog.py (+ cogs/rps_tournament/* submodules: schemas.py, rules.py, _persistence.py, _bot_matches.py, _stage.py, _quickplay.py, _helpers.py)_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !rpsregister (alias !rpsreg) | command | cogs/rps_tournament_cog.py:199 | | | |
+| !rpsstart (alias !rpsbegin) | command | cogs/rps_tournament_cog.py:369 | | | |
+| !rpsbot | command | cogs/rps_tournament_cog.py:411 | | | |
+| !rpsmatchup | command | cogs/rps_tournament_cog.py:424 | | | |
+| !rpshelp | command | cogs/rps_tournament_cog.py:724 | | | |
+| !rpssettings | command | cogs/rps_tournament_cog.py:741 | | | |
+| !rps | command | cogs/rps_tournament_cog.py:772 | | | |
+| on_guild_remove | listener | cogs/rps_tournament_cog.py:183 | | | |
+| on_reaction_add | listener | cogs/rps_tournament_cog.py:534 | | | |
+| RpsTournamentStage (message_pipeline stage) | listener | cogs/rps_tournament/_stage.py (registered cogs/rps_tournament_cog.py:145) | | | |
+| _RpsRegistrationView | panel/view | disbot/views/rps/registration.py:15 | | | |
+| _RpsMovePickerView | panel/view | disbot/views/rps/move_picker.py:12 | | | |
+| _RpsPvpChallengeView | panel/view | disbot/views/rps/pvp_challenge.py:28 | | | |
+| _RpsPvpResultView | panel/view | disbot/views/rps/pvp_play.py:30 | | | |
+| _RpsPvpPlayView | panel/view | disbot/views/rps/pvp_play.py:72 | | | |
+| _RpsView | panel/view | disbot/views/rps/solo_play.py:37 | | | |
+| _RpsSoloResultView | panel/view | disbot/views/rps/solo_play.py:141 | | | |
+| _RpsBetPresetView | panel/view | disbot/views/games/rps_panel.py:212 | | | |
+| _RpsBetPresetButton | panel/view | disbot/views/games/rps_panel.py:229 | | | |
+| _RpsBetCustomButton | panel/view | disbot/views/games/rps_panel.py:248 | | | |
+| _RpsCustomBetModal | panel/view | disbot/views/games/rps_panel.py:261 | | | |
+| _RpsChallengeSelectView | panel/view | disbot/views/games/rps_panel.py:293 | | | |
+| _RpsOpponentSelect | panel/view | disbot/views/games/rps_panel.py:308 | | | |
+| _RpsTournamentSubView | panel/view | disbot/views/games/rps_panel.py:353 | | | |
+| _RpsTournamentStartButton | panel/view | disbot/views/games/rps_panel.py:379 | | | |
+| _RpsTournamentJoinButton | panel/view | disbot/views/games/rps_panel.py:413 | | | |
+| _RpsTournamentMatchupButton | panel/view | disbot/views/games/rps_panel.py:447 | | | |
+| _RpsMatchupSelect | panel/view | disbot/views/games/rps_panel.py:483 | | | |
+| RPSPanelView (hub panel, build_help_menu_view hook) | panel/view | disbot/views/games/rps_panel.py:567 (built cogs/rps_tournament_cog.py:127-131) | | | |
+| RPS_DEFAULT_ENTRY_FEE (default entry fee setting) | setting | cogs/rps_tournament/schemas.py:25,74 (utils/settings_keys.py) | | | |
+| RPS_CONFIG_SCHEMA / register_schemas() | setting | cogs/rps_tournament/schemas.py:51,58 | | | |
+| capability rps_tournament.game.join | setting | disbot/utils/subsystem_registry.py:882 | | | |
+| capability rps_tournament.tournament.manage | setting | disbot/utils/subsystem_registry.py:883 | | | |
+| rps_players table | store | disbot/utils/db/migrations.py:291 | | | |
+| rps (help entry alias) | help | disbot/cogs/help/route.py:72 | | | |
+| rock paper scissors (help entry alias) | help | disbot/cogs/help/route.py:73 | | | |
+| ⚠ unverified: audit-event emission for tournament entry fee | event | routed via services.game_wager_workflow.enter_tournament (cogs/rps_tournament_cog.py:~305), not confirmed to emit_audit_action directly in this subsystem's own files | | | |
+
+**Unit kinds present:** command, listener (Cog.listener + message_pipeline stage), panel/view, setting (settings_key + subsystem schema + capabilities), store, help. No standalone `bus.emit`/`emit_audit_action` calls found directly inside rps_tournament's own files (grep was empty) — fee/escrow mutation delegates to `services.game_wager_workflow` / `services.tournament_state_service`, marked ⚠ unverified above.
+
+**Structural-pattern flags:** stateful game loop (per-instance tournament state: `self.players`/`self.scores`/`self.matches`/`self.current_round`); gateway listener (`@commands.Cog.listener()` on_guild_remove, on_reaction_add); scheduled/background loop (`registration_countdown`, `tasks.spawn` reminder + recovery tasks in `cog_load`); wizard-like multi-step registration → bracket flow. No `@bot.event` top-level handlers, no voice usage.
+
+---
+
+### counting
+_cogs: disbot/cogs/counting_cog.py, disbot/cogs/counting/_stage.py, disbot/cogs/counting/handler.py, disbot/cogs/counting/parsing.py, disbot/cogs/counting/game_logic.py, disbot/cogs/counting/_channel_manager.py, disbot/cogs/counting/leaderboard.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !countingmenu (cm) | command | disbot/cogs/counting_cog.py:179 | | | |
+| !start_match (sm) | command | disbot/cogs/counting_cog.py:196 | | | |
+| !end_match (em) | command | disbot/cogs/counting_cog.py:383 | | | |
+| !reset_count (rc) | command | disbot/cogs/counting_cog.py:432 | | | |
+| !toggle_turns (tt) | command | disbot/cogs/counting_cog.py:487 | | | |
+| !count_info (ci) | command | disbot/cogs/counting_cog.py:517 | | | |
+| !counttop (ct, counting_top) | command | disbot/cogs/counting_cog.py:572 | | | |
+| !count_rules (cr) | command | disbot/cogs/counting_cog.py:604 | | | |
+| !set_skip_numbers (ssn) | command | disbot/cogs/counting_cog.py:635 | | | |
+| !toggle_reset_on_wrong_count (trwc) | command | disbot/cogs/counting_cog.py:686 | | | |
+| _CountingHubView | panel/view | disbot/views/counting/hub_panel.py:168 | | | staff config hub, extends HubView, opened by !countingmenu |
+| counting message-count listener (⚠ unverified wiring) | listener | disbot/cogs/counting/_stage.py:54 | | | wraps `_process_counting_message`; triggering on_message hook not located in counting_cog.py itself — likely wired via message_router/stage dispatch elsewhere |
+| counting guild state store | store | disbot/utils/db/games/counting.py:8 | | | `get_counting_state`/`set_counting_state` — per-guild counting state (channels, counts, modes) |
+| subsystem_registry entry | setting | disbot/utils/subsystem_registry.py:886 | | | SUBSYSTEMS["counting"] capabilities incl. `counting.game.play`, `counting.game.configure`; entry_points count_info/counttop/countingmenu |
+
+**Unit kinds present:** command, panel, setting, listener, store
+**Structural-pattern flags:** stateful game loop (turn/mode/skip-number state machine driven by message parsing in handler.py/game_logic.py); no @bot.event/bus.on found directly in counting_cog.py — message intake wiring (`_process_counting_message`) is invoked from `_stage.py`, exact listener registration point unverified (⚠); no scheduled loop or voice usage found.
+
+
+---
+
+### chain
+_cogs: disbot/cogs/chain_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !chain | command (group) | disbot/cogs/chain_cog.py:69 | | | |
+| !chain create | command (subcommand) | disbot/cogs/chain_cog.py:79 | | | |
+| !chain delete | command (subcommand) | disbot/cogs/chain_cog.py:134 | | | |
+| !chain setlimit | command (subcommand) | disbot/cogs/chain_cog.py:167 | | | |
+| !chain removelimit | command (subcommand) | disbot/cogs/chain_cog.py:216 | | | |
+| !chain list | command (subcommand) | disbot/cogs/chain_cog.py:270 | | | |
+| !chainmenu | command (prefix) | disbot/cogs/chain_cog.py:253 | | | |
+| chain.game.play | setting/capability | disbot/utils/subsystem_registry.py:930 (~capabilities list) | | | |
+| chain.game.configure | setting/capability | disbot/utils/subsystem_registry.py:930 (~capabilities list) | | | |
+| _ChainMenuView | panel/view | disbot/cogs/chain_cog.py:580 | | | |
+| _CreateChainModal | panel/view (modal) | disbot/cogs/chain_cog.py:408 | | | |
+| _DeleteChainModal | panel/view (modal) | disbot/cogs/chain_cog.py:452 | | | |
+| _SetLimitModal | panel/view (modal) | disbot/cogs/chain_cog.py:488 | | | |
+| _ClearLimitModal | panel/view (modal) | disbot/cogs/chain_cog.py:542 | | | |
+| on_ready listener | listener | disbot/cogs/chain_cog.py:381-382 | | | |
+| _process_chain_message | listener (pipeline hook, non-Discord-decorator) | disbot/cogs/chain_cog.py:310 | | | |
+| emit_audit_action (via chain_service._emit) | event | disbot/services/chain_service.py:89-100 | | | |
+| chain_channels table | store | disbot/utils/db/games/chain.py:1 | | | |
+
+**Unit kinds present:** command, setting/capability, panel/view (incl. modals), listener, event, store
+**Structural-pattern flags:** message-pipeline listener (`_process_chain_message`, invoked from ChainStage in message pipeline, not a bare @bot.event) plus a HubView-based panel with modal-driven wizard-like flows (Create/Delete/SetLimit/ClearLimit modals); no scheduled loop, no voice, no wait_for-based multi-step wizard beyond modals, no persistent stateful game loop beyond simple counter (`chain_count` increment).
+
+
+---
+
+### leaderboard
+_cogs: disbot/cogs/leaderboard_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !leaderboard (aliases: lb, rankings, minelb, miningleaderboard, fishlb, dm_leaderboard, dm_lb, rpslb, farmlb, countlb, counting_leaderboard) | command | disbot/cogs/leaderboard_cog.py:216 | | | |
+| LeaderboardView | panel/view | disbot/cogs/leaderboard_cog.py:137 | | | |
+| _CategorySelect (discord.ui.Select, category dropdown callback) | panel/view | disbot/cogs/leaderboard_cog.py:152 | | | |
+| build_help_menu_view (help-menu direct-navigation hook returning hub) | panel/view | disbot/cogs/leaderboard_cog.py:243 | | | |
+| leaderboard.xp.view (capability) | setting | disbot/utils/subsystem_registry.py:956 | | | |
+| leaderboard.economy.view (capability) | setting | disbot/utils/subsystem_registry.py:957 | | | |
+| SUBSYSTEMS["leaderboard"] entry (entry_points leaderboard/lb, parent_hub economy) | setting | disbot/utils/subsystem_registry.py:937 | | | |
+| RankProvider registry (_PROVIDERS, ALIASES map — xp/coins/mining/creatures/fishing/farm/gamexp/crafting/deathmatch/rps/counting/karma providers) | store (read-only aggregation, ⚠ unverified as "owned" store — no dedicated leaderboard table; providers read other subsystems' tables) | disbot/services/rank_providers.py:627 | | | |
+| render_leaderboard_image (image-card rendering helper used by cog) | ⚠ unverified — helper, not a discrete grammar unit | disbot/utils/ux_patterns/image_builders.py | | | |
+
+**Unit kinds present:** command, panel/view, setting, store (aggregation-only, no owned table)
+**Structural-pattern flags:** none obvious — no @bot.event/bus.on listener, no wait_for wizard, no scheduled loop, no voice; cog is a stateless embed-rendering shell over the `services.rank_providers` registry (per module docstring), with a single command + a category-select dropdown view. No dedicated `help_catalogue.py` entry or DB table found for this subsystem — it aggregates read access to other subsystems' data (xp, economy/coins, mining, deathmatch, rps, farm, counting, karma, etc.).
+
+
+---
+
+### community
+_cogs: disbot/cogs/community_cog.py, disbot/cogs/community_spotlight_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !community | command | disbot/cogs/community_cog.py:41 | | | |
+| /community | command | disbot/cogs/community_cog.py:55 | | | |
+| !spotlight (alias !activity) | command | disbot/cogs/community_spotlight_cog.py:300 | | | |
+| CommunityHubView | panel/view | disbot/views/community/hub.py:259 | | | |
+| SpotlightView | panel/view | disbot/cogs/community_spotlight_cog.py:129 | | | |
+| GamesView | panel/view | disbot/cogs/community_spotlight_cog.py:191 | | | |
+| _GameSelect (select menu) | panel/view | disbot/cogs/community_spotlight_cog.py:213 | | | |
+| _CommunityChildButton | panel/view | disbot/views/community/hub.py:230 | | | |
+| build_community_hub_panel | panel/view | disbot/views/community/hub.py:144 | | | |
+| CommunityCog.build_help_menu_view | help | disbot/cogs/community_cog.py:47 | | | |
+| CommunitySpotlightCog.build_help_menu_view | help | disbot/cogs/community_spotlight_cog.py:278 | | | |
+| xp_service.EVT_LEVEL_UP subscription | listener | disbot/cogs/community_spotlight_cog.py:252 (bus.on, cog_load) | | | |
+| _on_level_up handler | listener | disbot/cogs/community_spotlight_cog.py:260 | | | |
+| _cache_trim_loop | scheduled loop | disbot/cogs/community_spotlight_cog.py:271 (@tasks.loop(hours=1)) | | | |
+
+**Unit kinds present:** command, panel/view, help, listener, scheduled loop
+**Structural-pattern flags:** listener (bus.on subscription to xp_service.EVT_LEVEL_UP in cog_load, plus bus.off in cog_unload) and a scheduled loop (@tasks.loop(hours=1) cache-trim). No stateful game loop, no wait_for wizard, no voice. No dedicated DB table/store or settings-registry key owned by this subsystem — community_cog is a router-only hub with no business logic; community_spotlight_cog reads XP/economy data via existing providers (xp_service, rank_providers, db.get_guild_xp_totals) rather than owning its own store.
+
+---
+
+### community_spotlight
+_cogs: disbot/cogs/community_spotlight_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !spotlight (alias !activity) | command | disbot/cogs/community_spotlight_cog.py:304 | | | |
+| SpotlightView | panel/view | disbot/cogs/community_spotlight_cog.py:129 | | | |
+| SpotlightView.xp_leaders button | panel/view | disbot/cogs/community_spotlight_cog.py:141 | | | |
+| SpotlightView.richest button | panel/view | disbot/cogs/community_spotlight_cog.py:151 | | | |
+| SpotlightView.games button | panel/view | disbot/cogs/community_spotlight_cog.py:162 | | | |
+| SpotlightView.refresh button | panel/view | disbot/cogs/community_spotlight_cog.py:179 | | | |
+| GamesView | panel/view | disbot/cogs/community_spotlight_cog.py:191 | | | |
+| GamesView.back button | panel/view | disbot/cogs/community_spotlight_cog.py:199 | | | |
+| _GameSelect | panel/view | disbot/cogs/community_spotlight_cog.py:213 | | | |
+| build_help_menu_view | help/hub entry | disbot/cogs/community_spotlight_cog.py:278 | | | |
+| community_spotlight.dashboard.view | capability/setting | disbot/utils/subsystem_registry.py:641 | | | |
+| xp.level_up listener (bus.on) | listener | disbot/cogs/community_spotlight_cog.py:252 | | | |
+| _on_level_up handler | listener | disbot/cogs/community_spotlight_cog.py:260 | | | |
+| _cache_trim_loop (@tasks.loop hours=1) | scheduled loop | disbot/cogs/community_spotlight_cog.py:271 | | | |
+| cog_load (bus.on + loop.start) | listener/loop setup | disbot/cogs/community_spotlight_cog.py:251 | | | |
+| cog_unload (bus.off + loop.cancel) | listener/loop teardown | disbot/cogs/community_spotlight_cog.py:256 | | | |
+
+**Unit kinds present:** command, panel/view (buttons + select), help/hub entry, setting/capability, listener (EventBus), scheduled loop.
+**Structural-pattern flags:** EventBus listener (`bus.on(xp_service.EVT_LEVEL_UP, ...)`), scheduled loop (`@tasks.loop(hours=1)` cache trim); no `@bot.event`, no `wait_for` wizard, no voice, no direct DB writes/owned tables (reads only via `db.get_guild_xp_totals` and rank providers) — no store unit found.
+
+---
+
+### karma
+_cogs: disbot/cogs/karma_cog.py, disbot/cogs/karma/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !thanks (aliases !rep, !thank) | command | disbot/cogs/karma_cog.py:209 | | | |
+| !karma [member] | command | disbot/cogs/karma_cog.py:224 | | | |
+| !karma add @user [reason] | command | disbot/cogs/karma_cog.py:235 | | | |
+| /karma [member] | command (slash) | disbot/cogs/karma_cog.py:248 | | | |
+| build_help_menu_view (Community-hub karma card hook) | panel/hub-hook | disbot/cogs/karma_cog.py:74 | | | |
+| HubView (karma card view) | panel/view | disbot/cogs/karma_cog.py:91 (constructed; class in views/base.py) | | | |
+| on_raw_reaction_add (react-to-thank) | listener | disbot/cogs/karma_cog.py:95-96 | | | |
+| karma.enabled | setting | disbot/cogs/karma/schemas.py:76 | | | |
+| karma.cooldown_seconds | setting | disbot/cogs/karma/schemas.py:87 | | | |
+| karma.daily_cap | setting | disbot/cogs/karma/schemas.py:101 | | | |
+| karma.reaction_emoji | setting | disbot/cogs/karma/schemas.py:112 | | | |
+| karma.granted (EVT_KARMA_GRANTED) | event | disbot/services/karma_service.py:38,178 | | | |
+| karma / karma_audit_log tables | store | disbot/migrations/093_karma.sql:15,32; disbot/utils/db/karma.py:30-207 | | | |
+| help entry | help | ⚠ unverified — no `karma` entry found in disbot/services/help_catalogue.py; discovered via SUBSYSTEMS entry_points/capabilities in disbot/utils/subsystem_registry.py:416-437 | | | |
+
+**Unit kinds present:** command, panel/hub-hook, view, setting, listener, event, store, (help entry unverified/absent)
+**Structural-pattern flags:** gateway listener (`@commands.Cog.listener()` on `on_raw_reaction_add`, react-to-thank) — no stateful game loop, no wait_for wizard, no scheduled loop, no voice.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-D-knowledge-platform.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-D-knowledge-platform.md
@@ -1,0 +1,529 @@
+# Lane D — Knowledge, AI & Platform (Axis 1)
+
+> **Status:** `reference` — this lane's workspace. The surface-unit inventories below are **pre-extracted** (facts only, tier columns blank). The Lane D agent **verifies + completes them against source**, fills BOTH tier columns, writes each subsystem's §2 manifest sketch, dispositions tier-3s, and adds reconsider/optimize recommendations — per [`../BRIEF.md`](../BRIEF.md). Treat the inventory as a starting scaffold, not ground truth.
+
+**Subsystems:** ai, btd6, project_moon, help, settings, logging, diagnostic, ux_lab, utility, general, proof_channel
+
+**Method:** [`../BRIEF.md`](../BRIEF.md) · [`../PARTITION.md`](../PARTITION.md) · `tools/grammar_spike/` · `../ground-truth/command-surface.json`.
+
+---
+
+### ai
+_cogs: disbot/cogs/ai_cog.py, disbot/cogs/ai_review_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !ai | command (group) | cogs/ai_cog.py:365 | | | |
+| !ai status | command | cogs/ai_cog.py:371 | | | |
+| !ai readiness | command | cogs/ai_cog.py:379 | | | |
+| !ai settings | command | cogs/ai_cog.py:409 | | | |
+| !ai why-no-response | command | cogs/ai_cog.py:417 | | | |
+| !ai policy | command | cogs/ai_cog.py:460 | | | |
+| !ai diagnostics | command | cogs/ai_cog.py:498 | | | |
+| !ai providers | command | cogs/ai_cog.py:503 | | | |
+| !ai routing | command | cogs/ai_cog.py:508 | | | |
+| !ai forget | command | cogs/ai_cog.py:523 | | | |
+| !ai support-report | command | cogs/ai_cog.py:551 | | | |
+| !aimenu | command (prefix) | cogs/ai_cog.py:519 | | | |
+| /ai status | command (slash) | cogs/ai_cog.py:581 | | | |
+| /ai readiness | command (slash) | cogs/ai_cog.py:589 | | | |
+| /ai diagnostics | command (slash) | cogs/ai_cog.py:623 | | | |
+| /ai providers | command (slash) | cogs/ai_cog.py:634 | | | |
+| /ai routing | command (slash) | cogs/ai_cog.py:645 | | | |
+| /ai forget | command (slash) | cogs/ai_cog.py:660 | | | |
+| /ai support-report | command (slash) | cogs/ai_cog.py:689 | | | |
+| /ai policy | command (slash) | cogs/ai_cog.py:713 | | | |
+| /ai settings | command (slash) | cogs/ai_cog.py:755 | | | |
+| /aimenu | command (slash) | cogs/ai_cog.py:777 | | | |
+| !aireview | command (group) | cogs/ai_review_cog.py:172 | | | |
+| !aireview channel | command | cogs/ai_review_cog.py:200 | | | |
+| !aireview off | command | cogs/ai_review_cog.py:223 | | | |
+| !aireview list | command | cogs/ai_review_cog.py:237 | | | |
+| !aireview export | command | cogs/ai_review_cog.py:275 | | | |
+| !aireview resolve | command | cogs/ai_review_cog.py:332 | | | |
+| !aireview preset | command (group) | cogs/ai_review_cog.py:351 | | | |
+| !aireview preset add | command | cogs/ai_review_cog.py:365 | | | |
+| !aireview preset from | command | cogs/ai_review_cog.py:381 | | | |
+| !aireview preset list | command | cogs/ai_review_cog.py:444 | | | |
+| !aireview preset remove | command | cogs/ai_review_cog.py:480 | | | |
+| AI settings panel view | panel/view | cogs/ai_cog.py:151-154 | | | `_build_ai_settings_panel` returns embed+View (⚠ view class unverified, not read in full) |
+| AI help menu embed/view | panel/view | cogs/ai_cog.py:788-791 | | | `build_help_menu_view` returns embed+View for aimenu |
+| on_raw_reaction_add (ai review) | listener | cogs/ai_review_cog.py:119 | | | reaction-based review triage listener |
+| bus.on EVT_AI_REVIEW_LOGGED | listener (EventBus) | cogs/ai_review_cog.py:109 | | | subscribes `_review_sub` in cog_load, unsubscribed line 112 |
+| _on_review_logged | listener (internal handler) | cogs/ai_review_cog.py:151 | | | handles the EVT_AI_REVIEW_LOGGED payload |
+| ai_policy_mutation bus.emit | event | services/ai_policy_mutation.py:382 | | | emits policy-change event with guild_id/mutation_id |
+| ai_policy_mutation bus.emit (2) | event | services/ai_policy_mutation.py:544 | | | second emit site in same service |
+| ai_review_log_service bus.emit | event | services/ai_review_log_service.py:297 | | | emits review-logged event consumed by ai_review_cog |
+| setting: AI_ENABLED | setting | utils/settings_keys/ai.py:10 | | | `ai_enabled` guild toggle |
+| setting: AI_NATURAL_LANGUAGE_ENABLED | setting | utils/settings_keys/ai.py:11 | | | `ai_natural_language_enabled` toggle |
+| setting: AI_DEFAULT_PROVIDER | setting | utils/settings_keys/ai.py:12 | | | `ai_default_provider` key |
+| setting: AI_DEFAULT_MODEL | setting | utils/settings_keys/ai.py:13 | | | `ai_default_model` key |
+| setting: AI_MINIMUM_LEVEL_DEFAULT | setting | utils/settings_keys/ai.py:14 | | | `ai_minimum_level_default` key |
+| setting: AI_COOLDOWN_SECONDS | setting | utils/settings_keys/ai.py:15 | | | `ai_cooldown_seconds` key |
+| setting: AI_FRESH_USER_MENTION_ALLOWANCE | setting | utils/settings_keys/ai.py:16 | | | `ai_fresh_user_mention_allowance` key |
+| setting: AI_GUILD_INSTRUCTION_PROFILE | setting | utils/settings_keys/ai.py:17 | | | `ai_guild_instruction_profile` key |
+| setting: AI_MEMORY_WINDOW_MINUTES | setting | utils/settings_keys/ai.py:24 | | | `ai_memory_window_minutes` key |
+| setting: AI_MEMORY_CHANNEL_SCAN_ENABLED | setting | utils/settings_keys/ai.py:30 | | | `ai_memory_channel_scan_enabled` key |
+| setting: AI_REVIEW_CHANNEL | setting | utils/settings_keys/ai.py:35 | | | `ai_review_channel` key |
+| store: ai_review_log | store | utils/db/ai_review.py:1 | | | table for logged AI answers, migration 100 |
+| store: ai_answer_presets | store | utils/db/ai_presets.py:26 | | | table for guild-curated preset answers |
+| SUBSYSTEMS["ai"] registry entry | registry/entry_points | utils/subsystem_registry.py:1122 | | | entry_points `ai`, `aimenu`; capabilities `ai.platform.view`, `ai.diagnostics.view`, `ai.provider.view`, `ai.routing.view`, plus M1 settings-UI capability (list truncated at read, ⚠ unverified full capability list) |
+| help catalogue entry | help | services/help_catalogue.py | | | ⚠ unverified — no direct "ai"/ai_cog reference found via grep; may be covered generically |
+
+**Unit kinds present:** command, panel, setting, listener, event, store, registry/entry_points, help (unverified)
+**Structural-pattern flags:** gateway (@commands.Cog.listener `on_raw_reaction_add`) listener + EventBus `bus.on`/`bus.emit` pub-sub (EVT_AI_REVIEW_LOGGED, ai_policy_mutation events); none of stateful game loop / wait_for wizard / scheduled loop / voice observed in these two cog files.
+
+
+---
+
+### btd6
+_cogs: disbot/cogs/btd6_cog.py, disbot/cogs/btd6_events_cog.py, disbot/cogs/btd6_ops_cog.py, disbot/cogs/btd6_reference_cog.py, disbot/cogs/btd6_strategy_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !btd6menu | command | disbot/cogs/btd6_cog.py:171 | | | |
+| /btd6menu | command | disbot/cogs/btd6_cog.py:182 | | | |
+| !btd6events (group) | command | disbot/cogs/btd6_events_cog.py:38 | | | |
+| !btd6events live | command | disbot/cogs/btd6_events_cog.py:48 | | | |
+| !btd6events event | command | disbot/cogs/btd6_events_cog.py:58 | | | |
+| !btd6events leaderboard | command | disbot/cogs/btd6_events_cog.py:72 | | | |
+| !btd6events sources | command | disbot/cogs/btd6_events_cog.py:85 | | | |
+| !btd6events source-health | command | disbot/cogs/btd6_events_cog.py:90 | | | |
+| !btd6events latest-data | command | disbot/cogs/btd6_events_cog.py:99 | | | |
+| !btd6events refresh-source | command | disbot/cogs/btd6_events_cog.py:104 | | | |
+| !btd6events grounding | command | disbot/cogs/btd6_events_cog.py:123 | | | |
+| !btd6ops (group) | command | disbot/cogs/btd6_ops_cog.py:41 | | | |
+| !btd6ops readiness | command | disbot/cogs/btd6_ops_cog.py:52 | | | |
+| !btd6ops runs | command | disbot/cogs/btd6_ops_cog.py:59 | | | |
+| !btd6ops source_enable | command | disbot/cogs/btd6_ops_cog.py:71 | | | |
+| !btd6ops source_disable | command | disbot/cogs/btd6_ops_cog.py:84 | | | |
+| !btd6ops seed-data | command | disbot/cogs/btd6_ops_cog.py:97 | | | |
+| !btd6ops announcechannel | command | disbot/cogs/btd6_ops_cog.py:105 | | | |
+| !btd6ref (group) | command | disbot/cogs/btd6_reference_cog.py:37 | | | |
+| !btd6ref tower | command | disbot/cogs/btd6_reference_cog.py:47 | | | |
+| !btd6ref hero | command | disbot/cogs/btd6_reference_cog.py:51 | | | |
+| !btd6ref round | command | disbot/cogs/btd6_reference_cog.py:55 | | | |
+| !btd6ref income | command | disbot/cogs/btd6_reference_cog.py:65 | | | |
+| !btd6ref rbe | command | disbot/cogs/btd6_reference_cog.py:75 | | | |
+| !btd6ref relic | command | disbot/cogs/btd6_reference_cog.py:85 | | | |
+| !btd6ref ct | command | disbot/cogs/btd6_reference_cog.py:90 | | | |
+| !btd6strat (group) | command | disbot/cogs/btd6_strategy_cog.py:39 | | | |
+| !btd6strat browse | command | disbot/cogs/btd6_strategy_cog.py:49 | | | |
+| !btd6strat mine | command | disbot/cogs/btd6_strategy_cog.py:58 | | | |
+| !btd6strat strategy | command | disbot/cogs/btd6_strategy_cog.py:73 | | | |
+| !btd6strat strategy-audit | command | disbot/cogs/btd6_strategy_cog.py:90 | | | |
+| !btd6strat submit | command | disbot/cogs/btd6_strategy_cog.py:99 | | | |
+| !btd6strat pending | command | disbot/cogs/btd6_strategy_cog.py:111 | | | |
+| !btd6strat strategies | command | disbot/cogs/btd6_strategy_cog.py:135 | | | |
+| !btd6strat why-no-response | command | disbot/cogs/btd6_strategy_cog.py:144 | | | |
+| BTD6PanelView | panel/view | disbot/views/btd6/panel.py:159 | | | |
+| BTD6AdminView | panel/view | disbot/views/btd6/admin_panel.py:86 | | | |
+| BTD6CategoryView | panel/view | disbot/views/btd6/hub_panels.py:291 | | | |
+| CTGroupConfirmView | panel/view | disbot/views/btd6/ct_group_flow.py:109 | | | |
+| CTGroupEntryView | panel/view | disbot/views/btd6/ct_group_flow.py:218 | | | |
+| HeroBrowserView / HeroDetailView | panel/view | disbot/views/btd6/hero_browser_view.py:196,213 | | | |
+| HeroStatsView | panel/view | disbot/views/btd6/hero_stats_view.py:55 | | | |
+| LeaderboardBrowserView/KindListView/DetailView | panel/view | disbot/views/btd6/leaderboard_browser_view.py:200,208,226 | | | |
+| LiveOverviewView/LiveEventsBrowserView/EventDetailView | panel/view | disbot/views/btd6/live_events_view.py:327,448,486 | | | |
+| ParagonStatsView | panel/view | disbot/views/btd6/paragon_stats_view.py:145 | | | |
+| ParagonCalculatorView/ParagonRequirementsView | panel/view | disbot/views/btd6/paragon_view.py:493,594 | | | |
+| StrategyReviewView | panel/view | disbot/views/btd6/strategy_review.py:133 (extends discord.ui.View directly, ⚠ unverified why) | | | |
+| TowerBrowserView/TowerDetailView | panel/view | disbot/views/btd6/tower_browser_view.py:264,305 | | | |
+| TowerEventsView | panel/view | disbot/views/btd6/tower_events_view.py:43 | | | |
+| TowerStatsView | panel/view | disbot/views/btd6/tower_stats_view.py:98 | | | |
+| BTD6_STRATEGY_SUBMISSION_CHANNEL | setting | disbot/utils/settings_keys/btd6.py:31 | | | |
+| BTD6_CT_GROUP_ID | setting | disbot/utils/settings_keys/btd6.py:33 | | | |
+| BTD6_VERSION_ANNOUNCEMENT_CHANNEL | setting | disbot/utils/settings_keys/btd6.py:35 | | | |
+| btd6 SUBSYSTEMS capabilities (query.ask, strategy.view, diagnostics.view, settings.configure) | setting | disbot/utils/subsystem_registry.py:801-805 | | | |
+| BTD6EventsCog / BTD6OpsCog / BTD6ReferenceCog / BTD6StrategyCog / BTD6Cog classes | listener (Cog registration) | disbot/cogs/btd6_cog.py:64; btd6_events_cog.py:26; btd6_ops_cog.py:31; btd6_reference_cog.py:24; btd6_strategy_cog.py:27 | | | |
+| BTD6Cog.cog_load auto-seed check | listener/lifecycle | disbot/cogs/btd6_cog.py:70,112,115 | | | |
+| btd6.version_detected subscriber (_on_version_detected) | listener | disbot/services/btd6_version_announce.py:111 | | | |
+| btd6.version_detected emit | event | disbot/services/btd6_patch_service.py:150-151 | | | |
+| btd6_data.py table(s) — game data blobs store | store | disbot/utils/db/btd6_data.py:1 (⚠ unverified exact CREATE TABLE — no CREATE TABLE found in file, likely migration-owned) | | | |
+| btd6_sources.py table(s) — source registry/health store | store | disbot/utils/db/btd6_sources.py:1 (⚠ unverified) | | | |
+| btd6_strategies.py table(s) — strategy submissions store | store | disbot/utils/db/btd6_strategies.py:1 (⚠ unverified) | | | |
+| help entries for btd6 commands | help | docs/help-command-surface-map.md (⚠ unverified line-level; grep hit, not confirmed per-command) | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, store, help
+
+**Structural-pattern flags:** gateway/EventBus listener (`bus.on(EVT_BTD6_VERSION_DETECTED, ...)` in disbot/services/btd6_version_announce.py:111) driving a version-announcement event chain; cog_load-time auto-seed lifecycle check (disbot/cogs/btd6_cog.py:70-115) rather than a scheduled `@tasks.loop`; heavy multi-step browser/hub panel views (Hero/Tower/Leaderboard/Live-events/Paragon browsers) implying wizard-like paginated navigation, though no explicit `wait_for` was found in the grepped cogs. No `@bot.event` or `@tasks.loop` found directly in the btd6 cog files (⚠ unverified exhaustive — only cogs/services named `btd6*` were grepped, not the full `disbot/cogs/btd6/` package internals).
+
+---
+
+### project_moon
+_cogs: disbot/cogs/project_moon_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !pm | command (group) | disbot/cogs/project_moon_cog.py:74 | | | |
+| /pm | command (slash) | disbot/cogs/project_moon_cog.py:175 | | | |
+| !pm lookup (aliases: search, what) | command (subcommand) | disbot/cogs/project_moon_cog.py:84 | | | |
+| !pm list | command (subcommand) | disbot/cogs/project_moon_cog.py:100 | | | |
+| !pm origins (aliases: origin, literary) | command (subcommand) | disbot/cogs/project_moon_cog.py:139 | | | |
+| !pm sinner (aliases: sinners) | command (subcommand) | disbot/cogs/project_moon_cog.py:144 | | | |
+| !pm sin (aliases: sins, affinity) | command (subcommand) | disbot/cogs/project_moon_cog.py:149 | | | |
+| !pm status (aliases: statuses, keyword) | command (subcommand) | disbot/cogs/project_moon_cog.py:154 | | | |
+| !pm ego (aliases: grade) | command (subcommand) | disbot/cogs/project_moon_cog.py:159 | | | |
+| !pm damage (aliases: damagetype) | command (subcommand) | disbot/cogs/project_moon_cog.py:164 | | | |
+| !pm mechanic (aliases: mechanics, combat) | command (subcommand) | disbot/cogs/project_moon_cog.py:169 | | | |
+| LimbusBrowseView | panel/view | disbot/views/projmoon/browse.py:185 | | | |
+| _KindButton | panel/view (component) | disbot/views/projmoon/browse.py:140 | | | |
+| _OverviewButton | panel/view (component) | disbot/views/projmoon/browse.py:155 | | | |
+| _OriginsButton | panel/view (component) | disbot/views/projmoon/browse.py:170 | | | |
+| build_help_menu_view | help hook (help-menu direct-nav) | disbot/cogs/project_moon_cog.py:191 | | | |
+| project_moon.lookup.view (entry_points/help metadata) | setting/registry entry | disbot/utils/subsystem_registry.py:808 | | | |
+
+**Unit kinds present:** command, panel/view, help hook, setting/registry entry.
+
+**Structural-pattern flags:** none obvious — read-only, deterministic reference cog; no @bot.event / bus.on listener, no bus.emit / emit_audit_action event, no DB store (grep of utils/db + migrations found no project_moon-owned table — "No writes, no DB, no AI gateway" per module docstring, disbot/cogs/project_moon_cog.py:16), no scheduled loop, no voice, no wait_for wizard, no settings_keys constant (subsystem_registry entries above are metadata/entry-points, not a db.get_setting key — ⚠ unverified whether any settings_keys constant exists elsewhere for this subsystem, grep found none).
+
+---
+
+### help
+_cogs: disbot/cogs/help_cog.py, disbot/cogs/help/panels.py, disbot/cogs/help/route.py (support modules, not a Cog subclass)_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !help | command | disbot/cogs/help_cog.py:284 | | | |
+| /help | command | disbot/cogs/help_cog.py:370 | | | |
+| HelpCategoryView | panel/view | disbot/cogs/help/panels.py:38 | | | |
+| HelpCategoryView._on_select | listener (component callback) | disbot/cogs/help/panels.py:94 | | | |
+| HelpEntityEditorView | panel/view | disbot/views/help/editor.py:285 | | | |
+| EntityPickerView | panel/view | disbot/views/help/editor.py:435 | | | |
+| _ResetAllConfirmView | panel/view | disbot/views/help/editor.py:526 | | | |
+| HelpEditorHomeView | panel/view | disbot/views/help/editor.py:567 | | | |
+| HomeMessageBuilderView | panel/view | disbot/views/help/home_builder.py:158 | | | |
+| HelpEntityEditorView Hide/Rename/Reset buttons | panel control | disbot/views/help/editor.py:309-373 | | | |
+| HelpEditorHomeView Hubs/Subsystems/Reset-all buttons | panel control | disbot/views/help/editor.py:570-614 | | | |
+| HomeMessageBuilderView Edit/Preview/Save/Reset buttons | panel control | disbot/views/help/home_builder.py:217-337 | | | |
+| help.menu.view | setting/capability | disbot/utils/subsystem_registry.py:1071 | | | |
+| help.settings.configure | setting/capability | disbot/utils/subsystem_registry.py:1072 | | | |
+| set_overlay_fields | mutation (hide/rename/redescribe entity) | disbot/services/help_overlay_mutation.py:150 | | | |
+| set_home_message | mutation (Help-Home title/body/color) | disbot/services/help_overlay_mutation.py:238 | | | |
+| reset_guild_overlay | mutation (reset all overlay rows) | disbot/services/help_overlay_mutation.py:326 | | | |
+| audit.action_recorded (help overlay writes) | event | disbot/services/help_overlay_mutation.py:363 (via services/audit_events.emit_audit_action) | | | |
+| help_overlay table | store | disbot/migrations/064_help_overlay.sql:26 (widened 067_help_overlay_home_message.sql) | | | |
+| get_guild_help_overlay | store accessor / cache | disbot/services/help_overlay.py:148 | | | |
+| build_help_catalogue | help catalogue builder | disbot/services/help_catalogue.py:116 | | | |
+| build_single_command_embed / build_not_found_embed | help entry rendering | disbot/cogs/help/route.py:166,192 | | | |
+
+**Unit kinds present:** command, panel/view, panel control (button), setting/capability, mutation, event, store, help-catalogue/rendering helper
+
+**Structural-pattern flags:** none obvious (no @bot.event/bus.on listener, no wait_for wizard, no scheduled loop, no voice); Help editor views are persistent-view button/select panels reached from the Server Management hub, not a gateway listener.
+
+
+---
+
+### settings
+_cogs: disbot/cogs/settings_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !settings | command (prefix group) | disbot/cogs/settings_cog.py:121 | | | |
+| !settings access | command (subcommand) | disbot/cogs/settings_cog.py:161 | | | |
+| /settings | command (slash) | disbot/cogs/settings_cog.py:194 | | | |
+| build_help_menu_view | help/nav hook | disbot/cogs/settings_cog.py:174 | | | |
+| SettingsHubView | panel/view (hub) | disbot/views/settings/hub.py:330 | | | |
+| _SubsystemSelect | panel/view (component) | disbot/views/settings/hub.py:138 | | | |
+| _GroupPageButton | panel/view (component) | disbot/views/settings/hub.py:191 | | | |
+| _OpenNeedsSetup | panel/view (component) | disbot/views/settings/hub.py:219 | | | |
+| _OpenInvalid | panel/view (component) | disbot/views/settings/hub.py:237 | | | |
+| _OpenMissingBindings | panel/view (component) | disbot/views/settings/hub.py:258 | | | |
+| _OpenAudit | panel/view (component) | disbot/views/settings/hub.py:279 | | | |
+| _OpenCommandAccess | panel/view (component) | disbot/views/settings/hub.py:300 | | | |
+| SubsystemSettingsView | panel/view (drill-down) | disbot/views/settings/subsystem_view.py:609 | | | |
+| RecentChangesView | panel/view (audit) | disbot/views/settings/audit_view.py:130 | | | |
+| InvalidSettingsView | panel/view | disbot/views/settings/invalid_settings.py:111 | | | |
+| MissingBindingsView | panel/view | disbot/views/settings/missing_bindings.py:103 | | | |
+| NeedsSetupView | panel/view | disbot/views/settings/needs_setup.py:131 | | | |
+| CommandAccessView | panel/view | disbot/views/settings/edit_command_access.py:492 | | | |
+| ChannelSettingSelectView | panel/view (discord.ui.View direct) | disbot/views/settings/edit_channel.py:157 | | | |
+| RoleSettingSelectView | panel/view (discord.ui.View direct) | disbot/views/settings/edit_role.py:155 | | | |
+| NumericPresetsView | panel/view (discord.ui.View direct) | disbot/views/settings/edit_number_presets.py:161 | | | |
+| NumberSettingModal | panel/view (modal) | disbot/views/settings/edit_number.py:21 | | | |
+| TextSettingModal | panel/view (modal) | disbot/views/settings/edit_text.py:19 | | | |
+| _DisabledHelpHookView | panel/view (fallback) | disbot/cogs/settings_cog.py:216 | | | |
+| settings.manager.view | setting/capability | disbot/utils/subsystem_registry.py (SUBSYSTEMS["settings"]["capabilities"]) | | | |
+| settings.manager_cog.enabled | setting (feature flag) | disbot/cogs/settings_cog.py:41 (`_FLAG_NAME`) | | | |
+| guild_settings | store (table, KV settings) | disbot/utils/db/settings.py:1; CREATE TABLE disbot/utils/db/migrations.py:272 | | | |
+| get_setting / set_setting | store (accessor) | disbot/utils/db/settings.py:21,29 | | | |
+| set_value_with_audit | store (accessor, audited write) | disbot/utils/db/settings_audit.py:33 | | | |
+| list_recent_for_guild / list_recent_for_key | store (accessor, audit history) | disbot/utils/db/settings_audit.py:133,155 | | | |
+| settings.changed (EVT_SETTINGS_CHANGED) | event (bus.emit) | disbot/services/settings_mutation.py:614 | | | |
+| emit_audit_action (settings mutation) | event (audit) | disbot/services/settings_mutation.py:385 | | | |
+
+**Unit kinds present:** command, panel/view, setting, store, event, help
+**Structural-pattern flags:** wait_for wizard-style modal flows (NumberSettingModal, TextSettingModal use discord.ui.Modal submit, not raw wait_for); no @bot.event/bus.on listener owned by this subsystem (it only emits `settings.changed`, does not subscribe); no scheduled loop; no voice; no stateful game loop. Otherwise: none obvious.
+
+---
+
+### logging
+_cogs: disbot/cogs/logging_cog.py, disbot/cogs/logging/panel.py, disbot/cogs/logging/select_view.py, disbot/cogs/logging/provision_view.py, disbot/cogs/logging/routes_panel.py, disbot/cogs/logging/schemas.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !logging | command (group) | disbot/cogs/logging_cog.py:313 | | | |
+| !logging status | command | disbot/cogs/logging_cog.py:329 | | | |
+| !logging set <kind> | command | disbot/cogs/logging_cog.py:335 | | | |
+| !logging create <kind> | command | disbot/cogs/logging_cog.py:372 | | | |
+| !logging routes | command | disbot/cogs/logging_cog.py:401 | | | |
+| !logging test | command | disbot/cogs/logging_cog.py:421 | | | |
+| on_message_delete | listener | disbot/cogs/logging_cog.py:170 | | | |
+| on_message_edit | listener | disbot/cogs/logging_cog.py:179 | | | |
+| on_member_join | listener | disbot/cogs/logging_cog.py:199 | | | |
+| on_member_remove | listener | disbot/cogs/logging_cog.py:212 | | | |
+| on_member_update | listener | disbot/cogs/logging_cog.py:221 | | | |
+| on_audit_log_entry_create | listener | disbot/cogs/logging_cog.py:257 | | | |
+| on_voice_state_update | listener | disbot/cogs/logging_cog.py:267 | | | |
+| on_raw_message_delete | listener | disbot/cogs/logging_cog.py:285 | | | |
+| _on_moderation_action (EVT_MOD_ACTION → private log) | event listener (bus.on) | disbot/services/server_logging.py:1854 | | | |
+| _on_moderation_action_public (EVT_MOD_ACTION → public log) | event listener (bus.on) | disbot/services/server_logging.py:1855 | | | |
+| _on_audit_action (EVT_AUDIT_ACTION_RECORDED) | event listener (bus.on) | disbot/services/server_logging.py:1856 | | | |
+| LoggingPanelView | panel/view | disbot/cogs/logging/panel.py:49 | | | |
+| LogChannelSelectView | panel/view | disbot/cogs/logging/select_view.py:129 | | | |
+| LogChannelProvisionView | panel/view | disbot/cogs/logging/provision_view.py:181 | | | |
+| LoggingRoutesView | panel/view | disbot/cogs/logging/routes_panel.py:223 | | | |
+| _RouteSelect | panel/view (sub-component) | disbot/cogs/logging/routes_panel.py:188 | | | |
+| _LogChannelSelect | panel/view (sub-component) | disbot/cogs/logging/select_view.py:90 | | | |
+| _ClearBindingButton | panel/view (sub-component) | disbot/cogs/logging/select_view.py:114 | | | |
+| _ConfirmCreateButton | panel/view (sub-component) | disbot/cogs/logging/provision_view.py:144 | | | |
+| _CancelButton | panel/view (sub-component) | disbot/cogs/logging/provision_view.py:160 | | | |
+| LOGGING_ENABLED | setting | disbot/utils/settings_keys/logging.py:10 | | | |
+| LOGGING_MOD_CHANNEL | setting | disbot/utils/settings_keys/logging.py:13 | | | |
+| LOGGING_CLEANUP_CHANNEL | setting | disbot/utils/settings_keys/logging.py:17 | | | |
+| LOGGING_AUTO_CREATE_CHANNELS | setting | disbot/utils/settings_keys/logging.py:22 | | | |
+| LOGGING_MESSAGES_ENABLED | setting | disbot/utils/settings_keys/logging.py:43 | | | |
+| LOGGING_MEMBERS_ENABLED | setting | disbot/utils/settings_keys/logging.py:44 | | | |
+| LOGGING_ROLES_ENABLED | setting | disbot/utils/settings_keys/logging.py:45 | | | |
+| LOGGING_MODERATION_ENABLED | setting | disbot/utils/settings_keys/logging.py:73 | | | |
+| LOGGING_CHANNELS_ENABLED | setting | disbot/utils/settings_keys/logging.py:74 | | | |
+| LOGGING_SERVER_ENABLED | setting | disbot/utils/settings_keys/logging.py:75 | | | |
+| LOGGING_VOICE_ENABLED | setting | disbot/utils/settings_keys/logging.py:76 | | | |
+| LOGGING_EVENT_ROUTING | setting | disbot/utils/settings_keys/logging.py:83 | | | |
+| LOGGING_IGNORED_CHANNELS | setting | disbot/utils/settings_keys/logging.py:91 | | | |
+| LOGGING_IGNORED_USERS | setting | disbot/utils/settings_keys/logging.py:92 | | | |
+| capability logging.settings.configure | setting (capability) | disbot/utils/subsystem_registry.py:1205 | | | |
+| capability logging.channel.bind | setting (capability) | disbot/utils/subsystem_registry.py:1206 | | | |
+| capability logging.channel.create | setting (capability) | disbot/utils/subsystem_registry.py:1207 | | | |
+| guild key-value settings store (no dedicated logging table found) | store | disbot/utils/db/ ⚠ unverified — no `log_bindings`/`log_channel` table located | | | |
+| help entry for `logging` subsystem | help | disbot/services/help_catalogue.py ⚠ unverified — no explicit "logging" string match found in help_catalogue.py | | | |
+
+**Unit kinds present:** command, listener, event listener (bus.on), panel/view, setting (incl. capability), store, help
+
+**Structural-pattern flags:** gateway (`@commands.Cog.listener()` on 8 Discord events: message delete/edit, member join/remove/update, audit-log-entry, voice-state, raw-message-delete) + EventBus `bus.on(...)` listener (3 subscriptions in server_logging.py) + select/confirm wizard-style views (LogChannelSelectView, LogChannelProvisionView). No stateful game loop, no scheduled loop, no voice-channel-audio usage (voice unit here is only voice-state-change logging, not audio).
+
+
+---
+
+### diagnostic
+_cogs: disbot/cogs/diagnostic_cog.py, disbot/cogs/diagnostic/platform_group.py (+ _platform_embeds.py, _log_buffer.py, _backfill.py, _helpers.py)_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !diagnostics / diag | command (prefix) | disbot/cogs/diagnostic_cog.py:57 | | | |
+| !lifecycle / lc | command (prefix) | disbot/cogs/diagnostic_cog.py:64 | | | |
+| /platform | command (slash) | disbot/cogs/diagnostic_cog.py:116 | | | |
+| !listcmds / list_commands_detailed | command (prefix) | disbot/cogs/diagnostic_cog.py:137 | | | |
+| !findcmd / find_command | command (prefix) | disbot/cogs/diagnostic_cog.py:148 | | | |
+| !validatejson / validate_json_files | command (prefix) | disbot/cogs/diagnostic_cog.py:183 | | | |
+| !checkdb / check_database | command (prefix) | disbot/cogs/diagnostic_cog.py:190 | | | |
+| !diag_status / diagnostic_bot_status | command (prefix) | disbot/cogs/diagnostic_cog.py:201 | | | |
+| !latency | command (prefix) | disbot/cogs/diagnostic_cog.py:208 | | | |
+| !sysinfo / system_info | command (prefix) | disbot/cogs/diagnostic_cog.py:220 | | | |
+| !querylogs / query_logs | command (prefix) | disbot/cogs/diagnostic_cog.py:231 | | | |
+| !errors / recent_errors | command (prefix) | disbot/cogs/diagnostic_cog.py:238 | | | |
+| !testnotify / test_notification | command (prefix) | disbot/cogs/diagnostic_cog.py:245 | | | |
+| !platform (group) | command (group) | disbot/cogs/diagnostic/platform_group.py:110 | | | |
+| platform status | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:131 | | | |
+| platform setup_readiness | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:137 | | | |
+| platform anchors | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:156 | | | |
+| platform identity | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:162 | | | |
+| platform runtime | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:179 | | | |
+| platform health | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:185 | | | |
+| platform startup | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:207 | | | |
+| platform findings | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:234 | | | |
+| platform finding <action> | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:267 | | | |
+| platform lifecycle | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:315 | | | |
+| platform caches | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:321 | | | |
+| platform media | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:327 | | | |
+| platform economy | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:340 | | | |
+| platform economy_trend | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:351 | | | |
+| platform locks | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:363 | | | |
+| platform tasks | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:369 | | | |
+| platform views | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:375 | | | |
+| platform slow | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:381 | | | |
+| platform automation | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:387 | | | |
+| platform sessions | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:402 | | | |
+| platform schemas | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:416 | | | |
+| platform settings_registry | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:422 | | | |
+| platform setting <subsystem> <name> | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:428 | | | |
+| platform customization | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:442 | | | |
+| platform provisioning | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:448 | | | |
+| platform participation_schemas | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:454 | | | |
+| platform resource_requirements | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:460 | | | |
+| platform bindings | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:466 | | | |
+| platform resources | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:472 | | | |
+| platform flags | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:478 | | | |
+| platform flag_manager | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:484 | | | |
+| platform migrations | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:507 | | | |
+| platform consistency | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:513 | | | |
+| platform backfill <action> | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:522 | | | |
+| platform command_access | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:533 | | | |
+| platform access | command (subcommand) | disbot/cogs/diagnostic/platform_group.py:559 | | | |
+| _PaginatorView | panel/view | disbot/views/diagnostic/paginator.py:21 | | | generic paginated embed view, BaseView subclass |
+| _DiagnosticsHubView | panel/view | disbot/views/diagnostic/hub_panel.py:41 | | | diagnostics hub panel, HubView subclass, opened by !diagnostics |
+| FlagManagerView | panel/view | disbot/views/diagnostic/flag_manager.py:304 | | | feature-flag manager panel, HubView subclass |
+| AutomationPanelView | panel/view | disbot/views/diagnostic/automation_panel.py:396 | | | automation status panel, HubView subclass |
+| _PlatformHubView | panel/view | disbot/views/diagnostic/platform_panel.py:332 | | | platform hub panel, HubView subclass opened by !platform |
+| diagnostic.health.view | setting/capability | disbot/utils/subsystem_registry.py:1094 | | | capability entry in SUBSYSTEMS["diagnostic"] |
+| diagnostic.latency.check | setting/capability | disbot/utils/subsystem_registry.py:1095 | | | capability entry in SUBSYSTEMS["diagnostic"] |
+| btd6.diagnostics.view | setting/capability (⚠ unverified subsystem owner) | disbot/utils/subsystem_registry.py:803 | | | referenced under related capability list, unclear which SUBSYSTEMS entry owns it |
+| health_findings store | store | disbot/utils/db/health_findings.py:1 | | | DB accessors for operational health findings table |
+| 057_operational_health_findings | store (migration) | disbot/migrations/057_operational_health_findings.sql:1 | | | creates operational_health_findings table |
+| platform_consistency store (⚠ related, not solely owned) | store | disbot/utils/db/platform_consistency.py:1 | | | consistency-layer DB accessors, adjacent subsystem per folio |
+| send_panel (diagnostics hub) | panel entry point | disbot/cogs/diagnostic_cog.py:60 | | | opens _DiagnosticsHubView via send_panel |
+| send_panel (platform hub) | panel entry point | disbot/cogs/diagnostic/platform_group.py:127 | | | opens _PlatformHubView via send_panel |
+| send_panel (automation panel) | panel entry point | disbot/cogs/diagnostic/platform_group.py:398 | | | opens AutomationPanelView via send_panel |
+| send_panel (flag manager) | panel entry point | disbot/cogs/diagnostic/platform_group.py:499 | | | opens FlagManagerView via send_panel |
+| diagnostic_helpers.build overview embed | help/embed | disbot/services/diagnostic_helpers.py:45 | | | static "Select a diagnostic tool below" overview embed |
+| _log_buffer.recent | log/store helper | disbot/cogs/diagnostic/_log_buffer.py:1 | | | in-memory recent-log buffer used by querylogs/errors |
+
+
+---
+
+### ux_lab
+_cogs: disbot/cogs/ux_lab_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !uxlab (alias !interfacelab) | command | disbot/cogs/ux_lab_cog.py:57 | | | |
+| /uxlab | command | disbot/cogs/ux_lab_cog.py:68 | | | |
+| build_help_menu_view (help/hub direct-nav hook) | help | disbot/cogs/ux_lab_cog.py:42 | | | |
+| cog_load (registers persistent view) | listener | disbot/cogs/ux_lab_cog.py:35 | | | |
+| UxLabHomeView | panel/view | disbot/views/ux_lab/home.py:78 | | | |
+| ExhibitWingView | panel/view | disbot/views/ux_lab/wing.py:38 | | | |
+| ButtonsWingView | panel/view | disbot/views/ux_lab/buttons.py:263 | | | |
+| _TimeoutDemoView | panel/view | disbot/views/ux_lab/buttons.py:252 | | | |
+| _ConfirmDeleteModal | panel/view | disbot/views/ux_lab/buttons.py:228 | | | |
+| CompareView | panel/view | disbot/views/ux_lab/compare.py:143 | | | |
+| _VerdictModal | panel/view | disbot/views/ux_lab/compare.py:102 | | | |
+| EmbedsWingView | panel/view | disbot/views/ux_lab/embeds.py:146 | | | |
+| ImageWingView | panel/view | disbot/views/ux_lab/image_cards.py:195 | | | |
+| _LabLayout (discord.ui.LayoutView) | panel/view | disbot/views/ux_lab/layout_v2.py:108 | | | |
+| LayoutWingView | panel/view | disbot/views/ux_lab/layout_v2.py:143 | | | |
+| MockupsWingView | panel/view | disbot/views/ux_lab/mockups.py:106 | | | |
+| _ThresholdModal | panel/view | disbot/views/ux_lab/mockups.py:473 | | | |
+| _ShortLongModal | panel/view | disbot/views/ux_lab/modals.py:136 | | | |
+| _LabelSelectModal | panel/view | disbot/views/ux_lab/modals.py:157 | | | |
+| _ValidationModal | panel/view | disbot/views/ux_lab/modals.py:191 | | | |
+| _DraftModal | panel/view | disbot/views/ux_lab/modals.py:214 | | | |
+| _ReportFormModal | panel/view | disbot/views/ux_lab/modals.py:232 | | | |
+| _TemplateModal | panel/view | disbot/views/ux_lab/modals.py:254 | | | |
+| ModalsWingView | panel/view | disbot/views/ux_lab/modals.py:279 | | | |
+| UxLabPersistentDemo | panel/view | disbot/views/ux_lab/persistent_demo.py:23 | | | |
+| ProbesBenchView | panel/view | disbot/views/ux_lab/probes.py:104 | | | |
+| _SearchModal | panel/view | disbot/views/ux_lab/selects.py:160 | | | |
+| SelectsWingView | panel/view | disbot/views/ux_lab/selects.py:177 | | | |
+
+**Unit kinds present:** command, panel/view (incl. modals), help, listener (cog_load registration only). No `setting` unit (capabilities list is empty by design — "zero-write workbench"), no `event` (emit_audit_action), no `store` (DB tables) found — confirmed by grep returning no matches, consistent with the code comment "the lab mutates nothing (CI-fenced by tests/unit/invariants/test_ux_lab_zero_write.py)".
+
+**Structural-pattern flags:** persistent view registered at cog_load (UxLabPersistentDemo, PersistentView, added via bot.add_view — a restart-surviving component-listener pattern); several `discord.ui.Modal` wizards (_ConfirmDeleteModal, _VerdictModal, _ThresholdModal, _ShortLongModal, _LabelSelectModal, _ValidationModal, _DraftModal, _ReportFormModal, _TemplateModal, _SearchModal) simulating wait_for-style forms; no @bot.event/bus.on gateway listener, no scheduled loop, no voice. Otherwise none obvious.
+
+---
+
+### utility
+_cogs: disbot/cogs/utility_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !utilitymenu | command | cogs/utility_cog.py:82 | | | |
+| /utility | command | cogs/utility_cog.py:99 | | | |
+| !myprofile | command | cogs/utility_cog.py:116 | | | |
+| /myprofile | command | cogs/utility_cog.py:135 | | | |
+| !clear (alias !purge) | command | cogs/utility_cog.py:162 | | | |
+| !info | command | cogs/utility_cog.py:181 | | | |
+| !serverinfo | command | cogs/utility_cog.py:251 | | | |
+| !userinfo | command | cogs/utility_cog.py:260 | | | |
+| !avatar | command | cogs/utility_cog.py:269 | | | |
+| !remind | command | cogs/utility_cog.py:277 | | | |
+| !invite | command | cogs/utility_cog.py:292 | | | |
+| !poll | command | cogs/utility_cog.py:298 | | | |
+| !ping | command | cogs/utility_cog.py:316 | | | |
+| !botinfo (alias !about) | command | cogs/utility_cog.py:334 | | | |
+| !membercount (alias !members) | command | cogs/utility_cog.py:374 | | | |
+| _UtilityPanelView | panel | cogs/utility_cog.py:472 | | | Main hub panel opened by utilitymenu/utility slash |
+| _UtilityChildButton | panel | cogs/utility_cog.py:461 | | | HubChildButton subclass for child-subsystem nav |
+| attach_back_to_utility_button | panel | cogs/utility_cog.py:416 | | | Adds Back-to-Utility button to child views |
+| _PollModal | panel | cogs/utility_cog.py:643 | | | discord.ui.Modal collecting poll question/options |
+| _RemindModal | panel | cogs/utility_cog.py:684 | | | discord.ui.Modal collecting reminder minutes/message |
+| cog_unload (reminder task cleanup) | listener | cogs/utility_cog.py:72 | | | Cancels in-memory "utility:" tasks on unload |
+
+**Unit kinds present:** command, panel
+**Structural-pattern flags:** wait_for wizard (modal-driven poll/remind flows: _PollModal, _RemindModal); none of stateful game loop / gateway listener / scheduled loop / voice obvious. No settings/db store/event/help-catalogue units found for this subsystem — utility_cog.py has no db.get_setting, bus.emit/emit_audit_action, or bot.event/Cog.listener calls (⚠ unverified beyond grep of utility_cog.py; SUBSYSTEMS["utility"] entry has no settings keys, only capabilities utility.info.server / utility.info.user / utility.tool.ping used for entry_points/menu discovery, not DB-backed settings).
+
+---
+
+### general
+_cogs: disbot/cogs/general_cog.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| !generalmenu (alias !gmenu) | command | cogs/general_cog.py:87 | | | |
+| !fact | command | cogs/general_cog.py:113 | | | |
+| !joke | command | cogs/general_cog.py:125 | | | |
+| !quote | command | cogs/general_cog.py:137 | | | |
+| !trivia | command | cogs/general_cog.py:152 | | | |
+| !motivate | command | cogs/general_cog.py:171 | | | |
+| !eightball (alias !8ball) | command | cogs/general_cog.py:184 | | | |
+| !greet | command | cogs/general_cog.py:191 | | | |
+| _GeneralPanelView | panel/view | cogs/general_cog.py:246 | | | |
+| _GeneralPanelView.fact_btn | panel/view | cogs/general_cog.py:262 | | | |
+| _GeneralPanelView.joke_btn | panel/view | cogs/general_cog.py:276 | | | |
+| _GeneralPanelView.quote_btn | panel/view | cogs/general_cog.py:290 | | | |
+| _GeneralPanelView.trivia_btn | panel/view | cogs/general_cog.py:304 | | | |
+| _GeneralPanelView.motivate_btn | panel/view | cogs/general_cog.py:328 | | | |
+| _GeneralPanelView.eightball_btn (opens _EightBallModal) | panel/view | cogs/general_cog.py:342 | | | |
+| _GeneralPanelView.greet_btn | panel/view | cogs/general_cog.py:350 | | | |
+| _GeneralPanelView.overview_btn | panel/view | cogs/general_cog.py:362 | | | |
+| _TriviaRevealView (reveal_btn) | panel/view | cogs/general_cog.py:222-236 | | | |
+| _EightBallModal | panel/view | cogs/general_cog.py:243 | | | |
+| build_help_menu_view (help-menu entry hook) | help | cogs/general_cog.py:99 | | | |
+| SUBSYSTEMS["general"] capabilities: general.info.view, general.community.interact | setting | utils/subsystem_registry.py:1027-1028 | | | |
+| SUBSYSTEMS["general"] entry_points: ["generalmenu"] | setting | utils/subsystem_registry.py:1017 | | | |
+
+**Unit kinds present:** command, panel/view, help, setting
+
+**Structural-pattern flags:** none obvious — stateless content-serving cog; no @bot.event/bus.on listeners, no DB tables/settings writes, no scheduled loops, no voice, no wait_for wizard. ⚠ unverified: docs/subsystems/general.md does not exist (checked, absent), so folio cross-reference could not be verified beyond subsystem_registry.py and source.
+
+
+---
+
+### proof_channel
+_cogs: disbot/cogs/proof_channel_cog.py, disbot/cogs/proof_channel/schemas.py, disbot/cogs/proof_channel/__init__.py_
+
+| Unit | Kind | File:line | Tier (as-written) | Tier (with amendments) | Rationale / gap |
+|---|---|---|---|---|---|
+| +prize | command | disbot/cogs/proof_channel_cog.py:121 | | | |
+| -prize | command | disbot/cogs/proof_channel_cog.py:138 | | | |
+| prizestatus | command | disbot/cogs/proof_channel_cog.py:152 | | | |
+| prizemenu | command | disbot/cogs/proof_channel_cog.py:169 | | | |
+| timedprize | command | disbot/cogs/proof_channel_cog.py:184 | | | |
+| _PrizeManagerView (prize manager panel) | panel/view | disbot/cogs/proof_channel_cog.py:312 | | | |
+| btn_grant (🏆 Grant Access button) | panel | disbot/cogs/proof_channel_cog.py:339-343 | | | |
+| btn_timed (⏱️ Timed Access button) | panel | disbot/cogs/proof_channel_cog.py:345-353 | | | |
+| btn_end (🔒 End Session button) | panel | disbot/cogs/proof_channel_cog.py:355-371 | | | |
+| btn_refresh (🔄 Refresh Status button) | panel | disbot/cogs/proof_channel_cog.py:373-382 | | | |
+| _PrizeWinnerModal (winner input modal) | panel | disbot/cogs/proof_channel_cog.py:219-254 | | | |
+| _TimedPrizeModal (duration input modal) | panel | disbot/cogs/proof_channel_cog.py:257-309 | | | |
+| build_help_menu_view (help-menu direct-nav hook) | help | disbot/cogs/proof_channel_cog.py:174-180 | | | |
+| proof_channel binding (channel setting) | setting | disbot/cogs/proof_channel/schemas.py:43-51 | | | |
+| proof_channel.settings.configure capability | setting | disbot/utils/subsystem_registry.py:982 | | | |
+| proof_channel.access.grant/revoke/timed capabilities | setting | disbot/utils/subsystem_registry.py:979-981 | | | |
+| proof resource requirement (optional channel) | setting | disbot/cogs/proof_channel/schemas.py:58-70 | | | |
+| cog_load → register_schemas | listener | disbot/cogs/proof_channel_cog.py:25-28 | | | |
+| cog_unload → cancel proof:* tasks | listener | disbot/cogs/proof_channel_cog.py:30-33 | | | |
+| _emit_prize_audit (prize_access_grant/revoke audit) | event | disbot/cogs/proof_channel_cog.py:413-454 | | | |
+| proof:unlock:<guild_id> scheduled auto-unlock task | event | disbot/cogs/proof_channel_cog.py:201-216, 292-305 | | | |
+
+**Unit kinds present:** command, panel, setting, listener, event, help
+**Structural-pattern flags:** wait_for-style modal wizard (`_PrizeWinnerModal`/`_TimedPrizeModal` via `send_modal`); scheduled/timed one-shot task (`tasks.spawn` auto-unlock after duration, not a recurring loop). No `@bot.event`/`bus.on` listener beyond cog_load/cog_unload lifecycle hooks; no dedicated DB table (uses generic bindings/subsystem_schema store, not a domain table); no voice.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-E-plans-ideas.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-E-plans-ideas.md
@@ -1,0 +1,9 @@
+# Lane E — Plans & Ideas (Axis 2)
+
+> **Status:** `reference` — the Lane E agent fills this. Reconsider everything **planned or ideated** for
+> the new bot (`docs/planning/*.md` minus `historical` · `docs/ideas/*.md` · `docs/roadmap.md`): keep /
+> improve / merge / drop / redesign, express the target capability in the §2 grammar, flag double-counts
+> with an Axis-1 subsystem, and deep-reason optimality. Output a forward-capability ledger. Method:
+> [`../BRIEF.md`](../BRIEF.md) · [`../PARTITION.md`](../PARTITION.md). Launch prompt: [`../HANDOFF-PROMPTS.md`](../HANDOFF-PROMPTS.md).
+
+_(empty scaffold — populated by the Lane E session)_

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-G-foundations.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-G-foundations.md
@@ -1,0 +1,10 @@
+# Lane G — Foundations & Runtime Skeleton, L0 (Axis 1)
+
+> **Status:** `reference` — the Lane G agent fills this. The **L0 substrate** under all 43 subsystems and
+> the first layer the new bot builds. Audit + reconsider + optimize + benchmark: lean `main.py` /
+> bootstrap · **dynamic cog auto-discovery + load (no hardcoded initial-extensions)** · env/config ·
+> helper/util architecture (`docs/helper-policy.md`) · kernel/runtime. Reads `disbot/bot1.py`,
+> `disbot/core/`, `disbot/utils/`. Method: [`../BRIEF.md`](../BRIEF.md) · [`../PARTITION.md`](../PARTITION.md).
+> Launch prompt: [`../HANDOFF-PROMPTS.md`](../HANDOFF-PROMPTS.md).
+
+_(empty scaffold — populated by the Lane G session; feeds the build plan's L0 layer)_


### PR DESCRIPTION
## Summary

Owner-directed prep: sets up the repo so an independently-launched fleet (2× Opus 4.8 + 1× Sonnet 5
ultracode + a few Codex / deep-research) produces the **final new-bot capability audit**, then a **Fable 5
capstone** rules it — the discovery/planning step before the new-repo build starts.

The audit's mandate (assembled with the owner this session): every capability intended for the new bot is
**mapped → reconsidered → simulated → optimized → benchmarked** across **three axes** — what we have (43
subsystems), what we planned (plans/ideas), and what the ecosystem has that we don't (known Discord bots)
— converging on **one unified, dependency-ordered, best-in-class build plan** (foundations → core
management → features; each layer production-grade before the next; every function must outperform any
other bot).

## What's in the substrate (`docs/analysis/rebuild-discovery/new-bot-capability-audit/`)

- **`BRIEF.md`** — the binding contract (3-axis mandate, 5 verbs, end-goal, per-capability schema, guardrails, exit bar).
- **`PARTITION.md`** — **7 disjoint lanes**: A–D (43 subsystems) · E (plans/ideas) · F (ecosystem benchmark) · **G (L0 foundations — bootstrap / dynamic cog-loader / lean `main.py` / helper-util architecture)** + model→lane matching.
- **`HANDOFF-PROMPTS.md`** — copy-paste startup prompts for all 7 lanes + the capstone + launch order.
- **`FINAL-REVIEW-HANDOFF.md`** — the Fable 5 capstone spec (verify-then-rule + the unified build plan).
- **`README.md`**, **`ground-truth/`** (271 commands + 43 subsystems dumped), **`lanes/`** (A–D pre-filled with extracted surface inventories via a 43-agent workflow; E/G scaffolds), **`findings/`**.

## Type of change

- [x] Documentation / tooling (discovery substrate)

## Checks

- [x] `check_docs.py --strict` green (badges + reachability)
- [x] Docs-only, read-only — no runtime or new-repo code touched
- [x] No secrets, tokens, or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke)_