### PR TITLE
CI-setup redesign brief (prime the next session)

### DIFF
--- a/.sessions/2026-07-05-ci-setup-brief.md
+++ b/.sessions/2026-07-05-ci-setup-brief.md
@@ -1,0 +1,16 @@
+# 2026-07-05 — CI-setup redesign brief (owner-directed prep)
+
+> **Status:** `in-progress` — born-red card; flips to `complete` as the deliberate final step.
+
+## What this session is doing
+
+Owner set the *next* session's topic: **find the best-possible CI setup for the bot** — get the same
+coverage with **fewer separate checks** where that helps, and **add what's genuinely needed**. Owner
+aiming decisions (this session's `AskUserQuestion`): **scope = everything end-to-end** (17 Actions
+workflows + 40 `check_*.py` + the Claude Code hooks); **optimize for = reliability + cost** (Actions
+minutes) — consolidation is the *means* to those, not the goal.
+
+This session **primes** that work: it inventories the current CI landscape and writes the scoping
+brief, so the CI-setup session starts on the redesign, not the discovery. Docs/planning only.
+
+<!-- Did/Outcome/enders filled in at the deliberate final flip. -->

--- a/.sessions/2026-07-05-ci-setup-brief.md
+++ b/.sessions/2026-07-05-ci-setup-brief.md
@@ -1,16 +1,107 @@
 # 2026-07-05 — CI-setup redesign brief (owner-directed prep)
 
-> **Status:** `in-progress` — born-red card; flips to `complete` as the deliberate final step.
+> **Status:** `complete` — deliberate final flip (born-red gate). Docs-only; `check_docs --strict`
+> green.
 
-## What this session is doing
+## What this session did
 
-Owner set the *next* session's topic: **find the best-possible CI setup for the bot** — get the same
-coverage with **fewer separate checks** where that helps, and **add what's genuinely needed**. Owner
-aiming decisions (this session's `AskUserQuestion`): **scope = everything end-to-end** (17 Actions
-workflows + 40 `check_*.py` + the Claude Code hooks); **optimize for = reliability + cost** (Actions
-minutes) — consolidation is the *means* to those, not the goal.
+The owner set the *next* session's topic — **find the best-possible CI setup** (fewer separate checks
+where it helps + add genuine gaps) — and asked me to confirm I understood and prime the repo. I
+confirmed with a concrete grasp of the sprawl, captured the two aiming decisions via `AskUserQuestion`
+(**scope = everything end-to-end; optimize for reliability + cost**), then **inventoried the CI
+landscape and wrote the scoping brief** so that session starts on the redesign, not the discovery.
 
-This session **primes** that work: it inventories the current CI landscape and writes the scoping
-brief, so the CI-setup session starts on the redesign, not the discovery. Docs/planning only.
+## Shipped (PR #1736, docs-only)
 
-<!-- Did/Outcome/enders filled in at the deliberate final flip. -->
+- **[`docs/planning/ci-setup-redesign-brief-2026-07-05.md`](../docs/planning/ci-setup-redesign-brief-2026-07-05.md)**
+  — the brief: mission + owner aiming decisions; a full inventory (17 Actions workflows by role · the
+  `code-quality` merge-gating bundle · the 40 `check_*.py` by run-context · the hooks); the reliability
+  pain points (CodeQL race, dropped-`synchronize` stalls + their compensators, cancellation/born-red
+  edge cases); the cost pain points (~8 workflows/push, unfiltered app-CI, push/PR duplication); the
+  genuine gaps to add (Q-0238, the two checker ideas); the **method** (inventory → classify each check
+  merge-gating/advisory/routine/dev-only → consolidate toward ~one required context → add gaps into the
+  right class → target-state design + phased migration); and the **owner-gated guardrail** (propose
+  before ripping out — CI/hooks/branch-protection are executable config).
+- **S5-ops sector** now points at the brief (the next session lands on it).
+
+## Key findings that shaped the brief
+
+- **8 workflows fire per push, mostly unfiltered** — the cost story; path-filtering the app-CI
+  workflows (botsite/dashboard/design-system) is an obvious lever.
+- **Only 5 of the 40 `check_*.py` run inside the merge gate** (`code-quality`); the other ~35 run via
+  hooks/routines/ad-hoc — so "what actually gates a merge" is much narrower than the checker count
+  suggests, and building the what-runs-where matrix is the session's first real task.
+- **`check_ci_coverage.py` + `ci-rerun-watchdog.yml` exist only to compensate** for the dropped-
+  `synchronize` CI stall — a tell that the trigger topology should be fixed at the root, not papered.
+- The **CodeQL merge-race** (this week's #1728→#1730) is the headline reliability defect, already
+  captured as router Q-0238 — folded into the brief as a gap to close.
+
+## Context delta
+
+- **Needed but not pointed to:** there was no single "CI map" doc — I had to derive the
+  workflow-by-role + check-by-run-context picture from the raw `.github/workflows/` + `scripts/`
+  listings. The brief now *is* that map (first draft); the session will make it authoritative.
+- **Decisions made alone:** none of substance — the two session-shaping forks (scope, optimize-for)
+  were put to the owner via `AskUserQuestion` and answered (everything; reliability+cost). The brief's
+  *method* (aim for ~one required context) is a recommendation the session/owner can revise.
+- **Flagged for maintainer:** the redesign itself is **owner-gated** (executable config) — the next
+  session proposes, you ratify before destructive changes. Q-0238 is the one concrete decision already
+  queued.
+- **🛠 Friction → guard:** n/a this session (docs-only; nothing blocked it). The CI-setup session *is*
+  the systemic friction→guard for the reliability issues we've been hitting.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session = the **next-session-prep / docs-banking** run (#1735). Strong: it banked every loose
+finding into a proper home and answered the substrate-kit question with a real evidence base (delegated
+candidate map + grounded reads) rather than a guess, correctly catching that the kit is already
+finalized. **What it could have done better:** its priority doc offered "live → Stage-2 walk /
+autonomous → §7.2 or A/B" but didn't anticipate that the owner might redirect to a *different* axis
+entirely (CI setup) — a reminder that a priority doc is a menu, not a prediction; the owner picks the
+axis. No system change needed — the menu did its job (the owner steered).
+
+## 💡 Session idea (Q-0089)
+
+Rolling forward the still-unbuilt idea from #1735 (**a maintained rebuild/CI gate-state readout**) —
+this session reinforces it: I again had to *derive* "what actually gates a merge" from raw listings
+(now for CI, last session for the rebuild phases). The generalized idea: **a single generated
+`gate-state` readout** (rebuild phase gates + CI required-checks) so no session re-derives "what's
+blocking / what's required." The CI half becomes concrete once the CI-setup session builds the
+what-runs-where matrix — the matrix *is* the CI gate-state source. Not filing a second idea file;
+noting the reinforcement so the CI-setup session can emit the readout as a byproduct.
+
+## 🧹 Grooming (Q-0015)
+
+Groomed the S5-ops queue: added the owner-directed CI-setup redesign as its now-top ▶ item with a
+turn-key brief — moving "improve CI reliability/cost" from scattered pain points (across several
+journal rules + Q-0238) into one scoped, startable plan.
+
+## 📋 Docs audit (Q-0104)
+
+New `plan`-badged brief + S5 pointer; `check_docs --strict` green. The aiming decisions are recorded
+in this log (the `AskUserQuestion` answers); no separate router Q needed (the topic is a directed
+work-item, not a product decision — Q-0238 already carries the one embedded decision).
+
+## 📤 Run report
+
+- **Did:** confirmed the owner's CI-setup intent, captured the two aiming decisions, and wrote the
+  scoping brief (with a first-draft CI inventory) to prime the dedicated session. · **Outcome:** shipped
+- **Shipped:** #1736 — docs-only (CI-setup brief + S5-ops pointer)
+- **Run type:** `manual` (owner-directed)
+- **⚑ Owner decisions needed:** none new here — the CI-setup session will surface proposals to
+  ratify; Q-0238 (CodeQL-in-merge-hold) remains the one already-queued CI decision.
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** none (owner-directed).
+- **↪ Next:** the dedicated **CI-setup redesign** session — start from
+  `docs/planning/ci-setup-redesign-brief-2026-07-05.md` (build the what-runs-where matrix, then the
+  target-state design + phased owner-gated migration).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1736, docs-only, on green) |
+| CI-red rounds | 0 (docs-only; born-red gate red is the intended hold; no CodeQL surface) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 new (reinforced the #1735 gate-state-readout idea) |
+| Ideas groomed | 1 (S5 CI-redesign scoped into a turn-key brief) |

--- a/docs/current-state/S5-ops.md
+++ b/docs/current-state/S5-ops.md
@@ -26,6 +26,13 @@
 *(offline-fit tags — `[offline]` self-mergeable now · `[needs-live-bot]` needs a running bot / runtime
 creds · `[owner]` needs an owner decision/action; see [`../repo-sector-map.md`](../repo-sector-map.md)
 § "the offline-fit startability tag". S5 is the executor outlier — most items are owner/Hermes-run.)*
+- **📍 OWNER-DIRECTED NEXT SESSION — the "best-possible CI setup" redesign:**
+  [`../planning/ci-setup-redesign-brief-2026-07-05.md`](../planning/ci-setup-redesign-brief-2026-07-05.md).
+  Scoped end-to-end (17 Actions workflows + 40 `check_*.py` + hooks); optimize for **reliability +
+  cost**; consolidate where it kills flakiness/minutes, add genuine gaps (Q-0238, the two checker
+  ideas). The brief carries the full inventory + method; the session produces the target-state design
+  + a phased, **owner-gated** migration (CI/hooks/branch-protection are executable config — propose
+  before ripping out). `[offline]` to *design + propose*; `[owner]` to *apply* destructive changes.
 - `[owner]` **Website two-site split rollout** — v1 is code-complete + reviewed; what remains is the
   owner-paced rollout (provision `botsite/` + submissions DB, domain cutover)
   ([handoff](../operations/website-split-next-steps-2026-06-19.md)).

--- a/docs/owner/claims/claude__save-fixes-implementation-8v1ziy.md
+++ b/docs/owner/claims/claude__save-fixes-implementation-8v1ziy.md
@@ -1,0 +1,6 @@
+- `claude/save-fixes-implementation-8v1ziy` · **CI-setup redesign brief (owner-directed)** — prime the
+  next session: inventory the CI landscape (17 Actions workflows + 40 `check_*.py` + hooks) and write a
+  scoping brief for a dedicated "best-possible CI setup" session (scope: everything end-to-end;
+  optimize for reliability + cost; consolidate where it kills flakiness/minutes; add genuine gaps).
+  Docs/planning only. · touches `docs/planning/` `docs/current-state/S5-ops.md` · 2026-07-05 ·
+  in-progress, PR opening

--- a/docs/owner/claims/claude__save-fixes-implementation-8v1ziy.md
+++ b/docs/owner/claims/claude__save-fixes-implementation-8v1ziy.md
@@ -1,6 +1,0 @@
-- `claude/save-fixes-implementation-8v1ziy` · **CI-setup redesign brief (owner-directed)** — prime the
-  next session: inventory the CI landscape (17 Actions workflows + 40 `check_*.py` + hooks) and write a
-  scoping brief for a dedicated "best-possible CI setup" session (scope: everything end-to-end;
-  optimize for reliability + cost; consolidate where it kills flakiness/minutes; add genuine gaps).
-  Docs/planning only. · touches `docs/planning/` `docs/current-state/S5-ops.md` · 2026-07-05 ·
-  in-progress, PR opening

--- a/docs/planning/ci-setup-redesign-brief-2026-07-05.md
+++ b/docs/planning/ci-setup-redesign-brief-2026-07-05.md
@@ -1,0 +1,124 @@
+# CI-setup redesign — session brief (2026-07-05)
+
+> **Status:** `plan` — a scoping brief for a **dedicated next session** (owner-directed). It
+> inventories the current CI landscape and frames the redesign so that session starts on the design,
+> not the discovery. **Not the redesign itself** — the target-state design + migration is the
+> session's deliverable.
+
+## Mission (owner-set)
+
+Find the **best-possible CI setup** for the bot: get the same coverage with **fewer separate checks**
+where that helps, and **add what's genuinely needed**. First-principles, not incremental tinkering.
+
+**Owner aiming decisions** (`AskUserQuestion`, 2026-07-05):
+- **Scope = everything, end-to-end** — the 17 GitHub Actions workflows **+** the 40 `scripts/check_*.py`
+  **+** the Claude Code hooks (`PostToolUse`/`Stop`/`PreToolUse` in `.claude/settings.json`), designed
+  as one coherent system.
+- **Optimize for = reliability + cost (Actions minutes).** Consolidation is the **means** to those two
+  ends, not a goal in itself — merge/drop checks specifically where it kills flakiness or minutes;
+  don't consolidate things that are already reliable and cheap just for tidiness.
+
+## Current landscape (inventoried 2026-07-05 — verify against source; workflows/scripts churn)
+
+### A. GitHub Actions workflows (17) — by role
+
+**Merge-gating (runs on `pull_request`):**
+| Workflow | Triggers | Role |
+|---|---|---|
+| `code-quality.yml` | pull_request, push | **The dominant check + cost.** Bundles: `check_quality.py` (black/isort/ruff/mypy/pytest) + `check_docs.py` + `check_consistency.py` + `check_session_gate.py` (born-red gate) + `check_stale_claims.py`. The one required context. |
+| `pr-conflict-guard.yml` | pull_request, push | The `conflict-guard` status (separate required-ish context). |
+| `codeql.yml` | pull_request, push, schedule | Security scan — **advisory, not required** → the merge-race (auto-merge fires on `code-quality` green before CodeQL reports; #1728→#1730). |
+| `codex-final-review.yml` | pull_request | Codex review trigger. |
+| `auto-merge-enabler.yml` | pull_request | Arms native auto-merge on non-draft `claude/*` PRs. |
+
+**Push-triggered app CI (fire on every push, mostly unfiltered — the cost story):**
+`botsite-ci.yml`, `dashboard-ci.yml`, `design-system-ci.yml`, `tool-pins.yml`, `pr-auto-update.yml`
+— **8 workflows fire per push** once you add code-quality/codeql/conflict-guard. Path-filtering (run
+botsite-ci only when `botsite/**` changes, etc.) is an obvious cost lever to evaluate.
+
+**Scheduled / dispatch routines (not merge-gating):**
+`backup-db.yml` (schedule), `ci-rerun-watchdog.yml` (schedule+dispatch), `reconciliation-trigger.yml`
+(issues+push), `dashboard-data-refresh.yml`, `btd6-data-refresh.yml`, `ai-evals.yml`,
+`parity-replay.yml` (dispatch).
+
+### B. Local checkers (40 `scripts/check_*.py`) — by run-context
+
+Only **5** run inside `code-quality` (the merge-gating bundle above). The other ~35 run via **hooks**
+(`check_branch_freshness`, `check_quality` on the Stop hook), **routines** (`check_reconciliation_due`,
+`check_reconcile_marker`, `check_ledger_hygiene`, `check_current_state_ledger`, `check_loop_health`,
+`check_routine_permission_surface`, …), or **ad-hoc / session-close** (`check_session_close_gate`,
+`check_docs`, `check_startability_tags`, `check_sector_map`, …). The session's first job is to build
+the **authoritative what-runs-where matrix** (script → CI / hook / routine / ad-hoc / dev-only →
+required or advisory). `scripts/check_ci_coverage.py` already exists but *only* to detect a CI plumbing
+failure (below) — a tell that the plumbing needs fixing, not more compensators.
+
+### C. Claude Code hooks (`.claude/settings.json`) — `PostToolUse` (auto-fix black/isort/ruff),
+`Stop` (`claude_stop_check.py` → prints the pre-PR command), `PreToolUse` (`check_branch_freshness`,
+`claude_pre_edit`). These are the *local* half of the same coverage — part of "end-to-end."
+
+## The reliability pain points to design out (owner priority #1)
+
+1. **The CodeQL merge-race** — CodeQL is advisory, so auto-merge fires on `code-quality` green before
+   it reports; a real alert then lands in merged `main` and needs a follow-up PR (#1728→#1730). Fix
+   options in **router Q-0238** (make code-scanning a required check, OR have `check_session_gate`
+   refuse green while an alert is open).
+2. **Dropped-`synchronize` stalls** — GitHub sometimes drops the `pull_request: synchronize` event, so
+   a head gets **no** `code-quality` run → no failure webhook → auto-merge waits forever
+   (`check_ci_coverage.py` + `ci-rerun-watchdog.yml` exist only to paper over this; #1283, #1594). A
+   more reliable trigger topology (or a required-check that can't be silently skipped) would retire the
+   compensators.
+3. **Cancellation / born-red edge cases** — the born-red session gate lives *inside* `code-quality`;
+   `conflict-guard` is a separate context; cancellation races were patched (`cancel-in-progress:
+   false`, #1275). Evaluate whether fewer required contexts = fewer stuck states.
+4. **Auto-merge timing** — the "flip the card releases the merge" hazard (journal Rule, 2026-07-05):
+   the gate can't currently hold for async scans. Q-0238 is the enforce-side.
+
+## The cost pain points to design out (owner priority #2)
+
+- **~8 workflows per push**, most unfiltered — `code-quality` is the repo's dominant Actions cost
+  (already has a docs-only fast path; the app-CI workflows mostly don't path-filter).
+- **Duplicated work** across `code-quality` (push+PR both fire) and the app-CI workflows.
+- Levers to evaluate: path-filtering the app-CI workflows; `concurrency` groups to cancel superseded
+  runs (code-quality already cancels superseded PR runs, Q-0126 — extend the pattern); collapsing
+  push+PR duplication; skipping the heavy suite on non-code changes (already partial).
+
+## Genuine gaps to ADD (need-driven, not more-jobs-driven)
+
+- **Q-0238** — code-scanning into the merge hold (the CodeQL race).
+- **audit-seam-coverage checker** ([idea](../ideas/audit-seam-coverage-checker-2026-07-05.md)) — would
+  have caught 3 of the 8 save-fixes bugs; verified as a real gap in current bot + rebuild.
+- **deferred-action restart-recovery checker**
+  ([idea](../ideas/deferred-action-restart-recovery-checker-2026-07-05.md)) — small; a 3rd instance is
+  already known (`utility_cog.py:61`).
+- Whatever the what-runs-where matrix surfaces as **coverage the merge gate doesn't actually enforce**
+  (a checker that only runs on a hook or a routine isn't a merge gate — decide which *should* be).
+
+## Method for the CI-setup session
+
+1. **Inventory → the what-runs-where matrix** (every workflow + every `check_*.py` + every hook →
+   trigger, run-context, required/advisory, cost, reliability history). This is the ground truth the
+   redesign reasons over.
+2. **Classify each check** by its true job: **merge-gating** (must be green to merge) · **advisory**
+   (informational; must NOT silently gate — the CodeQL lesson) · **routine** (scheduled/dispatch, not
+   per-PR) · **dev-only** (hook/local, never CI). Mis-classification is the root of both the race and
+   the cost.
+3. **Consolidate where it serves reliability/cost:** the ideal is **one required merge context** that
+   deterministically reflects "is this mergeable" (fewer stuck states, no dropped-context race);
+   path-filter the app-CI workflows; collapse push/PR duplication; retire compensators
+   (`check_ci_coverage`/`ci-rerun-watchdog`) if the trigger topology is fixed at the root.
+4. **Add the genuine gaps** (above) into the *right* class — a new checker joins the merge gate only if
+   it should block a merge; else it's advisory/routine.
+5. **Produce the deliverable:** a **target-state CI design** (the workflow set + the required-check
+   contract + the check→class matrix + the hook split) **and a phased, reversible migration plan**.
+
+## Guardrail — this is owner-gated executable config; propose before ripping out
+
+Workflows, `.claude/settings.json` hooks, and branch-protection required checks are **executable
+config** (autonomy boundary): the session **proposes the target design and gets owner sign-off before
+destructive changes** (removing a required context, deleting a workflow, changing what gates a merge).
+Migrate **incrementally, reversibly, warn-first** — never drop a check without proving the new setup
+covers it. The reconciliation/routine plumbing (S5) must keep working throughout.
+
+Home: **S5 Operations** ([`../current-state/S5-ops.md`](../current-state/S5-ops.md)) — this is an ops
+lane. Provenance: `.sessions/2026-07-05-ci-setup-brief.md`; the aiming decisions are that session's
+`AskUserQuestion` record.


### PR DESCRIPTION
Owner-directed prep: the next session is dedicated to finding the **best-possible CI setup** — same
coverage with **fewer separate checks** where that helps, plus **adding genuine gaps**. Owner aiming
decisions (captured this session): **scope = everything end-to-end** (17 Actions workflows + 40
`check_*.py` + hooks); **optimize for = reliability + cost**.

This PR inventories the CI landscape and writes the scoping brief so the CI-setup session starts on
the redesign, not the discovery. Docs/planning only — no runtime or workflow changes (those are
owner-gated executable config; the brief is a proposal-first plan).

> Born red via the `in-progress` session card; flips to `complete` (→ CI green → auto-merge) as the
> deliberate final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VDo2VJBLHrwPj9EuWAWxq

---
_Generated by [Claude Code](https://claude.ai/code/session_016VDo2VJBLHrwPj9EuWAWxq)_