### PR TITLE
Fix two confirmed prod loss paths: tournament fee forfeit + deploy-handoff XP double-fire

### DIFF
--- a/.sessions/2026-07-03-fix-prod-loss-paths.md
+++ b/.sessions/2026-07-03-fix-prod-loss-paths.md
@@ -1,0 +1,32 @@
+# 2026-07-03 — Fix two confirmed prod loss paths (from the engine-room audit)
+
+> **Status:** `in-progress`
+> **Branch:** `claude/fix-prod-loss-paths-2026-07-03` · **PR:** (pending first push)
+> **Session type:** runtime bug-fix (owner-directed follow-up to the PROMPT-A engine-room
+> audit #1690). Fixes two CONFIRMED live loss paths the audit surfaced; owner picked "fix the
+> 2 prod bugs" from the question panel.
+
+## What I'm about to do
+
+Both bugs verified against source this session before scoping:
+
+1. **Blackjack tournament entry-fee forfeit on a `BLACKJACK_TOURNAMENT_VERSION` bump.**
+   `disbot/cogs/blackjack_cog.py` `_recover_blackjack_tournament`: the version-mismatch branch
+   does `clear_by_id(row["id"]) + continue`, skipping the refund block — so on the next schema
+   version bump, every in-flight tournament's entry fee is forfeited, directly contradicting the
+   method's own docstring ("this one MUST refund"). **Fix:** refund the entry fee (`state["bet"]`)
+   regardless of version before clearing — the money was debited at launch and is owed whether or
+   not the rest of the state schema still parses.
+
+2. **XP (and every additive on_message effect) double-fires during the LP-4 deploy handoff.**
+   `bot1.py` releases the runtime lock *before* `bot.close()` drains (deliberate, fixes ~85s
+   downtime), so the incoming replica connects while the draining instance is still processing.
+   Discord delivers `MESSAGE_CREATE` to both gateway connections during the overlap, and
+   `db.add_xp` is additive with no per-message idempotency → double XP. **Fix (root, whole class):**
+   gate `core/runtime/message_pipeline.dispatch()` on `lifecycle.is_shutting_down()` — a draining
+   instance runs no message stages; the incoming replica owns ongoing traffic. One chokepoint fixes
+   xp / counting / chain / cleanup / rps / four_twenty / btd6 (all pipeline stages), not just XP.
+
+Plus regression tests for both, `check_quality --full` + `check_architecture --mode strict`.
+
+<!-- close-out appended before flipping to complete -->

--- a/.sessions/2026-07-03-fix-prod-loss-paths.md
+++ b/.sessions/2026-07-03-fix-prod-loss-paths.md
@@ -1,32 +1,100 @@
 # 2026-07-03 — Fix two confirmed prod loss paths (from the engine-room audit)
 
-> **Status:** `in-progress`
-> **Branch:** `claude/fix-prod-loss-paths-2026-07-03` · **PR:** (pending first push)
+> **Status:** `complete`
+> **Branch:** `claude/fix-prod-loss-paths-2026-07-03` · **PR:** #1693
 > **Session type:** runtime bug-fix (owner-directed follow-up to the PROMPT-A engine-room
-> audit #1690). Fixes two CONFIRMED live loss paths the audit surfaced; owner picked "fix the
-> 2 prod bugs" from the question panel.
+> audit #1690). Owner picked "fix the 2 prod bugs" from the question panel.
 
-## What I'm about to do
+## What happened
 
-Both bugs verified against source this session before scoping:
+Both bugs verified against source before scoping, then fixed with regression tests.
+Full CI mirror green (14,059 passed) + `check_architecture --mode strict` clean (no new
+violations).
 
-1. **Blackjack tournament entry-fee forfeit on a `BLACKJACK_TOURNAMENT_VERSION` bump.**
-   `disbot/cogs/blackjack_cog.py` `_recover_blackjack_tournament`: the version-mismatch branch
-   does `clear_by_id(row["id"]) + continue`, skipping the refund block — so on the next schema
-   version bump, every in-flight tournament's entry fee is forfeited, directly contradicting the
-   method's own docstring ("this one MUST refund"). **Fix:** refund the entry fee (`state["bet"]`)
-   regardless of version before clearing — the money was debited at launch and is owed whether or
-   not the rest of the state schema still parses.
+**Bug 1 — blackjack tournament entry-fee forfeit on a `VERSION` bump** (`blackjack_cog.py`
+`_recover_blackjack_tournament`). The version-mismatch branch did `clear_by_id` + `continue`,
+skipping the refund → a schema-version bump forfeited every live tournament's entry fee on the
+merge=deploy restart. **Nuance found mid-fix:** this was a *deliberate, tested* tradeoff — an
+existing test (`test_..._drops_version_mismatch_without_refund`) asserted the forfeit on purpose,
+rationale "the `bet` field may be in a foreign schema, refunding a wrong amount is worse." My
+audit mislabeled it a clean bug. **Surfaced to the owner** rather than silently reversing a tested
+money decision; owner chose **fix it** (2026-07-03 question panel). **Fix:** refund `state["bet"]`
+(guarded by the existing `int>0` check) regardless of version, then clear — the fee is owed
+whether or not the rest of the schema still parses; whoever bumps the version owns keeping `bet` =
+entry fee. Counter-test rewritten to assert the refund.
 
-2. **XP (and every additive on_message effect) double-fires during the LP-4 deploy handoff.**
-   `bot1.py` releases the runtime lock *before* `bot.close()` drains (deliberate, fixes ~85s
-   downtime), so the incoming replica connects while the draining instance is still processing.
-   Discord delivers `MESSAGE_CREATE` to both gateway connections during the overlap, and
-   `db.add_xp` is additive with no per-message idempotency → double XP. **Fix (root, whole class):**
-   gate `core/runtime/message_pipeline.dispatch()` on `lifecycle.is_shutting_down()` — a draining
-   instance runs no message stages; the incoming replica owns ongoing traffic. One chokepoint fixes
-   xp / counting / chain / cleanup / rps / four_twenty / btd6 (all pipeline stages), not just XP.
+**Bug 2 — XP (and every additive on_message effect) double-fires during the LP-4 deploy handoff**
+(`core/runtime/message_pipeline.py`). `main()` releases the runtime lock *before* `bot.close()`
+drains, so the incoming replica connects while this instance is still draining; Discord delivers
+`MESSAGE_CREATE` to both gateway connections during the overlap and `db.add_xp` is additive with no
+per-message idempotency → double XP. **Fix (root, whole class):** gate
+`message_pipeline.dispatch()` on `lifecycle.is_shutting_down()` — a draining instance runs no
+stages, so xp / counting / chain / cleanup / rps / four_twenty / btd6 (all pipeline stages) can't
+double-apply during the overlap; the incoming replica owns ongoing traffic. Does **not** regress
+LP-4 (the fast lock release stays).
 
-Plus regression tests for both, `check_quality --full` + `check_architecture --mode strict`.
+Tests: +2 pipeline tests (draining→no stages; running→stages run), rewrote the blackjack
+version-mismatch test to assert the refund. `disbot/core/runtime/message_pipeline.py` gains an
+intra-`core` import of `lifecycle` (allowed; the existing `services` import is the tracked one).
 
-<!-- close-out appended before flipping to complete -->
+## Decisions made alone
+
+- **Bug 2 fix approach:** gate the pipeline `dispatch` chokepoint on draining, rather than adding
+  per-message idempotency keys (a schema + dedup table). Rationale: one chokepoint covers the whole
+  additive-on_message class, no schema change, and it doesn't regress the LP-4 fast lock release.
+  (Bug 1's *direction* was owner-ratified via the panel, not decided alone.)
+
+## Flagged for maintainer (known limits)
+
+- **Bug 2 drain-gate leaves a tiny gap, by design:** messages sent during the ~1–2s handoff overlap
+  that the *old* instance received but the *new* instance didn't (not yet gateway-connected) get
+  **no** XP/moderation. That's a couple of messages per deploy — vastly better than double-awarding,
+  and moderation of persistent violations is unaffected.
+- **Bug 2 covers pipeline STAGES only.** All current additive on_message effects are pipeline stages
+  (verified against the stage-order table), so they're covered. A *future* additive effect added as
+  an independent (non-pipeline) `on_message` listener would need the same `is_shutting_down()` guard —
+  worth a checker if that pattern recurs.
+- **Bug 1** now refunds on any version mismatch; the residual risk the original code guarded against
+  (a future schema repurposing `bet`) is now owned by whoever bumps `BLACKJACK_TOURNAMENT_VERSION` —
+  they must keep `bet` = entry fee or update this handler. Owner-accepted.
+
+## 💡 Session idea (Q-0089)
+
+**Audit-finding triage heuristic: "flagged behavior that has a test asserting it = a deliberate
+tradeoff, not a bug."** Before an audit reports a behavior as a bug, grep for a test (or a code
+comment) that asserts the *current* behavior — if one exists, re-tag the finding "deliberate
+tradeoff to revisit" and cite the counter-rationale, rather than "confirmed bug." Grounded in this
+session: the engine-room audit called Bug 1 a "CONFIRMED critical" money bug, but
+`test_..._drops_version_mismatch_without_refund` proved it was an intentional choice — which changed
+it from "silently fix" to "ask the owner." Distinct from the previous session's class-4 absence-claim
+linter; this is a rung on the adversarial-verify pass. *(Recorded here; merits filing as an idea +
+index entry in a non-parallel session — deferred to avoid the shared-append collision with session B.)*
+
+## ⟲ Previous-session review (Q-0102)
+
+The PROMPT-A engine-room audit (#1690, this same conversation) delivered excellent breadth and
+cite-accuracy, but its Bug 1 finding **mislabeled a deliberate, tested tradeoff as a clean bug** —
+it cited `blackjack_cog.py:250-262` correctly but didn't grep for the counter-test that documents
+the forfeit as intentional. **System improvement it surfaces:** exactly the audit-triage heuristic
+above (check for a test asserting the flagged behavior before calling it a bug). The self-auditing
+loop worked here — verifying the audit's own finding before acting caught the mislabel and routed a
+money decision to the owner instead of a silent reversal.
+
+## 🛠 Friction → guard (Q-0194)
+
+**Friction:** an audit finding tagged "CONFIRMED critical" turned out to be a deliberate,
+test-encoded tradeoff — I nearly reversed a tested money decision on the audit's word. **Guard
+applied this session (process):** grepped for a test asserting the current behavior *before*
+treating the finding as a clean bug, found the counter-test, and surfaced the tradeoff to the owner
+(CLAUDE.md "look at the target before overwriting"). **Durable capture:** the Q-0089 audit-triage
+heuristic above — the enforcing form is a lint/step in the audit workflow ("finding + a test
+asserting it ⇒ downgrade to tradeoff"), routed as the session idea. No code guard shipped this
+session (the fix is the deliverable); the durable prevention is the recorded heuristic.
+
+## Grooming (Q-0015) · Self-initiated
+
+- **Grooming:** closed two of the audit's ranked issues end-to-end (its ledger's two silent-loss-path
+  findings) — advancing the audit → fix pipeline. The Bug-1 mislabel is fed back as a triage-heuristic
+  idea so the audit itself improves.
+- **⚑ Self-initiated:** none — executed owner-directed work (the panel choice "fix the 2 prod bugs",
+  and the Bug-1 direction ratified live). No self-initiated idea→plan→build promotion.

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -251,15 +251,19 @@ class BlackjackCog(commands.Cog):
                 version = row.get("version")
                 if version != BLACKJACK_TOURNAMENT_VERSION:
                     logger.info(
-                        "blackjack_tournament recovery: dropping "
-                        "version-mismatch row id=%s (saved=%s, current=%s)",
+                        "blackjack_tournament recovery: version-mismatch row "
+                        "id=%s (saved=%s, current=%s) — refunding the entry "
+                        "fee before dropping",
                         row["id"],
                         version,
                         BLACKJACK_TOURNAMENT_VERSION,
                     )
-                    await game_state_service.clear_by_id(row["id"])
-                    cleared += 1
-                    continue
+                # The entry fee was debited at launch and is owed regardless
+                # of the state-schema version: a VERSION bump on the
+                # merge=deploy restart must NOT forfeit live tournament fees
+                # (the previous code cleared version-mismatch rows without
+                # refunding).  `bet` is a stable top-level int in state, so
+                # refund it whenever present, then clear the row either way.
                 state = row.get("state") or {}
                 bet = state.get("bet")
                 if isinstance(bet, int) and bet > 0:

--- a/disbot/core/runtime/message_pipeline.py
+++ b/disbot/core/runtime/message_pipeline.py
@@ -133,6 +133,7 @@ from typing import Any, Protocol, runtime_checkable
 import discord
 from discord.ext import commands
 
+from core.runtime import lifecycle
 from services import metrics
 
 logger = logging.getLogger("bot.runtime.message_pipeline")
@@ -263,6 +264,18 @@ async def dispatch(bot: commands.Bot, message: discord.Message) -> None:
     See module docstring for the pre-filter rules, error-isolation
     semantics, and moderation-routing hook.
     """
+    # Deploy-handoff double-fire guard (LP-4).  main() releases the runtime
+    # lock BEFORE bot.close() drains, so the incoming replica connects while
+    # this instance is still draining.  Discord delivers MESSAGE_CREATE to
+    # BOTH gateway connections during the overlap; running the stages here
+    # would double-apply every additive side effect (db.add_xp is additive
+    # with no per-message idempotency → double XP; same class for counting /
+    # chain / rps / four_twenty / btd6).  A draining instance runs no stages
+    # — the incoming replica owns ongoing traffic.  This does not regress the
+    # LP-4 fast lock release; it only stops the OUTGOING instance from acting
+    # during the handoff overlap.
+    if lifecycle.is_shutting_down():
+        return
     if message.author.bot:
         return
     if message.guild is None:

--- a/docs/owner/claims/claude__fix-prod-loss-paths-2026-07-03.md
+++ b/docs/owner/claims/claude__fix-prod-loss-paths-2026-07-03.md
@@ -1,0 +1,1 @@
+- `claude/fix-prod-loss-paths-2026-07-03` · **fix 2 confirmed prod loss paths (from the engine-room audit #1690)** — (1) blackjack tournament entry-fee forfeit on VERSION bump; (2) XP double-fire during the LP-4 deploy-handoff overlap · `disbot/cogs/blackjack_cog.py` `disbot/core/runtime/message_pipeline.py` · 2026-07-03 · PR pending

--- a/docs/owner/claims/claude__fix-prod-loss-paths-2026-07-03.md
+++ b/docs/owner/claims/claude__fix-prod-loss-paths-2026-07-03.md
@@ -1,1 +1,0 @@
-- `claude/fix-prod-loss-paths-2026-07-03` · **fix 2 confirmed prod loss paths (from the engine-room audit #1690)** — (1) blackjack tournament entry-fee forfeit on VERSION bump; (2) XP double-fire during the LP-4 deploy-handoff overlap · `disbot/cogs/blackjack_cog.py` `disbot/core/runtime/message_pipeline.py` · 2026-07-03 · PR pending

--- a/tests/unit/cogs/test_blackjack_tournament_persistence.py
+++ b/tests/unit/cogs/test_blackjack_tournament_persistence.py
@@ -151,11 +151,17 @@ async def test_recover_blackjack_tournament_refunds_each_row():
 
 
 @pytest.mark.asyncio
-async def test_recover_blackjack_tournament_drops_version_mismatch_without_refund():
-    """A version-mismatch row's bet field may be in a foreign schema —
-    we drop the row but do NOT refund (the value might be wrong).
-    Operators investigating ``economy_audit_log`` see no spurious
-    blackjack_tournament:restart_refund entries for unrecognised data.
+async def test_recover_blackjack_tournament_refunds_version_mismatch():
+    """A VERSION bump must NOT forfeit live tournament entry fees.
+
+    The entry fee was debited at launch and is owed regardless of the
+    state-schema version, so recovery refunds the row's ``bet`` (guarded
+    by the int>0 sanity check) and then clears it even when the saved
+    version differs from the current one.  Owner decision 2026-07-03:
+    the money is really lost in the common case where ``bet`` is
+    unchanged, and whoever bumps the version owns keeping ``bet`` = the
+    entry fee (or updating this handler).  Previously the mismatch branch
+    cleared the row without refunding.
     """
     from cogs.blackjack_cog import BlackjackCog
 
@@ -177,7 +183,13 @@ async def test_recover_blackjack_tournament_drops_version_mismatch_without_refun
         ) as mock_refund,
     ):
         await cog._recover_blackjack_tournament()
-    mock_refund.assert_not_called()
+    mock_refund.assert_awaited_once()
+    assert mock_refund.await_args.kwargs["user_id"] == 222
+    assert mock_refund.await_args.kwargs["amount"] == 999
+    assert (
+        mock_refund.await_args.kwargs["reason"]
+        == "blackjack_tournament:restart_refund"
+    )
     mock_clear.assert_awaited_once_with(7)
 
 

--- a/tests/unit/runtime/test_message_pipeline.py
+++ b/tests/unit/runtime/test_message_pipeline.py
@@ -135,6 +135,33 @@ class TestPreFilter:
         await message_pipeline.dispatch(MagicMock(), _make_message(has_guild=False))
         assert s.calls == []
 
+    @pytest.mark.asyncio
+    async def test_draining_instance_runs_no_stages(self):
+        # LP-4 deploy-handoff double-fire guard: a draining instance releases
+        # the runtime lock before it finishes draining, so the incoming replica
+        # processes the same MESSAGE_CREATE.  Running stages here would
+        # double-apply additive effects (XP, counting, ...).  A draining
+        # instance must run no stages.
+        s = _SpyStage(name="x", order=10)
+        message_pipeline.register(s)
+        with patch.object(
+            message_pipeline.lifecycle, "is_shutting_down", return_value=True
+        ):
+            await message_pipeline.dispatch(MagicMock(), _make_message())
+        assert s.calls == []
+
+    @pytest.mark.asyncio
+    async def test_running_instance_runs_stages(self):
+        # Guard is scoped to draining only — a RUNNING instance dispatches
+        # normally (regression fence so the guard can't silently kill traffic).
+        s = _SpyStage(name="x", order=10)
+        message_pipeline.register(s)
+        with patch.object(
+            message_pipeline.lifecycle, "is_shutting_down", return_value=False
+        ):
+            await message_pipeline.dispatch(MagicMock(), _make_message())
+        assert len(s.calls) == 1
+
 
 # ---------------------------------------------------------------------------
 # Stage iteration


### PR DESCRIPTION
Owner-directed follow-up to the engine-room audit (#1690): fix the two **CONFIRMED** live loss paths it surfaced. Both verified against source before scoping.

## Bug 1 — blackjack tournament entry-fee forfeit on a `VERSION` bump (money)
`disbot/cogs/blackjack_cog.py` `_recover_blackjack_tournament`: the version-mismatch branch does `clear_by_id(row["id"])` + `continue`, **skipping the refund block** — so the next time `BLACKJACK_TOURNAMENT_VERSION` is bumped (schema change), every in-flight tournament's entry fee is forfeited on the merge=deploy restart. This directly contradicts the method's own docstring ("this one MUST refund").

**Fix:** refund the entry fee (`state["bet"]`) *regardless of version* before clearing — the fee was debited at launch and is owed whether or not the rest of the state schema still parses.

## Bug 2 — XP double-fires during the LP-4 deploy handoff (whole additive-on_message class)
`bot1.py` releases the runtime lock **before** `bot.close()` drains (deliberate LP-4 optimization, fixes ~85s downtime), so the incoming replica connects while the draining instance is still processing. Discord delivers `MESSAGE_CREATE` to **both** gateway connections during the overlap, and `db.add_xp` is additive (`xp = xp.xp + amount`) with no per-message idempotency → double XP.

**Fix (root, not symptom):** gate `core/runtime/message_pipeline.dispatch()` on `lifecycle.is_shutting_down()`. A draining instance runs **no** message stages; the incoming replica owns ongoing traffic. One chokepoint covers xp / counting / chain / cleanup / rps / four_twenty / btd6 (all pipeline stages) — not just XP. Does **not** regress LP-4 (the fast lock release stays); it only stops the *old* instance from double-applying during the overlap.

## Tests + checks
Regression tests for both paths; `check_quality --full` (black/isort/ruff + mypy + pytest) and `check_architecture --mode strict` green.

---

Born red (in-progress session card); flips to complete when the fixes + tests land. Auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVVV6dEciQdrirWJufnmui

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVVV6dEciQdrirWJufnmui)_