### PR TITLE
Capture 2 owner ideas: in-server release→test→verify loop + websites cutover-role

### DIFF
--- a/.sessions/2026-07-03-owner-ideas-release-loop-websites.md
+++ b/.sessions/2026-07-03-owner-ideas-release-loop-websites.md
@@ -1,0 +1,43 @@
+# 2026-07-03 — Capture 2 owner ideas: release→test→verify loop + websites cutover-role
+
+> **Status:** `complete`
+
+**Run type:** owner idea-drop, mid-conversation after the Tier-1 sitting (Q-0237). Docs-only,
+restarted fresh from `origin/main`. **PR TBD (opened this session).**
+
+**Did:** captured and classified two owner-originated rebuild ideas, both of which independently
+close gaps the Fable-5 judgment (§4) flagged as *missing*, so I cross-referenced each to its gap:
+
+1. **`rebuild-release-testing-loop-2026-07-03.md`** — the in-server release → test → verify loop:
+   (A) boot/release announcer of what changed so members know what to test; (B) per-command
+   "tested-since-its-change" coverage from real usage; (C) dedicated test/debug mode (full traces to
+   a channel, self-explaining actions); (D) explain-then-approve button = the `verified_live`
+   sign-off. Closes judgment #5 (change-comms), #7 (field-signal), #8 (co-test throughput) and is
+   the missing *mechanism* for the decided Q-0234 oracle + Q-0222 CUT-1 co-test + C-2 preview/confirm.
+2. **`rebuild-websites-cutover-role-2026-07-03.md`** — give the botsite + dev dashboard a rebuild
+   disposition (they die at cutover today — judgment #4), repoint the producer at the new repo's
+   manifest, and use them during the switch as the public cutover-comms surface and a
+   rebuild-progress/verified_live dashboard (the owner-consumable visual artifact judgment #16
+   flagged). Pairs with idea 1.
+
+Both routed as **new Stage-2 capability-corpus entries** (like D-2 media gen) + Gate-0 amendments to
+the verification/cutover story; idea-1's A/C flagged as also current-bot-buildable now. Design forks
+recorded in each doc (release-trigger vs every-boot; approve = gate vs sign-off, unified;
+test-mode audience/PII; site interim producer).
+
+**⚑ Self-initiated:** none — pure capture of owner-dropped ideas per the Q-0172 classify-then-route
+discipline; no promotion to plan/implementation (the ideas note they're ready to promote when the
+owner wants).
+
+**💡 Session idea (Q-0089):** none new — this session's whole purpose was capturing the owner's two
+ideas; forcing an additional one would be filler (Q-0089 bar). The captured ideas stand.
+
+**⟲ Previous-session review (Q-0102):** the Tier-1 sitting (#1703) closed the decision loop in one
+pass because the judgment pre-tiered the queue with recommendations — good. It could have gone one
+step further and, at the end, *offered* to capture any follow-on ideas the decisions triggered;
+instead this idea-drop came unprompted a turn later. **System note:** a decisions-recording session
+could end by asking "did answering these surface anything to capture?" — cheap, and it keeps the
+associative-idea flow (the owner's working style) from relying on him to re-raise it.
+
+**Docs audit (Q-0104):** `check_docs --strict` + `check_plan_homing` green; both ideas indexed in
+`docs/ideas/README.md` with gap cross-refs; nothing left in chat only.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,20 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`rebuild-release-testing-loop-2026-07-03.md`](./rebuild-release-testing-loop-2026-07-03.md) —
+  **owner idea (2026-07-03):** the in-server **release → test → verify loop** — a boot/release
+  announcer of what changed (so members know what to test), per-command "tested-since-its-change"
+  coverage from real usage, a dedicated **test/debug mode** (full traces to a channel, actions
+  self-explain), and an **explain-then-approve button** that doubles as the `verified_live`
+  sign-off. Closes judgment gaps #5/#7/#8 and is the missing *mechanism* for the decided Q-0234
+  oracle + Q-0222 CUT-1 live co-test. Routes as new Stage-2 capabilities; A/C could ship in the
+  current bot now.
+- [`rebuild-websites-cutover-role-2026-07-03.md`](./rebuild-websites-cutover-role-2026-07-03.md) —
+  **owner idea (2026-07-03):** give the off-Discord **botsite + dev dashboard** a rebuild
+  disposition (they die at cutover today — judgment #4), repoint their producer at the new repo's
+  manifest, and use them **during the switch** as the public changelog/cutover-comms surface and a
+  **rebuild-progress + verified_live dashboard** (the owner-consumable visual artifact judgment #16
+  flagged missing). Pairs with the release-loop idea.
 - [`fleet-structured-output-placeholder-guard-2026-07-03.md`](./fleet-structured-output-placeholder-guard-2026-07-03.md) —
   **session idea (2026-07-03, Q-0089, final-judgment PR #1701):** reject placeholder values
   (`test`, `t/e/f`, `TODO`) in required evidence/reasoning fields of fleet structured outputs, with

--- a/docs/ideas/rebuild-release-testing-loop-2026-07-03.md
+++ b/docs/ideas/rebuild-release-testing-loop-2026-07-03.md
@@ -1,0 +1,87 @@
+# Idea — the in-server release → test → verify loop (announce · coverage · test-mode · approve)
+
+> **Status:** `ideas` — capture (owner-originated). **Subsystem:** none (rebuild platform /
+> verification tooling — touches diagnostic, help, command-surface, every cog's dispatch seam).
+> **Provenance:** owner idea-drop, 2026-07-03, immediately after the Fable-5 final judgment
+> (PR #1701). Closes judgment gaps #5 (change-communication), #7 (field-signal), #8 (co-test
+> throughput) and is the missing *mechanism* for the already-decided Q-0234 oracle + Q-0222 CUT-1
+> `verified_live` sign-off. Source wins over this doc (Q-0120).
+
+## Why this matters — it closes known holes, it's not new scope
+
+The Fable-5 judgment flagged, as gaps that survived the whole planning day: **no user-facing
+change-communication mechanic** (§4 #5 — merge=deploy + D-5 drops + Q-0224 renames all change
+user-visible behavior with no way to tell users), **no field-signal / feedback intake after
+cutover** (§4 #7), and **the live co-test serializes 271 commands through one human with no
+throughput mechanism** (§4 #8, stress oracle-gatev). The owner's idea is the concrete machinery for
+all three — and the confirm/approve half is the *implementation* of the `verified_live` per-command
+sign-off that Q-0234 and Q-0222 already decided but left as an abstract registry.
+
+## The loop (four components, ship incrementally)
+
+### A. In-server release announcer
+On a **new release** (not every merge=deploy boot — see fork 1), the bot posts a digest to a
+designated channel: **new / changed / improved commands and functions**, so members know what to
+test. Generated from the **manifest** (every command is declared, with its version/changed-at) ×
+the **changelog** (`docs/bot-changelog.md` today) — the same declared surface the whole rebuild is
+built on, so the announcer is *generated*, not hand-written.
+
+### B. Per-command "tested-since-change" coverage
+The manifest declares each command's **changed-at version**; a small **usage store** records each
+command's **last-invoked-at (+ by-whom / where)**. Derived signal: **"changed since vN but not
+exercised since the change"** — live test-coverage from real usage, surfaced in the announcer ("3 of
+today's 7 changed commands haven't been tried yet") and to the operator. This is a genuinely novel
+oracle: coverage measured from *production usage*, complementing the parity goldens (which measure
+coverage from a fixed corpus).
+
+### C. Dedicated test/debug mode
+A per-scope toggle (see fork 3). When on, every command execution emits a **full debug trace** to a
+dedicated channel — resolved inputs, the authority decision, DB deltas, events emitted, timing —
+and **actions self-explain** wherever possible. This is the observability half the runtime audit
+already wants; in test mode it's surfaced live instead of buried in logs.
+
+### D. Explain-then-approve (the `verified_live` sign-off, in Discord)
+In test mode, an action is **explained and then confirmed via a button** before/after it runs — and
+that confirmation **doubles as the `verified_live` sign-off** (Q-0234/Q-0222). This unifies two
+things the plan already has: the **C-2 preview/confirm/apply** pipeline (extended from setup drafts
+to any command under test) *and* the per-command live-test checklist. It turns the owner's
+"command-by-command, does it beat the old bot" co-test from an external checklist into an in-Discord
+button flow — directly relieving the one-human-bottleneck (judgment §4 #8).
+
+## Open design forks (resolve when promoted)
+
+1. **Trigger: release-triggered, not every boot.** merge=deploy reboots the worker many times a day
+   (Q-0193); "announce every boot" would spam. Announce only when there is **something new since the
+   last announced version**, dedup'd by a stored last-announced marker.
+2. **"Approve" semantics — both, unified.** Reading it as (a) a *safety gate* (explain the action,
+   press to let it commit — the C-2 preview/confirm extended to arbitrary test-mode commands) and
+   (b) a *verification sign-off* (press = "this did the right thing" → feeds `verified_live`). The
+   same button serves both: confirm-to-run in test mode, and the confirmation is recorded as the
+   sign-off.
+3. **Test-mode audience:** owner-only · per-guild admin opt-in · or open to designated community
+   testers. The debug channel's **verbosity + PII policy** depends on this (a public tester channel
+   must scrub member data; an owner-only channel need not).
+4. **Coverage store scope:** per-command last-used is cheap; per-(command × guild) or per-user is
+   richer but larger — bound it.
+
+## Routing
+
+- **New capability-corpus entries for Stage 2** (like D-2 media generation was added mid-review):
+  the announcer, the coverage signal, and the test/verify mode become named capabilities the
+  subsystem walk places and the Gate-0 grammar supports (a `changed_at`/version field on CommandSpec
+  for A/B; the test-mode dispatch hook; the sign-off store for D).
+- **Amends the verification/cutover story at Gate-0:** folds into the Q-0234 oracle (D is its live
+  half) and the Q-0222 CUT-1 `verified_live` registry (D is its UI); the announcer is the
+  user-comms half CUT-3 currently lacks (judgment §4 #9/#11).
+- **A/C could also ship in the *current* bot now** (a release announcer + a debug channel are
+  buildable against today's `command_manifest` + `docs/bot-changelog.md`) if the owner wants a
+  near-term win before the rebuild lands — but D (sign-off) is best built once on the new manifest.
+
+## Pointers
+
+- Judgment gaps this closes: `final-judgment-fable5-2026-07-03.md` §4 (#5, #7, #8), §5 (the co-test
+  bottleneck).
+- Decisions it implements/enriches: Q-0234 (oracle) · Q-0222 (CUT-1 `verified_live`) · C-2 (draft
+  preview/confirm/apply, Q-0228) · Q-0193 (merge=deploy, why trigger ≠ boot).
+- Companion idea (the off-Discord surface for the announcer + coverage):
+  `rebuild-websites-cutover-role-2026-07-03.md`.

--- a/docs/ideas/rebuild-websites-cutover-role-2026-07-03.md
+++ b/docs/ideas/rebuild-websites-cutover-role-2026-07-03.md
@@ -1,0 +1,68 @@
+# Idea — the off-Discord websites: rebuild disposition, cutover role, and staying current
+
+> **Status:** `ideas` — capture (owner-originated). **Subsystem:** none (off-Discord surface /
+> operations). **Provenance:** owner idea-drop, 2026-07-03, after the Fable-5 final judgment
+> (PR #1701). Closes judgment gap §4 #4 (the off-Discord surface has no rebuild disposition and
+> structurally dies at cutover) and serves gaps #16 (owner-consumable visual artifacts), #9/#11
+> (cutover user-comms). Source wins over this doc (Q-0120).
+
+## The gap the judgment found
+
+The shipped **public bot site** (`botsite/` — marketing, `/changelog`, interactive command
+reference) and the **developer dashboard** are fed by one producer,
+`scripts/export_dashboard_data.py`, which **AST-parses the OLD repo** (`disbot/utils/
+subsystem_registry.py`, `docs/bot-changelog.md`, `.sessions/*.md`). Nothing in the rebuild plan
+dispositions them, so at cutover the new repo has no equivalent producer and **both sites go stale
+or die** (judgment §4 #4). The owner's insight closes this and turns it into an asset.
+
+## The owner's insight — the sites are useful *during* the switch, and must stay current
+
+1. **A cutover-comms surface.** The public changelog site is the natural public face of the
+   in-server release announcer (companion idea
+   `rebuild-release-testing-loop-2026-07-03.md`) — the "what changed / what to test" story for
+   users who aren't in a test channel, and the user-facing communication CUT-3 currently lacks
+   (judgment §4 #9/#11).
+2. **A progress + verification dashboard.** During the multi-month dual-repo build, the dashboard
+   can track **rebuild progress** (Stage-2 rows walked, subsystems triaged, `verified_live`
+   coverage, parity-golden pass rate, open owner-gated decisions) — which is also the
+   **owner-consumable visual artifact** the judgment flagged as missing (§4 #16: every gate hands a
+   non-coder, visually-oriented owner prose/JSON with nothing rendered).
+3. **They must stay updated with progress** — so their producer has to become a first-class,
+   maintained part of the rebuild, not an afterthought that rots.
+
+## Disposition (the rebuild answer)
+
+- **Repoint the producer at the new repo's manifest.** The new bot's **declared surface is a
+  cleaner data source than AST-parsing** — the command reference, changelog, and coverage all fall
+  out of the manifest + the release/coverage stores (idea A/B), so the sites are *generated from the
+  same declarations as everything else*. This is the repo-as-artifact framing (Q-0234 part 3)
+  applied to the sites.
+- **Decide which site stays vs merges** (fork): the public marketing/changelog site and the
+  internal dev/progress dashboard may want different hosting, update cadence, and audiences during
+  the dual-repo interim.
+- **Give it a cutover role in D-3/CUT-3:** the public changelog + a status page are part of the
+  user-comms and progressive-exposure plan the judgment flagged as absent (§4 #11 / stress D-3).
+
+## Open forks (resolve when promoted)
+
+1. **Interim producer:** does the site keep reading the *old* repo until cutover, switch to the
+   *new* repo's manifest as soon as it has a surface, or run both side-by-side (old = live bot, new
+   = progress)? (Ties to the frozen-reference / old-bot-interim policy, judgment §4 #21.)
+2. **Hosting + update cadence** during the dual-repo months — and who/what regenerates it (a
+   routine? a CI step on merge?).
+3. **Scope of the progress dashboard** — how much of the Stage-2/verified_live/owner-queue state it
+   surfaces, and whether it's public or owner-only.
+
+## Routing
+
+- A rebuild-scoped disposition item: fold into the **Stage-3 consolidation** (the sites are part of
+  the cutover + repo-as-artifact story) and give the producer a home in the new repo's manifest
+  consumers.
+- Pairs with `rebuild-release-testing-loop-2026-07-03.md` — the sites are the off-Discord surface
+  for the same announce/coverage data.
+
+## Pointers
+
+- Judgment gaps this closes: `final-judgment-fable5-2026-07-03.md` §4 (#4, #16, #9/#11).
+- Shipped producer to port: `scripts/export_dashboard_data.py`; sites under `botsite/`.
+- Framing: Q-0234 part 3 (repo-as-artifact) · D-3/Q-0222 (cutover).

--- a/docs/owner/claims/claude-superbot-phase-a-judgment-e8yhlm.md
+++ b/docs/owner/claims/claude-superbot-phase-a-judgment-e8yhlm.md
@@ -1,1 +1,1 @@
-- `claude/superbot-phase-a-judgment-e8yhlm` · record the 7 Tier-1 owner decisions from the Fable-5 judgment sitting (router Q-0237 + amendment pointers in the 3 decision docs + final-judgment §6) · docs-only · 2026-07-03
+- `claude/superbot-phase-a-judgment-e8yhlm` · capture 2 owner-originated rebuild ideas (in-server release→test→verify loop; websites cutover-role) + index · docs/ideas only · 2026-07-03


### PR DESCRIPTION
Captures and classifies two owner-originated rebuild ideas dropped after the Tier-1 sitting. Both independently close gaps the Fable-5 judgment (§4) flagged as *missing*, so each is cross-referenced to its gap. Docs-only (`docs/ideas/` + index).

**1. `rebuild-release-testing-loop-2026-07-03.md`** — the in-server release → test → verify loop: (A) a boot/release announcer of what changed so members know what to test; (B) per-command "tested-since-its-change" coverage from real usage; (C) a dedicated test/debug mode (full traces to a channel, self-explaining actions); (D) an explain-then-approve button that doubles as the `verified_live` sign-off. Closes judgment #5 (change-comms), #7 (field-signal), #8 (co-test throughput) and is the missing *mechanism* for the decided Q-0234 oracle + Q-0222 CUT-1 co-test + C-2 preview/confirm.

**2. `rebuild-websites-cutover-role-2026-07-03.md`** — give the botsite + dev dashboard a rebuild disposition (they die at cutover today — judgment #4), repoint their producer at the new repo's manifest, and use them during the switch as the public cutover-comms surface and a rebuild-progress/`verified_live` dashboard (the owner-consumable visual artifact judgment #16 flagged missing).

Both routed as new Stage-2 capability-corpus entries + Gate-0 amendments; idea 1's A/C flagged as also current-bot-buildable now. Design forks recorded in each doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFiE1tptamXznnSg9S5n9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFiE1tptamXznnSg9S5n9S)_