### PR TITLE
docs: rebuild-plan review session + user-automation idea capture

### DIFF
--- a/.sessions/2026-07-07-rebuild-plan-review-and-automation-idea.md
+++ b/.sessions/2026-07-07-rebuild-plan-review-and-automation-idea.md
@@ -1,0 +1,96 @@
+# 2026-07-07 — Rebuild plan review (owner Q&A) + user-automation idea capture
+
+> **Status:** `complete` — deliberate final flip (born-red gate, Q-0133). Docs-only session: no
+> `disbot/` runtime changes, no plan edits to frozen/canonical documents. One new idea capture doc.
+
+## What this session did
+
+The owner asked three things, in sequence, purely conversational:
+
+1. **"Explain the rebuild plan in plain language — what will this bot be when it's done?"**
+   Read the canonical plan (`docs/planning/rebuild-canonical-plan-2026-07-06.md`), its owner-briefing
+   companion, and the design spec's plain-language summary/executive-summary sections, plus
+   `docs/current-state.md` for feature texture. Answered in chat only — no doc changes (a read-only
+   explanation task).
+2. **"Do you think there are improvements or overlooked items?"**
+   Cross-checked my own candidate gaps against the corpus's own self-review
+   (`rebuild-verification-review-2026-07-03.md`, `rebuild-final-review-report-2026-07-07.md`) before
+   asserting anything — most of what I would have flagged (layer-V thinness, AI-answer verification
+   being a different oracle shape than golden parity, the human-lane verified_live bottleneck, cost
+   posture, rollback-window length) turned out either already named as the plan's own top risk or
+   already resolved; reported back which of my points were genuinely additive vs. already covered,
+   rather than re-presenting the self-review as if it were my own finding.
+3. **Owner floated a product idea:** a guardrailed, unlockable, user-self-service recurring
+   scheduler ("cron jobs for themselves") — e.g. a daily rank ping, or a periodic game-state check —
+   explicitly requested as a **foundational, cross-subsystem** primitive, not a one-off command.
+   Captured as `docs/ideas/user-self-service-automation-scheduler-2026-07-07.md`: dedup-checked
+   against existing prior art (`!remind`'s known restart-loss bug, the competitive-teardown #8
+   scheduler-slice idea, the future-product-direction notification-profiles idea), split the ask into
+   a low-risk notify-only tier and a higher-risk auto-acting tier (named the concrete fairness failure
+   mode: automating an action a forgetful human would otherwise miss is a real balance break, not a
+   QoL win), and tied the design to the not-yet-built K9 durability band so it can land as a kernel
+   extension instead of a later per-feature bolt-on.
+
+## Shipped (this PR)
+
+- **New:** `docs/ideas/user-self-service-automation-scheduler-2026-07-07.md`.
+- **This session log.**
+- No `disbot/` changes. No edits to the canonical plan or any frozen rebuild doc — deliberately
+  routed as a standalone idea doc instead of editing `rebuild-canonical-plan-2026-07-06.md` directly,
+  since that document's whole value is that every line traces to a decisions-log entry from a
+  reviewed pass; the idea doc names exactly where it should land (K9's Phase-B step) for whenever
+  that amendment pass happens.
+
+## 🛠 Friction → guard (Q-0194)
+
+No new friction this session that warrants a checker/hook — the workflow (read plan → answer →
+capture idea → commit/push) worked as designed, including the Stop-hook catching the untracked idea
+file and prompting the commit+push that produced this PR.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session (`2026-07-06-gate-v-arm-d-live-testing.md`) ran Gate V's Arm D live-testing pass
+carefully, with a well-reasoned sandbox-methodology fallback it folded back into the source doc for
+future sessions. One thing worth flagging forward: that session's own "💡 Session idea" proposed a
+reusable in-process synthetic-gateway-with-real-HTTP harness (one fidelity tier above what it built)
+— it's a small, well-scoped, ready-to-pick-up idea that hasn't been picked up in the two days since
+(band #1770→#1783 shipped a lot of rebuild-consolidation work but not this). **Concrete improvement
+for the system:** nothing structural to fix here — this is a plain reminder that a good idea captured
+in a session log's prose (rather than as its own `docs/ideas/` file) is easy to lose track of once
+several bands pass; worth grooming it into its own idea file next time someone is in that area, so it
+surfaces in `docs/ideas/` greps instead of only in one old session log.
+
+## 💡 Session idea (Q-0089)
+
+Already delivered as this session's substantive idea capture (§ above): the user-self-service
+automation scheduler. No separate filler idea added — one genuine idea, not two thin ones.
+
+## 🧹 Grooming (Q-0015)
+
+This session's idea capture doubles as its own grooming: it explicitly routes a raw owner drop into
+a structured `docs/ideas/` entry with prior-art cross-references and a named landing spot (K9
+Phase-B), rather than leaving it to be re-derived from chat history later.
+
+## 📋 Docs audit (Q-0104)
+
+New idea doc cross-references and is reachable from existing related ideas (fun-and-ease-brainstorm
+C4, competitive-teardown #8, future-product-direction) and from the canonical plan's automation
+section (B-2) by path. No new owner-facing decision needed routing to the question router — the one
+open call the idea doc names (whether auto-acting automations should ever ship) is explicitly left
+for whoever picks up the K9 landing, since no subsystem needs it yet and nothing is blocked.
+
+## 📤 Run report
+
+- **Did:** explained the rebuild plan in plain language; gave an independent critique of the plan
+  cross-checked against its own self-review; captured a new owner-proposed feature idea with a
+  concrete design sketch and fairness analysis. **Outcome:** shipped (docs-only).
+- **Shipped:** this PR — 1 new idea doc + this session log. No runtime change.
+- **Run type:** `manual` (owner-directed, live conversation).
+- **⚑ Owner decisions needed:** none blocking. The idea doc names one open product call (notify-only
+  vs. ever allowing auto-acting automations) but explicitly does not block anything today.
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** the idea capture went slightly beyond the owner's literal words — added the
+  notify-vs-act risk split and the concrete fairness-failure definition, and proposed the specific
+  K9 landing point, none of which the owner specified verbatim.
+- **↪ Next:** no forced next step. Natural pickup point is whenever K9's Phase-B per-step plan gets
+  written (canonical plan §5 step 10) — fold this idea in then, per its own "Recommended routing."

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,14 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`user-self-service-automation-scheduler-2026-07-07.md`](./user-self-service-automation-scheduler-2026-07-07.md) —
+  **session idea (2026-07-07, Q-0089, rebuild-plan-review session):** owner-proposed guardrailed,
+  unlockable, user-facing recurring scheduler ("cron jobs for themselves" — a daily rank ping, a
+  periodic game-state check), explicitly asked for as a **foundational, cross-subsystem** primitive
+  rather than a one-off command. Splits the ask into a low-risk notify-only tier and a higher-risk
+  auto-acting tier (names the concrete fairness failure: automating an action a forgetful human would
+  otherwise miss is a balance break, not a QoL win) and ties the design to the not-yet-built K9
+  durability band so it lands as a kernel extension instead of a later per-feature bolt-on.
 - [`substrate-kit-auto-drafted-handoff-2026-07-07.md`](./substrate-kit-auto-drafted-handoff-2026-07-07.md) —
   **session idea (2026-07-07, Q-0089, final-review session #1778):** the Phase-2.5 A/B measured the
   same failure twice — sessions with a rendered ledger/session-log scaffolding in-repo still write

--- a/docs/ideas/user-self-service-automation-scheduler-2026-07-07.md
+++ b/docs/ideas/user-self-service-automation-scheduler-2026-07-07.md
@@ -1,0 +1,106 @@
+# User-facing self-service automation scheduler (personal "cron jobs")
+
+> **Status:** `ideas` — capture only, not approved for implementation. Dropped by the owner
+> 2026-07-07 during the rebuild-plan review session, as a design input for the not-yet-built K9
+> durability band. **Subsystem:** none (cross-cutting kernel capability; consumed by many
+> subsystems once built).
+>
+> **Timing note:** this is worth folding in *before* K9 is built (canonical plan
+> [`rebuild-canonical-plan-2026-07-06.md`](../planning/rebuild-canonical-plan-2026-07-06.md) §5
+> step 10), not after — K9's `ManagedTaskSpec`/`sb_due_queue` machinery already exists on paper for
+> exactly this shape of problem (Interval/Cron/OneShot/EventTrigger, misfire/catch-up, boot-reconcile).
+> Bolting a user-facing variant on after the port bands ship would recreate the "smeared feature"
+> pattern the whole rebuild exists to kill.
+
+## The ask, in the owner's words
+
+> "there should be an easy way for users to set cron jobs for themselves in the bot, with
+> guardrails ofcourse, and in an unlockable way for certain features, like a user should be able to
+> set a recurring command for themselves, or a recurring notification etc, to automate some parts
+> of games or stat checking etc... this should probably also be a foundational function used by
+> multiple subsystems, like recurring roles or channels etc"
+
+Concrete examples given: "send my rank every morning at 8am"; "after every 6 hours check on the
+chicken farm." The explicit constraint: it must improve quality of life, **not** become an unfair
+advantage over players who don't set one up.
+
+## Why this isn't already covered
+
+Prior art exists, but all of it is narrower than what's being asked for here:
+
+- `!remind` exists today but is **in-memory only — loses every reminder on restart**
+  (`docs/ideas/fun-and-ease-brainstorm-2026-06-09.md` C4, an owner ease-pick, still unbuilt).
+- `docs/ideas/competitive-teardown-2026-06-10.md` #8 ("RemindMe + user-facing scheduler slice")
+  scoped this as a reminder-command port, not a cross-subsystem primitive with fairness guardrails.
+- `docs/ideas/future-product-direction-2026-06-07.md` ("Notification subscription profiles") is
+  the closest prior framing — extend the existing scheduler/notification ownership — but is about
+  *subscribing to system-generated events* (health/mod digests), not user-declared recurring
+  triggers against arbitrary game state.
+- The rebuild's own automation ruling (canonical plan §2.4 B-2) frames automation as **admin/system**
+  facing: scheduled announcements, retention sweeps, health loops. Nothing in the frozen specs
+  reserves a *user-scoped* producer the way `Producer.HUMAN_SETUP` was reserved for the setup wizard
+  (§11 A-9). This idea is asking for the equivalent: a `Producer.USER_SELF_SERVICE` (or similar)
+  kind on the same K9 due-queue.
+
+## The two categories, and why they carry very different risk
+
+**A. Notify-only ("send my rank every morning at 8am").** Low risk. This is a scheduled *read* of
+already-current state, delivered as a DM/ping. It changes nothing about game balance — the user
+still has to act on what they see. This is functionally identical to the reminders idea already on
+the books, generalized to "any read-only query a subsystem opts into," not just a free-text note.
+
+**B. Recurring *checks tied to action* ("check on the chicken farm every 6 hours").** Higher risk.
+Depending on what "check" means, this can silently become an unfair-advantage lever:
+
+- If "check" means **notify** ("your chicken farm is ready to collect") — safe, same as category A.
+- If "check" means **auto-collect/auto-claim on the user's behalf** — this is where fairness breaks.
+  A user who never has to remember to log in gets strictly more value than one who does, for the
+  same amount of attention. That is the exact failure mode the owner is flagging.
+
+**Recommended default: automations are notify-only by default.** A subsystem may explicitly opt an
+action into "automatable" status only when the action is provably idempotent-and-time-bounded in a
+way that manual and automated execution produce the *same* outcome a player would get by remembering
+to log in at any point in the window (e.g., claiming a daily reward that doesn't decay is fine to
+automate; something with decay, streak bonuses, or a limited-window bonus is not, because automation
+would then reliably capture value a forgetful human player would miss).
+
+## Design sketch (for whoever picks this up)
+
+1. **One kernel primitive, subsystem opt-in.** Extend K9's `ManagedTaskSpec` grammar with a
+   user-scoped trigger kind. Each subsystem's manifest declares which of its read-only queries
+   (category A) or idempotent claim-actions (category B, opt-in only) are "automation-eligible," at
+   what minimum interval, and whether it's notify-only or action-taking. This keeps the fairness
+   call where it belongs — with whoever designs that specific game/subsystem — instead of the
+   kernel silently exposing every command to automation.
+2. **Guardrails, enforced centrally so no subsystem has to reinvent them:**
+   - a floor on interval (e.g. no more often than every N minutes) to stop notification spam and
+     cap any residual advantage;
+   - a per-user cap on total active personal automations (prevents one power-user from turning the
+     bot into their personal automation farm);
+   - unlock gating — tie the *capability* (not each individual automation) to something like rank,
+     level, or a cosmetic-currency unlock, consistent with the existing "cosmetic-only, no bot-side
+     billing" decision (Q-0039) — makes automation itself a QoL reward, not a day-one default;
+   - quiet hours / timezone respect, reusing the timezone/locale idea already noted against
+     `!remind`/birthdays (`docs/ideas/superbot-vision-2026-06-10.md`);
+   - delivery through the existing notification/settings authority, not a bespoke path.
+3. **Durability for free.** Because this rides K9's due-queue, restart-survival, misfire policy, and
+   boot-reconcile come along at no extra design cost — this is the concrete payoff of doing it as a
+   kernel extension instead of a per-feature bolt-on.
+4. **"Recurring roles/channels"** (the owner's other example) is a related but distinct case —
+   *admin-declared* time-based lifecycle automation (temp roles that expire, scheduled channel
+   archival), which the canonical plan already partly covers as K9 consumers (role_grants expiry
+   sweep, §11 A-8). Worth naming explicitly as a sibling consumer of the same due-queue, but it does
+   not need the fairness guardrails above since it's operator-declared, not user-self-service.
+
+## Open question that is genuinely the owner's to make, not an agent's
+
+Whether *any* category-B action-taking automation should ever ship, versus notify-only forever.
+The notify-only default above is a recommendation, not a ruling — this is a product-feel call
+about how much "idle game" behavior is wanted, and it should get an explicit answer once a
+subsystem actually wants to use category B (no subsystem does yet, so nothing is blocked today).
+
+## Recommended routing
+
+Fold as a K9 landing when Phase-B's per-step plan for K9 (canonical plan §5 step 10) is written —
+analogous to how §11 A-8's background-obligation landings were added. Until then this stays a
+capture; nothing here blocks the rebuild start.


### PR DESCRIPTION
## Summary

- Reviewed the rebuild canonical plan with the owner in conversation: explained what the rebuilt bot will be in plain language, then gave an independent critique of the plan (cross-checked against the plan's own self-review before asserting anything as a genuine gap).
- Captured a new owner-proposed feature idea: a guardrailed, unlockable, user-facing recurring scheduler ("cron jobs for themselves" — e.g. a daily rank ping, a periodic game-state check), explicitly requested as a foundational, cross-subsystem primitive rather than a one-off command. See [`docs/ideas/user-self-service-automation-scheduler-2026-07-07.md`](docs/ideas/user-self-service-automation-scheduler-2026-07-07.md).
- The idea doc splits the ask into a low-risk notify-only tier and a higher-risk auto-acting tier (names the concrete fairness-break failure mode), and ties the design to the not-yet-built K9 durability band so it can land as a kernel extension rather than a later per-feature bolt-on.

No `disbot/` runtime changes. No edits to the canonical plan or any frozen rebuild doc — the idea is captured standalone and names where it should land (K9's Phase-B step) for a future amendment pass.

## Linked issue / plan

New capture: [`docs/ideas/user-self-service-automation-scheduler-2026-07-07.md`](docs/ideas/user-self-service-automation-scheduler-2026-07-07.md), linked from `docs/ideas/README.md`. References `docs/planning/rebuild-canonical-plan-2026-07-06.md` §2.4 B-2 / §5 step 10 (K9) as the eventual landing spot.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tooling / CI
- [ ] Breaking change

## Checks

- [x] `python3.10 scripts/check_quality.py --check-only` passes (docs-only diff; no Python changed)
- [x] `python3.10 scripts/check_architecture.py --mode strict` passes (exit 0; only pre-existing known warnings, unrelated to this diff)
- [x] Docs / ledger updated — new idea doc linked from `docs/ideas/README.md`; `check_docs.py --strict` and `check_session_log.py --strict` both green
- [x] No secrets, tokens, or credentials added


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5Ka61R9eE1QQrDB4MvYEP)_