### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-06T21:47:52Z",
+    "generated_at": "2026-07-07T00:00:50Z",
     "build": {
-      "commit": "666c802a",
-      "subject": "docs(reconcile): 36th Q-0107 pass — band-#1770",
-      "committed_at": "2026-07-06T21:47:52Z"
+      "commit": "026de980",
+      "subject": "Merge pull request #1772 from menno420/claude/jolly-johnson-3s6zq5",
+      "committed_at": "2026-07-07T00:00:50Z"
     },
     "counts": {
       "functions": 43,


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.