### PR TITLE
Cut permission prompts: broaden MCP allowlist + endorse invocation centralizations (Q-0228/Q-0229)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,6 +65,11 @@
       "mcp__github__get_job_logs",
       "mcp__github__actions_list",
 
+      "mcp__Claude_Code_Remote",
+      "mcp__github",
+      "mcp__codegraph",
+      "mcp__context7",
+
       "Bash(grep*)",
       "Bash(rg*)",
       "Bash(cat*)",

--- a/.sessions/2026-07-03-permission-allowlist-and-endorse.md
+++ b/.sessions/2026-07-03-permission-allowlist-and-endorse.md
@@ -1,8 +1,48 @@
 # 2026-07-03 — Permission allowlist fix + Q-0228 centralization endorsement (owner-live)
 
-> **Status:** `in-progress` — owner-directed housekeeping continuing the rebuild conventions
-> session: (1) broaden the `.claude/settings.json` allow list with whole-MCP-server entries so
-> tools like `send_later` stop prompting (owner: "I really never deny any requests — isn't there
-> a universal way to allow all"); (2) record the provenance Q for that executable-config change;
-> (3) update Q-0228 + the conventions log §6 to reflect the owner endorsing the C-1…C-7
-> centralizations as foundations to document + decide. Executable-config + docs; no `disbot/` code.
+> **Status:** `complete` — PR #1683. Owner-directed housekeeping continuing the rebuild
+> conventions session. Executable-config + docs; no `disbot/` code.
+
+## What shipped (PR #1683)
+
+1. **`.claude/settings.json`** — added whole-MCP-server allow entries (`mcp__Claude_Code_Remote`,
+   `mcp__github`, `mcp__codegraph`, `mcp__context7`) so MCP tools like `send_later` stop
+   prompting. The destructive-ops `ask` brake (rm -r, force-push, railway, sudo, psql, docker)
+   is untouched. Owner-directed → applied under the Q-0106 executable-config exception.
+2. **Router Q-0229** — provenance + the diagnosis: `defaultMode: bypassPermissions` and
+   `skipDangerousModePermissionPrompt` were **already** set, but the web/remote surface
+   downgrades project-scope bypass for safety and consults the explicit `allow` list instead —
+   so the allowlist is the reliable lever, and the truly universal switch lives at the
+   code.claude.com environment level. (`AskUserQuestion` prompting is by design, not a gate.)
+3. **Q-0228 + conventions log §6** — moved from "proposed, pending reaction" to
+   **owner-endorsed foundations** (the C-1…C-7 invocation-stack centralizations), per the owner's
+   confirmation that they're "good foundations and should be documented."
+
+## 💡 Session idea (Q-0089)
+
+Covered by this session's earlier cards (#1679 schema-growth ledger, #1680 invocation
+centralization set) — per Q-0089's "forced filler is worse than none," no new idea is minted for
+this small housekeeping PR; the genuine new idea this working session produced is the C-1…C-7 set,
+now owner-endorsed.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous card: **#1680 (conventions freeze).** It correctly captured C-1…C-7 as *proposals* rather
+than decisions — good discipline (didn't put words in the owner's mouth), and the owner did then
+endorse them, validating the capture-as-proposal call. **Improvement surfaced:** the permission
+friction that triggered *this* PR is a textbook Q-0194 "friction → guard" case — a recurring
+prompt that interrupted the session. The durable guard was the allowlist edit (config tier), which
+is exactly the right rung of the enforce-ladder; the lesson for next time is to reach for the
+config guard the *first* time a prompt recurs, not the third.
+
+## Docs audit (Q-0104)
+
+- `.claude/settings.json` JSON validated; `check_docs --strict` ✓ (run at close)
+- Owner decision → Q-0229; Q-0228 status updated; conventions §6 updated ✓
+- Ledger entry #1683 added ✓
+- Chat-only residue: none — the "universal allow" answer + the environment-level lever are in Q-0229.
+
+## ⚑ Self-initiated
+
+None — the settings change is owner-directed (Q-0229), the Q-0228 update reflects the owner's
+explicit endorsement.

--- a/.sessions/2026-07-03-permission-allowlist-and-endorse.md
+++ b/.sessions/2026-07-03-permission-allowlist-and-endorse.md
@@ -1,0 +1,8 @@
+# 2026-07-03 — Permission allowlist fix + Q-0228 centralization endorsement (owner-live)
+
+> **Status:** `in-progress` — owner-directed housekeeping continuing the rebuild conventions
+> session: (1) broaden the `.claude/settings.json` allow list with whole-MCP-server entries so
+> tools like `send_later` stop prompting (owner: "I really never deny any requests — isn't there
+> a universal way to allow all"); (2) record the provenance Q for that executable-config change;
+> (3) update Q-0228 + the conventions log §6 to reflect the owner endorsing the C-1…C-7
+> centralizations as foundations to document + decide. Executable-config + docs; no `disbot/` code.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -240,6 +240,13 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1683 (2026-07-03, workflow — cut permission prompts + endorse invocation centralizations, Q-0229/Q-0228)** —
+  broadened `.claude/settings.json` with whole-MCP-server allow entries (`mcp__Claude_Code_Remote`,
+  `mcp__github`, `mcp__codegraph`, `mcp__context7`) so tools like `send_later` stop prompting —
+  the destructive-ops `ask` brake left intact (Q-0229 diagnosis: web downgrades project-scope
+  `bypassPermissions`, so the explicit allow list is the reliable lever); and updated Q-0228 + the
+  conventions log §6 to record the owner **endorsing** the C-1…C-7 invocation-stack centralizations
+  as foundations to build toward.
 - **#1680 (2026-07-03, S3 rebuild — Phase-A conventions freeze: naming · invocation ladder · mod-actions-as-data · authority, Q-0224…Q-0228)** —
   the owner-live conventions-freeze continuation of Stage 1, folded into the
   [conventions decisions log](planning/rebuild-conventions-invocation-authority-2026-07-03.md):

--- a/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
+++ b/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
@@ -1,0 +1,6 @@
+# Claim — claude/bot-plan-review-stage-1-4o9c6w
+
+- `claude/bot-plan-review-stage-1-4o9c6w` · permission-allowlist improvement (broaden MCP
+  server allows to cut prompts, owner-directed) + Q-0228 centralization endorsement fold-in ·
+  files: `.claude/settings.json`, `docs/owner/maintainer-question-router.md`,
+  `docs/planning/rebuild-conventions-invocation-authority-2026-07-03.md`, `docs/current-state.md` · 2026-07-03

--- a/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
+++ b/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
@@ -1,6 +1,0 @@
-# Claim — claude/bot-plan-review-stage-1-4o9c6w
-
-- `claude/bot-plan-review-stage-1-4o9c6w` · permission-allowlist improvement (broaden MCP
-  server allows to cut prompts, owner-directed) + Q-0228 centralization endorsement fold-in ·
-  files: `.claude/settings.json`, `docs/owner/maintainer-question-router.md`,
-  `docs/planning/rebuild-conventions-invocation-authority-2026-07-03.md`, `docs/current-state.md` · 2026-07-03

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -8285,11 +8285,13 @@ everywhere" walks every command; **(b)** transparency — a bot-owner action in 
 
 ---
 
-### Q-0228 — PROPOSED (pending owner reaction): invocation-stack centralizations (2026-07-03)
+### Q-0228 — ENDORSED (owner-confirmed as foundations to document + decide): invocation-stack centralizations (2026-07-03)
 
 > **Context.** Same session, owner asked *"are there any other things related to this we could
-> centralize?"* Captured as **proposals**, not decisions — the owner reacts; blessed ones become
-> Gate-0/Phase-B contracts.
+> centralize?"* → then confirmed: *"yes all the things you mentioned are good candidates to
+> further think about and properly decide upon, your recommendations are good foundations and
+> should be documented."* So C-1…C-7 are **endorsed directions** (documented, to be decided in
+> detail at Gate-0) — not yet frozen contracts, but no longer merely speculative proposals.
 
 **Proposed (agent-recommended):** **C-1** one command **resolver** all four rungs funnel through
 (authority + arg validation + cooldown + audit — the convergence point, strongest recommend);
@@ -8301,4 +8303,39 @@ channel templates + serves the D&D example); **C-4** one **response/result gramm
 uses); **C-6** one **cooldown/rate-limit engine** (also the abuse-posture home); **C-7** one
 **description surface** feeding slash/help/NL-router/fuzzy/suggestions.
 
-**Homes:** conventions log §6. **▶ Owner action:** confirm which of C-1…C-7 to adopt.
+**Homes:** conventions log §6. **▶ Next:** each C-item's *detailed* decision (scope, contract
+shape) lands in its Gate-0 / Phase-B plan; the owner endorsed all seven as worth building toward
+(C-1 the command resolver is the load-bearing one — without it the four invocation rungs
+re-implement authority and drift, a safety bug).
+
+---
+
+### Q-0229 — DIRECTED: broaden the `.claude/settings.json` allowlist with whole-MCP-server entries to cut permission prompts (2026-07-03)
+
+> **Context.** Owner reported recurring permission prompts in sessions — including this one, for
+> `send_later` "and some other things" — and asked *"how we can improve the always allowlist… I
+> really never deny any requests, so isn't there a universal way to allow all actions you can
+> do?"* Investigated the actual config (Q-0120: check ground truth, not memory).
+
+**Findings.** `permissions.defaultMode` is **already** `bypassPermissions` and
+`skipDangerousModePermissionPrompt` is already true — the file already *requests* universal allow.
+The prompts persist because **on the Claude Code web/remote surface a project-file
+`bypassPermissions` is not fully honored** (it's treated as advisory for safety); the surface
+instead consults the explicit **`allow`** list, and MCP tools from the `Claude_Code_Remote` /
+`github` servers weren't on it. `AskUserQuestion` "prompting" is **by design** (it *is* the
+question UI, not a permission gate) — not fixable via the allowlist.
+
+**Decision (owner-directed in-session; Q-0106 executable-config exception — owner is the live
+reviewer, applied directly with this provenance Q).** Add **whole-MCP-server** allow entries —
+`mcp__Claude_Code_Remote`, `mcp__github`, `mcp__codegraph`, `mcp__context7` (bare `mcp__<server>`
+matches every tool on that server) — to `.claude/settings.json`. The destructive-ops **`ask`**
+brake (rm -r, force-push, railway, sudo, psql, docker, …) is **left intact** — it deliberately
+overrides bypass, matching the Q-0213 "destructive/irreversible stays ask-first" boundary.
+
+**The truly universal lever, for the record:** the only switch above the `allow` list is the
+**environment-level** permission mode on code.claude.com (or the in-session mode toggle) — the
+file can't force it on the web because the surface downgrades project-scope bypass by design. If
+the owner wants zero prompts for a class the allowlist can't cover, that's the place to set it.
+
+**Homes:** `.claude/settings.json` (the four entries) · this Q (provenance) ·
+`.sessions/2026-07-03-permission-allowlist-and-endorse.md`.

--- a/docs/planning/rebuild-conventions-invocation-authority-2026-07-03.md
+++ b/docs/planning/rebuild-conventions-invocation-authority-2026-07-03.md
@@ -167,11 +167,14 @@ Each of the above is **one engine steered by data**, per the Stage-1 keystone:
 
 ---
 
-## 6. Proposed invocation-stack centralizations (PROPOSALS — pending owner reaction)
+## 6. Invocation-stack centralizations — owner-endorsed foundations (Q-0228)
 
-Owner asked "what else related to this could we centralize?" Applying the second-consumer rule to
-the invocation/command area. **These are proposals, not decisions** — captured for the owner to
-react to; the ones he blesses become Gate-0 / Phase-B contracts.
+Owner asked "what else related to this could we centralize?" then confirmed: *"yes all the things
+you mentioned are good candidates to further think about and properly decide upon, your
+recommendations are good foundations and should be documented."* So the seven below are
+**endorsed directions to build toward**, documented here as the foundations; each item's *detailed*
+contract (scope, exact shape) is decided in its Gate-0 / Phase-B plan. (Applies the second-consumer
+rule to the invocation/command area.)
 
 - **C-1 — The command resolver (the convergence point).** *Strongly recommend.* All four rungs
   must funnel through **one** resolver that takes "a candidate command + args" and applies


### PR DESCRIPTION
## Summary

Owner-directed housekeeping continuing the rebuild conventions session:

- **`.claude/settings.json`** — add whole-MCP-server allow entries (`mcp__Claude_Code_Remote`, `mcp__github`, `mcp__codegraph`, `mcp__context7`) so tools like `send_later` stop prompting. The existing destructive-ops `ask` brake is untouched. (Executable config, owner-directed in-session → applied under the Q-0106 exception, provenance **Q-0229**.)
- **Router Q-0229** — records the config change + the diagnosis (why `bypassPermissions` from a project file doesn't fully silence prompts on the web surface, and that the explicit allow list is the reliable lever).
- **Q-0228 + conventions log §6** — updated from "proposed, pending reaction" to **owner-endorsed foundations to document + decide** (the C-1…C-7 invocation-stack centralizations), per the owner's confirmation.

Executable-config + docs only; no `disbot/` code.

## Type of change

- [x] Tooling / CI
- [x] Documentation

## Checks

- [x] JSON validated (`python3.10 -m json.tool`)
- [x] `check_architecture --mode strict` (no disbot files)
- [x] No secrets, tokens, or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmfSqMnWXDbNaUmk6TnFdK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmfSqMnWXDbNaUmk6TnFdK)_