### PR TITLE
Add short quick-launch prompts to the ultracode brief + durable-home verification

### DIFF
--- a/.sessions/2026-07-03-ultracode-quicklaunch.md
+++ b/.sessions/2026-07-03-ultracode-quicklaunch.md
@@ -1,0 +1,6 @@
+# 2026-07-03 — Ultracode quick-launch prompts + durable-home verification
+
+> **Status:** `in-progress` — owner-directed: verified everything from the session has a durable
+> home (18 Q-blocks, 10 docs, 8 ledger entries, settings change, checkers green, 5 ideas indexed),
+> then added two SHORT startup/launcher prompts to the ultracode brief that point each parallel
+> session at its full PROMPT A / PROMPT B. Docs-only; no code, no workflow launched.

--- a/.sessions/2026-07-03-ultracode-quicklaunch.md
+++ b/.sessions/2026-07-03-ultracode-quicklaunch.md
@@ -1,6 +1,50 @@
 # 2026-07-03 — Ultracode quick-launch prompts + durable-home verification
 
-> **Status:** `in-progress` — owner-directed: verified everything from the session has a durable
-> home (18 Q-blocks, 10 docs, 8 ledger entries, settings change, checkers green, 5 ideas indexed),
-> then added two SHORT startup/launcher prompts to the ultracode brief that point each parallel
-> session at its full PROMPT A / PROMPT B. Docs-only; no code, no workflow launched.
+> **Status:** `complete` — PR #1689. Owner-directed. Docs-only; no code, no workflow launched.
+
+## What shipped (PR #1689)
+
+1. **Durable-home verification (reported to owner):** confirmed on `main` — all 18 owner decisions
+   Q-0219…Q-0236 in the router; all 10 session docs (5 planning + 5 ideas) exist; all 8 session
+   PRs (#1679–#1688) in the ledger; the `.claude/settings.json` allowlist change landed;
+   `check_docs --strict` + `check_plan_homing` green; all 5 session ideas indexed. Only flag was
+   benign newest-merge lag (records at the #1710 recon pass — not drift).
+2. **Two short quick-launch prompts** added to
+   [`rebuild-foundational-mechanics-ultracode-brief-2026-07-03.md`](../docs/planning/rebuild-foundational-mechanics-ultracode-brief-2026-07-03.md)
+   (⚡ Quick launch section) — one-liners that point each parallel session at its full PROMPT A /
+   PROMPT B, so the owner launches with a short paste instead of the whole prompt.
+
+## 💡 Session idea (Q-0089)
+
+No new idea — small verification+convenience PR at the tail of a session that already produced five
+genuine ideas; Q-0089's anti-filler bar applies.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous card: **#1688 (the two ultracode prompts).** Solid — disjoint scopes + shared method +
+rubric scoring. **Gap it left, fixed here:** the *launchers* for those prompts existed only as an
+intention; had the owner not asked, the short-launch convenience would have lived only in chat —
+which the durable-home check would then have flagged. Lesson: when a doc is meant to be *used* by a
+human action later (launch, paste, run), ship the one-line "how to invoke" **in the doc** at write
+time, not just the full artifact — the invocation path is part of the deliverable.
+
+## Docs audit (Q-0104)
+
+- `check_docs --strict` + `check_session_gate` at close (below); no ledger entry needed (this PR is
+  itself the verification + a convenience edit; the substantive ledger entries #1679–#1688 already
+  present and were the thing verified).
+- No new owner decision (Q-0236 already covers the ultracode prep); no router change.
+
+## ⚑ Self-initiated
+
+None — owner-directed (verify durable homes + give two short startup prompts).
+
+## Session total: nine PRs
+
+#1679 · #1680 · #1683 · #1684 · #1685 · #1686 · #1687 · #1688 · #1689.
+
+## For the next session / the owner
+
+- **Launch** the two sessions with the quick-launch prompts (⚡ section of the brief).
+- Then: their issues ledgers → **Stage-2 subsystem walk** (rubric-driven) → **Gate V** → **Phase B**
+  → **migration**. Still-open: preset hide-vs-disable (Q-0232).

--- a/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
+++ b/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
@@ -1,4 +1,0 @@
-# Claim — claude/bot-plan-review-stage-1-4o9c6w
-
-- `claude/bot-plan-review-stage-1-4o9c6w` · add short quick-launch prompts to the ultracode brief +
-  durable-home verification (owner-directed) · docs-only · files: ultracode brief · 2026-07-03

--- a/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
+++ b/docs/owner/claims/claude-bot-plan-review-stage-1-4o9c6w.md
@@ -1,0 +1,4 @@
+# Claim — claude/bot-plan-review-stage-1-4o9c6w
+
+- `claude/bot-plan-review-stage-1-4o9c6w` · add short quick-launch prompts to the ultracode brief +
+  durable-home verification (owner-directed) · docs-only · files: ultracode brief · 2026-07-03

--- a/docs/planning/rebuild-foundational-mechanics-ultracode-brief-2026-07-03.md
+++ b/docs/planning/rebuild-foundational-mechanics-ultracode-brief-2026-07-03.md
@@ -8,6 +8,25 @@
 
 ---
 
+## ⚡ Quick launch — the two short startup prompts (paste one per session)
+
+Short launchers that point each session at its full prompt below. The `ultracode:` keyword makes
+each write + run its own workflow; it reads this doc and executes its half verbatim.
+
+**Session A (engine room):**
+```text
+ultracode: Read docs/planning/rebuild-foundational-mechanics-ultracode-brief-2026-07-03.md and run its "PROMPT A — the engine room" verbatim. This is the runtime/logic half; a parallel session runs PROMPT B (presentation/verification), so hold strictly to your scope boundary. Follow .claude/CLAUDE.md — claim your lane, born-red PR, auto-merge on green.
+```
+
+**Session B (surface + proving):**
+```text
+ultracode: Read docs/planning/rebuild-foundational-mechanics-ultracode-brief-2026-07-03.md and run its "PROMPT B — the surface + the proving" verbatim. This is the presentation/UX + verification half; a parallel session runs PROMPT A (runtime/logic), so hold strictly to your scope boundary. Follow .claude/CLAUDE.md — claim your lane, born-red PR, auto-merge on green.
+```
+
+*(The full prompts are in the two sections below; the launchers just save you pasting them.)*
+
+---
+
 ## What a dedicated ultracode session can do (researched — informs the prompt design)
 
 From the official docs ([code.claude.com/docs/en/workflows](https://code.claude.com/docs/en/workflows)):


### PR DESCRIPTION
## Summary

Owner-directed: after verifying every session decision has a durable home (18 Q-blocks Q-0219…Q-0236, 10 docs, 8 ledger entries, settings change, checkers green, 5 ideas indexed — all confirmed on `main`), add two **short startup/launcher prompts** to the ultracode brief so the owner can launch each parallel session with a one-liner that points it at its full `PROMPT A` / `PROMPT B`.

Docs-only; no code, no workflow launched.

## Type of change

- [x] Documentation

## Checks

- [x] `check_architecture --mode strict` (docs-only)
- [x] Docs updated
- [x] No secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmfSqMnWXDbNaUmk6TnFdK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmfSqMnWXDbNaUmk6TnFdK)_