### PR TITLE
Harden new-bot capability-audit BRIEF (prompt-refinement launch preconditions)

### DIFF
--- a/.sessions/2026-07-02-audit-brief-hardening.md
+++ b/.sessions/2026-07-02-audit-brief-hardening.md
@@ -1,0 +1,46 @@
+# 2026-07-02 — Harden the new-bot capability-audit BRIEF (prompt-refinement pass)
+
+> **Status:** `complete`
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** (opening)
+> **Session type:** follow-up — apply the owner's GPT prompt-refinement suggestions to the shared contract
+
+## What happened
+
+The owner ran the fleet handoff prompts through a GPT prompt-engineering project; it returned refined
+per-session prompts + suggested shared-contract edits. Verified the refinements against source (Q-0120):
+all 14 read-paths the prompts reference exist. Applied the four genuinely-good shared edits to
+`BRIEF.md` **once** (they propagate to every lane, since all read BRIEF first) rather than duplicating
+them into each prompt:
+
+- **Substrate precondition** — confirm the contract files exist (on `main` via #1661); report if missing,
+  don't invent the schema.
+- **Documentation-only boundary** — the precise allowed-writes rule (assigned audit md + findings +
+  session/PR metadata; no `disbot/`, tests, migrations, configs, generated, or new-repo code).
+- **Capstone carry-forward fields** — every recommendation carries dependency-layer · done-definition ·
+  outperform-target · owner-gated status (the capstone can't order the build plan without them).
+- **Phase-3 hard stop** — the rebuild is owner-gated; the audit is planning evidence, not build approval.
+
+Added a `HANDOFF-PROMPTS.md` header pointer so a repo-launcher knows the preconditions live in BRIEF.
+Docs-only; read-only; no runtime code.
+
+## ⚑ Self-initiated
+
+None beyond the owner's direction — applied the owner-relayed GPT suggestions after verifying them.
+
+## 💡 Session idea
+
+**Fold the "launch preconditions" block into the substrate-kit templates.** The four guards added here
+(substrate check · docs-only boundary · carry-forward fields · owner-gate hard stop) are generic to *any*
+multi-agent audit contract, not just this one — a good addition to the `/fleet-audit` skill idea captured
+last session, as the default contract header. Dedup: extends the prior fleet-substrate idea, doesn't duplicate.
+
+## ⟲ Previous-session review
+
+The previous session (the audit-substrate prep) correctly put the shared contract in one `BRIEF.md` that
+every lane reads — which is exactly why this hardening was a **one-file** change instead of editing seven
+prompts. That "one shared contract" decision paid off immediately. No miss to flag; the design held.
+
+## 📊 Telemetry
+
+- new-bot-capability-audit BRIEF hardened with 4 launch-precondition/boundary guards (verified vs source)
+- Docs-only; `check_docs --strict` green; zero runtime code

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
@@ -136,6 +136,26 @@ For **each subsystem in your lane**, write one section into your lane file
 - **Stay in your lane** (see `PARTITION.md`) — subsystems are assigned disjointly so lanes never
   collide. If you finish early, do a *verify* pass on an adjacent lane's tier-3 findings, don't re-audit.
 
+## Launch preconditions & hard boundaries (every lane, before any work)
+
+*(Added 2026-07-02 from the prompt-refinement pass — stated once here so every lane inherits them.)*
+
+- **Substrate precondition.** This substrate merged to `main` in **#1661**, so a fresh checkout has it.
+  Before working, confirm your checkout contains `BRIEF.md`, `PARTITION.md`, your lane file, and
+  `ground-truth/`. If any are missing, **stop and report the missing contract — do not invent the
+  schema.**
+- **Documentation-only boundary (the precise read-only rule).** The *only* writes allowed are: your
+  **assigned audit markdown** under `docs/analysis/rebuild-discovery/new-bot-capability-audit/`, an
+  optional findings note explicitly assigned to your lane, the session-journal/log entries the repo
+  workflow requires, and the PR metadata for those docs. **No** `disbot/`, tests, migrations, configs,
+  generated files, or any new-repo code.
+- **Capstone carry-forward fields.** Every per-capability recommendation must carry: **dependency-layer
+  guess · production-grade done-definition · outperform target** (or `pending Lane F`) **·
+  owner-gated / blocked / external-dependency status.** The capstone can't order the build plan without them.
+- **Phase-3 hard stop (owner gate).** The rebuild design is **owner-gated**: no Phase-3 / new-repo
+  implementation until the owner approves the design spec. This audit produces **planning evidence, not
+  build approval** — never start implementation or treat a lane finding as a green light to build.
+
 ## Exit bar — when the design is "durable enough to start building"
 
 The final review (see `FINAL-REVIEW-HANDOFF.md`) declares GO when, **across all 43 subsystems**:

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/HANDOFF-PROMPTS.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/HANDOFF-PROMPTS.md
@@ -1,8 +1,15 @@
 # Handoff prompts — copy-paste to launch each planned session
 
-> **Status:** `reference`. One ready-to-paste startup prompt per planned agent. Launch the four lanes in
-> parallel (they're file-disjoint), then the Fable 5 capstone once they've landed. Each prompt is
-> self-contained; the agent reads the shared contract from the repo.
+> **Status:** `reference`. One ready-to-paste startup prompt per planned agent (7 lanes + capstone).
+> Launch lanes A–D + G in parallel (file-disjoint), plus E/F cross-cutting, then the Fable 5 capstone.
+> Each prompt is self-contained; the agent reads the shared contract from the repo.
+>
+> **Preconditions live in [`BRIEF.md`](./BRIEF.md) § "Launch preconditions & hard boundaries"** — the
+> substrate-verification step, the precise docs-only write boundary, the capstone carry-forward fields,
+> and the **Phase-3 owner-gate hard stop** (no new-repo code until the owner approves). Since every lane
+> reads `BRIEF.md` first, those apply to *all* prompts below. **These prompts were refined via a
+> prompt-engineering pass (2026-07-02); fuller expanded per-lane variants exist and are equivalent** —
+> both read the same hardened contract, so either launches a well-guarded session.
 
 ---
 


### PR DESCRIPTION
## Summary

Applies the owner's GPT prompt-refinement suggestions to the fleet's shared contract. The owner ran the
7-lane handoff prompts through a prompt-engineering pass; I verified its suggestions against source
(Q-0120 — all 14 read-paths the refined prompts reference exist) and applied the four genuinely-good
shared edits to **`BRIEF.md` once** — since every lane reads `BRIEF.md` first, they propagate to all seven
lanes + the capstone without editing each prompt:

- **Substrate precondition** — confirm the contract files exist (on `main` via #1661); report if missing, don't invent the schema.
- **Documentation-only boundary** — the precise allowed-writes rule (assigned audit md + findings + session/PR metadata; no `disbot/`, tests, migrations, configs, generated, or new-repo code).
- **Capstone carry-forward fields** — every recommendation carries dependency-layer · done-definition · outperform-target · owner-gated status (the capstone can't order the build plan without them).
- **Phase-3 hard stop** — the rebuild is owner-gated; the audit is planning evidence, **not** build approval.

Also added a `HANDOFF-PROMPTS.md` header pointer to the new BRIEF preconditions section.

## Type of change

- [x] Documentation (shared-contract hardening)

## Checks

- [x] `check_docs.py --strict` green
- [x] Docs-only, read-only — no runtime code
- [x] No secrets, tokens, or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke)_