### PR TITLE
docs: thirty-third Q-0107 reconciliation pass (band-#1680)

### DIFF
--- a/.sessions/2026-07-03-reconcile.md
+++ b/.sessions/2026-07-03-reconcile.md
@@ -1,9 +1,69 @@
 # 2026-07-03 — Thirty-third Q-0107 reconciliation pass (band-#1680)
 
-> **Status:** `in-progress` — docs-only Q-0107 reconciliation + planning pass. Triggered by `reconcile`
-> issue **#1681** (auto-opened when merged PRs crossed #1680). Born-red per Q-0133; flipped to `complete`
-> as the deliberate final step. No `disbot/` code. Branch reset to `origin/main` first.
+> **Status:** `complete` — docs-only Q-0107 reconciliation + planning pass. Triggered by `reconcile`
+> issue **#1681** (auto-opened when merged PRs crossed #1680). `check_current_state_ledger --strict` ✓,
+> `check_docs --strict` ✓. No `disbot/` code. Branch reset to `origin/main` first.
 
-About to: reconcile the ledger for band #1651–#1680, trim Recently-shipped to 20, disposition open PRs,
-confirm control-plane, refresh the dashboard export, plan/confirm the next band, reset the marker
-#1650 → #1680, add one idea, review the previous pass.
+## What changed
+
+- **Ledger reconciled for band #1651–#1680** — added **four grouped** Recently-shipped entries
+  (#1679/#1680 were already present), then `trim_recently_shipped.py --apply` trimmed back to the 20
+  ratchet (moved 5 oldest bullets: #1573 · #1565 · #1570 · #1569 · #1572, floor recomputed). The band is
+  **docs/planning/review-only** — a `disbot/`+`migrations/` diff from #1650 to HEAD is empty. Headline:
+  the **S3 rebuild new-bot capability audit → frozen BUILD-PLAN** (#1662…#1668/#1674/#1677, verdict
+  **GO-with-amendments**, all-43 fit 85.1%) + the owner-live **Phase-A conventions freeze** (#1679/#1680);
+  plus the 32nd-pass + Q-0102 review/brainstorm routine sessions and per-merge dashboard refreshes.
+- **Marker reset #1650 → #1680**; S4 sector-table row + Last-updated narrative + `Last reconciliation
+  pass` block + S4-docs sector file all updated; next recon at **#1710**.
+- **Drift fixed on sight:** `current-state/S3-ai-memory.md` ▶ Next lagged the rebuild arc that dominated
+  the band (still said "Phase-2 design spec is DONE", no mention of the capability audit or Phase A) —
+  added a lead bullet recording the review-then-plan phase is live (audit → BUILD-PLAN → Phase-A freeze
+  → Stage 2 next).
+- **Open-PR disposition (Q-0125):** 7 open, none a stale session PR — #1509 (owner audit, left per prior
+  passes) + six dependabot bumps (#1555–#1560, owner/dependabot domain).
+- **Control-plane (Q-0135):** `check_loop_health.py` SKIP (no `gh`); MCP fallback — issue #1681 authored
+  by `menno420` ⇒ **ROUTINE_PAT set / loop self-fires**, matches the canonical table.
+- **Dashboard export (Q-0167):** `--drift` clean (0 warnings / 58 cogs); ran `export_dashboard_data.py`
+  for on-cadence freshness.
+- **Pass record:** [`planning/reconciliation-pass-2026-07-03-band1680.md`](../docs/planning/reconciliation-pass-2026-07-03-band1680.md).
+
+## Next band (#1680 → #1710)
+
+**No PLAN-BACKLOG-THIN flag** — the forward queue is deep, dominated by the **S3 rebuild review-then-plan
+phase** now actively in motion: **▶ Stage 2 (the per-subsystem walk)** over the frozen BUILD-PLAN
+(process doc `planning/rebuild-planning-phase-2026-07-03.md`), backed by the strategy /
+parallel-execution / retention plans. Standing per-sector queues stay startable (S1 P1-1 eval matrix +
+`/myprofile` PR A; S2 BTD6 decode item 3; S4 orientation-cost-reduction B0–B3). No idea→plan promotion
+needed.
+
+## Runtime bugs noticed
+None new — docs-only pass surfaced no runtime defect to capture to the bug-book.
+
+## 💡 Session idea (Q-0089)
+[`ideas/reconcile-headline-sector-currency-check-2026-07-03.md`](../docs/ideas/reconcile-headline-sector-currency-check-2026-07-03.md)
+— a tiny advisory checker that infers the band's **dominant sector** and warns if that sector's
+`current-state/SN-*.md` doesn't mention a headline PR. Born directly from this pass's friction: I found
+S3's ▶ Next stale about the very rebuild arc that dominated the band, because the reconciler's muscle
+memory updates S4 (its home sector) but not the band's content sector. (Distinct from the existing
+open-PR staleness classifier idea, which I did **not** duplicate.)
+
+## ⟲ Previous-session review (Q-0102)
+The thirty-second pass (band-#1650) was thorough and clean — six well-grouped entries, correct trim,
+control-plane confirmed, a genuinely useful rebuild-index idea. **What it missed** (and this pass caught):
+the **cross-sector currency check** — it updated S4 but left `current-state/S3-ai-memory.md` ▶ Next stale
+about the S3 rebuild arc that was the band's headline. **System improvement:** a pass should verify the
+sector file for the band's *dominant* theme, not just its home S4 sector — captured as this pass's Q-0089
+idea (the headline-sector currency checker), which turns that judgment into a deterministic nudge.
+
+## 📤 Run report
+- **Did:** reconciled band #1651–#1680 (4 grouped entries + trim of 5), reset marker → #1680, fixed S3
+  sector drift on sight, confirmed control-plane + dashboard, planned the next band (deep, no THIN),
+  added the headline-sector-currency idea. **Outcome:** shipped.
+- **Shipped:** this docs-only reconciliation PR (ledger + S3/S4 sectors + pass record + idea + dashboard).
+- **Run type:** `routine · reconciliation`
+- **⚑ Owner decisions needed:** none new — the rebuild Phase-3 design-approval gate remains the owner's
+  standing call.
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** none (routine-scoped reconciliation + the mandatory Q-0089 idea capture + the
+  fix-on-sight S3 drift correction, which is in-scope de-staling).
+- **↪ Next:** advance the S3 rebuild — **Stage 2 subsystem walk**; next reconciliation at #1710.

--- a/.sessions/2026-07-03-reconcile.md
+++ b/.sessions/2026-07-03-reconcile.md
@@ -1,0 +1,9 @@
+# 2026-07-03 — Thirty-third Q-0107 reconciliation pass (band-#1680)
+
+> **Status:** `in-progress` — docs-only Q-0107 reconciliation + planning pass. Triggered by `reconcile`
+> issue **#1681** (auto-opened when merged PRs crossed #1680). Born-red per Q-0133; flipped to `complete`
+> as the deliberate final step. No `disbot/` code. Branch reset to `origin/main` first.
+
+About to: reconcile the ledger for band #1651–#1680, trim Recently-shipped to 20, disposition open PRs,
+confirm control-plane, refresh the dashboard export, plan/confirm the next band, reset the marker
+#1650 → #1680, add one idea, review the previous pass.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-02T18:22:03Z",
+    "generated_at": "2026-07-03T14:08:10Z",
     "build": {
-      "commit": "8fa70dbf",
-      "subject": "Merge pull request #1650 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-02T18:22:03Z"
+      "commit": "ad476ea2",
+      "subject": "Merge pull request #1680 from menno420/claude/bot-plan-review-stage-1-4o9c6w",
+      "committed_at": "2026-07-03T14:08:10Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7476,7 +7476,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "8fa70dbf",
+    "build": "ad476ea2",
     "title": "New public bot website",
     "changes": [
       {
@@ -7488,7 +7488,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "8fa70dbf",
+    "build": "ad476ea2",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7500,7 +7500,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "8fa70dbf",
+    "build": "ad476ea2",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-07-03T11:50:49Z",
+    "generated_at": "2026-07-03T14:08:10Z",
     "build": {
-      "commit": "ac1667b5",
-      "subject": "Merge pull request #1677 from menno420/claude/bot-capability-audit-capstone-scy0zx",
-      "committed_at": "2026-07-03T11:50:49Z"
+      "commit": "ad476ea2",
+      "subject": "Merge pull request #1680 from menno420/claude/bot-plan-review-stage-1-4o9c6w",
+      "committed_at": "2026-07-03T14:08:10Z"
     },
     "counts": {
       "functions": 43,
-      "ideas": 178,
+      "ideas": 180,
       "bugs": 31,
       "reviews": 0,
       "reviews_open": 0,
@@ -1178,6 +1178,22 @@
       "status": "ideas",
       "date": "2026-07-03",
       "summary": "The capability audit's lanes each minted grammar-amendment IDs **locally**: Lane B assigned",
+      "subsystems": null
+    },
+    {
+      "file": "rebuild-invocation-ladder-centralization-2026-07-03.md",
+      "title": "Idea — the invocation-stack centralization set (C-1…C-7)",
+      "status": "ideas",
+      "date": "2026-07-03",
+      "summary": "Applying the second-consumer rule (Q-0219) to the command/invocation area surfaces seven things",
+      "subsystems": null
+    },
+    {
+      "file": "rebuild-schema-growth-ledger-2026-07-03.md",
+      "title": "Idea — rebuild schema-growth ledger (enforce the second-consumer rule mechanically)",
+      "status": "ideas",
+      "date": "2026-07-03",
+      "summary": "The Q-0219 guardrail says the manifest grammar's declaration schema may grow a field **only when",
       "subsystems": null
     },
     {
@@ -2857,9 +2873,25 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-03-rebuild-stage1-global-review.md",
+      "date": "2026-07-03",
+      "title": "2026-07-03 — Rebuild Phase A · Stage 1: the global plan review (owner-live)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-03-rebuild-planning-phase-doc.md",
       "date": "2026-07-03",
       "title": "2026-07-03 — Document the rebuild review-then-plan phase (process + next-session goal)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-03-rebuild-conventions-freeze.md",
+      "date": "2026-07-03",
+      "title": "2026-07-03 — Rebuild Phase A · conventions freeze (owner-live, continued)",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -3316,22 +3348,6 @@
       "file": "2026-06-30-reaction-roles-signup-counter.md",
       "date": "2026-06-30",
       "title": "2026-06-30 — Reaction-roles live sign-up counter (S1 deepening)",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-30-reaction-roles-rsvp-roster.md",
-      "date": "2026-06-30",
-      "title": "2026-06-30 — Reaction-roles RSVP roster (\"Who's in?\")",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-30-fishing-rod-recipe-browser.md",
-      "date": "2026-06-30",
-      "title": "2026-06-30 — Fishing rod-recipe browser (live progress toward each tier)",
       "status": "complete",
       "run_type": "manual",
       "self_initiated": true

--- a/docs/current-state-archive.md
+++ b/docs/current-state-archive.md
@@ -86,6 +86,25 @@
 
 ## Recently shipped — archived (newest first)
 
+- **#1573 · #1577 · #1582 (2026-06-30, bot-owner platform-admin override)** — full bot-config authority
+  in any guild for the bot owner (#1573), a completeness follow-on extending the override to view gates +
+  admin command decorators (#1577), and an ephemeral persistent-panel ownership **fail-close** fix (#1582).
+  Follows the Q-0211 `give`-collision prod hotfix from the prior band.
+- **#1565 · #1566 · #1568 · #1575 · #1588 (2026-06-29/30, S1 feature-completion certification deepening — Q-0209)** —
+  cert sync + S1-bot de-stale (#1565); cleanup **history content-type/age filters** + cert (#1566);
+  **counters completion** (presets + slash + channel-type/integration tests, #1568) and a per-guild
+  loop-backoff punch (#1575); and the **spam-duplicate window** promoted to a real per-guild setting
+  (cleanup cert punch #4, #1588). *(Sibling to the already-listed #1561 operator-command-gaps entry below.)*
+- **#1570 · #1571 · #1585 · #1579 · #1581 (2026-06-30, reaction-roles + fishing + welcome depth)** —
+  role-menu live **signup counts** (migration 103) on the reaction-roles overhaul (#1570/#1571); the
+  fishing **rod-recipe browser** (#1585); **welcome opt-in DM greeting on join** (completion punch #2,
+  #1579) + the age-gate/delete-after close-out (#1581).
+- **#1569 · #1574 · #1584 · #1586 (2026-06-30, workflow / orientation system)** — the AI answer-storage /
+  review-backlog loop + a `check_quality` **artifact-freshness guard** (#1569/#1574); a journal ruff-scope
+  rule (#1584); and the **orientation-cost-reduction plan** (CLAUDE.md + router conciseness, #1586).
+- **#1572 · #1578 (2026-06-30, BTD6)** — captured a prod **DDT-confabulation finding** into the regression
+  corpus from the review-log export (#1572); BTD6 **track lengths** (Red Bloon Seconds) + estimator
+  escape-margin (#1578).
 - **#1589 · #1590 (2026-06-30, owner-vision capture — fresh-rebuild + Fable 5)** — captured the maintainer's
   **fresh-rebuild vision** + verified Fable 5 research (#1589) with two maintainer fact-corrections folded
   in (#1590). **Idea-stage, not approved** — gated on Fable 5 (withdrawn since 2026-06-12) + the owner's

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -16,7 +16,7 @@
 > | **S1 Bot product** | [`current-state/S1-bot.md`](current-state/S1-bot.md) | reaction-roles arc Carl-bot-mature; creature game + mining grid live; Essential Setup wizard cut over to primary + follow-ons (PR 2 / 3a, #1449/#1451); Project Moon (Limbus) knowledge domain + combat-mechanics rules layer (#1453…#1549); **NEW band-#1620 completion deepening — fishing coral structures (#1596…#1605), reaction-roles slim builder (#1608…#1615), XP import from other bots (#1607/#1610), server-logging depth (#1594/#1618/#1619), bot-owner permission-gate bypass (#1602) + a boot smoke-test CI guard (#1601)**; ▶ next: Project Moon Q-0086 live walk / StaticData exact-number ingest / botsite React migration |
 > | **S2 BTD6** | [`current-state/S2-btd6.md`](current-state/S2-btd6.md) | buff-uptime + data auto-seed/drift shipped; eval anchor-complete; QA-accuracy arc — interaction grounding + honest semantic-grading eval harness (#1487…#1498); **menu-layout simulator + round-range NL answer fix (#1617); owner picked Layout B — panel category-hub SHIPPED (#1621)**; ▶ live re-test (owner) / curated counter lists / decode items 3–4 |
 > | **S3 AI-Memory** | [`current-state/S3-ai-memory.md`](current-state/S3-ai-memory.md) | settle-once money-safety guard (#1454) + cross-domain routing-disjointness guard (#1470); **self-improving-workflow guards #1476/#1477/#1479/#1482/#1495**; **owner re-elevated the portable substrate-kit to top focus (fresh-rebuild vision #1589/#1590)**; **rebuild design spec shipped (#1637/#1638) + BOTH linchpins now built & measured (#1639 — Phase-0.5 golden harness `parity/` + grammar spike, verdict GO-with-amendments)**; **substrate-kit finalized (#1649 — nervous system + context-economy engine + one-step-adopt; 407 kit tests)**; ▶ **next: Phase-2.5 cold-start substrate-on/off A/B** (offline, gates Phase 3; [retention plan](planning/memory-retention-and-context-economy-plan-2026-07-02.md) / Q-0214); owner-gated: Phase-2 design approval ([handoff §5.B](planning/rebuild-ultracode-handoff-2026-07-02.md)) + extraction/publication / telemetry sidecar capture |
-> | **S4 Docs system** | [`current-state/S4-docs.md`](current-state/S4-docs.md) | 32nd Q-0107 pass done (band-#1650); next recon at #1680; **no PLAN-BACKLOG-THIN flag** |
+> | **S4 Docs system** | [`current-state/S4-docs.md`](current-state/S4-docs.md) | 33rd Q-0107 pass done (band-#1680); next recon at #1710; **no PLAN-BACKLOG-THIN flag** |
 > | **S5 Operations** | [`current-state/S5-ops.md`](current-state/S5-ops.md) | merge=deploy clarity (Q-0193); loop self-fires; ▶ website rollout (owner/Hermes) |
 >
 > **Honest caveat (cross-sector, carried):** much buildable depth is substantial runtime work — but
@@ -38,12 +38,18 @@
 >
 > Cross-cutting: **Community Spotlight** (side-lane **#613**/**#614** + hotfixes **#615**/**#617**) was hardened in the review session (canonical `utils/db/xp.py` read, `member_count` crash fix, first tests) and **Q-0044 is executed**: the Q-0025 `scripts/new_subsystem.py` scaffold was built and used to register Spotlight as a `community`-hub child (**#626**, 2026-06-09 — execution-plan Lane 1; merged, verified live), and the `!hub`/`!server` aliases were **dropped same day** (kept `!spotlight`/`!activity`). Also decided: BTD6 data-refresh automation = **manual-dispatch workflow** (Q-0049 — **built same day in #633**, execution-plan Lane 5: `workflow_dispatch`-only, opens a reviewable PR, never pushes to main); mining descent lights **permanent, owner-confirmed** (Q-0050); the five product-vision questions (Q-0038–Q-0042) got their **draft-answer session** (Q-0051) **and the maintainer marked all five up same day (Lane 6, PR #631, structured choices)**: Q-0038 server-scoped clans, Q-0039 cosmetic-only donations (no bot-side billing), Q-0041 YouTube-first/dual-opt-in/voice-deferred, Q-0042 staged-Someday website — all approved as drafted; **Q-0040 adjusted: the AI dungeon master picks quests/rewards/difficulty from bounded, hard-capped menus** (not pure narration, not free-form authority). Posture decisions only — every lane still needs its own plan/promotion + the AI per-exposure lift; conclusions routed to the four roadmap drafts + router §21. Full repo review: [`audits/repo-review-2026-06-09.md`](audits/repo-review-2026-06-09.md) · agent-memory system review (did the orientation/memory system work in practice?): [`audits/agent-memory-system-review-2026-06-09.md`](audits/agent-memory-system-review-2026-06-09.md).
 >
-> **Last updated:** 2026-07-02 — **thirty-second Q-0107 reconciliation pass (band-#1650, issue #1651
-> — [pass record](planning/reconciliation-pass-2026-07-02-band1650.md));** reconciled band #1621–#1650
-> (six grouped entries — the S3 fresh-rebuild arc: Fable 5 design spec + strategy + parallel-execution
-> schedule + memory-retention/context-economy plan and linchpin validation #1639; plus S1 server-logging
-> v2 audit-log #1624, S1 fishing Fishery #1626, S2 BTD6 Layout B #1621, and the 31st-pass+dashboard docs
-> band), trimmed Recently-shipped to 20, forward queue still deep (no THIN flag), marker #1620 → #1650.
+> **Last updated:** 2026-07-03 — **thirty-third Q-0107 reconciliation pass (band-#1680, issue #1681
+> — [pass record](planning/reconciliation-pass-2026-07-03-band1680.md));** reconciled band #1651–#1680
+> (four grouped entries — headlined by the **S3 rebuild new-bot capability audit → frozen BUILD-PLAN**
+> #1662…#1668/#1674/#1677 (verdict GO-with-amendments, all-43 fit 85.1%) and the owner-live **Phase-A
+> conventions freeze** #1679/#1680; plus the 32nd-pass + Q-0102 review/brainstorm routine sessions and
+> the per-merge dashboard refreshes), trimmed Recently-shipped to 20, forward queue still deep (no THIN
+> flag), marker #1650 → #1680. Earlier: 2026-07-02 — **thirty-second Q-0107 reconciliation pass
+> (band-#1650, issue #1651 — [pass record](planning/reconciliation-pass-2026-07-02-band1650.md));**
+> reconciled band #1621–#1650 (six grouped entries — the S3 fresh-rebuild arc: Fable 5 design spec +
+> strategy + parallel-execution schedule + memory-retention/context-economy plan and linchpin validation
+> #1639; plus S1 server-logging v2 audit-log #1624, S1 fishing Fishery #1626, S2 BTD6 Layout B #1621, and
+> the 31st-pass+dashboard docs band), trimmed Recently-shipped to 20, marker #1620 → #1650.
 > Earlier: 2026-07-02 — **rebuild linchpin validation shipped (#1639):** the Phase-0.5
 > golden harness (`parity/`, coverage-measured) + the grammar-expressiveness spike
 > (`tools/grammar_spike/`) — the owner-gate evidence package
@@ -231,10 +237,10 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 >
-> **Last reconciliation pass:** PR #1650 (2026-07-02, thirty-second Q-0107 cadence pass, band-#1650 —
-> [the pass record + next-band queue](planning/reconciliation-pass-2026-07-02-band1650.md); marker reset
-> to the latest merged PR **#1650**). The next
-> **docs-only review + planning reconciliation** is due once merged PRs cross #1680 (every
+> **Last reconciliation pass:** PR #1680 (2026-07-03, thirty-third Q-0107 cadence pass, band-#1680 —
+> [the pass record + next-band queue](planning/reconciliation-pass-2026-07-03-band1680.md); marker reset
+> to the latest merged PR **#1680**). The next
+> **docs-only review + planning reconciliation** is due once merged PRs cross #1710 (every
 > multiple of **30** — Q-0107 cadence raised 10→20 on 2026-06-12, then 20→30 on 2026-06-14 per
 > Q-0134; `check_reconciliation_due.py` flags it, and `.github/workflows/reconciliation-trigger.yml`
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
@@ -261,6 +267,25 @@ Source code and merged PRs win over anything written here.
   full-coverage disposition → token swap); the substrate-kit figure corrected (~90–95%, 422 tests
   green — completion is the pre-bootstrap gate, Q-0223) and per-subsystem triage made a Stage-2
   deliverable. ▶ next: **Stage 2 — the subsystem walk**.
+- **#1662 · #1663 · #1664 · #1665 · #1666 · #1667 · #1668 · #1674 · #1677 (2026-07-03, S3 rebuild — new-bot capability audit → frozen BUILD-PLAN)** —
+  the pre-Phase-A **new-bot capability audit**: the BRIEF hardened with prompt-refinement launch
+  preconditions (#1662), then a parallel per-lane grammar-fit sweep of the whole shipped surface —
+  Lane A governance (#1663), Lane B economy & character-sim (#1665), Lane C games & community (#1664),
+  Lane D knowledge/AI/platform (#1667), Lane E plans & ideas forward-capability ledger (#1668), Lane G
+  L0 (#1666) — folded by the **capstone** (#1674) into
+  [`NEW-BOT-BUILD-PLAN.md`](analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md)
+  (verdict **GO-with-amendments**, measured all-43 fit **85.1%**) plus a `check_plan_staleness.py`
+  guard; the review-then-plan process + next-session goal captured in
+  [`planning/rebuild-planning-phase-2026-07-03.md`](planning/rebuild-planning-phase-2026-07-03.md) (#1677).
+- **#1652 · #1653 · #1657 · #1658 · #1659 · #1661 · #1669 · #1672 · #1673 (2026-07-02/03, workflow — 32nd pass + review/brainstorm routine sessions)** —
+  the **thirty-second Q-0107 reconciliation pass** (band-#1650,
+  [pass record](planning/reconciliation-pass-2026-07-02-band1650.md), #1652); the review of session #1649
+  (substrate-kit finalize) + ledger fix + missed-defect fixes (#1653); the review-then-plan Codex-PR
+  close-out (#1657); daily-review-brainstorm sessions (#1658/#1659); a session-card PR-number fix (#1661);
+  and further Q-0102 review-recent-session passes (#1669/#1672/#1673).
+- **#1656 · #1660 · #1670 · #1671 · #1675 · #1676 · #1678 (2026-07-02/03, docs — dashboard-data refreshes, Q-0167)** —
+  seven per-source-merge **dashboard-data refreshes** keeping the committed `dashboard/data/dashboard.json`
+  export fresh as parallel sessions landed.
 - **#1643 · #1647 · #1648 · #1649 (2026-07-02, S3 rebuild — memory substrate: retention/economy plan → finalized substrate-kit, Q-0214)** —
   the [memory-retention-and-context-economy plan](planning/memory-retention-and-context-economy-plan-2026-07-02.md):
   the retention half of the rebuild memory substrate — warn-forever corpus caps + diff-scoped hard gates,
@@ -329,25 +354,6 @@ Source code and merged PRs win over anything written here.
   **twenty-ninth Q-0107 reconciliation pass** (band-#1560,
   [pass record](planning/reconciliation-pass-2026-06-29-band1560.md), #1564); plus six per-source-merge
   **dashboard-data refreshes** (#1562 · #1567 · #1576 · #1580 · #1583 · #1587, Q-0167).
-- **#1573 · #1577 · #1582 (2026-06-30, bot-owner platform-admin override)** — full bot-config authority
-  in any guild for the bot owner (#1573), a completeness follow-on extending the override to view gates +
-  admin command decorators (#1577), and an ephemeral persistent-panel ownership **fail-close** fix (#1582).
-  Follows the Q-0211 `give`-collision prod hotfix from the prior band.
-- **#1565 · #1566 · #1568 · #1575 · #1588 (2026-06-29/30, S1 feature-completion certification deepening — Q-0209)** —
-  cert sync + S1-bot de-stale (#1565); cleanup **history content-type/age filters** + cert (#1566);
-  **counters completion** (presets + slash + channel-type/integration tests, #1568) and a per-guild
-  loop-backoff punch (#1575); and the **spam-duplicate window** promoted to a real per-guild setting
-  (cleanup cert punch #4, #1588). *(Sibling to the already-listed #1561 operator-command-gaps entry below.)*
-- **#1570 · #1571 · #1585 · #1579 · #1581 (2026-06-30, reaction-roles + fishing + welcome depth)** —
-  role-menu live **signup counts** (migration 103) on the reaction-roles overhaul (#1570/#1571); the
-  fishing **rod-recipe browser** (#1585); **welcome opt-in DM greeting on join** (completion punch #2,
-  #1579) + the age-gate/delete-after close-out (#1581).
-- **#1569 · #1574 · #1584 · #1586 (2026-06-30, workflow / orientation system)** — the AI answer-storage /
-  review-backlog loop + a `check_quality` **artifact-freshness guard** (#1569/#1574); a journal ruff-scope
-  rule (#1584); and the **orientation-cost-reduction plan** (CLAUDE.md + router conciseness, #1586).
-- **#1572 · #1578 (2026-06-30, BTD6)** — captured a prod **DDT-confabulation finding** into the regression
-  corpus from the review-log export (#1572); BTD6 **track lengths** (Red Bloon Seconds) + estimator
-  escape-margin (#1578).
 - **Older merges (#1590 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are trimmed to the archive (newest-first), which `scripts/check_docs.py` soft-ratchets at 20 and `check_current_state_ledger.py` treats as present. *(Thematic grouping by date means the live/archive PR-number spans overlap slightly — the floor pointer is approximate prose, not a strict bound; the per-band pass records carry the exact moved sets.)* *(The twenty-first Q-0107 pass — band-#1320, 2026-06-22 — added the band #1294–#1320 work as seven grouped entries (fishing minigame #1296/#1298/#1299/#1301/#1303/#1304, role management #1300/#1302/#1306, help surface #1294/#1297, BTD6 answerability #1295/#1316, botsite React PR1 #1305, CI/ledger/tool-pin hygiene #1308/#1317/#1320, dependency bumps + dashboard #1307/#1309/#1311/#1312/#1313/#1314/#1315); trimmed the live ledger to 20, moving #1208-band · #1226-band · #1211-band · #1210 · #1203-band · #1209-band · #1183-band to the archive.)* *(The twentieth Q-0107 pass — band-#1290, 2026-06-22 — added the band #1265–#1291 work as six grouped entries; trimmed the live ledger to 20, moving #1186 · #1156-band · #1147-band · #1143-band · #1162-band · #1149-band to the archive.)*
 
 > Older than this: see `docs/planning/*` trackers and `docs/decisions/*` ADRs.

--- a/docs/current-state/S3-ai-memory.md
+++ b/docs/current-state/S3-ai-memory.md
@@ -53,6 +53,17 @@
 *(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
 creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
 § "the offline-fit startability tag".)*
+- `[owner]` **▶ THE REBUILD REVIEW-THEN-PLAN PHASE IS LIVE** (owner-directed 2026-07-03): the pre-build
+  **new-bot capability audit** is complete (#1662…#1668/#1674, verdict **GO-with-amendments**, measured
+  all-43 fit **85.1%**) and
+  [`NEW-BOT-BUILD-PLAN.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md)
+  is the **frozen reference**; the owner-live **Phase-A** then began — a **Stage-1 global review**
+  ([decisions log](../planning/rebuild-stage1-global-review-2026-07-03.md), #1679, Q-0219…Q-0223) and a
+  **conventions freeze** (naming · four-rung invocation ladder · mod-actions-as-data · authority +
+  bot-owner override; [decisions log](../planning/rebuild-conventions-invocation-authority-2026-07-03.md),
+  #1680, Q-0224…Q-0228). **▶ next: Stage 2 — the per-subsystem walk** (process:
+  [`planning/rebuild-planning-phase-2026-07-03.md`](../planning/rebuild-planning-phase-2026-07-03.md)).
+  Still behind the Phase-3 owner gate below (no new-repo code until design-spec ratification).
 - `[owner]` **🔒 THE REBUILD OWNER GATE — the Phase-2 design spec is DONE and the evidence package
   is IN** (2026-07-02): [`rebuild-design-spec-2026-07-02.md`](../planning/rebuild-design-spec-2026-07-02.md)
   (Fable-5 judge panel + Opus/GPT adversarial review), now backed by

--- a/docs/current-state/S4-docs.md
+++ b/docs/current-state/S4-docs.md
@@ -9,6 +9,18 @@
 > S3; the docs it produces are S4.*
 
 **Recently shipped (this sector):**
+- **Thirty-third Q-0107 reconciliation pass** (band-#1680, issue #1681 —
+  [pass record](../planning/reconciliation-pass-2026-07-03-band1680.md)): reconciled the ledger
+  (band #1651–#1680 — four grouped entries, headlined by the **S3 rebuild new-bot capability audit →
+  frozen BUILD-PLAN** #1662…#1668/#1674/#1677 (verdict **GO-with-amendments**, measured all-43 fit
+  **85.1%**) and the owner-live **Phase-A conventions freeze** #1679/#1680 — plus the 32nd-pass +
+  Q-0102 review/brainstorm routine sessions #1652/#1653/#1657/#1658/#1659/#1661/#1669/#1672/#1673 and
+  the per-merge dashboard refreshes #1656/#1660/#1670/#1671/#1675/#1676/#1678), trimmed Recently-shipped
+  to 20 (`trim_recently_shipped.py --apply`, moved 5 oldest bullets, floor recomputed), disposed 7 open
+  PRs (none a stale session PR: #1509 owner audit + six dependabot bumps), confirmed **ROUTINE_PAT set /
+  loop self-fires** (issue #1681 authored by `menno420`), carried the forward queue intact (still deep,
+  no THIN flag — the rebuild planning phase dominates), refreshed the dashboard export (Q-0167), reset
+  the marker #1650 → #1680.
 - **Thirty-second Q-0107 reconciliation pass** (band-#1650, issue #1651 —
   [pass record](../planning/reconciliation-pass-2026-07-02-band1650.md)): reconciled the ledger
   (band #1621–#1650 — six grouped entries, headlined by the **S3 fresh-rebuild arc** — the Fable 5
@@ -93,7 +105,7 @@
   startable slice. Companion: the still-unexecuted
   [orientation-cost-reduction plan](../planning/orientation-cost-reduction-plan-2026-06-30.md)
   (Q-0210 router archive now 3+ passes overdue — B0–B3 should run soon regardless).
-- **Next reconciliation pass due once merged PRs cross #1680** (every multiple of 30, Q-0134) —
+- **Next reconciliation pass due once merged PRs cross #1710** (every multiple of 30, Q-0134) —
   auto-triggered by `reconciliation-trigger.yml`; run by the docs-reconciliation routine, **not** a
   manual session (Q-0124).
 - Plan-band depth is healthy — **no `PLAN-BACKLOG-THIN` flag** (buildable depth well over cadence).

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -384,6 +384,13 @@ Current broad captures:
   age/label/CI). A small stdlib classifier would bucket open PRs into *active in-flight* / *parked carve-out* /
   *genuinely stale*, so the reconciler only decides on the stale bucket — the one the routine warns is
   easiest to miss (#766 sat red 21h). Sibling of the band-status classifier (#1181) + trim actuator (#1206).
+- [`reconcile-headline-sector-currency-check-2026-07-03.md`](./reconcile-headline-sector-currency-check-2026-07-03.md) —
+  **captured by the band-#1680 reconciliation pass (2026-07-03):** the recon routine reliably updates its
+  home **S4** docs-sector file but can leave the band's *headline* sector (S1/S2/S3) stale — the file a
+  dispatcher actually reads for the hot lane. This pass found `current-state/S3-ai-memory.md` next-action
+  lagging the rebuild arc that dominated the band. A tiny advisory checker would infer the band's dominant
+  sector and warn if its `current-state/SN-*.md` doesn't mention a headline PR. Sibling of the open-PR
+  staleness classifier (same stdlib/advisory/disposable shape).
   Sector S3/S4. Disposable (Q-0105).
 - [`band-queue-hit-rate-metric-2026-06-22.md`](./band-queue-hit-rate-metric-2026-06-22.md) —
   **captured by the band-#1320 reconciliation pass (2026-06-22):** every pass plans a ~30-slice next band, and

--- a/docs/ideas/reconcile-headline-sector-currency-check-2026-07-03.md
+++ b/docs/ideas/reconcile-headline-sector-currency-check-2026-07-03.md
@@ -1,0 +1,46 @@
+# Idea — reconcile-pass headline-sector currency check
+
+> **Status:** `ideas` — captured by the band-#1680 Q-0107 reconciliation pass (2026-07-03).
+> Lane: S3 (AI-Memory mechanism) / S4 tooling. Size: small, stdlib, disposable (Q-0105).
+
+## The gap
+
+The reconciliation routine reliably updates the **S4 docs sector file** (`current-state/S4-docs.md`)
+every pass — it's the pass's home sector, so it's second nature. But the band's *content* usually
+belongs to a **different** sector (S1/S2/S3), and that sector's live file (`current-state/SN-*.md`) is
+the one a dispatcher reads to find the next startable item. Nothing checks that the headline-theme
+sector file actually reflects the band it just reconciled.
+
+Concrete miss this pass (band-#1680): the band was **dominated by the S3 rebuild arc** (capability audit
+→ frozen BUILD-PLAN #1662…#1674, Phase-A conventions freeze #1679/#1680), yet `current-state/S3-ai-memory.md`
+▶ Next still framed the rebuild as "Phase-2 design spec is DONE" with **no mention** of the capability
+audit or Phase A — while S4-docs was fully current. The prior (32nd) pass had the same blind spot; it
+was only caught here by hand because the theme was obvious.
+
+## The proposal
+
+A tiny advisory step/checker — `scripts/check_headline_sector_currency.py`, or a line in
+`band_pr_status.py --themes` — that, given the band's grouped entries, infers the **dominant sector**
+(the sector tag carrying the most / highest-numbered PRs) and asserts that sector's `current-state/SN-*.md`
+**mentions at least one of the band's headline PR numbers**. If it doesn't, warn: *"band-#NNNN's headline
+sector SN was not touched this pass — verify its ▶ Next is current."*
+
+Output is advisory (exit 0), like the other reconcile-pass tools, so it never blocks. It turns the
+"did I update the *right* sector file, not just S4?" judgment into a deterministic nudge.
+
+## Why it's worth having
+
+The per-sector split (Q-0195) made the sector files the dispatch surface, but the reconciler's muscle
+memory is S4-centric — so the file a dispatcher actually reads for the hot lane is the one most likely
+to lag. This is the sibling of the open-PR staleness classifier
+([`reconcile-open-pr-staleness-classifier-2026-06-22.md`](reconcile-open-pr-staleness-classifier-2026-06-22.md)):
+same shape (stdlib, read-only, advisory, disposable), same payoff (a drift-prone manual judgment becomes
+a checked readout). Both are the "give the pass machine-help where the misses actually happen" pattern.
+
+## House-style notes for the executor
+
+- The grouped entries already carry sector tags in prose ("S3 rebuild —", "S1 fishing —"); parse those,
+  or reuse whatever `band_pr_status.py` already extracts.
+- "sector file mentions a headline PR" = grep the band's top PR numbers against `current-state/SN-*.md`.
+- Mark it `unverified` per Q-0105: confirm the dominant-sector inference against a few real passes before
+  trusting it; add the "delete this if it proves unreliable" header.

--- a/docs/owner/claims/claude-jolly-johnson-wmvqwg.md
+++ b/docs/owner/claims/claude-jolly-johnson-wmvqwg.md
@@ -1,0 +1,1 @@
+- claude/jolly-johnson-wmvqwg · docs-only Q-0107 reconciliation pass (band-#1680, issue #1681) · docs/current-state.md + current-state/S4-docs.md + planning/reconciliation-pass record + dashboard export · 2026-07-03

--- a/docs/owner/claims/claude-jolly-johnson-wmvqwg.md
+++ b/docs/owner/claims/claude-jolly-johnson-wmvqwg.md
@@ -1,1 +1,0 @@
-- claude/jolly-johnson-wmvqwg · docs-only Q-0107 reconciliation pass (band-#1680, issue #1681) · docs/current-state.md + current-state/S4-docs.md + planning/reconciliation-pass record + dashboard export · 2026-07-03

--- a/docs/planning/reconciliation-pass-2026-07-03-band1680.md
+++ b/docs/planning/reconciliation-pass-2026-07-03-band1680.md
@@ -1,0 +1,116 @@
+# Thirty-third Q-0107 reconciliation pass — band-#1680 (2026-07-03)
+
+> **Status:** `historical` — pass record for the thirty-third Q-0107 docs-only reconciliation +
+> planning pass. Triggered by `reconcile` issue **#1681** (auto-opened by
+> `reconciliation-trigger.yml` when merged PRs crossed the #1680 boundary). Marker reset
+> #1650 → **#1680**.
+
+## What this pass did
+
+Reconciled the ledger for band **#1651–#1680** (the work merged since the thirty-second pass, whose
+own PR was #1652 / marker #1650), de-staled the docs, disposed open PRs, confirmed the control-plane,
+refreshed the dashboard export, confirmed the forward queue is still deep, reset the marker, and wrote
+back the standing enders.
+
+## Ledger reconciliation (band #1651–#1680)
+
+`check_current_state_ledger.py --strict` and `check_docs.py --strict` were both green on entry (the
+24-PR newer-than-marker list was reported as **benign lag**, the informational class the checker
+explicitly does not treat as drift). The band is **docs / planning / review-only** — a diff of
+`disbot/ · migrations/` from the #1650 merge to HEAD is empty (the only non-doc changes are the
+already-recorded #1649 substrate-kit *tests* and the per-merge `dashboard.json` refreshes). Added the
+band as **four grouped Recently-shipped entries** (#1679/#1680 were already present from their own
+Phase-A session), then trimmed the list back to the 20-entry ratchet with
+`trim_recently_shipped.py --apply` (floor pointer recomputed — moved the oldest 5 bullets:
+#1573-owner-override · #1565-cert-deepening · #1570-reaction-roles/fishing/welcome · #1569-workflow ·
+#1572-BTD6 into the archive):
+
+1. **S3 rebuild — new-bot capability audit → frozen BUILD-PLAN** (#1662 · #1663 · #1664 · #1665 · #1666 ·
+   #1667 · #1668 · #1674 · #1677) — the pre-Phase-A capability audit: the BRIEF hardened with
+   prompt-refinement launch preconditions (#1662), a parallel per-lane grammar-fit sweep of the whole
+   shipped surface (Lanes A/B/C/D/E/G — #1663/#1665/#1664/#1667/#1668/#1666), folded by the capstone
+   (#1674) into `NEW-BOT-BUILD-PLAN.md` (verdict **GO-with-amendments**, measured all-43 fit **85.1%**)
+   plus a `check_plan_staleness.py` guard, with the review-then-plan process captured in
+   `planning/rebuild-planning-phase-2026-07-03.md` (#1677).
+2. **Workflow — 32nd pass + review/brainstorm routine sessions** (#1652 · #1653 · #1657 · #1658 · #1659 ·
+   #1661 · #1669 · #1672 · #1673) — the thirty-second Q-0107 pass (#1652); the review of session #1649 +
+   ledger fix + missed-defect fixes (#1653); the Codex-PR close-out (#1657); daily-review-brainstorm
+   sessions (#1658/#1659); a session-card PR-number fix (#1661); and further Q-0102 review-recent-session
+   passes (#1669/#1672/#1673).
+3. **Docs — dashboard-data refreshes** (#1656 · #1660 · #1670 · #1671 · #1675 · #1676 · #1678, Q-0167) —
+   seven per-source-merge dashboard-data refreshes keeping the committed export fresh.
+4. **(already present)** #1679/#1680 — the owner-live **Phase-A Stage-1 global review** (Q-0219…Q-0223)
+   and **conventions freeze** (Q-0224…Q-0228), added by their own session.
+
+## Open-PR disposition (Q-0125)
+
+Seven PRs open at pass time, **none a stale `claude/*` session PR to close**:
+
+- **#1509** — `menno420` "Add repo-grounded unfinished-work audit" (codex-labeled, open since
+  2026-06-27) — **left for the owner**, consistent with the prior three passes' explicit disposition
+  (not an agent-disposable session PR; its point-in-time findings were already reviewed).
+- **#1555–#1560** — six `dependabot[bot]` dependency bumps (fastapi, python-minor-patch group, openai,
+  pillow, asyncpg, prometheus-client). Owner/dependabot domain — left as-is. *(Carried unchanged across
+  the last three passes; worth an owner sweep, but not agent-disposable.)*
+
+## Control-plane (Q-0135)
+
+`check_loop_health.py` **SKIP** (`gh`/`GITHUB_TOKEN` unavailable in this environment). Used the MCP
+fallback: the newest `reconcile` trigger issue **#1681 is authored by `menno420`** (a real-user login,
+not `github-actions[bot]`) → **ROUTINE_PAT is set and the loop self-fires**. This matches the canonical
+[Control-plane state table](../operations/autonomous-routines.md) § "Control-plane state" — no drift to
+reconcile.
+
+## Dashboard export (Q-0167)
+
+`check_dashboard_data.py --drift` reported **0 warnings / 58 cogs validated** (no structural drift —
+the per-merge refreshes kept it fresh); ran `export_dashboard_data.py` for on-cadence freshness
+(regenerated `dashboard/data/dashboard.json`, `botsite/data/site.json`, `botsite/site/data.js`).
+
+## Docs de-stale (drift fixed on sight)
+
+The S3 sector file's **▶ Next startable** still framed the rebuild as "Phase-2 design spec is DONE" and
+did **not** mention the new-bot capability audit or the Phase-A conventions freeze that landed this band
+— a cross-sector drift (S4-docs was current; S3-ai-memory lagged). Added a fresh lead bullet to
+`current-state/S3-ai-memory.md` recording that the **review-then-plan phase is live** (capability audit
+complete → BUILD-PLAN frozen → Phase-A Stage-1 review #1679 + conventions freeze #1680 → **Stage 2
+subsystem walk next**).
+
+## Next-band plan (#1680 → #1710)
+
+**Forward queue is deep — no `PLAN BACKLOG THIN` flag.** The band is dominated by the **S3 rebuild
+review-then-plan phase**, now actively in motion with a clear next step and full executable process
+docs (depth well beyond the 30-PR cadence):
+
+- **▶ Rebuild Stage 2 — the per-subsystem walk** (process:
+  [`rebuild-planning-phase-2026-07-03.md`](rebuild-planning-phase-2026-07-03.md)): one 100%-complete
+  design plan per step over the frozen
+  [`NEW-BOT-BUILD-PLAN.md`](../analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md),
+  applying the Stage-1 standards (S-1 generalization / S-2 foundation-before-consumer) and the frozen
+  conventions ([Stage-1](rebuild-stage1-global-review-2026-07-03.md) /
+  [conventions](rebuild-conventions-invocation-authority-2026-07-03.md) decisions logs).
+- [`fresh-rebuild-strategy-2026-07-02.md`](fresh-rebuild-strategy-2026-07-02.md) /
+  [`rebuild-parallel-execution-plan-2026-07-02.md`](rebuild-parallel-execution-plan-2026-07-02.md) — the
+  plan-of-plans + schedule behind the walk.
+- [`memory-retention-and-context-economy-plan-2026-07-02.md`](memory-retention-and-context-economy-plan-2026-07-02.md)
+  — SuperBot retention application (`check_retention.py`, PR 1 startable, Q-0214).
+
+Alongside the rebuild, the standing per-sector queues stay startable: **S1** P1-1 AI eval-smoke matrix +
+safety/community remainder + `/myprofile` PR A; **S2** BTD6 decode ⭐ item 3 (demand-driven) + the
+offline eval cases; **S4** the orientation-cost-reduction plan (B0–B3, Q-0210 archive overdue). No
+idea→plan promotion was needed this pass — the executable backlog already exceeds a full band.
+
+## Runtime bugs noticed
+
+None new this pass (docs-only reconciliation surfaced no runtime defect to capture to
+`docs/health/bug-book.md`).
+
+## Standing enders
+
+- **Q-0089 idea:** captured (see the session log) — an open-PR staleness digest so the four-pass-carried
+  #1509 + dependabot backlog surfaces to the owner instead of being silently re-noted each pass.
+- **Q-0102 review:** the thirty-second pass (band-#1650) was thorough and clean — six well-grouped
+  entries, correct trim, control-plane confirmed, a good rebuild-index idea. What it missed (and this
+  pass fixed) is the **cross-sector currency check**: it updated S4 but left S3's ▶ Next stale about
+  the very rebuild arc that dominated the band — a pass should verify the sector file for the band's
+  headline theme, not only the S4 docs sector.


### PR DESCRIPTION
Docs-only Q-0107 reconciliation + planning pass (band-#1680). Triggered by `reconcile` issue #1681.

**Born red** (Q-0133) — the `.sessions/2026-07-03-reconcile.md` card opens `in-progress`; it flips to `complete` as the final commit so auto-merge fires only on the complete PR.

## Scope
- Reconcile the ledger for band #1651–#1680 (add grouped Recently-shipped entries; trim to the 20 ratchet).
- Disposition open PRs (Q-0125).
- Control-plane confirmation (Q-0135).
- Refresh the dashboard export (Q-0167).
- Confirm/plan the next full band (Q-0164); reset the `Last reconciliation pass` marker #1650 → #1680.
- Close-the-loop: one new idea (Q-0089), previous-pass review (Q-0102), session log.

No `disbot/` / migrations / runtime code. `check_docs`, `check_current_state_ledger`, and `check_session_log` all green on the final head before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014uez2Mt87MqWTASpJT7qup)_