### PR TITLE
Lane F — ecosystem benchmark (verified) completes the new-bot capability audit fleet

### DIFF
--- a/.sessions/2026-07-02-lane-f-ecosystem-benchmark.md
+++ b/.sessions/2026-07-02-lane-f-ecosystem-benchmark.md
@@ -1,7 +1,7 @@
 # 2026-07-02 — Lane F ecosystem benchmark (verify + incorporate owner-provided deep-research)
 
-> **Status:** `in-progress`
-> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #(opening)
+> **Status:** `complete`
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #1672
 > **Session type:** owner-directed — owner pasted the Lane F deep-research (ecosystem benchmark vs known
 > Discord bots) and said "this is lane F." Task: verify it against source (Q-0120) and land it as the
 > fleet's 7th lane so the Fable 5 capstone is unblocked.
@@ -14,4 +14,54 @@ already-shipped subsystems as missing "gaps"). Preserve the genuine competitor c
 targets; fix the SuperBot side; produce the per-domain outperform targets all six merged lanes deferred as
 `pending Lane F`. Docs-only.
 
-<!-- close-out enders (Q-0089 / Q-0102 / Q-0104) + Status flip added at session end -->
+## What shipped
+
+- `findings/ecosystem-benchmark.md` — the corrected Lane F: competitor catalog + verified SuperBot-status
+  column + per-domain outperform targets (resolves the six merged lanes' `pending Lane F`) + genuine gaps vs
+  deliberate omissions vs deferred options.
+- `findings/README.md` — real markdown link to the new doc (reachability).
+- **This completes the 7-lane fleet** (A, B, C, D, E, G merged + F now) → the Fable 5 capstone is unblocked.
+
+**The verification mattered.** The raw owner-provided Lane F flagged **ticketing** and **advanced reaction
+roles** as the top missing "strong-fit additions" — both already ship (`ticket` subsystem; `role` menu
+builder + reaction panel + role packs). It also wrongly claimed no gambling (`casino`/poker ship), text-only
+welcome (`welcome_card` renders images), and no web config (`dashboard/` Flask app). Landing it verbatim would
+have made the capstone recommend building things that exist. Corrected column cites source throughout (Q-0120).
+
+## ⚑ Self-initiated
+
+None beyond the owner's direct request ("this is lane F"). The *correction* of the raw research against source
+is the Q-0120 obligation, not scope creep — the owner relies on cross-agent output being verified before it
+feeds the build plan.
+
+## 💡 Session idea
+
+**A `known-vs-shipped` guard for benchmark lanes.** Lane F's failure mode — an external agent asserting
+SuperBot lacks X when X ships — is mechanically detectable: any ecosystem/benchmark doc that says "SuperBot has
+no <word>" can be cross-checked against `ground-truth/subsystems.json` + a `def <word>` / cog grep, and flagged
+when the word IS a shipped subsystem. A tiny checker (`scripts/check_benchmark_claims.py`) run over
+`findings/*.md` would catch "we don't have tickets" when `ticket` is subsystem #33, turning the Q-0120 manual
+verify into an automated tripwire for this doc class. Dedup: no existing checker reads the benchmark findings
+against the subsystem ground truth.
+
+## ⟲ Previous-session review
+
+Previous session (the two Codex lanes D/E I verified + merged) did well: D's citations were 5/5 accurate and E
+correctly deferred to Axis-1. **What the fleet as a whole could have done better** — and Lane F is the proof —
+is give every lane the **subsystem ground-truth list up front** as a "you already have these, don't call them
+gaps" guard. Lane F (an *external* deep-research agent) never saw `subsystems.json`, so it re-derived
+SuperBot's surface from guesswork and got it wrong. **System improvement:** the `HANDOFF-PROMPTS.md` for any
+Axis-3/benchmark lane should hard-require reading `ground-truth/subsystems.json` first and phrase every "gap"
+as "verified absent from the 43 subsystems," not "seems missing." (Captured as the session idea above, in
+enforceable form.)
+
+## 📊 Telemetry
+
+- PR #1672 · docs-only · `findings/ecosystem-benchmark.md` (new) + `findings/README.md` link + this log.
+- 7 SuperBot-side claims in the raw research corrected against source; 5 were flat contradictions.
+- Fleet complete: 7/7 lanes merged/landing (A,B,C,D,E,G merged; F this PR) → capstone unblocked.
+
+## Doc audit (Q-0104)
+
+`check_docs --strict` green (new doc linked from findings/README → reachable) · Lane F provenance + corrections
+documented in-doc and here · ledger unaffected (docs-only) · no claim file opened (PR is the in-flight signal).

--- a/.sessions/2026-07-02-lane-f-ecosystem-benchmark.md
+++ b/.sessions/2026-07-02-lane-f-ecosystem-benchmark.md
@@ -1,0 +1,17 @@
+# 2026-07-02 — Lane F ecosystem benchmark (verify + incorporate owner-provided deep-research)
+
+> **Status:** `in-progress`
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #(opening)
+> **Session type:** owner-directed — owner pasted the Lane F deep-research (ecosystem benchmark vs known
+> Discord bots) and said "this is lane F." Task: verify it against source (Q-0120) and land it as the
+> fleet's 7th lane so the Fable 5 capstone is unblocked.
+
+## What I'm about to do (born-red placeholder)
+
+Incorporate the owner-provided Lane F ecosystem benchmark into `findings/ecosystem-benchmark.md` — but
+**corrected against shipped source**, because the raw research misread SuperBot's own surface badly (flagged
+already-shipped subsystems as missing "gaps"). Preserve the genuine competitor catalog + best-in-class
+targets; fix the SuperBot side; produce the per-domain outperform targets all six merged lanes deferred as
+`pending Lane F`. Docs-only.
+
+<!-- close-out enders (Q-0089 / Q-0102 / Q-0104) + Status flip added at session end -->

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/README.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/README.md
@@ -2,8 +2,9 @@
 
 > **Status:** `reference`. Home for the cross-cutting research lanes + the capstone outputs.
 
-- `ecosystem-benchmark.md` — **Lane F** (Axis 3): the known-Discord-bot capability-gap catalog +
-  outperform targets. Any other Codex / deep-research addenda also land here (labeled external).
+- [`ecosystem-benchmark.md`](./ecosystem-benchmark.md) — **Lane F** (Axis 3): the known-Discord-bot
+  capability-gap catalog + outperform targets (verified against source; the fleet's 7th and final lane). Any
+  other Codex / deep-research addenda also land here (labeled external).
 - `FINAL-REVIEW.md` — **capstone** deliverable 1: the grammar GO / GO-with-amendments / NO-GO verdict +
   the aggregated all-43 fit table + the consolidated amendment list.
 - `NEW-BOT-BUILD-PLAN.md` — **capstone** deliverable 2: the corpus + the dependency-layered build order

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/ecosystem-benchmark.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/ecosystem-benchmark.md
@@ -1,0 +1,127 @@
+# Lane F — Ecosystem benchmark (Axis 3): known-Discord-bot capability gaps + outperform targets
+
+> **Status:** `audit` — the Axis-3 lane of the new-bot capability audit: what the known Discord-bot ecosystem
+> does that SuperBot doesn't, and the per-capability **outperform target** the other six lanes deferred as
+> `pending Lane F`.
+> **Provenance:** external deep-research (owner-provided, 2026-07-02) **verified and corrected against shipped
+> source by Opus 4.8** (Q-0120). The competitor catalog is the deep-research contribution; the SuperBot-status
+> column and every correction are source-checked against the 43-subsystem ground truth + `disbot/` source.
+> **Prepared:** 2026-07-02.
+
+## ⚠ Corrections applied to the raw research (Q-0120 — read this first)
+
+The raw Lane F deep-research **misread SuperBot's own surface**, repeatedly flagging **already-shipped
+subsystems as missing "gaps."** The collaboration model requires cross-agent output be verified against
+shipped source before it feeds the capstone; here is what changed and why. **The capstone must use the
+corrected column, not the raw research's gap list.**
+
+| Raw Lane F claim | Verified source reality | Corrected verdict |
+|---|---|---|
+| **Ticketing** is the #1 missing "strong-fit addition" | `ticket` subsystem — `ticket new/close/claim/add/remove`, `ticketpanel`, `ticketsetup`, `ticketlimit`, `ticketblacklist`; `services/ticket_service.py` + `ticket_mutation.py`; `views/tickets/{hub,config_panel,control,launcher,confirm}.py`; `utils/db/tickets.py` | **Already shipped.** Not a build — a *benchmark* target vs Ticket Tool. |
+| **Advanced reaction roles** are a missing "strong-fit addition" | `role` subsystem — `views/roles/reaction_panel.py`, `role_menu_builder.py`, `role_menu_view.py`, `_role_pack_flow.py`, `main_panel.py` | **Already shipped** (menus + reaction panel + role packs). Benchmark vs Carl-bot UX. |
+| **"No typical gambling/spins"** in games | `casino` subsystem — `cogs/casino_cog.py`, `views/casino/poker_table.py`, `hub.py`; gambling mechanics present | **Wrong.** Casino/poker ships; plus blackjack, deathmatch, rps_tournament. |
+| **Welcome is "probably text only"** | `services/welcome_service.py` renders a `welcome_card` (image) | **Wrong.** Image welcome cards ship. |
+| **"No polling_cog"** | `poll` implemented in `utility` (`cogs/utility_cog.py`) | Capability exists (no dedicated cog, but present). |
+| **Web config "requires code changes"** | `dashboard/` Flask app — `app.py`, `auth.py`, `Procfile` | **Wrong.** A web dashboard exists (and a live-editor plan is in Lane E). |
+| **Automod is only "basic"** | `automod` subsystem — `services/automod_service.py` + `automod_config.py` + `cogs/automod/listener.py` + `schemas.py` + `settings_keys/automod.py` | Understated. A real configurable automod subsystem ships. |
+
+**Net effect:** SuperBot's shipped breadth is **wider than the raw research assumed** — it already covers the
+mainstream bots' headline specialties (tickets, reaction roles, automod, welcome images, casino, web dashboard)
+*and* carries domains **no mainstream bot has** (BTD6, Project Moon, mining/fishing/creature world-games). The
+real Axis-3 work is therefore **UX/depth/config parity on features SuperBot already ships**, plus a small set of
+**genuine** gaps — not "build the basics competitors have."
+
+## Method & sources
+
+Competitor capabilities were drawn from the owner-provided deep-research (official bot sites/docs/top.gg, with
+fan-wikis avoided). The **SuperBot column is ground truth**: the 43-subsystem inventory
+(`ground-truth/subsystems.json`), `ground-truth/command-surface.json`, and direct `disbot/` source reads. Every
+"already shipped" correction above cites the source path. Competitor specifics that could not be re-verified
+from source here are marked ⚠ and should be re-confirmed by the capstone before becoming hard outperform
+commitments.
+
+## Competitor capability catalog (who specializes in what)
+
+Most popular bots lead with **one deep specialty** + standard moderation/utility. SuperBot is unusual in being
+*broad-and-deep across many domains at once*.
+
+| Bot | Headline specialty | Notable capabilities | Overlaps a SuperBot subsystem? |
+|---|---|---|---|
+| **MEE6** | Welcome/onboarding, leveling, custom commands | Level roles, reaction roles, automod, web dashboard (much paywalled) | welcome, xp, role, automod |
+| **Carl-bot** | Reaction roles (best-in-class UX), automod | Button/dropdown role menus, logging, reminders, feeds, giveaways | role, automod, logging, community |
+| **Dyno** | Moderation + web dashboard | Automod filters, modlog, mod actions, custom commands, web module toggles | moderation, automod, logging, admin |
+| **YAGPDB** | Modular automod + feeds + self-roles | Grouped self-roles, RSS/reddit/YouTube feeds, custom command scripting | role, automod, community |
+| **Ticket Tool** | Support tickets | Threaded/channel tickets, claim, transcripts, close-with-reason | **ticket** |
+| **Dank Memer** | Economy game | Currency, gambling minigames, items, shops, memes | economy, casino, games, inventory |
+| **Tatsu** | Global economy + social | Universal credits, pets, house/rooms, rank cards, leaderboards | economy, xp, leaderboard, creature |
+| **ProBot** | Welcome + logs + levels | Image welcome, in-depth logs (DM/webhook), leveling | welcome, logging, xp |
+| **Arcane** | Leveling + analytics | Rank cards, XP analytics, YouTube roles, leaderboards | xp, leaderboard |
+| **Mudae** | Anime/character collectables | Gacha collection game (niche) | (unique to Mudae) |
+| **Music bots** (Rythm/Groovy/etc.) | Voice/music streaming | Queue, playback | **none** (SuperBot has no voice) |
+
+## Per-domain outperform targets (fills the six lanes' `pending Lane F`)
+
+For each domain: SuperBot's **verified** status, the best-in-class competitor, and the concrete
+**outperform/parity target** the capstone folds into that capability's done-definition.
+
+| Domain | SuperBot status (verified) | Best-in-class | Outperform / parity target |
+|---|---|---|---|
+| **Moderation / automod** | `moderation`, `automod`, `security`, `image_moderation` all ship | Dyno | Match Dyno's filter configurability (badword/invite/caps/spam triggers→actions) via the audited mutation seam; **beat by being free** + fully audited. |
+| **Tickets / support** | `ticket` ships (new/close/claim/blacklist/limit/panel) | Ticket Tool | Reach transcript export + thread-mode parity; SuperBot already has claim/blacklist/limits Ticket Tool gates behind premium. |
+| **Reaction roles** | `role` ships (menu builder, reaction panel, role packs) | Carl-bot | Match Carl's button/dropdown UX polish + role-hierarchy preflight; SuperBot already has the builder + audit seam. |
+| **Welcome / onboarding** | `welcome` ships incl. `welcome_card` image | ProBot / MEE6 | Match ProBot's card customization depth; unify with the visual-card-engine plan (Lane E). |
+| **Leveling / XP** | `xp`, `leaderboard`, `karma` ship | Arcane / Tatsu | Add rank-card visuals (visual-card-engine, Lane E) + multi-leaderboard analytics; XP core already ships. |
+| **Economy** | `economy`, `inventory`, `treasury`, `casino`, `games` ship | Dank Memer / Tatsu | Unify all games on one audited ledger (settle-once); SuperBot's game *breadth* already exceeds Dank Memer's. |
+| **Logging / audit** | `logging` ships (8 gateway listeners, routes, panels) | ProBot / Carl-bot | Reach DM-log + webhook-route + out-of-channel-log depth; SuperBot has the route/panel spine. |
+| **Community engagement** | `community`, `community_spotlight`, `counters`, `counting`, `four_twenty` ship; polls in `utility` | Carl / Dyno | Ship native **giveaways** (plan-only today — Lane E); promote poll to first-class. |
+| **Web config** | `dashboard/` Flask app ships | Dyno / MEE6 | Reach live-editor + full module-toggle parity (Lane E dashboard/live-editor plans); keep it free. |
+| **Knowledge / AI** | `ai`, `btd6`, `project_moon` ship (unique domains) | — (no mainstream equivalent) | **Category-defining, not catch-up** — no mainstream bot has grounded game-knowledge domains; the target is depth/eval quality, not a competitor. |
+| **World / collection games** | `mining`, `fishing`, `creature`, `farm` ship | Tatsu (pets) / Mudae (gacha) | Unify on one world/economy primitive; SuperBot's world-game depth is already beyond mainstream bots. |
+
+## Genuine verified gaps (real Axis-3 additions to consider)
+
+- **Native giveaways** — not a shipped subsystem; **plan-only** (`giveaway-system-plan`, Lane E). Competitors
+  (Carl, Dyno, GiveawayBot) have it. Genuine gap, already routed → build per the Lane E plan; outperform bar =
+  free + native + audited.
+- **Voice / music** — genuinely **absent** (no voice subsystem). See deliberate omissions.
+- **External data feeds** (RSS/reddit/YouTube/weather) — YAGPDB/Dyno have them; SuperBot has no general feed
+  primitive. ⚠ Candidate `deferred known option`, not a commitment.
+- **Grouped self-roles** (YAGPDB-style role groups) — SuperBot has role menus/packs; explicit *exclusive-group*
+  semantics ⚠ unverified. Minor; capstone to confirm against `role` schema.
+
+## Deliberate omissions (documented, not gaps to close)
+
+- **Voice / music streaming** — complexity + licensing + third-party dependency; consistent with the
+  `voice-music-architecture-review` plan's caution. Deliberate scope exclusion.
+- **Premium/paywall architecture** — SuperBot is free-for-everyone (owner mission); the competitor pattern of
+  gating features behind payment is a *deliberate anti-goal*, not a missing feature.
+- **Deep niche gacha** (Mudae-style anime collection) — a self-contained niche; SuperBot's creature/collection
+  loop is its own design, not a Mudae clone.
+
+## Deferred known options (documented for a future session — not build commitments)
+
+- **Advanced/deep AI chat (open-domain NLP)** — fast-moving; SuperBot's `ai` is grounded/eval-first by design.
+  Keep offline-first; revisit as the space matures.
+- **External analytics dashboards** (public stat pages) — beyond current scope; the `dashboard/` app could grow
+  here later.
+- **Multi-bot / migration integrations** — the `bot-migration-assistant` plan (Lane E) is the routed home.
+
+## Uncertainties & source caveats (⚠)
+
+- Competitor feature sets change frequently; the catalog reflects *stated* capabilities at research time, not a
+  guaranteed-current catalog. The capstone should treat specific competitor claims as directional.
+- A few competitor specifics (exact automod trigger granularity, Ticket Tool transcript internals, Tatsu
+  house/pet depth) were not independently re-verified from primary sources in this pass — marked directional.
+- SuperBot claims are **not** caveated: every "already shipped" statement cites `disbot/` source or the
+  43-subsystem ground truth and is authoritative.
+
+## Handoff to the capstone
+
+- Every domain now carries a concrete **outperform target** — the six merged lanes' `pending Lane F` cells can
+  be resolved from the table above.
+- The dominant capstone lesson: **SuperBot's shipped breadth already meets or exceeds mainstream-bot breadth,
+  and its knowledge/world-game domains are category-defining.** The build plan's outperform column is therefore
+  mostly **"match best-in-class UX/depth/config on what we already have"** + a short list of genuine gaps
+  (giveaways = planned; feeds = deferred), **not** "build the basics."
+- Cross-references: shipped subsystems (Lanes A–D), planned enhancements (Lane E: giveaways, reaction-roles
+  overhaul, visual-card-engine, dashboard live-editor, bot-migration-assistant), L0 host (Lane G).


### PR DESCRIPTION
## Summary

Lands **Lane F (Axis 3 — ecosystem benchmark)**, the 7th and final lane of the new-bot capability audit, from
owner-provided deep-research — **verified and corrected against shipped source (Q-0120)**. With A–E + G already
merged, this unblocks the Fable 5 capstone. Docs-only.

## Why it needed correction, not just landing

The raw Lane F deep-research misread SuperBot's own surface — it flagged **already-shipped subsystems as
missing "gaps."** Verified against the 43-subsystem ground truth + source:

| Raw Lane F claim | Source reality | Correction |
|---|---|---|
| Ticketing is the #1 missing "strong-fit addition" | `ticket` subsystem: `ticket new/close/claim/add/remove`, `ticketpanel`, `ticketblacklist`, hub/config/control views | **already shipped** → benchmark, not build |
| Advanced reaction roles are a missing "strong-fit addition" | `role`: `reaction_panel.py`, `role_menu_builder.py`, role-pack flows | **already shipped** |
| "No typical gambling/spins" | `casino` subsystem + poker table + gambling mechanics | **wrong** |
| Welcome is "probably text only" | `welcome_service` renders `welcome_card` (image) | **wrong** |
| "No polling_cog" | `poll` implemented in `utility` | capability exists |
| Web config needs code changes | `dashboard/` Flask app (`app.py`, `auth.py`) | **wrong** |

**Genuine verified gaps** (kept): voice/music (absent — deliberate omission), giveaways (plan-only, already in
Lane E). The **competitor catalog + best-in-class targets** (the real value) are preserved and turned into the
per-domain **outperform targets** all six merged lanes deferred as `pending Lane F`.

## Change

- `findings/ecosystem-benchmark.md` — the corrected Lane F: competitor catalog, verified SuperBot-status
  column, per-domain outperform targets, genuine gaps vs deliberate omissions vs deferred options.
- Provenance: external deep-research (owner-provided) + Opus source-verification; corrections documented inline.

## Test plan

`python3.10 scripts/check_docs.py --strict`. Docs-only; no `disbot/` / runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke)_