### PR TITLE
Document the rebuild review-then-plan phase (process + next-session goal)

### DIFF
--- a/.sessions/2026-07-03-rebuild-planning-phase-doc.md
+++ b/.sessions/2026-07-03-rebuild-planning-phase-doc.md
@@ -1,10 +1,82 @@
 # 2026-07-03 — Document the rebuild review-then-plan phase (process + next-session goal)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
+> **Branch:** `claude/bot-capability-audit-capstone-scy0zx` · **PR:** #1677
+> **Session type:** owner-directed docs — capture the next-phase process after the capstone.
 
-**About to do (owner-directed):** the capability-audit capstone (#1674) is merged — the
-BUILD-PLAN is the frozen reference. The owner wants (1) one more **content review pass** over the
-whole plan in dedicated brainstorming sessions (commands / functions / methods), and *then* (2) a
-**per-step planning phase** — one 100%-complete design plan per step before building any code,
-every file designed to handle its entire eventual surface. This session documents that phase
-sequence + the immediate next-session goal so the next session lands running. Docs-only.
+## What happened
+
+The capability-audit capstone (#1674) merged; the BUILD-PLAN is the frozen reference. The owner
+directed the next phase and asked me to document it so the next session lands running:
+
+1. **One more content review pass first** — dedicated owner-led brainstorming sessions over the
+   whole plan, focused on the **commands / functions / methods** (not feasibility — the capstone
+   settled that; this decides whether the surface is *right* and gives it exact names).
+2. **Then per-step planning** — one **100%-complete design plan per step** before any code, every
+   file designed from line one to handle its **entire eventual surface** (bounded by the corpus,
+   not open-ended). The same "declare completely once" bet as the manifest grammar.
+
+Wrote [`docs/planning/rebuild-planning-phase-2026-07-03.md`](../docs/planning/rebuild-planning-phase-2026-07-03.md):
+the three-phase sequence (Content review → Per-step planning → Build), Phase A as the explicit
+next-session goal with a 7-topic seed agenda, the Phase-B process design (fixed plan template,
+hard completeness test = "a fresh agent could build it with zero further decisions",
+adversarial-completeness gate, two-level layer/component hierarchy, dependency-order starting at
+the Gate-0 grammar freeze, sequential-on-the-spine/parallel-on-the-leaves, plan-is-source-of-truth,
+plans-are-the-permanent-design-record), and the **durable-fix ledger** assigning every open
+uncertainty (ModerationActionSpec, compound-composition, forward-fit, G-22/R-12/P-1, Lane-D trust)
+to the phase/plan that must resolve it. Cross-linked from the BUILD-PLAN top pointer and the S4
+current-state ▶ Next.
+
+The doc distilled a genuine capstone-chat discussion; the improvements over the owner's raw idea
+(completeness test, corpus-boundedness, dependency-order-of-planning, two-level hierarchy,
+provides/consumes, plans-as-permanent-record, the plan-is-truth feedback loop) are folded in as
+the process design.
+
+## ⚑ Self-initiated
+
+Docs-only within the owner's explicit request; nothing beyond the documented scope. Cross-links +
+the S4 pointer are the "make it discoverable" half of "document so the next session knows the
+goal" — not separately directed, but the obvious completion of the instruction (a doc no session
+finds is not documented). Flagged for visibility, not because it's out of scope.
+
+## 💡 Session idea
+
+**A `parity/`-golden *recapture* protocol for current-bot bug fixes.** The capstone routed six
+live bugs (two money bugs) as immediate current-bot work, *and* the rebuild will parity-check the
+new bot against the frozen old bot's captured behavior. Those collide: if a current-bot bug is
+fixed **after** its golden is captured, parity later "verifies" the *fixed* behavior — fine — but
+if fixed **before** capture with no re-capture step, the golden encodes the buggy behavior and the
+rebuild faithfully reproduces the bug. The durable fix is a one-line protocol: *every current-bot
+behavior fix must re-capture its golden (or explicitly note "pre-capture, no golden yet")*, wired
+into the bug-fix session checklist. Cheap, prevents a silent bug-preservation class the merge=
+deploy + parity-oracle combination otherwise invites. Dedup-checked: no existing golden-recapture
+protocol in `docs/ideas/` (the doc-set reviewer proposed the *idea* in the capstone chat; this
+files it durably).
+
+## ⟲ Previous-session review
+
+The previous session (this same branch, the capstone #1674) did the hard synthesis well and, to
+its credit, **surfaced its own uncertainties honestly** rather than shipping a clean-looking
+verdict — which is exactly what made *this* owner-directed follow-up productive (the owner could
+act on a named uncertainty list). One thing it could have done better, which this session
+corrects: it left the "what happens next" implicit in FINAL-REVIEW §7 (the Gate-0 checklist) and
+BUILD-PLAN §4, scattered across two large docs — a next session would have had to reconstruct the
+phase sequence. **System improvement:** a capstone/verdict artifact should always ship with a
+**one-page "next phase" pointer** as a first-class sibling doc, not buried in a §7 — the reference
+plan and the process-to-execute-it are different genres and want different files (which is now the
+shape: BUILD-PLAN = *what*, rebuild-planning-phase = *how we proceed*). Cheap convention, prevents
+the "great artifact, unclear next step" gap.
+
+## 📊 Telemetry
+
+- PR #1677 · 1 process doc + 2 cross-links (BUILD-PLAN pointer, S4 ▶ Next) + 1 idea file + this log
+- Docs-only; `check_docs --strict` green; no runtime touched; Phase-3 owner gate unchanged
+- Born-red gate held through the session as designed (the #1677 CI "failure" was `check_session_gate`
+  on the in-progress card — flipped complete as the final step)
+
+## Doc audit (Q-0104)
+
+`check_docs --strict` green (new doc badged + linked + reachable) · new idea file indexed in
+`docs/ideas/README.md` · `check_current_state_ledger --strict` benign newest-merge lag
+only (this PR unmerged) · no new owner decisions taken (the doc *records* an owner directive — the
+phase sequence — but mints no new binding rule) · claim released at close.

--- a/.sessions/2026-07-03-rebuild-planning-phase-doc.md
+++ b/.sessions/2026-07-03-rebuild-planning-phase-doc.md
@@ -1,0 +1,10 @@
+# 2026-07-03 — Document the rebuild review-then-plan phase (process + next-session goal)
+
+> **Status:** `in-progress`
+
+**About to do (owner-directed):** the capability-audit capstone (#1674) is merged — the
+BUILD-PLAN is the frozen reference. The owner wants (1) one more **content review pass** over the
+whole plan in dedicated brainstorming sessions (commands / functions / methods), and *then* (2) a
+**per-step planning phase** — one 100%-complete design plan per step before building any code,
+every file designed to handle its entire eventual surface. This session documents that phase
+sequence + the immediate next-session goal so the next session lands running. Docs-only.

--- a/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md
+++ b/docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md
@@ -10,6 +10,12 @@
 > §7 spec-amendment pass lands and the owner ratifies the design spec (Phase-3 gate).
 > **Provenance rule:** where this plan and a lane file disagree, the lane file's per-unit ledger
 > is the deeper record; where any doc and shipped source disagree, source wins (Q-0120).
+>
+> **▶ What happens next (owner-directed 2026-07-03):** this plan is the **frozen reference**. The
+> next phase is (A) one more **content review pass** over the whole surface — commands / functions
+> / methods — in dedicated owner-led sessions, then (B) **one 100%-complete design plan per step**
+> before any code. The process + the immediate next-session goal live in
+> [`../../../../planning/rebuild-planning-phase-2026-07-03.md`](../../../../planning/rebuild-planning-phase-2026-07-03.md).
 
 ---
 

--- a/docs/current-state/S4-docs.md
+++ b/docs/current-state/S4-docs.md
@@ -75,6 +75,14 @@
 - **Ledger / docs in sync** — `check_current_state_ledger.py` and `check_docs.py` green.
 
 **▶ Next:**
+- **▶ Rebuild — the review-then-plan phase (owner-directed 2026-07-03; capstone #1674 merged):** the
+  new-bot capability audit is complete — verdict **GO-with-amendments** (measured all-43 fit 85.1%),
+  and [`NEW-BOT-BUILD-PLAN.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md)
+  is the **frozen reference**. Next: (A) one more owner-led **content review pass** over the whole
+  surface (commands / functions / methods), then (B) **one 100%-complete design plan per step**
+  before any code. Process + next-session goal:
+  [`planning/rebuild-planning-phase-2026-07-03.md`](../planning/rebuild-planning-phase-2026-07-03.md).
+  Still behind the Phase-3 owner gate (design-spec ratification); no new-repo code yet.
 - **▶ SuperBot retention application — startable (owner-directed brainstorm, PR #1643; Q-0214):** the
   **kit-native** context-economy engine already shipped in **#1649** (`substrate-kit/src/engine/economy/`);
   what remains here is applying retention to SuperBot's *own* docs via a `check_retention.py`

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,11 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`golden-recapture-on-bugfix-2026-07-03.md`](./golden-recapture-on-bugfix-2026-07-03.md) —
+  **session idea (2026-07-03, Q-0089, rebuild-planning-phase session):** a one-line protocol —
+  every current-bot behavior fix must **re-capture its `parity/` golden** (or record "pre-capture,
+  no golden yet") — so the rebuild's parity oracle never green-lights a *fixed* bug's old buggy
+  behavior. The six audit-routed bugs are the first candidates; applies through cutover.
 - [`rebuild-amendment-registry-2026-07-03.md`](./rebuild-amendment-registry-2026-07-03.md) —
   **session idea (2026-07-03, Q-0089, capability-audit capstone #1674):** one committed registry
   file as the **sole minting authority** for rebuild grammar-amendment IDs (G-n families, R-n

--- a/docs/ideas/golden-recapture-on-bugfix-2026-07-03.md
+++ b/docs/ideas/golden-recapture-on-bugfix-2026-07-03.md
@@ -1,0 +1,37 @@
+# Golden recapture on current-bot bug fix — a protocol so parity never preserves a bug
+
+> **Status:** `ideas` — session idea (2026-07-03, Q-0089, rebuild-planning-phase doc session).
+> Surfaced by the capstone's doc-set reviewer; filed durably here.
+
+## The collision
+
+Two things the rebuild does at once:
+
+1. The capability audit routed **six live current-bot bugs** (two money bugs — deathmatch PvP
+   double-settle, blackjack free-tournament double-pay) as immediate fixes, independent of the
+   rebuild.
+2. The rebuild **parity-checks the new bot against the frozen old bot's captured behavior** (the
+   `parity/` golden harness, #1639) — "does the rebuilt subsystem reproduce the shipped one?"
+
+These collide on timing. If a current-bot bug is fixed **after** its golden is captured, parity
+later verifies the *fixed* behavior — fine. But if a bug is fixed **before** capture and the
+golden is **not re-captured**, the golden encodes the *buggy* behavior, and the rebuild faithfully
+reproduces the bug — parity goes green on a bug. The merge=deploy cadence (every merge redeploys)
+plus a behavior-capture oracle makes this an easy silent class.
+
+## The durable fix (one line, a checklist item)
+
+**Every current-bot behavior fix must re-capture its `parity/` golden — or explicitly record
+"pre-capture, no golden yet"** — wired into the bug-fix session checklist (and, once the harness
+is a required gate, into the capture protocol itself). A fix without a golden decision is
+incomplete.
+
+## Why it's worth having
+
+- It's cheap (a checklist line + a one-shot recapture command per fix).
+- It prevents a bug-*preservation* class that is invisible precisely because parity is green.
+- It applies **now** (the six routed fixes are the first candidates) and **through cutover** (any
+  fix landed while capture is still running against the live bot).
+
+Related: `NEW-BOT-BUILD-PLAN.md` §6.3 (the six routed bugs) + §4.4 (the doc-set reviewer's
+golden-recapture proposal); the rebuild parity harness (design spec §6, linchpin validation).

--- a/docs/owner/claims/claude-bot-capability-audit-capstone-scy0zx.md
+++ b/docs/owner/claims/claude-bot-capability-audit-capstone-scy0zx.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/bot-capability-audit-capstone-scy0zx` · document the rebuild review-then-plan phase process + next-session goal (owner-directed 2026-07-03) · expected files: `docs/planning/rebuild-planning-phase-2026-07-03.md`, cross-links in the BUILD-PLAN + current-state, docs-only · 2026-07-03

--- a/docs/owner/claims/claude-bot-capability-audit-capstone-scy0zx.md
+++ b/docs/owner/claims/claude-bot-capability-audit-capstone-scy0zx.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/bot-capability-audit-capstone-scy0zx` · document the rebuild review-then-plan phase process + next-session goal (owner-directed 2026-07-03) · expected files: `docs/planning/rebuild-planning-phase-2026-07-03.md`, cross-links in the BUILD-PLAN + current-state, docs-only · 2026-07-03

--- a/docs/planning/rebuild-planning-phase-2026-07-03.md
+++ b/docs/planning/rebuild-planning-phase-2026-07-03.md
@@ -1,0 +1,206 @@
+# Rebuild — the review-then-plan phase (process + next-session goal)
+
+> **Status:** `plan` — the bridge between the merged capability-audit capstone (the **frozen
+> reference**: `NEW-BOT-BUILD-PLAN.md` + `FINAL-REVIEW.md`) and writing the per-step
+> implementation plans. **Read this to know what the next sessions do, in what order, and why.**
+> **Prepared:** 2026-07-03 (owner-directed, following PR #1674). Owner decision this session:
+> *plan every step to completeness before building — but do one more content review pass first.*
+
+---
+
+## Where we are
+
+- **The capstone is merged (#1674).** Its two deliverables under
+  [`../analysis/rebuild-discovery/new-bot-capability-audit/findings/`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/README.md)
+  are the **frozen reference**:
+  - [`FINAL-REVIEW.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/FINAL-REVIEW.md)
+    — verdict **GO-with-amendments** (measured all-43 fit 63.8% → 85.1%), the consolidated
+    amendment list (G-1…G-24 + riders + refuted set), the danger-zone answers.
+  - [`NEW-BOT-BUILD-PLAN.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md)
+    — the single dependency-ordered plan (L0 → L5), every capability with disposition,
+    dependencies, done-definition, outperform target.
+  These answer *what to build and in what order.* **Don't re-open them — refine downstream.**
+- **The design spec** ([`rebuild-design-spec-2026-07-02.md`](./rebuild-design-spec-2026-07-02.md))
+  awaits **Gate-0** (fold the G-9…G-24 amendments into §2) and **owner ratification** (the
+  Phase-3 gate). **No new-repo code exists, and none starts until both land.**
+
+## The owner's directive (2026-07-03): plan every step to completeness before building
+
+Execute the BUILD-PLAN, but at this phase **the deliverable of each step is a plan, not code.**
+Produce **one design plan per step, 100% complete, before the next begins** — every
+architectural rule honored, every option weighed and decided, nothing left to figure out later.
+
+**The file-completeness philosophy (the standing rule for every file the rebuild creates):**
+*every file is designed from its first line to handle its entire eventual surface — not the slice
+needed today.* No "we'll patch it when we add X." This is the **same bet as the manifest
+grammar**: declare the complete surface once, generate from it, never hand-patch. The file
+principle and the grammar principle are one principle — which is why this discipline fits the
+rebuild rather than fighting it.
+
+**Bounded, so "complete" doesn't become "infinite":** completeness is measured against the
+**capability corpus** (the 43-subsystem surface + the named amendments + the documented
+known-options), *not* open-ended speculation. A file is complete when it handles its full
+*declared* surface and **deliberately defers** anything on the known-options menu with a labeled
+reason. The corpus is the boundary of "everything we'd ever expect."
+
+---
+
+## The phase sequence
+
+```
+  [DONE] Capstone ──► [PHASE A] Content review pass ──► [PHASE B] Per-step planning ──► [PHASE C] Build
+         (frozen        (owner-led brainstorming:         (one 100%-complete plan          (execute plans;
+          reference)     commands/functions/methods)       per step, dependency-ordered)    plan = source of truth)
+```
+
+**Phase A is the immediate next work.** Phases B and C are documented here so the whole arc is
+visible, but **do not start Phase B until Phase A's surface decisions are captured** — a per-step
+plan cannot be "100% complete" against a command/method surface that is still under discussion.
+
+---
+
+## PHASE A — the content review pass  ◄◄ THE NEXT SESSION'S GOAL
+
+**What it is.** One more review pass over the *whole* plan, run as **dedicated, owner-led
+brainstorming / discussion sessions**, focused on the **actual surface** — the commands,
+functions, and methods the new bot will expose and use. Multiple sessions; unhurried.
+
+**Why it comes before per-step planning.** The capstone validated **feasibility** (*can we build
+this durably?* — yes, 85%) and **order**. It did **not** decide the surface *content* at the
+command/method level — the lane dispositions say "keep economy," not "these are economy's exact
+commands, named thus, with these methods behind them." Settling that in **discussion is cheap**;
+discovering it mid-plan or mid-build is expensive. This pass turns the frozen *what* into a
+decided *exact surface* the per-step plans can be complete against.
+
+**Who / how.** Owner-driven. The agent's role is **thinking-partner + decision-capturer**, not an
+autonomous pass — the owner designs and visualizes the surface; the agent pressure-tests each
+choice against source, the architecture rules, and the competitor targets, and records every
+decision durably. (This is exactly the collaboration model: the owner brings the vision, the
+agent brings the cross-checked correctness.)
+
+**Seed agenda (the topics to walk).** Not exhaustive — a starting spine:
+
+1. **The command surface, per subsystem.** The audit inventoried **271 commands**. For each:
+   keep / merge / drop / **rename**, and the exact final name + aliases. The audit gave
+   dispositions; this pass gives *names*.
+2. **Prefix vs slash per surface.** The audit flagged subsystems with **zero slash commands**
+   (role, channel's 17 prefix verbs). Decide the target command *kind* for each surface (the
+   grammar's `CommandSpec.kind`), and where the slash-native selects retire a prefix resolver.
+3. **Naming conventions + the collision class.** Two name collisions crash-looped production
+   (`give` Q-0211, `dock`/`sail` BUG-0030). Decide naming conventions **now** so the K1 namespace
+   registry gets clean input — the registry *enforces* uniqueness, but the human decides the
+   scheme.
+4. **Cross-cutting method / seam conventions.** The audited-mutation seam signatures, the
+   `WorkflowResult` shape, handler-ref naming, provider-ref naming — the recurring *method*
+   patterns every subsystem reuses. Decide them once here so 43 plans inherit one vocabulary.
+5. **The open uncertainties** (each must be *decided* here or assigned to its owning Phase-B
+   plan — see the ledger below): does `ModerationActionSpec` declare the mod-action envelope
+   (lifting moderation from 64%) or do the seams stay tier-3? Can the workflow engine atomically
+   compose several specs (farm-`collect` canary)? The three embedded decisions (G-22 staging
+   lanes, R-12 world-store, P-1 event-feed).
+6. **Hub / navigation topology.** The sim optimizes *arrangement*, but a human decides the
+   *semantic* hub structure (what belongs under which hub). Decide the hub tree.
+7. **The outperform targets, made concrete.** Turn "match Dyno's automod filters" /
+   "beat Ticket Tool on transcripts" into the **specific feature list** each subsystem must ship
+   (the done-definition's outperform half needs real items, not a competitor name).
+
+**Output of Phase A.** An **annotated / refined BUILD-PLAN** (or a companion decisions log) that
+records, per subsystem: the exact command surface, the naming, the method conventions, the hub
+placement, the resolved uncertainties, and the concrete outperform feature list. This is the
+input every Phase-B plan consumes.
+
+---
+
+## PHASE B — the per-step planning process (for when Phase A is done)
+
+Documented now so the target is visible; **not started until Phase A's surface is decided.**
+
+- **A fixed plan template** (the first Phase-B artifact — write it before the first plan, so every
+  plan is uniform and reviewable). Mandatory sections: *files created · the complete public
+  contract (every function/field/error the file will ever expose) · provides / consumes (its
+  stable interface up, its frozen dependencies down) · architectural rules honored (with the
+  specific INV / layer-boundary citations) · options considered and the decision + why · open
+  uncertainties resolved · production-grade done-definition (which `parity/` goldens + tests) ·
+  deliberate deferrals (labeled, with why) · build order within the plan.*
+- **"100% complete" has a hard test:** a plan is complete when **a fresh agent with no context
+  could build it from the plan + the frozen upstream contracts, making zero further design
+  decisions.** Each finished plan gets an **adversarial-completeness pass** — a reviewer whose
+  only job is to find one open decision; finds none → complete. (The audit's adversarial-verify
+  pattern, applied to plans. It also structurally closes the Lane-D "one-agent, unverified" trust
+  gap — everything gets a second set of eyes.)
+- **Dependency order, contracts frozen before dependents.** You cannot write a complete blackjack
+  plan while `ChallengeSessionSpec`'s fields are still moving. So planning follows the build
+  order: **the grammar/kernel contracts are planned and frozen first** — the **Gate-0 grammar
+  freeze is the first Phase-B plan** (fold G-9…G-24, settle `ModerationActionSpec` and the
+  composition contract, freeze every spec every later plan references). Only then are L1/L2/L3
+  plans complete, because they reference frozen ground.
+- **Two levels, not 40 flat files.** A **layer plan** (the L0 kernel, the L1 operator spine)
+  freezes that layer's shared contracts + internal sequencing; **component plans** underneath
+  (one per engine, one per subsystem) are complete *against the frozen layer contract*. This is
+  what makes "100% complete" tractable — a component plan can be complete precisely because
+  everything above it is frozen.
+- **Sequential on the spine, parallel on the leaves.** The strict "one before the next" applies
+  to the **contract-freezing plans** on the dependency spine. Once a layer's contracts are frozen,
+  the component plans within/below it are independent and can be written in parallel (the
+  manifest-per-file design makes them collide at compile, not merge).
+- **Every uncertainty is owned by exactly one plan, and its resolution is recorded there** (the
+  durable-fix rule — see the ledger). Nothing floats.
+- **The plans are the permanent design record, not scaffolding.** Because the manifest is
+  generated, the chain is *plan → manifest → generated code*. The plan is the durable "why"
+  behind each manifest; it survives every regeneration. That is why the effort pays off long
+  after the first build.
+
+## PHASE C — build (for reference)
+
+Execute the plans as code, in the same dependency order. **The plan is the source of truth:** if
+execution reveals the plan was wrong, **stop, fix the plan, then resume** — never let code
+silently drift from the design (that would forfeit the whole benefit). Each contradiction found
+in a cheap docs artifact instead of in shipped code is the process working.
+
+---
+
+## Open uncertainties → where each gets resolved (the durable-fix ledger)
+
+Per the owner's "if it has a clear durable fix, document that we use it" instruction. Each row is
+assigned to the phase/plan that must kill it, so none floats. (Full context:
+[`FINAL-REVIEW.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/FINAL-REVIEW.md)
+§3 / §4; the capstone chat 2026-07-03.)
+
+| Uncertainty | Resolved in | Note / leaning |
+|---|---|---|
+| **`ModerationActionSpec`?** — is an audited mod-action (warn/timeout/kick/ban) tier-3 forever (Lane A), or is there a declarable action *envelope* (preserve-map) that lifts moderation from 64%? The two independent passes disagree. | **Phase A** discussion → **Gate-0 grammar plan** records the decision | Resolvable by expressing one action against the grammar (~1hr spot-check). Leaning: the envelope (target/hierarchy/DM/cleanup/audit/log-route) *is* declarable; only the escalation decision is the thin handler. Settle it, document it, use it. |
+| **Compound-composition** — can the workflow engine atomically compose several declared specs in one transaction with clean audit (farm `collect` = G-13+G-12+progression)? Lane B flagged it "unproven." | **Gate-0 / K7 workflow-engine plan** specifies the compound-workflow contract; **farm `collect` is the named canary** | The composable legs already exist in source (`debit_in_txn`/`credit_in_txn`), so it's promising. The real design question is **audit semantics** — one row for the compound op, or N. The plan must answer it. Prototype before trusting economy/game fit numbers. |
+| **Forward-fit is unmeasured** — the 85% is all *retrofit*; no data on building *unbuilt* capabilities. | **Phase B**: the plan template makes "write the manifest + measure fit **before** code" mandatory for every new subsystem; **giveaways planned first** as the forward-fit proof | Cheapest de-risk of the biggest epistemic gap; converts it on a docs exercise, not on the flagship feature. |
+| **G-22 staging lanes** — standardize to one `StagedBuilderSpec`, or bless three staging lanes? | **Phase A** → its owning L1 plan | Leaning: standardize (three ways to stage a draft is the fragmentation the rebuild kills), but it's a family for recurrence-1 today — owner's call. |
+| **R-12 world-store** — a convention or a real dataclass? | **L0 grammar plan** | Leaning: convention (mining-only; a primitive for one consumer is over-engineering). |
+| **P-1 event-feed spec** — ratify or hold? | **L0/L2 plan**, after the 2nd instance check | Hold until the boards family (L5) supplies the 2nd instance; low stakes. |
+| **Lane D trust** — 440 units, no adversarial pass, one-agent tiers; the big lifts lean on soft riders. | **Phase B** adversarial-completeness pass re-verifies as a side effect; a targeted re-check of ai/btd6/diagnostic recommended before their plans finalize | logging reproduced the spike exactly (good calibration), but re-verify the three biggest lifts. |
+
+---
+
+## Doc-set freshness the Gate-0 plan must also fix
+
+(From the capstone's rebuild-doc-set consistency check — carried so the Gate-0 session sweeps
+them in one pass, per `NEW-BOT-BUILD-PLAN.md` §4.4):
+
+- The **design spec still presents its amendment set as complete** ("six named amendments — now
+  folded in") with **zero pointer to the capstone** — Gate-0's first edit.
+- **Phantom "handoff §F"** cited by three docs (the handoff ends at §E).
+- **Stale handoff §C** would rebuild the already-shipped `parity/` harness with a disproved
+  mechanism (dpytest).
+- **Strategy Phase-0 never stamped done** (kit finalized #1649).
+- Numeric drift to reconcile once: command-surface denominators (271 vs 406+73), settings-key
+  counts (~114 vs 120), kit test counts (399/407/422).
+
+---
+
+## Pointers
+
+- Frozen reference:
+  [`NEW-BOT-BUILD-PLAN.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md)
+  · [`FINAL-REVIEW.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/FINAL-REVIEW.md)
+- The grammar to freeze: [`rebuild-design-spec-2026-07-02.md`](./rebuild-design-spec-2026-07-02.md) §2
+- The amendment-registry idea (mint IDs in one place):
+  [`../ideas/rebuild-amendment-registry-2026-07-03.md`](../ideas/rebuild-amendment-registry-2026-07-03.md)
+- Collaboration model (owner-designs / agent-builds-cross-checked):
+  [`../collaboration-model.md`](../collaboration-model.md)


### PR DESCRIPTION
## Summary

Follows the merged capability-audit capstone (#1674). The BUILD-PLAN is now the frozen reference; this PR documents **what happens next**, per the owner's 2026-07-03 directive:

1. **Phase A — one more content review pass** over the whole plan, in dedicated owner-led brainstorming sessions focused on the actual **commands / functions / methods** (not feasibility — the capstone settled that; this decides whether the surface is *right*).
2. **Phase B — per-step planning** — one 100%-complete design plan per step before any code, each file designed from line one to handle its entire eventual surface (the same "declare completely once" bet as the manifest grammar). Template-driven, dependency-ordered starting at the Gate-0 grammar freeze, adversarial-completeness-gated, with every open uncertainty assigned to the plan that owns it.
3. **Phase C — build** — execute the plans; the plan is the source of truth.

New doc: `docs/planning/rebuild-planning-phase-2026-07-03.md`, cross-linked from the BUILD-PLAN and the current-state rebuild sector so a fresh session lands running.

**Docs-only** — no runtime changes; the Phase-3 owner gate is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7ctXczPFoTUMz9o6dhDab

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7ctXczPFoTUMz9o6dhDab)_