### PR TITLE
Refresh the Fable 5 capstone prompt for the completed 7-lane fleet

### DIFF
--- a/.sessions/2026-07-02-capstone-prompt-refresh.md
+++ b/.sessions/2026-07-02-capstone-prompt-refresh.md
@@ -1,7 +1,7 @@
 # 2026-07-02 — Refresh the Fable 5 capstone prompt for the completed fleet
 
-> **Status:** `in-progress`
-> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #(opening)
+> **Status:** `complete`
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #1673
 > **Session type:** owner-directed — "create a revised prompt for Fable if necessary, or a quick start prompt
 > pointing Fable to the right file." The capstone prompts predate the fleet completing → revision necessary.
 
@@ -12,4 +12,41 @@ for the now-complete 7-lane fleet: fix "four lanes"→"seven", note the amendmen
 (Lanes D/F added G-7…G-10), and add the **Lane F source-correction guard** (don't propose ADD-from-ecosystem
 for capabilities that already ship). Then hand the owner a quick start prompt. Docs-only.
 
-<!-- close-out enders added at session end, then Status flipped -->
+## What shipped
+
+- `FINAL-REVIEW-HANDOFF.md` + capstone block in `HANDOFF-PROMPTS.md`: "four lanes"→"seven (all merged)",
+  amendment set G-1…G-6 → **G-1…G-10** (D/F added G-7…G-10), and the **Lane F source-correction guard**
+  (re-check ground truth before any ADD-from-ecosystem; competitor catalog is directional).
+- Quick start prompt handed to the owner in chat.
+
+## ⚑ Self-initiated
+
+None beyond the owner request. The revision was gated on "if necessary" — it was (stale lane count + missing
+G-7…G-10 would have had the capstone consolidate the wrong amendment set).
+
+## 💡 Session idea
+
+**Stamp handoff prompts with a `depends-on: <state>` freshness line.** These capstone prompts went stale the
+moment the fleet's shape changed (4→7 lanes, G-6→G-10) because nothing tied them to the state they assume. A
+one-line machine-checkable header (e.g. `> depends-on: lanes A–G merged · amendments G-1..G-10`) plus a tiny
+checker that flags a handoff prompt whose asserted state contradicts the live substrate would catch prompt-drift
+the same way `check_current_state_ledger` catches ledger-drift. Dedup: no existing checker validates prompt docs
+against the state they claim.
+
+## ⟲ Previous-session review
+
+The prior step (my Lane F verify + land) correctly caught the raw research's errors — good Q-0120 discipline.
+**What it could have done in the same pass:** update these capstone prompts *then*, since landing Lane F is
+exactly what made "four lanes / G-1…G-6" stale. I split it into a second PR instead. **System improvement:**
+a lane-landing checklist item — "if this is the last lane, refresh the capstone handoff" — would fold the
+prompt-refresh into the completing PR instead of a follow-up (captured as the freshness-header idea above).
+
+## 📊 Telemetry
+
+- PR #1673 · docs-only · 3 files (FINAL-REVIEW-HANDOFF.md, HANDOFF-PROMPTS.md, this log).
+- Fixes: 3 staleness classes (lane count, amendment range, Lane F guard) across both capstone-prompt docs.
+
+## Doc audit (Q-0104)
+
+`check_docs --strict` green · no new docs (edits to existing reachable files) · ledger unaffected (docs-only)
+· no claim file (PR is the in-flight signal).

--- a/.sessions/2026-07-02-capstone-prompt-refresh.md
+++ b/.sessions/2026-07-02-capstone-prompt-refresh.md
@@ -1,0 +1,15 @@
+# 2026-07-02 — Refresh the Fable 5 capstone prompt for the completed fleet
+
+> **Status:** `in-progress`
+> **Branch:** `claude/review-recent-session-qcyc44` · **PR:** #(opening)
+> **Session type:** owner-directed — "create a revised prompt for Fable if necessary, or a quick start prompt
+> pointing Fable to the right file." The capstone prompts predate the fleet completing → revision necessary.
+
+## What I'm about to do (born-red placeholder)
+
+Freshen the two capstone-prompt docs (`FINAL-REVIEW-HANDOFF.md` + the capstone block in `HANDOFF-PROMPTS.md`)
+for the now-complete 7-lane fleet: fix "four lanes"→"seven", note the amendment set is now **G-1…G-10**
+(Lanes D/F added G-7…G-10), and add the **Lane F source-correction guard** (don't propose ADD-from-ecosystem
+for capabilities that already ship). Then hand the owner a quick start prompt. Docs-only.
+
+<!-- close-out enders added at session end, then Status flipped -->

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/FINAL-REVIEW-HANDOFF.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/FINAL-REVIEW-HANDOFF.md
@@ -1,7 +1,9 @@
 # Final review handoff — the Fable 5 capstone
 
 > **Status:** `reference`. This is the startup context for the **final Fable 5 session** (ultracode or
-> normal) that turns the four lanes' findings into one durable go/no-go on the rebuild grammar.
+> normal) that turns the seven lanes' findings into one durable go/no-go on the rebuild grammar.
+> **All seven lanes (A–G + F) are merged to `main`** as of 2026-07-02 — every input below is present and
+> source-verified; you are synthesizing a complete substrate, not waiting on anything.
 
 ## Your input (the whole substrate — all three axes)
 
@@ -13,7 +15,12 @@
   optimize recommendations. **L0 (Lane G) leads the build order — read it first.**
 - **Axis 2 — what we planned:** `lanes/lane-E-plans-ideas.md` — the forward-capability ledger.
 - **Axis 3 — what the ecosystem has:** `findings/ecosystem-benchmark.md` — the known-Discord-bot
-  capability-gap catalog + any other Codex / deep-research addenda in `findings/`.
+  capability-gap catalog + any other Codex / deep-research addenda in `findings/`. **Guard:** the raw Lane F
+  deep-research misread SuperBot's own surface (it flagged shipped subsystems — ticketing, reaction roles,
+  casino, welcome image cards, web dashboard — as missing "gaps"); the doc's SuperBot-status column is
+  already source-corrected, but **before you schedule any ADD-from-ecosystem, re-check the 43-subsystem
+  ground truth that it isn't already shipped.** Treat the competitor catalog as directional (outperform
+  targets), not as a build list.
 - **The baseline:** [`tools/grammar_spike/RESULTS.md`](../../../../tools/grammar_spike/RESULTS.md) (the
   3-subsystem spike this extends) and the design spec §2 + §10.1 risk 5.
 
@@ -30,10 +37,13 @@
    "85% is probably a floor" with a measured fact. Weight honestly — note if the mean is carried by a
    few high-fit CRUD subsystems while the stateful cluster drags.
 
-3. **Consolidate the amendment list.** Merge every lane's proposed `G-<n>` into one deduplicated set
-   (G-1…G-6 already exist — extend, don't renumber them). For each: what it adds, which subsystems need
-   it, and whether it's a **soft** spec note or a **structural** new primitive family. Flag any amendment
-   that implies real §2 redesign (not just a docs pass) — those are the durability-critical ones.
+3. **Consolidate the amendment list.** Merge every lane's proposed `G-<n>` into one deduplicated set.
+   The set already runs **G-1…G-10**: G-1…G-6 from the spike (GatewayListenerSpec, list-valued settings,
+   AnnouncementRouteSpec, CommandSpec.cooldown, validator bounds, per-kind namespaces) **plus Lanes D/F's
+   G-7 `KnowledgeDomainSpec` · G-8 AI platform specs (`AITaskProfileSpec`/`AIProviderGatewaySpec`) · G-9
+   `TimedTaskSpec` · G-10 `ModalFormSpec`** — extend/dedup, don't renumber. For each: what it adds, which
+   subsystems need it, and whether it's a **soft** spec note or a **structural** new primitive family. Flag
+   any amendment that implies real §2 redesign (not just a docs pass) — those are the durability-critical ones.
 
 4. **Answer the structural danger zones.** For each of stateful-games / gateway-listeners / `wait_for`
    wizards / scheduled-loops / voice: does the grammar (with amendments) express it, or does it stay a

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/HANDOFF-PROMPTS.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/HANDOFF-PROMPTS.md
@@ -211,17 +211,19 @@ OUTPUT: write docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lan
 
 ```
 You are Fable 5 running the CAPSTONE review of the new-bot-capability-audit audit in the menno420/superbot
-repo. Four independent lanes (2 Opus + 1 Sonnet ultracode + Codex/deep-research) have measured whether the
-rebuild's §2 manifest grammar can express all 43 subsystems as tier-1/2 declarations. Turn their findings
-into one durable go/no-go — this is the gate between "planning/discovery" and "creating the new repo."
+repo. Seven independent lanes (A–G, across Opus + Sonnet ultracode + Codex/deep-research) have measured
+whether the rebuild's §2 manifest grammar can express all 43 subsystems as tier-1/2 declarations, plus the
+planned (Lane E) and ecosystem (Lane F) axes. All seven are MERGED to main — the substrate is complete. Turn
+their findings into one durable go/no-go — this is the gate between "planning/discovery" and "creating the
+new repo."
 
 READ FIRST:
 1. docs/analysis/rebuild-discovery/new-bot-capability-audit/FINAL-REVIEW-HANDOFF.md   (your full spec — follow it)
 2. docs/analysis/rebuild-discovery/new-bot-capability-audit/BRIEF.md
-3. All four docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-*.md + anything in findings/
+3. All SEVEN lanes: docs/analysis/rebuild-discovery/new-bot-capability-audit/lanes/lane-*.md (A,B,C,D,E,G) + findings/ecosystem-benchmark.md (Lane F) + anything else in findings/
 4. tools/grammar_spike/RESULTS.md  (the 3-subsystem baseline you extend)
 
-DO: (1) VERIFY before trusting — spot-check the highest-leverage tier-3 verdicts against source; do not average lane numbers blindly (Q-0120 — the spike caught cross-agent maps mis-reading source 4×); down-weight "⚠ unverified" rows and re-derive disputed ones. (2) Compute the measured all-43 tier-1/2 fit (as-written vs with-amendments; 43 rows + overall; note if the mean is carried by high-fit CRUD subsystems while the stateful cluster drags). (3) Consolidate the amendment list (extend G-1…G-6, dedup; mark each soft-spec-note vs structural-new-family). (4) Answer each structural danger zone (stateful games / gateway listeners / wait_for wizards / scheduled loops / voice) — expressible, documented escape hatch, or needs a new family. (5) Per-subsystem preserve/redesign/drop disposition (fold with ../codex-preserve-map-synthesis-2026-07-02.md).
+DO: (1) VERIFY before trusting — spot-check the highest-leverage tier-3 verdicts against source; do not average lane numbers blindly (Q-0120 — the spike caught cross-agent maps mis-reading source 4×; Lane F's raw research misread SuperBot's own surface and had to be source-corrected). Down-weight "⚠ unverified" rows and re-derive disputed ones; before scheduling any ADD-from-ecosystem, re-check it isn't already a shipped subsystem. (2) Compute the measured all-43 tier-1/2 fit (as-written vs with-amendments; 43 rows + overall; note if the mean is carried by high-fit CRUD subsystems while the stateful cluster drags). (3) Consolidate the amendment list — the set already runs G-1…G-10: G-1…G-6 (spike) + G-7 KnowledgeDomainSpec, G-8 AI platform specs (AITaskProfileSpec/AIProviderGatewaySpec), G-9 TimedTaskSpec, G-10 ModalFormSpec (Lanes D/F); extend/dedup, don't renumber; mark each soft-spec-note vs structural-new-family. (4) Answer each structural danger zone (stateful games / gateway listeners / wait_for wizards / scheduled loops / voice) — expressible, documented escape hatch, or needs a new family. (5) Per-subsystem preserve/redesign/drop disposition (fold with ../codex-preserve-map-synthesis-2026-07-02.md).
 
 RULE THE VERDICT: GO / GO-with-amendments / NO-GO — with evidence, never a soft "looks fine." A subsystem class with no clean grammar answer is a NO-GO — that is exactly the "needs re-rebuilding in a year" failure this whole pass exists to catch.
 


### PR DESCRIPTION
## Summary

The capstone-prompt docs predate the fleet completing, so they're stale in ways that would degrade the Fable 5
capstone. Freshens both so the "right prompt file" is actually correct. Docs-only.

## Changes

`FINAL-REVIEW-HANDOFF.md` + the capstone block in `HANDOFF-PROMPTS.md`:
- **"four lanes" → "seven lanes"** (A–G + F all merged; the capstone reads all seven).
- **Amendment set G-1…G-6 → G-1…G-10** — Lanes D/F added **G-7 KnowledgeDomainSpec · G-8 AI platform specs
  (AITaskProfileSpec/AIProviderGatewaySpec) · G-9 TimedTaskSpec · G-10 ModalFormSpec**; the capstone must
  consolidate all ten, not just the spike's six.
- **Lane F source-correction guard** — Lane F's ecosystem benchmark was corrected against source (it flagged
  shipped subsystems as gaps); the capstone must trust its "already ships" column and apply the same "does
  this already ship?" check before proposing any ADD-from-ecosystem (ticketing, reaction roles, casino,
  welcome image cards, dashboard all already ship).

## Test plan

`python3.10 scripts/check_docs.py --strict`. Docs-only; no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXhfSG1x5kjAY9KmuDojke)_