### PR TITLE
feat(economy): wire the ready-but-unwired transfer() to !pay / !transfer

### DIFF
--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-07-06T21:47:52Z",
+    "generated_at": "2026-07-07T08:25:26Z",
     "build": {
-      "commit": "666c802a",
-      "subject": "docs(reconcile): 36th Q-0107 pass — band-#1770",
-      "committed_at": "2026-07-06T21:47:52Z"
+      "commit": "b06fe45",
+      "subject": "feat(economy): wire the ready-but-unwired transfer() to !pay / !transfer",
+      "committed_at": "2026-07-07T08:25:26Z"
     }
   },
   "counts": {
-    "commands": 484,
+    "commands": 485,
     "features": 43,
     "games": 12
   },
@@ -3718,6 +3718,27 @@
         },
         {
           "title": "Mining & Exploration — Brainstorm & Roadmap",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "pay",
+      "aliases": [
+        "transfer"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Send coins to another member. Usage: !pay @user <amount>",
+      "description": "Send coins to another member. Usage: !pay @user <amount>",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Wager / money-flow map — generated trace of game coin paths",
           "status": "ideas"
         }
       ],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -4086,6 +4086,26 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "pay",
+    "area": "economy",
+    "status": "in-progress",
+    "summary": "Send coins to another member. Usage: !pay @user <amount>",
+    "description": "Send coins to another member. Usage: !pay @user <amount>",
+    "usage": "!pay",
+    "aliases": [
+      "transfer"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "Wager / money-flow map — generated trace of game coin paths"
+      }
+    ]
+  },
+  {
     "name": "pending",
     "area": "games",
     "status": "in-progress",
@@ -7536,7 +7556,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "666c802a",
+    "build": "b06fe45",
     "title": "New public bot website",
     "changes": [
       {
@@ -7548,7 +7568,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "666c802a",
+    "build": "b06fe45",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7560,7 +7580,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "666c802a",
+    "build": "b06fe45",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-07T06:21:44Z",
+    "generated_at": "2026-07-07T08:25:26Z",
     "build": {
-      "commit": "0c9ce92c",
-      "subject": "Merge pull request #1779 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-07T06:21:44Z"
+      "commit": "b06fe45",
+      "subject": "feat(economy): wire the ready-but-unwired transfer() to !pay / !transfer",
+      "committed_at": "2026-07-07T08:25:26Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 55,
-      "commands": 484,
+      "commands": 485,
       "setting_keys": 120,
       "setting_domains": 17,
       "typed_settings": 100,
@@ -7162,6 +7162,19 @@
             "jobs"
           ],
           "brief": "Show all jobs, requirements, and your mastery for each.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "pay",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "transfer"
+          ],
+          "brief": "Send coins to another member. Usage: !pay @user <amount>",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -346,6 +346,75 @@ class EconomyCog(commands.Cog):
         embed.add_field(name="🏆 Level", value=str(xp_row["level"]), inline=True)
         await ctx.send(embed=embed)
 
+    # ------------------------------------------------------------------ !pay
+
+    @commands.cooldown(rate=3, per=10, type=commands.BucketType.user)
+    @commands.command(name="pay", aliases=["transfer"])
+    async def pay(
+        self,
+        ctx: commands.Context,
+        member: discord.Member = None,
+        amount: int = None,
+    ):
+        """Send coins to another member. Usage: !pay @user <amount>"""
+        if member is None or amount is None:
+            await ctx.send("Usage: `!pay @user <amount>`", delete_after=10)
+            return
+        if member.bot:
+            await ctx.send("❌ You can't pay a bot.", delete_after=10)
+            return
+        if member.id == ctx.author.id:
+            await ctx.send("❌ You can't pay yourself.", delete_after=10)
+            return
+        if amount <= 0:
+            await ctx.send("❌ Amount must be positive.", delete_after=10)
+            return
+        gid = ctx.guild.id
+        try:
+            new_from, new_to = await economy_service.transfer(
+                gid,
+                ctx.author.id,
+                member.id,
+                amount,
+                reason="gift",
+                actor_id=ctx.author.id,
+            )
+        except economy_service.InsufficientFundsError:
+            coins = await db.get_coins(ctx.author.id, gid)
+            await ctx.send(
+                f"❌ Not enough coins — you have **{coins:,}** 🪙, "
+                f"tried to send **{amount:,}** 🪙.",
+                delete_after=10,
+            )
+            return
+
+        embed = discord.Embed(
+            title="💸 Payment sent",
+            description=f"{ctx.author.mention} → {member.mention}",
+            color=ECONOMY_COLOR,
+        )
+        embed.set_author(
+            name=ctx.author.display_name,
+            icon_url=ctx.author.display_avatar.url,
+        )
+        embed.add_field(name="Amount", value=f"**{amount:,}** 🪙", inline=True)
+        embed.add_field(name="Your balance", value=f"**{new_from:,}** 🪙", inline=True)
+        embed.add_field(
+            name=f"{member.display_name}'s balance",
+            value=f"**{new_to:,}** 🪙",
+            inline=True,
+        )
+        await ctx.send(embed=embed)
+
+        log_embed = discord.Embed(
+            title="💸 Coins transferred",
+            description=(
+                f"{ctx.author.mention} paid {member.mention} **{amount:,}** 🪙"
+            ),
+            color=ECONOMY_COLOR,
+        )
+        await post_log_embed(self.bot, gid, log_embed)
+
     # ------------------------------------------------------------------ !setlogchannel
 
     @commands.command(name="setlogchannel")

--- a/tests/unit/cogs/test_economy_pay.py
+++ b/tests/unit/cogs/test_economy_pay.py
@@ -1,0 +1,150 @@
+"""Cog-level tests for `!pay` / `!transfer` (peer coin transfer).
+
+Wires the long-ready, fully-audited `economy_service.transfer()` to a user
+command (FINAL-REVIEW §6.3 "ready-but-unwired"). Named `pay`/`transfer`, NOT
+`give` — the `give` token is banned surface-wide after the #1541 boot
+collision (Q-0211; `tests/unit/invariants/test_extension_integrity.py` pins
+the ban). The service already guards positivity / self-transfer /
+insufficient funds inside one transaction with two audit rows; the cog layer
+adds the UX guards (missing args, bot recipient, friendly copy) and mirrors
+the sibling money-command idiom (ECONOMY_COLOR embed + `post_log_embed`).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.economy_cog import EconomyCog
+from services.economy_service import InsufficientFundsError
+
+
+def _ctx(*, guild_id: int = 55, author_id: int = 7) -> MagicMock:
+    ctx = MagicMock()
+    ctx.guild = MagicMock()
+    ctx.guild.id = guild_id
+    ctx.author = MagicMock(spec=discord.Member)
+    ctx.author.id = author_id
+    ctx.author.bot = False
+    ctx.author.mention = f"<@{author_id}>"
+    ctx.author.display_name = "Payer"
+    ctx.send = AsyncMock()
+    return ctx
+
+
+def _member(id_: int = 9, *, bot: bool = False) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = id_
+    m.bot = bot
+    m.mention = f"<@{id_}>"
+    m.display_name = "Payee"
+    return m
+
+
+def _cog() -> EconomyCog:
+    return EconomyCog(MagicMock())
+
+
+async def _invoke(cog, ctx, member, amount):
+    await cog.pay.callback(cog, ctx, member, amount)
+
+
+@pytest.mark.asyncio
+async def test_pay_happy_path_transfers_and_logs():
+    cog, ctx, member = _cog(), _ctx(), _member()
+    with (
+        patch(
+            "cogs.economy_cog.economy_service.transfer",
+            new_callable=AsyncMock,
+            return_value=(90, 110),
+        ) as transfer,
+        patch(
+            "cogs.economy_cog.post_log_embed",
+            new_callable=AsyncMock,
+        ) as log,
+    ):
+        await _invoke(cog, ctx, member, 10)
+
+    transfer.assert_awaited_once_with(
+        55,
+        7,
+        9,
+        10,
+        reason="gift",
+        actor_id=7,
+    )
+    embed = ctx.send.call_args.kwargs["embed"]
+    field_values = [f.value for f in embed.fields]
+    assert "**90**" in field_values[1]  # payer balance
+    assert "**110**" in field_values[2]  # payee balance
+    log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("member", "amount"),
+    [
+        (None, 10),  # missing member
+        ("payee", None),  # missing amount
+        ("bot", 10),  # bot recipient
+        ("self", 10),  # self-transfer
+        ("payee", 0),  # non-positive
+        ("payee", -5),
+    ],
+)
+async def test_pay_guard_rails_never_reach_the_service(member, amount):
+    cog, ctx = _cog(), _ctx()
+    target = {
+        None: None,
+        "payee": _member(),
+        "bot": _member(bot=True),
+        "self": None,
+    }.get(member, _member())
+    if member == "self":
+        target = _member(id_=ctx.author.id)
+
+    with patch(
+        "cogs.economy_cog.economy_service.transfer",
+        new_callable=AsyncMock,
+    ) as transfer:
+        await _invoke(cog, ctx, target, amount)
+
+    transfer.assert_not_awaited()
+    ctx.send.assert_awaited_once()  # friendly copy, no crash
+
+
+@pytest.mark.asyncio
+async def test_pay_insufficient_funds_is_friendly():
+    cog, ctx, member = _cog(), _ctx(), _member()
+    with (
+        patch(
+            "cogs.economy_cog.economy_service.transfer",
+            new_callable=AsyncMock,
+            side_effect=InsufficientFundsError("user=7 has 3 coins, needs 10"),
+        ),
+        patch(
+            "cogs.economy_cog.db.get_coins",
+            new_callable=AsyncMock,
+            return_value=3,
+        ),
+        patch(
+            "cogs.economy_cog.post_log_embed",
+            new_callable=AsyncMock,
+        ) as log,
+    ):
+        await _invoke(cog, ctx, member, 10)
+
+    message = ctx.send.call_args.args[0]
+    assert "Not enough coins" in message
+    assert "**3**" in message
+    log.assert_not_awaited()
+
+
+def test_pay_never_uses_the_banned_give_token():
+    # Q-0211: `give` crashed the bot at boot via a top-level name collision
+    # and is banned surface-wide; this command must never regrow it.
+    names = {EconomyCog.pay.name, *EconomyCog.pay.aliases}
+    assert "give" not in names
+    assert names == {"pay", "transfer"}


### PR DESCRIPTION
Owner-directed via the rebuild final-review brief §3.H (FINAL-REVIEW §6.3 "ready-but-unwired" item), executed under Q-0241.

`economy_service.transfer()` — atomic two-leg move, two `economy_audit_log` rows, `EVT_BALANCE_CHANGED` per party — was fully built and tested with zero command wiring. Now wired as **`!pay` (alias `!transfer`)**.

⚠ **Deliberate naming divergence from the brief's `!give/!pay` shorthand:** `give` is banned surface-wide (Q-0211) after the #1541 boot-collision crash-loop; the invariant test pins the ban. A new Q-0211 regression test in this PR pins that this command never regrows it.

- Cog-layer UX guards (missing args / bot recipient / self / non-positive) short-circuit with friendly copy; `InsufficientFundsError` renders the actual balance
- Sibling money-command idiom: 3/10 user cooldown, ECONOMY_COLOR embed with both post-transfer balances, `post_log_embed` audit echo
- Generated command-surface artifacts (dashboard.json / site.json) regenerated for the new command (485 commands)
- Tests: happy path (exact service args), 6 guard rails, insufficient funds, banned-token regression
- **Live-exercised against real local Postgres** (Arm-D pattern): seed → transfer → balances 70/35 ✓ → exactly 2 audit rows ✓ → insufficient-funds raises cleanly ✓

⚑ Self-made decision (Q-0240, flagged): shipped **ungated** (matching `daily`/`work`/`balance` — self-serve verbs on an audited seam); if the owner wants a kill-switch, the reversible path is a declarative `economy.currency.transfer` capability wired to the existing governance gate (additive, no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br3wUUNkaHnYC9ZJk8279V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br3wUUNkaHnYC9ZJk8279V)_