### PR TITLE
fix(games): settle-once guards for deathmatch duel, blackjack + rps free-tournament payouts (FINAL-REVIEW §6.3)

### DIFF
--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -9,6 +9,7 @@ from discord.ext.commands import BucketType, cooldown
 from services import mining_workflow
 from utils import db, equipment
 from utils.mining import workshop as mining_workshop
+from utils.terminal_guard import SettleOnceMixin
 
 # Base duel constants — the floor every fighter starts from before equipped
 # combat gear (utils.equipment.EffectiveStats) tilts it.
@@ -91,7 +92,7 @@ async def _tick_duel_gear_wear(
     return notes
 
 
-class _DuelView(discord.ui.View):
+class _DuelView(SettleOnceMixin, discord.ui.View):
     def __init__(
         self,
         cog: Deathmatch,
@@ -150,7 +151,10 @@ class _DuelView(discord.ui.View):
 
     async def on_timeout(self) -> None:
         duel = self.duel
-        if duel.is_over:
+        # Shares the settle-once claim with ``_resolve`` so a timeout firing
+        # just as the finishing blow lands can't write a second W/L + gear-wear
+        # settlement (the Gate-V Arm-D live-confirmed double-write).
+        if not self.claim_settlement():
             return
         opponent = duel.player2 if duel.turn == duel.player1 else duel.player1
         duel.is_over = True
@@ -228,6 +232,11 @@ class _DuelView(discord.ui.View):
             winner, loser = duel.player1, duel.player2
 
         if winner:
+            # Settle-once: claim inside the winner branch (a non-finishing
+            # move must not consume the claim), before any await, so a
+            # finishing-blow double-click or a racing timeout short-circuits.
+            if not self.claim_settlement():
+                return
             duel.is_over = True
             self.cog.active_duels.pop(self.duel_key, None)
             await self.cog.update_leaderboard(

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -69,6 +69,7 @@ from services import (  # noqa: F401 — game_state_service kept for back-compat
     game_wager_workflow,
     tournament_state_service,
 )
+from utils.terminal_guard import SettleOnceMixin
 from utils.ui_constants import INFO_COLOR
 from views.rps import _RpsRegistrationView
 from views.rps._helpers import RPS_PVP_ESCROW_SUBSYSTEM
@@ -76,7 +77,11 @@ from views.rps._helpers import RPS_PVP_ESCROW_SUBSYSTEM
 logger = logging.getLogger("bot")
 
 
-class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: ignore[call-arg]
+class RockPaperScissorsCog(
+    SettleOnceMixin,
+    commands.Cog,
+    name="Rock Paper Scissors",
+):  # type: ignore[call-arg]
     """Rock Paper Scissors: quick play, PvP, bot matches, tournaments."""
 
     def __init__(self, bot) -> None:
@@ -397,6 +402,7 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
             return
 
         self.tournament_active = True
+        self.rearm_settlement()  # new tournament → new payout claim
         self.game_mode = mode
         self.current_round = self.players.copy()
         random.shuffle(self.current_round)
@@ -662,6 +668,10 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
     async def check_tournament_progress(self, guild, last_channel):
         """Checks if the tournament is over or starts a new round."""
         if len(self.current_round) == 1:
+            # Settle-once: racing resolvers both reach here; the FREE-reward
+            # leg has no escrow rows, so this claim is its only guard.
+            if not self.claim_settlement():
+                return
             winner = self.current_round[0]
             # P0-1 — pay the winner the escrowed pot (the sum of the
             # actual entry rows, not a recomputed fee×players) and delete

--- a/disbot/services/blackjack_state.py
+++ b/disbot/services/blackjack_state.py
@@ -114,7 +114,7 @@ class _PvPState(SettleOnceMixin):
         self.messages: dict[int, discord.Message] = {}
 
 
-class _BjTournament(TournamentRegistration):
+class _BjTournament(TournamentRegistration, SettleOnceMixin):
     def __init__(
         self,
         host_id: int,

--- a/disbot/utils/terminal_guard.py
+++ b/disbot/utils/terminal_guard.py
@@ -63,3 +63,12 @@ class SettleOnceMixin:
     def is_settled(self) -> bool:
         """Whether the terminal transition has already been claimed."""
         return self._settlement_claimed
+
+    def rearm_settlement(self) -> None:
+        """Reset the claim for a NEW terminal cycle.
+
+        For long-lived holders whose terminal transition recurs per cycle
+        (a cog holding per-tournament state), call this exactly once at the
+        start of each cycle — never from a settling path.
+        """
+        self._settlement_claimed = False

--- a/disbot/views/blackjack/tournament_views.py
+++ b/disbot/views/blackjack/tournament_views.py
@@ -223,6 +223,14 @@ async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
     if len(tourn.results) < len(tourn.players):
         return  # not all players finished
 
+    # Settle-once: two players finishing concurrently (or a timeout racing the
+    # last hand) each reach here past the all-finished check; claim before any
+    # await so exactly one caller runs the payout. The paid path is already
+    # row-consumption idempotent, but the FREE-tournament reward leg has no
+    # escrow rows to consume — this claim is its only double-pay guard.
+    if not tourn.claim_settlement():
+        return
+
     announce = bot.get_channel(tourn.announce_id)
     guild = bot.get_guild(tourn.guild_id)
 

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -882,15 +882,23 @@ def rule_card_engine_helper_duplication(
 # Rule 6 — settle-once adoption (money-safety)
 # ---------------------------------------------------------------------------
 
-# The escrow-paying wager helpers (``services/game_wager_workflow.py``).  A call
-# to either *moves the pot* — a payout or a refund — so running it twice
-# double-settles.  These are the precise, unambiguous money-safety sites; the
-# fuzzier "posts a terminal result" leg the idea also sketches
+# The settle sinks.  ``settle_pvp``/``refund_pvp``/``payout_tournament`` are
+# the escrow-moving wager helpers (``services/game_wager_workflow.py``) — a
+# call *moves the pot* (payout / refund / tournament pot + FREE reward), so
+# running one twice double-settles; ``payout_tournament``'s free-reward leg has
+# no escrow rows to consume, making the caller-side claim its ONLY guard.
+# ``update_leaderboard`` is the deathmatch W/L recorder — the non-wager settle
+# the 2026-07-06 Gate-V Arm-D live run double-wrote through the unguarded
+# ``_DuelView`` (FINAL-REVIEW §6.3 #1); its lone definition wraps
+# ``db.update_deathmatch`` behind a single method, so call sites are precise.
+# The fuzzier "posts a terminal result" leg the idea also sketches
 # (``settle-once-architecture-guard-2026-06-24.md``) is deliberately NOT
 # implemented here — static "settles via a result message reachable from
 # ``on_timeout``" detection is false-positive-prone, and a warn-clean rule must
 # stay precise (the idea's own "be conservative, warn-first" caution).
-_WAGER_SETTLE_CALLS = frozenset({"settle_pvp", "refund_pvp"})
+_WAGER_SETTLE_CALLS = frozenset(
+    {"settle_pvp", "refund_pvp", "payout_tournament", "update_leaderboard"}
+)
 
 # The settle-once guard primitive (``utils/terminal_guard.py``).
 _SETTLE_ONCE_MIXIN = "SettleOnceMixin"
@@ -973,7 +981,7 @@ def _settle_site_is_guarded(
 def rule_settle_once_adoption(
     files: list[Path],
     exceptions: dict,
-    roots: tuple[str, ...] = ("views/", "services/"),
+    roots: tuple[str, ...] = ("views/", "services/", "cogs/"),
 ) -> list[Finding]:
     """Flag a wager-settle site that does not adopt the settle-once guard.
 
@@ -993,11 +1001,15 @@ def rule_settle_once_adoption(
     rule never asks for a wrong change.
 
     Warn-only (Q-0105 — the mixin is young; graduate to ``error`` once it stays
-    clean across a few sessions).  Runs clean today (both callers adopt).  Scopes
-    ``views/`` + ``services/`` (the RPS/blackjack views call it; a state object
-    like ``blackjack_state._PvPState`` lives in ``services/``).  ``game_wager_workflow``
-    itself only *defines* ``settle_pvp``/``refund_pvp`` (never calls them), so it is
-    not matched.  Allowlist a verified single-trigger exception in
+    clean across a few sessions).  Runs clean today (all callers adopt).  Scopes
+    ``views/`` + ``services/`` + ``cogs/`` — the 2026-07-07 widening: the
+    deathmatch human-duel view lives in ``cogs/`` and its unguarded W/L write
+    was live-confirmed by Gate-V Arm D, so the cog layer is in scope, and the
+    tournament payout / deathmatch leaderboard sinks joined the sink set.
+    ``game_wager_workflow`` itself only *defines* the wager sinks (never calls
+    them), and ``Deathmatch.update_leaderboard`` — the single-trigger wrapper
+    whose body calls ``db.update_deathmatch`` — is itself a definition, not a
+    matched call.  Allowlist a verified single-trigger exception in
     ``consistency_exceptions.yml``.
     """
     cfg = exceptions.get("settle_once_adoption", {})

--- a/tests/unit/cogs/test_settle_once_fixes.py
+++ b/tests/unit/cogs/test_settle_once_fixes.py
@@ -1,0 +1,309 @@
+"""Settle-once retrofits for the three unguarded money/stat settlement paths.
+
+Pins the FINAL-REVIEW §6.3 fixes (2026-07-07):
+
+1. **deathmatch `_DuelView`** — the Gate-V Arm-D live-confirmed double-write:
+   a finishing-blow re-entry (double-click, or a timeout racing the final
+   move) used to run ``update_leaderboard`` + gear wear twice. Now
+   ``SettleOnceMixin``-guarded, mirroring the bot-duel sibling.
+2. **blackjack `_check_tourn_done`** — every player's ``_finish_round`` (and
+   ``on_timeout``) awaits between recording its result and the all-finished
+   check, so two concurrent finishers both reached the payout; the paid path
+   is row-consumption idempotent but the FREE-reward leg has no escrow rows,
+   so the claim is its only double-pay guard.
+3. **rps `check_tournament_progress`** — the same shape via ``register_move``'s
+   two ``not self.matches`` branches; per-tournament claim re-armed at start
+   (`rearm_settlement`, the new mixin seam for long-lived cog-held state).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+def _player(id_: int, name: str = "P") -> SimpleNamespace:
+    return SimpleNamespace(id=id_, display_name=name, mention=f"<@{id_}>", bot=False)
+
+
+def _stub_interaction(user) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = user
+    interaction.guild_id = 0
+    interaction.message = AsyncMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# 1. deathmatch _DuelView
+# ---------------------------------------------------------------------------
+
+
+def _duel_view(cog, p1, p2):
+    from cogs.deathmatch_cog import _Duel, _DuelView
+
+    duel = _Duel(p1, p2)  # type: ignore[arg-type]
+    key = (p1.id, p2.id)
+    cog.active_duels[key] = duel
+    return duel, _DuelView(cog, duel, key, MagicMock(), guild_id=42)
+
+
+@pytest.mark.asyncio
+async def test_duel_finishing_resolve_settles_once():
+    """A second finishing `_resolve` short-circuits: one W/L + one gear tick."""
+    cog = MagicMock()
+    cog.active_duels = {}
+    cog.update_leaderboard = AsyncMock()
+    p1, p2 = _player(1, "One"), _player(2, "Two")
+    duel, view = _duel_view(cog, p1, p2)
+    duel.player2_hp = 0  # already-lethal state: any resolve finishes
+
+    with patch(
+        "cogs.deathmatch_cog._tick_duel_gear_wear",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as wear:
+        await view._resolve(_stub_interaction(p1), "hit")
+        await view._resolve(_stub_interaction(p2), "hit")
+
+    cog.update_leaderboard.assert_awaited_once()
+    wear.assert_awaited_once()
+    assert view.is_settled
+
+
+@pytest.mark.asyncio
+async def test_duel_timeout_then_finish_settles_once():
+    """The Arm-D race: timeout fires, then the queued finishing move runs."""
+    cog = MagicMock()
+    cog.active_duels = {}
+    cog.update_leaderboard = AsyncMock()
+    p1, p2 = _player(1, "One"), _player(2, "Two")
+    duel, view = _duel_view(cog, p1, p2)
+    view.message = AsyncMock()
+
+    with patch(
+        "cogs.deathmatch_cog._tick_duel_gear_wear",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        await view.on_timeout()
+        duel.player2_hp = 0
+        await view._resolve(_stub_interaction(p1), "hit")
+
+    cog.update_leaderboard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_duel_finish_then_timeout_settles_once():
+    cog = MagicMock()
+    cog.active_duels = {}
+    cog.update_leaderboard = AsyncMock()
+    p1, p2 = _player(1, "One"), _player(2, "Two")
+    duel, view = _duel_view(cog, p1, p2)
+    view.message = AsyncMock()
+    duel.player2_hp = 0
+
+    with patch(
+        "cogs.deathmatch_cog._tick_duel_gear_wear",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        await view._resolve(_stub_interaction(p1), "hit")
+        await view.on_timeout()
+
+    cog.update_leaderboard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_duel_non_finishing_move_does_not_consume_the_claim():
+    """A regular turn must leave the claim intact for the real finish."""
+    cog = MagicMock()
+    cog.active_duels = {}
+    cog.update_leaderboard = AsyncMock()
+    p1, p2 = _player(1, "One"), _player(2, "Two")
+    duel, view = _duel_view(cog, p1, p2)
+
+    with patch(
+        "cogs.deathmatch_cog._tick_duel_gear_wear",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        await view._resolve(_stub_interaction(p1), "poke")  # nobody at 0 HP
+        assert not view.is_settled
+        duel.player2_hp = 0
+        await view._resolve(_stub_interaction(p2), "hit")
+
+    cog.update_leaderboard.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 2. blackjack _check_tourn_done
+# ---------------------------------------------------------------------------
+
+
+def _bj_tournament():
+    from services.blackjack_state import _BjTournament
+
+    tourn = _BjTournament(
+        host_id=1,
+        guild_id=10,
+        announce_id=20,
+        entry_fee=0,  # FREE tournament — the unguarded leg
+        rounds=1,
+        duration_mins=5,
+    )
+    tourn.players = [1, 2]
+    tourn.results = {1: 20, 2: 18}
+    return tourn
+
+
+@pytest.mark.asyncio
+async def test_free_tournament_pays_once_across_concurrent_checks():
+    from views.blackjack import tournament_views
+
+    tourn = _bj_tournament()
+    bot = MagicMock()
+    bot.get_channel.return_value = None
+    bot.get_guild.return_value = None
+    settle = SimpleNamespace(paid=True, amount=200, new_winner_balance=200)
+
+    with (
+        patch.object(
+            tournament_views.game_wager_workflow,
+            "payout_tournament",
+            new_callable=AsyncMock,
+            return_value=settle,
+        ) as payout,
+        patch.object(
+            tournament_views.tournament_state_service,
+            "clear_active",
+            new_callable=AsyncMock,
+        ),
+    ):
+        # Two players' _finish_round callbacks both pass the all-finished
+        # check before either pays — the claim lets exactly one through.
+        await tournament_views._check_tourn_done(tourn, bot)
+        await tournament_views._check_tourn_done(tourn, bot)
+
+    payout.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unfinished_tournament_never_takes_the_claim():
+    from views.blackjack import tournament_views
+
+    tourn = _bj_tournament()
+    tourn.results = {1: 20}  # one player still playing
+    bot = MagicMock()
+
+    with patch.object(
+        tournament_views.game_wager_workflow,
+        "payout_tournament",
+        new_callable=AsyncMock,
+    ) as payout:
+        await tournament_views._check_tourn_done(tourn, bot)
+
+    payout.assert_not_awaited()
+    assert not tourn.is_settled
+
+
+# ---------------------------------------------------------------------------
+# 3. rps check_tournament_progress
+# ---------------------------------------------------------------------------
+
+
+def _rps_cog():
+    from cogs.rps_tournament_cog import RockPaperScissorsCog
+
+    cog = RockPaperScissorsCog.__new__(RockPaperScissorsCog)
+    cog.bot = MagicMock()
+    cog.tournament_active = True
+    cog.entry_fee = 0  # FREE tournament — the unguarded leg
+    cog.current_round = [_player(7, "Winner")]
+    cog.scores = {}
+    cog.matches = {}
+    cog.match_channels = {}
+    cog.players = []
+    return cog
+
+
+def _rps_patches(rps_tournament_cog, payout_result):
+    return (
+        patch.object(
+            rps_tournament_cog.game_wager_workflow,
+            "payout_tournament",
+            new_callable=AsyncMock,
+            return_value=payout_result,
+        ),
+        patch.object(
+            rps_tournament_cog.tournament_state_service,
+            "clear_active",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            rps_tournament_cog,
+            "delete_all_match_channels",
+            new_callable=AsyncMock,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_rps_final_payout_fires_once_across_racing_checkers():
+    from cogs import rps_tournament_cog
+
+    cog = _rps_cog()
+    cog.rearm_settlement()
+    guild = MagicMock()
+    guild.id = 99
+    guild.system_channel = AsyncMock()
+    channel = AsyncMock()
+    settle = SimpleNamespace(paid=True, amount=100, new_winner_balance=100)
+
+    payout_p, clear_p, delete_p = _rps_patches(rps_tournament_cog, settle)
+    with payout_p as payout, clear_p, delete_p:
+        await cog.check_tournament_progress(guild, channel)
+        # The second racing resolver enters the winner branch while the first
+        # is still mid-flight (both saw self.matches empty — each awaits
+        # between deleting its pair and register_move's check). Model that
+        # re-entry state: the winner is still in current_round, the claim is
+        # already consumed.
+        cog.current_round = [_player(7, "Winner")]
+        await cog.check_tournament_progress(guild, channel)
+
+    payout.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rps_rearm_allows_the_next_tournament_to_pay():
+    from cogs import rps_tournament_cog
+
+    cog = _rps_cog()
+    cog.rearm_settlement()
+    guild = MagicMock()
+    guild.id = 99
+    guild.system_channel = AsyncMock()
+    channel = AsyncMock()
+    settle = SimpleNamespace(paid=True, amount=100, new_winner_balance=100)
+
+    payout_p, clear_p, delete_p = _rps_patches(rps_tournament_cog, settle)
+    with payout_p as payout, clear_p, delete_p:
+        await cog.check_tournament_progress(guild, channel)
+        # Next tournament starts → the claim re-arms → its final pays again.
+        cog.rearm_settlement()
+        cog.current_round = [_player(8, "NextWinner")]
+        await cog.check_tournament_progress(guild, channel)
+
+    assert payout.await_count == 2

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -1002,6 +1002,84 @@ def _settle_findings(mod, tmp_path, monkeypatch, src, *, rel="views/pvp.py"):
     return mod.rule_settle_once_adoption([tmp_path / rel], {})
 
 
+# The deathmatch human-duel shape the 2026-07-07 widening exists to catch: a
+# cog-layer view whose W/L write (update_leaderboard) is reachable from a
+# button resolve AND on_timeout with no claim — the Gate-V Arm-D live
+# double-write (FINAL-REVIEW §6.3 #1).
+_SETTLE_COG_DUEL_NO_GUARD = """\
+import discord
+
+
+class _DuelView(discord.ui.View):
+    async def _resolve(self, interaction):
+        await self.cog.update_leaderboard(winner_id=1, loser_id=2, guild_id=3)
+
+    async def on_timeout(self):
+        await self.cog.update_leaderboard(winner_id=2, loser_id=1, guild_id=3)
+"""
+
+# An unguarded tournament payout in a cog — the FREE-reward leg has no escrow
+# rows to consume, so the caller-side claim is its only double-pay guard.
+_SETTLE_COG_TOURNAMENT_NO_GUARD = """\
+from services import game_wager_workflow
+
+
+class _Tourn:
+    async def check_progress(self, guild):
+        await game_wager_workflow.payout_tournament(
+            guild_id=guild.id, subsystem="x", winner_id=1, reason="win",
+            free_reward=100, free_reason="free",
+        )
+"""
+
+
+def test_settle_flags_unguarded_cog_duel_view(mod, tmp_path, monkeypatch):
+    # cogs/ joined the scan roots in the 2026-07-07 widening.
+    findings = _settle_findings(
+        mod, tmp_path, monkeypatch, _SETTLE_COG_DUEL_NO_GUARD, rel="cogs/dm.py"
+    )
+    assert len(findings) == 2
+    assert {f.qualname for f in findings} == {
+        "_DuelView._resolve",
+        "_DuelView.on_timeout",
+    }
+
+
+def test_settle_cog_duel_view_with_mixin_is_clean(mod, tmp_path, monkeypatch):
+    src = _SETTLE_COG_DUEL_NO_GUARD.replace(
+        "class _DuelView(discord.ui.View):",
+        "class _DuelView(SettleOnceMixin, discord.ui.View):",
+    )
+    assert (
+        _settle_findings(mod, tmp_path, monkeypatch, src, rel="cogs/dm.py") == []
+    )
+
+
+def test_settle_flags_unguarded_tournament_payout(mod, tmp_path, monkeypatch):
+    findings = _settle_findings(
+        mod,
+        tmp_path,
+        monkeypatch,
+        _SETTLE_COG_TOURNAMENT_NO_GUARD,
+        rel="cogs/tourn.py",
+    )
+    assert len(findings) == 1
+    assert "payout_tournament" in findings[0].message
+
+
+def test_settle_guarded_tournament_payout_is_clean(mod, tmp_path, monkeypatch):
+    src = _SETTLE_COG_TOURNAMENT_NO_GUARD.replace(
+        "        await game_wager_workflow.payout_tournament(",
+        "        if not self.claim_settlement():\n"
+        "            return\n"
+        "        await game_wager_workflow.payout_tournament(",
+    )
+    assert (
+        _settle_findings(mod, tmp_path, monkeypatch, src, rel="cogs/tourn.py")
+        == []
+    )
+
+
 def test_settle_flags_unguarded_wager_settle(mod, tmp_path, monkeypatch):
     findings = _settle_findings(mod, tmp_path, monkeypatch, _SETTLE_NO_GUARD)
     assert len(findings) == 1


### PR DESCRIPTION
Owner-directed via the rebuild final-review brief §3.H (FINAL-REVIEW §6.3 "fix now" list), executed under Q-0241. Every claim re-verified against HEAD source before fixing (Q-0120); cleanup/slowmode/bot_spam/role-teardown items from §6.3 were confirmed **already fixed** by #1728 and are not touched here.

**Three fixes, one class (unguarded settlement paths):**
1. **deathmatch `_DuelView`** (Arm-D live-confirmed double-write): `SettleOnceMixin` retrofit mirroring the `_BotDuelView` sibling — claim inside `_resolve`'s winner branch + shared claim in `on_timeout`. One W/L write + one gear-wear tick, ever.
2. **blackjack FREE-tournament double-pay**: `_BjTournament` adopts the mixin; `_check_tourn_done` claims past the all-finished check. The paid path stays row-consumption idempotent (Arm-D verified); the FREE reward leg has no escrow rows, so the claim is its only guard.
3. **rps FREE-tournament double-pay** (adjacent instance found during verification): both semifinal resolvers await between deleting their match entries and `register_move`'s `not self.matches` check, so both can reach the final payout. Per-tournament claim, re-armed at tournament start via the new documented `SettleOnceMixin.rearm_settlement()` seam.

**Enforcement (friction → guard, Q-0194):** `check_consistency` Rule 6 widened — `cogs/` joins the scan roots, `payout_tournament` + `update_leaderboard` join the settle-sink set. The checker now flags exactly this class of non-adopter; runs clean on the fixed tree.

**Tests:** 8 concurrency regressions (double-resolve, timeout↔finish races both orders, non-finishing move keeps the claim, double-check payouts, re-arm across tournaments) + 4 Rule-6 checker regressions. Full local CI mirror green; `check_architecture --mode strict` 0 errors.

⚑ Self-made decisions (Q-0240, flagged): O-6 resolved as **mixin retrofit** (uniform with all sibling adopters + checker-recognizable, over a bespoke `is_over` guard); blackjack guard = in-process claim (Option B) rather than restructuring free tournaments to write sentinel escrow rows (Option A) — smaller diff, matches the PvP sibling idiom, no entry-fee flow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br3wUUNkaHnYC9ZJk8279V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br3wUUNkaHnYC9ZJk8279V)_