### PR TITLE
Q-0240 decide-and-flag decision model + revise Fable brief (foundational consolidation)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,6 +58,16 @@ The short version that governs how you work:
   isn't watching **when it improves the workflow** — the project's whole premise is AI running
   its own project with only light guidance. Within the rails above, default to **acting and
   improving**; never hold back a contained, reversible improvement just because no one is watching.
+  **Decide-and-flag over route-up (owner directive Q-0240, 2026-07-06):** when a decision is *reversible
+  until a downstream gate* — which nearly every planning/design call is, since nothing executes until the
+  maintainer's go/no-go — **decide it yourself** (recommendation + one-line rationale + a flag on the run
+  report), don't park it for the owner. This holds even for "too-technical" / architectural design calls:
+  the maintainer *usually takes the recommended decision* and would rather review the set **once, at the
+  gate**, than answer them one at a time. So the "architectural → ask" trigger above means *irreversible*
+  architectural change to a live system, **not** a reversible-on-paper planning decision. Route to the
+  owner only genuine **product/intent** ambiguity; irreversible / production / external work is
+  **decided-and-flagged-for-veto, not blocked** — the sole stop-and-wait is *executing* something
+  irreversible before the gate. Full model: `docs/owner/agent-decision-authority.md`.
 - **Unclear owner intent.** Consult or add to
   `docs/owner/maintainer-question-router.md` when product/owner intent is genuinely
   unclear; unanswered questions are not approval. Preserve maintainer answers and

--- a/.sessions/2026-07-06-fable-decision-authority-and-foundational-consolidation.md
+++ b/.sessions/2026-07-06-fable-decision-authority-and-foundational-consolidation.md
@@ -1,0 +1,67 @@
+# 2026-07-06 — Fable decision authority (Q-0240) + foundational-consolidation brief revision
+
+> **Status:** `complete` — deliberate final flip (born-red gate, Q-0133). Docs/config-doc only (no
+> `disbot/` runtime code): `check_docs.py --strict` (new `owner-guidance` doc reachable),
+> `check_plan_homing.py --strict`, `check_current_state_ledger.py --strict` all green.
+
+## What this session did
+
+Owner directive (in-session, two parts): (1) **"let fable decide … things are too technical for me
+anyways … redesign the repo so fable will make its own decisions"** and (2) Fable should **also
+reconsider whether the plan properly defines all foundational layers** (AI integration, automation, the
+live command-probing/verification tooling) and **consolidate everything into one comprehensive correct
+plan.** Applied the rule change directly (in-session owner = live reviewer, Q-0106 exception).
+
+**Shipped (PR #TBD):**
+- **Governance change — Q-0240 (decide-and-flag over route-up).**
+  - New durable doc `docs/owner/agent-decision-authority.md` — agents decide reversible-until-a-gate
+    calls themselves (recommend + rationale + flag), don't route them; the safety brake is reframed
+    (irreversible/production/external is decided-and-flagged-for-veto, not blocked; the only stop-and-wait
+    is *executing* something irreversible before the gate). Owner's control point = one review pass at
+    the gate.
+  - Router `Q-0240` block recording the decision + provenance.
+  - Surgical `.claude/CLAUDE.md` § Act-vs-ask clause (owner-directed, provenance Q-0240) — clarifies that
+    "architectural → ask" means *irreversible* architectural change, not a reversible-on-paper planning
+    decision.
+- **Fable brief revision** (`rebuild-newrepo-start-fable5-ultracode-brief-2026-07-06.md`) — folded in
+  BOTH: (a) the decide-and-flag model (replaced the "owner-decision packet — do not decide" with a
+  DECISIONS LOG + a short FLAG-FOR-GATE list; the session decides every call), and (b) the
+  **foundational-completeness + consolidation** scope — the prompt now has the session reconsider the
+  L0/foundational taxonomy (AI-invocation/provider seam vs L4 knowledge domain; automation/scheduling as
+  a foundational layer near K5/K7; the parity+Arm-D+wire-level verification tooling as a defined
+  verification foundation) and fold the scattered plan into ONE canonical source-of-truth plan.
+
+Also: reverted an incidental harness-added `.claude/settings.local.json` permission entry (kept this PR
+to intended docs changes; executable-config stays owner-gated).
+
+## ⚑ Self-initiated
+
+None beyond the owner's two in-session directives (the rule change + the brief revision). The rule change
+is exactly the kind Q-0240 now governs — but it was owner-directed, so it ships with its provenance Q.
+
+## 💡 Session idea (Q-0089)
+
+**A decide/flag/veto lint for planning artifacts.** Now that Q-0240 makes "decide-and-flag" the default,
+a cheap checker could scan `docs/planning/` deliverables for the anti-pattern it replaces — parked
+"owner-decision packet"/"route to owner"/"TBD-owner" language on decisions that are reversible-on-paper —
+and nudge the author to decide-and-flag instead. It would keep the new norm from silently eroding back to
+route-everything-up as sessions churn. Cheap AST/grep checker, advisory tier (Q-0105 disposable). Pairs
+with the launch-brief-template idea. (Grep-checked `docs/ideas/` — not present.)
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous (this branch): the Fable brief v1 (#1768). **Did well:** it already flagged (in my own reply)
+that the six-decision packet was over-conservative and offered the two-tier split — which is exactly what
+the owner then confirmed and expanded. Surfacing my own over-caution proactively is what let this turn
+move fast. **Missed / system delta:** v1 encoded the over-routing as *doc content* (a packet the Fable
+session would dutifully produce) rather than checking it against the repo's own act-vs-ask norm — had I
+cross-read the brief against CLAUDE.md's Q-0014/Q-0129/Q-0172 lean when writing it, I'd have written
+decide-and-flag from the start. The durable lesson (now the Q-0089 idea): a planning artifact that parks
+reversible decisions is drifting from the repo's stated autonomy norm — worth a lint.
+
+## ▶ Next action
+
+Owner runs the revised brief: fresh `claude-fable-5`, `/effort xhigh`, paste §3. It now produces ONE
+consolidated correctly-layered plan (with AI-integration / automation / verification-tooling placed
+correctly), a runnable Phase-2.5 procedure, the test-guild design, and a decisions-log + short
+flag-for-gate list — deciding its own calls per Q-0240. Next action after it is a **Phase-3 go/no-go**.

--- a/docs/owner/agent-decision-authority.md
+++ b/docs/owner/agent-decision-authority.md
@@ -1,0 +1,56 @@
+# Agent decision authority — decide-and-flag over route-up
+
+> **Status:** `owner-guidance` — how much an agent decides for itself vs. hands to the maintainer.
+> **Provenance:** owner directive **Q-0240** (2026-07-06): *"let fable decide … I'm usually going with
+> the recommended decisions and things are usually too technical for me anyways … redesign the repo so
+> fable will make its own decisions."* Applies to every capable agent (Fable/Opus/Sonnet/Codex), not
+> just Fable. Binding pointer lives in `.claude/CLAUDE.md` § Working agreement (Act vs. ask).
+
+## The rule
+
+**Default: decide, don't route.** When a decision is **reversible until a downstream gate**, make the
+call yourself — with a recommendation, a one-line rationale, and a flag — and keep going. Do **not** park
+it for the maintainer. This covers the vast majority of planning, design, and technical calls, because
+in a planning artifact **nothing executes until the maintainer's go/no-go gate**, so every decision on
+paper is reversible by the maintainer with a single veto at that gate.
+
+This explicitly includes decisions that are **"too technical," "architectural," or "the agent's call to
+make":** the maintainer's standing instruction is that he *usually takes the recommended decision* and
+would rather spend his attention **once, at the gate**, reviewing a coherent set of already-made calls
+than answer them one at a time up front. A recommendation he'll almost certainly accept is not a
+question — it's a decision with a checkbox. (This is the same instinct as Q-0014 "assume he'd want the
+better one" and Q-0172 "build freely + flag", extended from *building* to *deciding*.)
+
+## The one carve-out — and even it is decide-and-flag, not block
+
+The genuine safety brake is unchanged (`CLAUDE.md`: *irreversible / external / production still asks
+first*). But "asks first" now means **decide the recommendation and flag it prominently for veto**, not
+**block and wait**. Only stop-and-wait when the action would *execute* something irreversible before the
+gate — creating the new repo, writing production code, touching the live token / prod DB / Railway,
+moving user data. On paper, decide; at execution, gate.
+
+| Decision shape | What the agent does |
+|---|---|
+| Reversible-until-a-gate (nearly all planning/design/technical calls) | **Decide + one-line rationale + flag on the run report.** No routing. |
+| Irreversible **once executed** but decided *on paper* now (e.g. a data-migration contract, a schema shape) | **Decide the recommended ruling**, flag it **prominently** as "veto at the gate." Don't block. |
+| Formally reserved by a prior owner-endorsed gate (e.g. the Gate-0 rows) | **Pre-fill the recommended ruling per item** so the owner's sitting is a fast bless-or-override. Don't pre-empt the gate, don't route it as an open question. |
+| Would *execute* something irreversible before the gate (create repo, prod write, data move) | **Stop and ask** — this is the real brake. |
+
+## How the maintainer stays in control
+
+Not by gatekeeping each decision — by reviewing the **flagged set at the gate**:
+
+- Every self-made decision is recorded (decision · options weighed · rationale) in the artifact's own
+  **decisions log**, and flagged on the session run report's `⚑ Self-initiated:` line (`.sessions/`).
+- High-stakes decisions (the irreversible-once-executed / formally-reserved ones) are surfaced in a
+  short **flag-for-gate list** at the top of the deliverable, each phrased as a one-line veto item.
+- The maintainer's review is **one pass at the go/no-go**: skim the flag list, veto anything he
+  disagrees with, green-light the rest. That is his control point — not a hundred up-front questions.
+
+## What still goes to the question router
+
+The router (`maintainer-question-router.md`) is for **genuine product/vision/intent ambiguity an agent
+cannot resolve from source, the goal, or a defensible default** — "which of two *products* do you want,"
+not "which of two *implementations* is better." A technical decision with a defensible best answer is
+**not** a router question; decide it and flag it. When in doubt about which bucket a decision is in, ask:
+*would the maintainer plausibly reject the recommended option?* If not, it's a decision, not a question.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -8685,3 +8685,24 @@ config (workflows / branch protection / `settings.json`) — owner-gated per the
 required context; nothing is deleted. **Homes (on decision):** `.github/workflows/` + branch-protection +
 `.claude/settings.json` + `.claude/CLAUDE.md` § CI/Session workflow. Provenance:
 `.sessions/2026-07-05-ci-setup-redesign.md`.
+
+---
+
+## Q-0240 — Agent decision authority: decide-and-flag over route-up (owner-directed, 2026-07-06)
+
+**Owner directive (in-session):** *"let fable decide … I'm usually going with the recommended decisions
+and things are usually too technical for me anyways … redesign the repo so fable will make its own
+decisions."* → **Applied directly** (the in-session owner is the live reviewer — the Q-0106 exception —
+so the rule change ships now with this provenance Q, not as a proposal).
+
+**Decision.** Agents **decide reversible-until-a-gate calls themselves** (recommendation + one-line
+rationale + a flag on the run report) and do **not** route them to the owner. This includes
+"too-technical / architectural" *design* calls, because planning/design decisions are reversible by the
+owner's single go/no-go veto at the gate. The safety brake is unchanged but **reframed**: irreversible /
+production / external work is **decided-and-flagged for veto**, not blocked — the only stop-and-wait is
+*executing* something irreversible **before** the gate (creating the new repo, prod write, moving user
+data). The owner's control point is **one review pass at the gate**, not per-decision gatekeeping.
+
+**Home:** [`docs/owner/agent-decision-authority.md`](agent-decision-authority.md) (full model + the
+decide/flag/veto table); binding pointer in `.claude/CLAUDE.md` § Working agreement (Act vs. ask).
+Provenance: `.sessions/2026-07-06-fable-decision-authority-and-foundational-consolidation.md`.

--- a/docs/planning/rebuild-newrepo-start-fable5-ultracode-brief-2026-07-06.md
+++ b/docs/planning/rebuild-newrepo-start-fable5-ultracode-brief-2026-07-06.md
@@ -1,10 +1,15 @@
-# Rebuild — Fable 5 Ultracode brief: finalize the new-repo-start method (2026-07-06)
+# Rebuild — Fable 5 Ultracode brief: finalize the new-repo-start method + consolidate the foundational plan (2026-07-06)
 
-> **Status:** `plan` — a **paste-ready launch brief** for one Fable 5 Ultracode session whose job is to
-> **finalize the *method* of starting the new repo** — not to start it. Mirrors the launch-pad style of
+> **Status:** `plan` — a **paste-ready launch brief** for one Fable 5 Ultracode session that (a)
+> **finalizes the *method* of starting the new repo** and (b) **consolidates the scattered rebuild plan
+> into one comprehensive, correctly-layered, internally-consistent plan** — verifying that every
+> *foundational* capability (AI integration, automation, the live verification/command-probing tooling)
+> has a correct home in the layer model. It does **not** start the repo. Mirrors the launch-pad style of
 > [`rebuild-ultracode-handoff-2026-07-02.md`](rebuild-ultracode-handoff-2026-07-02.md) §5, tuned for how
-> Fable 5 actually behaves. Source + merged PRs win over this doc; the prompt tells the session to
-> re-verify everything against live source (Q-0120).
+> Fable 5 actually behaves. Source + merged PRs win over this doc; the prompt re-verifies against live
+> source (Q-0120). **Decision model: the session DECIDES its own calls and flags the high-stakes ones —
+> it does not route decisions to the owner** (owner directive **Q-0240**;
+> [`../owner/agent-decision-authority.md`](../owner/agent-decision-authority.md)).
 
 ## 0. How to launch
 
@@ -17,25 +22,31 @@ the session to *use* that fan-out for the independent review lanes and keep the 
 
 Gate V just closed (`../analysis/rebuild-discovery/gate-v/GATE-V-SYNTHESIS.md`): the plan is
 source-accurate, **Sequence C** (capability-class, games-as-late-consumers) is adopted, and the fleet
-handed Phase B a punch-list. What now stands between the project and actually **starting the new repo**
-(Phase 3) is a small, *decidable* set of things — **two gates and a handful of open method decisions** —
-plus the confidence that the test strategy will catch regressions during cutover. This session's job is
-to **close that gap on paper** so the owner can green-light the build with one sitting, not ten.
+handed Phase B a punch-list. Two things now stand between the project and **starting the new repo**
+(Phase 3): the start *method* isn't consolidated into one executable plan, and the rebuild plan is
+**scattered across a dozen docs** whose *foundational-layer definitions may be incomplete or
+mis-placed* — e.g. AI integration is filed as an L4 "domain" though its invocation/provider seam is
+cross-cutting infrastructure; automation/scheduling isn't clearly a foundational layer; the live
+verification/command-probing tooling isn't defined as a foundation at all. This session closes both: a
+**ratifiable start method** *and* **one comprehensive, correctly-layered plan** that is the single source
+of truth.
 
-The maintainer's framing (verified in the planning set): **"finalizing the method = closing decisions,
-not writing code."** The new-repo `sb/` package must not be created here. The deliverable is a
-*ratifiable* start method + the owner-decision packet for the few calls that are genuinely the owner's.
+**The decision model changed (Q-0240).** The session does **not** hand its calls to the owner. Nearly
+every decision here is reversible until the owner's Phase-3 go/no-go, so the session **decides each call
+itself, records the rationale, and flags the high-stakes ones** for the owner's *one-pass veto at the
+gate*. The maintainer usually takes the recommendation and would rather review the set once than answer a
+hundred questions. The only stop-and-wait is *executing* something irreversible (creating the repo, prod
+writes, moving user data) — which this session never does.
 
 ## 2. Fable-5 operating notes (the prompt embeds these — they materially change output quality)
 
-Fable 5 is Anthropic's most capable model but **degrades when over-prescribed** — prompts written as
-step-by-step scripts for weaker models reduce its output. So this brief gives it the **goal, the
-constraints, and the grounding**, and lets it choose its own path. The prompt bakes in the behavioral
-tuning Anthropic documents for Fable 5: act when it has enough to act (don't re-litigate settled
-decisions or narrate options it won't pursue), don't tidy/refactor beyond the task, ground every
-progress claim on a tool result, respect explicit boundaries, **delegate independent lanes to
-asynchronous sub-agents** (Fable sustains long-running sub-agent collaboration well), keep a memory
-surface, and expect **minutes-long turns**. Run it at `xhigh`.
+Fable 5 **degrades when over-prescribed** — scripts written for weaker models reduce its output. So this
+brief gives it the **goal, the constraints, and the grounding**, and lets it choose its path. Baked-in
+Fable tuning: act when it has enough (don't re-litigate settled decisions or narrate options it won't
+pursue); **decide its own calls and flag them** rather than parking them (Q-0240); don't tidy/refactor
+beyond scope; ground every progress claim on a tool result; respect explicit boundaries; **delegate
+independent lanes to asynchronous sub-agents** (Fable sustains long-running sub-agent collaboration
+well); keep a memory surface; expect **minutes-long turns**. Run at `xhigh`.
 
 ---
 
@@ -45,143 +56,169 @@ surface, and expect **minutes-long turns**. Run it at `xhigh`.
 You are a Claude Fable 5 session running in Anthropic Ultracode on menno420/superbot. Effort: xhigh.
 
 GOAL
-Finalize the METHOD for starting the fresh-rebuild repo, so the maintainer can green-light Phase 3 (the
-new-repo build) in a single sitting. You are NOT starting the repo and NOT writing new-repo (`sb/`)
-code. Your deliverable is a ratifiable start-method plan + an owner-decision packet for the calls that
-are genuinely the owner's + a concrete test-guild design. "Finalize the method" = close the decidable
-decisions and cleanly frame the rest — not build.
+Two things, one deliverable:
+(1) Finalize the METHOD for starting the fresh-rebuild repo, so the maintainer can green-light Phase 3 in
+    a single sitting.
+(2) Consolidate the scattered rebuild plan into ONE comprehensive, correctly-layered, internally-
+    consistent plan — the single source of truth — and in doing so RECONSIDER whether the plan properly
+    defines ALL foundational layers. In particular check that these genuinely-foundational capabilities
+    have a correct, explicit home in the layer model, not a scattered or mis-placed one: AI integration
+    (its invocation/NL-routing/provider/tool-calling seam is cross-cutting infrastructure, distinct from
+    the knowledge DOMAINS btd6/project_moon — does the foundational half belong lower/earlier?);
+    automation/scheduling (the AutomationScheduler + templated multi-step actions — is it a foundational
+    layer near K5 managed-tasks / K7 workflow-engine, or under-defined?); and the live
+    verification/command-probing tooling (parity + the Arm D live-test + the test-guild command-driver +
+    the wire-level live-bot loop — should be a DEFINED verification foundation, not an afterthought).
+You are NOT starting the repo and NOT writing new-repo (`sb/`) code.
 
-WHY THIS MATTERS (so you can connect the work to intent rather than infer it)
-Gate V just closed: the plan is source-accurate, Sequence C (games-as-late-consumers) is adopted. The
-only things between here and the build are two gates and a few open method decisions. The maintainer
-designs and visualizes; he relies on you to make the start method correct, complete, and low-risk so he
-can commit with confidence. The current repo is becoming the "artifact" (the why); the new repo will be
-the clean source of truth. Do this well and the next action is a go/no-go, not more planning.
+DECISION MODEL (important — this is how the maintainer wants you to work; ref docs/owner/agent-decision-
+authority.md, Q-0240)
+DECIDE your own calls; do not route them to the owner. Nearly every decision here is reversible until the
+maintainer's Phase-3 go/no-go, so make each call yourself with a recommendation + a one-line rationale,
+record it in a DECISIONS LOG, and keep moving. This includes "too-technical" / architectural design calls
+(manifest format, layer placement, F-3 posture, rollback window, test-guild colocation, …) — he usually
+takes the recommendation and reviews the set once, at the gate. Do NOT produce an "owner-decision packet"
+of open questions. Instead produce a short FLAG-FOR-GATE list: the handful of calls that are irreversible-
+once-executed or were formally reserved by a prior gate — DECIDE those too (recommend the ruling), but
+flag them prominently as one-line veto items for the go/no-go. Two named flag-for-gate items: the
+backward-compat DATA contract (irreversible; touches user balances/inventory/xp/settings) and the Gate-0
+rows (12 owner-only default values + L-21, formally reserved — pre-fill your recommended ruling per row so
+the owner's sitting is a fast bless-or-override). Route to the maintainer-question-router ONLY genuine
+product/vision ambiguity you cannot resolve from source + a defensible default — not technical calls.
+
+WHY THIS MATTERS (connect the work to intent, don't infer it)
+Gate V closed; Sequence C is adopted. The maintainer designs and visualizes and relies on you to make the
+foundation correct/complete and the start method low-risk so he can commit with confidence. He has
+explicitly asked you to make your own decisions — trust that. The current repo becomes the "artifact"
+(the why); the new repo becomes the clean source of truth. Do this well and the next action is a
+go/no-go, not more planning.
 
 HOW TO WORK (Fable-tuned — follow this, it changes output quality)
-- When you have enough to act, act. Don't re-derive facts already in the docs, re-litigate decisions the
-  maintainer already made, or narrate options you won't pursue in user-facing text (thinking is exempt).
-  Where you're weighing a call, give a recommendation, not a survey.
-- Use Ultracode's parallel sub-agents for the independent review lanes below, running asynchronously
-  while you synthesize; keep the final reconciliation and the owner-decision packet for yourself. Give
-  each sub-agent the goal + the anchors + "verify against live source, cite path:line," not a script.
-- Ground every claim on a tool result (a file you read, a command you ran). If something isn't verified,
-  say so. Never report a checker/test as passing unless it actually ran. Source + merged PRs win over
-  any planning doc (Q-0120) — when a doc and the code disagree, the code wins and you record the drift.
-- Keep a working memory file as you go (scratch notes / decisions / open threads); consult it before
-  each lane so long sub-agent runs don't lose context.
-- Don't tidy, refactor, or expand scope beyond finalizing the method. Don't decide the owner-only items
-  (below) — route them to `docs/owner/maintainer-question-router.md` as a clean packet.
-- Repo caveats: CI is Python 3.10 — run any checker via `python3.10` (`python3.10 scripts/check_quality.py
-  --check-only`, `python3.10 -m pytest …`); bare tools give false results. CodeGraph `dead-unresolved`/
-  zero-caller is ~100% false-positive here and EventBus/registry edges are invisible to graph tools —
-  never assert dead/no-wiring from a graph tool; grep the wiring and read the source.
+- When you have enough to act, act. Don't re-derive facts already in the docs or narrate options you
+  won't pursue (thinking is exempt). Where you weigh a call, decide it with a recommendation, not a survey.
+- Use Ultracode's parallel sub-agents for the review lanes below, async, while you synthesize; keep the
+  reconciliation, the layer taxonomy, and the decisions log for yourself. Give each sub-agent goal +
+  anchors + "verify against live source, cite path:line," not a script.
+- Ground every claim on a tool result. If unverified, say so; never report a checker/test as passing
+  unless it ran. Source + merged PRs win over any planning doc (Q-0120) — code wins, record the drift.
+- Keep a working memory file (scratch notes / decisions / open threads); consult it before each lane so
+  long sub-agent runs don't lose context.
+- Don't tidy/refactor or expand scope beyond (1)+(2). Repo caveats: CI is Python 3.10 — run any checker
+  via python3.10 (python3.10 scripts/check_quality.py --check-only, python3.10 -m pytest …); bare tools
+  give false results. CodeGraph dead-unresolved/zero-caller is ~100% false-positive here and EventBus/
+  registry edges are invisible to graph tools — never assert dead/no-wiring from a graph tool; grep the
+  wiring and read the source.
 
 ORIENT FIRST (read in this order, then stop reading and start deciding)
-.claude/CLAUDE.md → docs/collaboration-model.md → docs/current-state.md + docs/current-state/S3-ai-memory.md
-→ docs/AGENT_ORIENTATION.md. Then the two that define the endpoint you're finalizing the path to:
-docs/analysis/rebuild-discovery/gate-v/GATE-V-SYNTHESIS.md (the just-closed Gate V verdict + Phase-B
-punch-list) and docs/planning/next-session-priority-2026-07-05.md (owner's own "what's left" read).
+.claude/CLAUDE.md → docs/collaboration-model.md → docs/owner/agent-decision-authority.md (how you decide)
+→ docs/current-state.md + docs/current-state/S3-ai-memory.md → docs/AGENT_ORIENTATION.md. Then the two
+that define the endpoint: docs/analysis/rebuild-discovery/gate-v/GATE-V-SYNTHESIS.md (the Gate V verdict
++ Phase-B punch-list) and docs/planning/next-session-priority-2026-07-05.md (owner's "what's left").
 
-THE FIVE THINGS TO REVIEW (the maintainer named these — spawn a sub-agent lane per cluster; anchors given)
-1. MEMORY SUBSTRATE-KIT — substrate-kit/README.md + substrate-kit/src/engine/ + substrate-kit/dist/bootstrap.py
-   (the whole install is `python3 bootstrap.py adopt`) + tests/unit/substrate_kit/ (~422 tests) +
-   .sessions/2026-07-02-ultracode-memory-substrate-finalize.md. It is FINISHED (#1649) and stdlib-only.
-   Confirm that against source; identify the ONLY genuinely-open kit item that blocks a new-repo bootstrap:
-   the Phase-2.5 cold-start substrate-on/off A/B (specced in fresh-rebuild-strategy §3/§5.2, NEVER run).
-   Note the two deliberate not-fully-wired seams (review-seam provisioned-not-wired; harvest-table stub)
-   and whether either blocks bootstrap. Deliverable: a one-page "kit is bootstrap-ready EXCEPT X" verdict.
-2. THE BOT'S CODE — disbot/ is both the thing being rebuilt AND the correctness oracle (the new repo
-   replays against it). You don't re-audit it (Gate V did); confirm the L0 readiness the synthesis
-   already established and the systemic findings it must carry (audited-write atomicity across
-   economy/karma/xp; deathmatch _DuelView settle-once gap). Use python3.10 scripts/context_map.py <file>
-   and grep, per the caveats.
-3. THE PLANS — docs/planning/rebuild-planning-phase-2026-07-03.md (phase arc + MIGRATION section),
-   fresh-rebuild-strategy-2026-07-02.md (§3 order+gates, §3.1 model allocation, §7 open decisions),
-   rebuild-parallel-execution-plan-2026-07-02.md (schedule + the "two gates" framing), the Gate-0 packet
-   docs/analysis/rebuild-discovery/foundations/gate-0/ (owner-decision-packet.md = 12 owner-only rows +
-   L-21; phase-b-l0-build-order.md = the 16-step S0–S15 L0 build order), the frozen reference
-   docs/analysis/rebuild-discovery/new-bot-capability-audit/findings/NEW-BOT-BUILD-PLAN.md, and
-   railway-setup-plan-2026-07-02.md (§4–6 cutover). TWO phase vocabularies coexist (planning-phase's
-   Capstone→A→GateV→B→C→Migration vs strategy's Phase 0–5); reconciling them into ONE canonical arc is
-   part of your job.
-4. THE SIMULATORS — tools/sim/ (8), tools/game_sim/ (2), tools/grammar_spike/. These are DESIGN/decision
-   tools, not runtime tests. Confirm what each proves (one line each) and, crucially, which ones the
-   new-repo-start method should re-run or wire in as living checks (esp. grammar_spike: ~85% of surface
-   units declarable — the linchpin fit number).
-5. HOW TO TEST THE BOT — parity/README.md + parity/COVERAGE.md (the black-box golden harness: 465 cases,
-   current bot = oracle, rebuild replays red-until-parity; run `python3.10 -m parity.run capture|check|
-   coverage` against a truncatable Postgres, NEVER prod). Coverage is deliberately breadth-not-depth
-   (prefix 96% / slash 88% / components 94% but events 21% / tables 25% / settings 2%). The 11,510-test
-   suite is white-box and CANNOT be the oracle (<10% transferable). tests/evals/ is the one pre-existing
-   black-box asset. Live fidelity today is service-layer only (Arm D, LIVE-VERIFIED-EVIDENCE-PACK.md) —
-   the full command pipeline (converters/cooldowns/before_invoke) is not yet exercised live, partly
-   because Discord's author.bot guard blocks bot-authored message-command invocation.
+THE REVIEW LANES (spawn a sub-agent per cluster; anchors given)
+1. MEMORY SUBSTRATE-KIT — substrate-kit/README.md + substrate-kit/src/engine/ + substrate-kit/dist/
+   bootstrap.py (whole install = `python3 bootstrap.py adopt`) + tests/unit/substrate_kit/ (~422 tests) +
+   .sessions/2026-07-02-ultracode-memory-substrate-finalize.md. FINISHED (#1649), stdlib-only. Confirm
+   against source; the ONE open kit item that blocks a new-repo bootstrap is the Phase-2.5 cold-start
+   substrate-on/off A/B (fresh-rebuild-strategy §3/§5.2, NEVER run). Note the two deliberate not-wired
+   seams (review-seam provisioned-not-wired; harvest-table stub); say whether either blocks bootstrap.
+2. THE BOT'S CODE + THE FOUNDATIONAL-LAYER TAXONOMY — disbot/ is both the thing rebuilt AND the
+   correctness oracle (the new repo replays against it). Don't re-audit it (Gate V did); carry its L0
+   readiness + systemic findings (audited-write atomicity across economy/karma/xp; deathmatch _DuelView
+   settle-once gap). THEN do the foundational-completeness pass: walk the current L0/kernel set (K0
+   config, K1 namespace, K2 manifest compiler, K3 DB seam, K4 EventBus→outbox, K5 lifecycle+tasks, K6
+   authority, K7 workflow engine, K8 interaction runtime, K9/K10) against the LIVE bot and ask "is every
+   genuinely-foundational capability here, at the right layer?" Explicitly resolve: (a) AI integration —
+   grep disbot/services/ai_*/ + the invocation ladder (rebuild-conventions-invocation-authority Q-0225,
+   exact→fuzzy→NL-intent→NL-orchestration) — which parts are foundational invocation/provider seam
+   (belong at/near K8) vs L4 knowledge domain; (b) automation — grep disbot for AutomationScheduler +
+   automation templates — is scheduling/templated-action a foundational layer (near K5/K7) or scattered;
+   (c) verification tooling — parity/ + Arm D + tools/livebot idea — define it as a foundational
+   verification layer. Use python3.10 scripts/context_map.py <file> + grep, per the caveats.
+3. THE PLANS — rebuild-planning-phase-2026-07-03.md (phase arc + MIGRATION), fresh-rebuild-strategy-2026-
+   07-02.md (§3 order+gates, §3.1 model allocation, §7 open decisions), rebuild-parallel-execution-plan-
+   2026-07-02.md ("two gates"), the Gate-0 packet docs/analysis/rebuild-discovery/foundations/gate-0/
+   (owner-decision-packet.md = 12 rows + L-21; phase-b-l0-build-order.md = the 16-step S0–S15 L0 order),
+   the frozen NEW-BOT-BUILD-PLAN.md, railway-setup-plan-2026-07-02.md (§4–6 cutover). TWO phase
+   vocabularies coexist (planning-phase Capstone→A→GateV→B→C→Migration vs strategy Phase 0–5) — reconcile
+   into ONE canonical arc. Flag any place the scattered docs DISAGREE on a foundational definition.
+4. THE SIMULATORS — tools/sim/ (8) + tools/game_sim/ (2) + tools/grammar_spike/. DESIGN/decision tools,
+   not runtime tests. One line each on what it proves; decide which to re-run or wire as living checks
+   (esp. grammar_spike: ~85% of surface units declarable — the linchpin fit number).
+5. HOW TO TEST THE BOT — parity/README.md + parity/COVERAGE.md (black-box golden harness: 465 cases,
+   current bot = oracle, rebuild replays red-until-parity; run python3.10 -m parity.run capture|check|
+   coverage against a truncatable Postgres, NEVER prod). Coverage is breadth-not-depth (prefix 96% /
+   slash 88% / components 94% but events 21% / tables 25% / settings 2%). The 11,510-test suite is
+   white-box, CANNOT be the oracle (<10% transferable). tests/evals/ is the one pre-existing black-box
+   asset. Live fidelity today is service-layer only (Arm D, LIVE-VERIFIED-EVIDENCE-PACK.md) — the full
+   command pipeline (converters/cooldowns/before_invoke) isn't exercised live, partly because Discord's
+   author.bot guard blocks bot-authored message-command invocation.
 
-THE FOUR DELIVERABLES (this is the finalized method)
-A. ONE canonical new-repo-start method. Reconcile the two phase vocabularies into a single arc ending at
-   Phase 3. State plainly: the two hard gates that block all new-repo code — (1) Gate-0 owner
-   ratification (rule/bless the 12 owner-only default values + L-21; grammar shapes are already frozen),
-   (2) Phase-2.5 cold-start proof (never run) — plus the design-spec owner approval. Then the concrete
-   start sequence: create repo → bootstrap the finished substrate-kit → build the two spines → run the
-   16-step S0–S15 L0 build (critical path K0→K1→K2→K3→K7→K8), under the container-first 3-phase cutover
-   (CUT-1 container-only live test on the test-bot token → CUT-2 manifest-driven selective import →
-   CUT-3 token swap + retirement), on a new Railway project (superbot-next). Keep the repo-as-artifact
-   framing. Output a single ordered "to start the new repo, do these N steps; steps k..m are owner-gated"
-   list an operator could execute.
-B. The owner-decision packet — the small set of calls that genuinely gate the start and are the owner's,
-   framed for a one-sitting ruling (each: the decision, the options, your recommendation, the
-   consequence, the owning artifact). At minimum: Gate-0's 12 rows + L-21; the backward-compat contract
-   (strategy §7 calls it "the single biggest rebuild decision"); the manifest physical format (Python
-   dataclasses vs YAML/JSON); F-3 intent-denial posture (degrade vs fail-closed); the rollback window;
-   whether the test guild is the live "Superbot Admin" HQ guild or strictly separate. Route these to
-   docs/owner/maintainer-question-router.md — do not decide them.
+THE DELIVERABLES (one consolidated plan + its supporting pieces)
+A. ONE comprehensive, correctly-layered, canonical rebuild plan — the single source of truth. It states:
+   the corrected/complete FOUNDATIONAL-LAYER taxonomy (with AI-invocation, automation/scheduling, and the
+   verification substrate placed correctly, and any missing foundational layer named); the one canonical
+   phase arc (the two vocabularies reconciled); the two hard gates blocking all new-repo code (Gate-0
+   ratification; Phase-2.5 cold-start) + the design-spec approval; and the ordered start sequence — create
+   repo → bootstrap the finished substrate-kit → build the two spines → run the 16-step S0–S15 L0 build
+   (critical path K0→K1→K2→K3→K7→K8) under the container-first 3-phase cutover (CUT-1 container-only live
+   test on the test-bot token → CUT-2 manifest-driven selective import → CUT-3 token swap + retirement) on
+   a new Railway project (superbot-next), keeping the repo-as-artifact framing. Output a single ordered
+   "to start the new repo, do these N steps; steps k..m are owner-gated" list an operator could execute.
+   Where the old scattered docs are now superseded by this one, say so (link, don't delete).
+B. The FOUNDATIONAL-COMPLETENESS findings that feed A — your explicit rulings on AI-integration layering,
+   automation/scheduling layering, and the verification-substrate layer, each as a decided call with
+   rationale (per the DECISION MODEL — decide, don't ask). Include any foundational layer you found
+   MISSING or mis-placed and where you put it.
 C. The TEST-GUILD design — a concrete Discord test-guild layout with a proper channel per function so
-   every subsystem has a home to be exercised and observed. Start from this proposed category-zone
-   seed (refine it against the real cog set in disbot/cogs/, ~55 cogs): #operator-core (settings/
-   diagnostic/help/admin/server-management/setup) · #moderation-safety (moderation/automod/security/
-   cleanup/image-moderation/logging) · #server-structure (channel/role/ticket/counters/proof-channel) ·
-   #presentation (welcome/ux-lab/card-engine) · #economy-progression (economy/karma/xp/community/
-   leaderboard/profile) · #games (blackjack/rps/deathmatch/fishing/farm/creature/casino/counting/chain/
-   four-twenty/mining/giveaways/starboard/explore) · #knowledge-ai (ai/btd6/project-moon) ·
-   #utility-misc (utility/general) · #control-plane (dashboard/boards/migration/health). For each zone,
-   say which subsystems get their own channel vs share, and how the layout maps onto the CUT-1
-   container-only live test. Then solve the fidelity gap: how the guild drives the FULL command pipeline
-   (not just the service layer) given the author.bot guard — e.g. a low-privilege human/second-account
-   driver, or an in-process wire-level walker (see docs/ideas/wire-level-live-bot-loop-2026-07-02.md).
-   Tie it back to parity/ (the golden oracle) and the verified_live sign-off. Output a channel manifest
-   + a per-zone "what you'd exercise here and what proves it" table.
-D. Make Phase-2.5 concretely runnable. It's the one open, OFFLINE, non-owner-gated step that closes a
-   gate (the substrate-on-vs-off cold-start A/B validating the portability thesis). Turn "specced but
-   never run" into a runnable procedure: what environment, what to measure (boot viability, orientation
-   budget, first-session behavior with the kit ON vs OFF), what the pass bar is, and what artifact it
-   produces. This is the highest-leverage single thing to unblock Phase 3.
+   every subsystem has a home to be exercised and observed. Seed to refine against disbot/cogs/ (~55
+   cogs): #operator-core (settings/diagnostic/help/admin/server-management/setup) · #moderation-safety
+   (moderation/automod/security/cleanup/image-moderation/logging) · #server-structure (channel/role/
+   ticket/counters/proof-channel) · #presentation (welcome/ux-lab/card-engine) · #economy-progression
+   (economy/karma/xp/community/leaderboard/profile) · #games (blackjack/rps/deathmatch/fishing/farm/
+   creature/casino/counting/chain/four-twenty/mining/giveaways/starboard/explore) · #knowledge-ai (ai/
+   btd6/project-moon) · #utility-misc (utility/general) · #control-plane (dashboard/boards/migration/
+   health). Per zone: which subsystems get their own channel vs share, and how the layout maps onto CUT-1.
+   Then solve the fidelity gap: how the guild drives the FULL command pipeline (not just the service
+   layer) given the author.bot guard — a low-privilege human/second-account driver, or an in-process
+   wire-level walker (docs/ideas/wire-level-live-bot-loop-2026-07-02.md). Tie back to parity/ + the
+   verified_live sign-off. Output a channel manifest + a per-zone "what you'd exercise / what proves it".
+D. Make Phase-2.5 concretely runnable — the one open, OFFLINE, non-owner-gated step that closes a gate
+   (substrate-on-vs-off cold-start A/B). Turn "specced but never run" into a runnable procedure: what
+   environment, what to measure (boot viability, orientation budget, first-session behavior kit ON vs
+   OFF), the pass bar, and the artifact it produces. Highest-leverage single thing to unblock Phase 3.
+E. The DECISIONS LOG + FLAG-FOR-GATE list — every method call you made (decision · options weighed ·
+   rationale), plus the short flag-for-gate list (the backward-compat data contract + the Gate-0 rows
+   with your pre-filled recommended rulings) for the owner's one-pass veto at the go/no-go.
 
 CONSTRAINTS
-- Planning/finalization only. You MAY create/refine planning docs and route owner decisions. You MUST
-  NOT: create the new repo or any `sb/` code; touch production (Railway, the live token, the prod DB);
-  run parity against a non-throwaway Postgres; decide owner-only items. Test-guild work is DESIGN here —
-  actually standing it up is operator work you spec, not do.
+- Planning/consolidation only, but you DECIDE (per the DECISION MODEL) — you do not park decisions. You
+  MUST NOT: create the new repo or any `sb/` code; touch production (Railway, the live token, the prod
+  DB); run parity against a non-throwaway Postgres; execute the test-guild build (spec it, don't stand it
+  up). The safety brake is EXECUTING something irreversible — deciding it on paper is expected.
 - Match CI: python3.10 for any checker/test. Don't claim something ran unless it ran.
-- If a genuine blocker appears (a source/plan conflict that changes the method, a missing canonical
-  artifact, an owner-only call with no safe default), surface it in the packet rather than guessing.
+- Stop-and-ask only for genuine product/vision ambiguity you can't resolve from source + a defensible
+  default, or a source/plan conflict that changes the foundation and has no safe call. Everything else:
+  decide and flag.
 
 OUTPUT
-Write the finalized method as a new planning doc under docs/planning/ (a single canonical
-new-repo-start plan), with the owner-decision packet and the test-guild manifest either in it or as
-linked companions, homed in docs/planning/README.md. Open a PR ready. The session is done when the
-maintainer can read the plan and the packet and green-light Phase 3 (or answer the packet) without
-re-deriving any of it.
+Write the consolidated plan as a new canonical doc under docs/planning/ (the single source of truth),
+with the foundational-completeness findings, test-guild manifest, Phase-2.5 procedure, and decisions-log
++ flag-for-gate list either in it or as linked companions, homed in docs/planning/README.md. Mark the
+docs it supersedes. Open a PR ready. Done when the maintainer can read the plan + skim the flag-for-gate
+list and green-light Phase 3 without re-deriving any of it.
 ```
 
 ---
 
 ## 4. Provenance
 
-Built 2026-07-06 after Gate V closed. Grounded by a 3-lane research fan-out (substrate-kit + Phase-2.5;
+Built 2026-07-06 after Gate V closed; **revised the same day** to (1) adopt the decide-and-flag decision
+model (owner directive **Q-0240** → `../owner/agent-decision-authority.md`) so the session makes its own
+calls instead of routing them, and (2) add the **foundational-completeness + consolidation** scope the
+maintainer asked for — verify every foundational capability (AI integration, automation, the live
+verification/command-probing tooling) is correctly layered, and fold the scattered plan into one
+canonical source of truth. Grounded by a 3-lane research fan-out (substrate-kit + Phase-2.5;
 new-repo-start/migration method + Gate-0; test infra + simulators + test-guild), each verified against
-live source. Fable-5 tuning (anti-overplanning, no-tidying, ground-claims, boundaries, async sub-agents,
-memory surface, xhigh effort, minutes-long turns) taken from Anthropic's Fable 5 guidance and folded in
-so the prompt gives goal+constraints+grounding rather than an over-prescribed script. The four
-deliverables map to the maintainer's ask: finalize the start method, review the kit/code/plans/sims/
-tests, and design a per-function test guild.
+live source. Fable-5 tuning (anti-overplanning, decide-and-flag, no-tidying, ground-claims, boundaries,
+async sub-agents, memory surface, xhigh, minutes-long turns) from Anthropic's Fable 5 guidance.


### PR DESCRIPTION
## Summary

Two owner-directed in-session changes (applied directly with provenance per the Q-0106 exception).

**1. Decision-authority change — Q-0240 (decide-and-flag over route-up).** Agents now **decide reversible-until-a-gate calls themselves** (recommendation + rationale + flag) instead of routing them to the owner. The safety brake is reframed: irreversible / production / external work is **decided-and-flagged-for-veto, not blocked** — the only stop-and-wait is *executing* something irreversible before the gate. The owner's control point is one review pass at the gate, not per-decision gatekeeping.
- New durable doc `docs/owner/agent-decision-authority.md` (the model + a decide/flag/veto table)
- Router `Q-0240` recording the decision
- A surgical `.claude/CLAUDE.md` § Act-vs-ask clause clarifying that "architectural → ask" means *irreversible* architectural change, not a reversible-on-paper planning decision

**2. Fable brief revision** (`rebuild-newrepo-start-fable5-ultracode-brief-2026-07-06.md`) — folds in both:
- the decide-and-flag model (a **DECISIONS LOG + short FLAG-FOR-GATE list** replaces the old "owner-decision packet — do not decide"), and
- the **foundational-completeness + consolidation** scope the maintainer asked for: the session now reconsiders whether the plan properly defines all foundational layers — **AI integration** (invocation/provider seam vs L4 knowledge domain), **automation/scheduling** (foundational layer near K5/K7?), and the **live verification/command-probing tooling** (parity + Arm D + wire-level loop as a defined verification foundation) — and consolidates the scattered plan into **one canonical source-of-truth plan**.

Also reverted an incidental harness-added `.claude/settings.local.json` permission entry to keep this PR to intended docs changes (executable config stays owner-gated).

## Linked issue / plan

Provenance Q-0240 in `docs/owner/maintainer-question-router.md`; revises the brief added in #1768.

## Type of change

- [x] Documentation

## Checks

- [x] Docs/config-doc only (no `disbot/` runtime code); `check_docs.py --strict`, `check_plan_homing.py --strict`, `check_current_state_ledger.py --strict` all green
- [x] No secrets, tokens, or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsyC9YRMyBdiRookLbopjg)_