### PR TITLE
docs: capture channel/role authority gap + moderation + backup/export gaps

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,22 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`channel-role-scoped-authority-gap-2026-07-07.md`](./channel-role-scoped-authority-gap-2026-07-07.md) —
+  **⚠ time-sensitive (2026-07-07, owner-raised):** neither the live governance stack nor the frozen
+  K6 authority design (`Lane{CAPABILITY,TIER}` + `ChannelAccessDecision`) can express "only role X in
+  channel Y" — confirmed at both layers. K6 hasn't been built yet and sits on the strand-1 chain
+  (S8/K7 consumes it), so this is worth deciding before the next K6-touching session, not filed for
+  later like most of this backlog.
+- [`moderation-feature-gaps-2026-07-07.md`](./moderation-feature-gaps-2026-07-07.md) —
+  **session idea (2026-07-07, owner-raised):** researched the live moderation/security stack against
+  competitor-bot feature sets — most suspected gaps turned out already shipped; three genuine misses
+  found: a join-time verification/CAPTCHA gate, a dedicated ban-appeal/modmail flow distinct from the
+  general ticket system, and custom trigger→response commands. Feature-level, not architectural.
+- [`guild-config-backup-and-data-export-gap-2026-07-07.md`](./guild-config-backup-and-data-export-gap-2026-07-07.md) —
+  **session idea (2026-07-07, foundational-capability sweep):** two adjacent misses found while
+  checking the rebuild's K0-K10 taxonomy for completeness — self-service per-guild settings
+  backup/restore (distinct from whole-DB disaster recovery), and the "export" half of GDPR-style user
+  data requests (erasure is thoroughly mechanized; export never reappeared after the original idea).
 - [`user-self-service-automation-scheduler-2026-07-07.md`](./user-self-service-automation-scheduler-2026-07-07.md) —
   **session idea (2026-07-07, Q-0089, rebuild-plan-review session):** owner-proposed guardrailed,
   unlockable, user-facing recurring scheduler ("cron jobs for themselves" — a daily rank ping, a

--- a/docs/ideas/channel-role-scoped-authority-gap-2026-07-07.md
+++ b/docs/ideas/channel-role-scoped-authority-gap-2026-07-07.md
@@ -1,0 +1,99 @@
+# Channel-level, role-scoped access is missing — live bot AND the frozen rebuild design
+
+> **Status:** `ideas` — capture only, not approved for implementation. Owner-raised 2026-07-07
+> ("it's currently not easily possible to add certain role restrictions to certain channels"),
+> researched the same day against both the live bot and the rebuild's frozen K6 design.
+> **Subsystem:** none (cross-cutting authority-model gap; confirmed in both the live governance
+> stack and the rebuild's K6 authority engine).
+>
+> **Priority flag: this one is time-sensitive, unlike most items in this backlog.** K6 (the
+> rebuild's authority engine) has **not been built yet** (canonical plan
+> [`rebuild-canonical-plan-2026-07-06.md`](../planning/rebuild-canonical-plan-2026-07-06.md) §5 step
+> 9 — "not started"), and per the plan's own build-order note, K6 sits **on the strand-1 chain**:
+> S8 (K7, the workflow engine) consumes K4+K5+K6, so a missing K6 primitive is not a cheap
+> after-the-fact patch — it is upstream of everything K7/K8 build on. This is the one item from
+> this session's sweep worth raising **before** the next K6-touching session, not filed for later.
+
+## The gap, confirmed at both layers
+
+**Live bot today** — three separate systems handle "who can do what where," and none of them can
+express "only role X in channel Y":
+
+- **Command-channel admission** (`disbot/core/runtime/command_access.py:189-259`) — a guild-wide,
+  per-command *channel allow-list*. No role dimension at all.
+- **Cog routing** (`disbot/services/command_routing.py:57-79`) — per-channel/per-category on/off
+  toggle for a whole cog. Also role-blind.
+- **Governance visibility/tier** (`disbot/governance/capability.py`,
+  `disbot/governance/models.py:89-106`) — an ordinal rank (`user < mod < admin < owner`-like)
+  resolved from a member's roles but collapsed into one tier string. It answers "does this member's
+  *rank* clear the bar," never "is this member specifically in role X."
+- **Access Map** (`disbot/services/access_projection.py`) — explicitly documented as composing only
+  the three systems above ("no policy of its own"), so it inherits the same blind spot rather than
+  closing it; it even notes it "cannot model live Discord channel-permission overrides"
+  (`access_projection.py:396-397`).
+
+The one place a *specific role* could plausibly be targeted — `ChannelLifecycleService`'s
+`overwrite_target_id`/`"role"` parameter (`disbot/services/channel_lifecycle_service.py:102-103,
+521-527`), which edits real Discord channel permission overwrites — is wired, but **every live
+caller hardcodes `@everyone`** (`disbot/cogs/channel_cog.py:498-529`'s `!lock`/`!unlock`,
+`disbot/views/channels/restrict_panel.py:147-178`). There is no `!channel lock @role` command or UI
+path today, even though the plumbing underneath could support it.
+
+**The frozen rebuild design (K6)** has the identical shape, not an improvement:
+
+- `resolve_authority` classifies every authority check into exactly `Lane{CAPABILITY, TIER}`
+  (canonical plan §2.1 K6 row; `rebuild-gate0-worklist-2026-07-04.md:75-79`) — still capability-name
+  or ordinal-tier, never a specific role.
+- Channel admission is formalized as `ChannelAccessDecision`/`AccessMode{all_channels,
+  selected_channels, disabled_except_bootstrap}` — **the same guild-wide, role-blind allow-list
+  model as today's `command_access.py`**, verbatim value strings preserved on purpose.
+- `BindingSpec.authority_ref` (design spec §2.5) reuses the same capability/tier authority for who
+  may *configure* a binding — still not "who may use the feature this binding points at."
+
+So this isn't a bug to fix in the old bot and forget — it's a primitive the frozen grammar doesn't
+have, and the rebuild is currently on track to carry the exact same gap forward.
+
+## What "restriction" could mean — two distinct asks worth separating
+
+1. **A convenience command to manage Discord's own native channel permission overwrites for an
+   arbitrary role** ("`!channel restrict #farming @Farmers`" — a common feature in other mod bots).
+   This is mostly a UI/command gap today: the service-layer plumbing (`overwrite_target_id`) already
+   supports an arbitrary role, it's just never exposed past `@everyone`.
+2. **A bot-level declarative concept**: a subsystem's channel binding (or a command/feature) says
+   "only role X may interact with this," enforced by the bot's own authority check — independent of,
+   and layered on top of, raw Discord permissions (so it still works even if the channel is
+   otherwise visible to everyone, e.g. a channel that's *readable* by all but where only a
+   "Farmers" role can run farm commands). Neither the live governance stack nor the frozen K6 design
+   has this primitive at all.
+
+Both are real gaps; (2) is the foundational one and the reason this needs deciding before K6/K7/K8
+lock in, since it's an authority-model shape question, not a feature to bolt on later.
+
+## Design sketch (for whoever picks this up)
+
+1. **Add a role-scoped lane to the authority model** — e.g. `Lane.ROLE_SET` alongside
+   `CAPABILITY`/`TIER` in `resolve_authority`'s classification, so a `BindingSpec.authority_ref` or a
+   `CommandSpec` can declare "requires membership in one of these Discord role IDs" as a first-class
+   alternative to a capability name or an ordinal tier, resolved into the same `AuthorityDecision`
+   shape everything else already consumes.
+2. **Extend `ChannelAccessDecision`/`AccessMode`** with a role-scoped variant (or let the existing
+   allow-list model carry a per-entry role-set instead of being purely guild-wide), so "this
+   channel's bot features are gated to role X" is expressible without inventing a second system next
+   to it.
+3. **Re-check at interaction time, not just panel-open** — this needs to follow the same rule
+   already established for authority elsewhere in the design (a user losing the role mid-session
+   must be denied on the next click, not just at initial admission).
+4. **Separately, expose the existing overwrite plumbing properly** — a `!channel restrict <channel>
+   <role>` command/UI path that lets `overwrite_target_id` target an arbitrary role, not just
+   `@everyone`. This is the smaller, live-bot-only half and could ship independently of the K6 work
+   above if there's appetite to fix it before the rebuild even starts.
+
+## Recommended routing
+
+This should be raised explicitly with whoever writes K6's Phase-B per-step plan (canonical plan §5
+step 9, not yet started) — ideally *before* that plan is written, since retrofitting a role-scoped
+authority lane after K7/K8 are built against the current `Lane{CAPABILITY,TIER}` shape is
+substantially more expensive than adding it now. Given the "frozen grammar" discipline this repo
+uses, this is the kind of finding that would normally become a numbered amendment (like the
+canonical plan's §11 A-series) at the next review pass that touches K6 — flagging it here so it
+doesn't have to be rediscovered from scratch then.

--- a/docs/ideas/guild-config-backup-and-data-export-gap-2026-07-07.md
+++ b/docs/ideas/guild-config-backup-and-data-export-gap-2026-07-07.md
@@ -1,0 +1,49 @@
+# Two adjacent gaps: self-service guild-config backup/restore, and GDPR "export my data"
+
+> **Status:** `ideas` — capture only, not approved for implementation. Surfaced 2026-07-07 during a
+> foundational-capability sweep requested by the owner, cross-checked against the rebuild's frozen
+> taxonomy so nothing already-covered gets re-reported.
+> **Subsystem:** none (cross-cutting; adjacent to K3/S14 backup-DR and the privacy/erasure rubric).
+
+## 1. Self-service, per-guild config backup/restore — not covered anywhere
+
+The rebuild has thorough **infrastructure-level** backup/DR: S14 covers whole-database `pg_dump` /
+restore-verify / RPO targets, and CUT-3's N=7-day rollback window covers the migration cutover
+itself (`rebuild-canonical-plan-2026-07-06.md` §2.1 B-4, §5 step 17). Neither of those is a
+**self-service, single-guild** feature — there's no "export my server's SuperBot settings" or "roll
+my server back to last week's configuration" independent of a full database disaster-recovery
+event. The closest existing idea, a guild template/provisioning model
+(`docs/ideas/future-product-direction-2026-06-07.md:152`), is framed as a template for *new* server
+setups, not backup/restore of an *existing* server's live config. This capability doesn't appear
+anywhere in the K0-K10 taxonomy or the B-1..B-4 rulings.
+
+Worth having an explicit answer either way: build it (a per-guild settings snapshot/restore,
+probably a thin read/write over the same settings-registry the settings engine already owns), or
+rule that whole-DB backup + the owner's own manual intervention is sufficient and this is
+deliberately out of scope. Either is fine — what's missing is that no one has looked at it yet.
+
+## 2. GDPR-style "export my data" — half-built (erasure is solid, export isn't)
+
+An earlier gap-analysis idea (`docs/ideas/gap-analysis-2026-06-11.md:21-26`) named this as a twinned
+"export & erasure" concern, relevant since the project is EU-based. Since then, the **erasure**
+half has been thoroughly mechanized in the rebuild: rubric class 12 (privacy/retention/erasure),
+`StoreSpec.data_class`/`erasure_ref`/`cache_scope`, a `check_data_lifecycle` checker, and a dedicated
+`sb/kernel/privacy/erasure.py` executor are all named and land at build step S11
+(`rebuild-gate0-worklist-2026-07-04.md:171-178`, canonical plan §11 A-... adjacent to the backup/DR
+row). But the **export** half — a user-facing "give me everything you have keyed to my user ID" —
+does not reappear anywhere in the Gate-0 grammar or the S0-S15 build order. It looks like it quietly
+dropped out between the original idea capture and the formalized privacy rubric.
+
+This is worth re-raising specifically as "export," not "export & erasure" generically, since erasure
+is done and only needs a mention that export is its still-open sibling. The practical build cost
+should be small relative to what's already landing: the `StoreSpec` walk that erasure already needs
+(enumerating every store that holds user-keyed data) is most of the plumbing an export command would
+need too — it's a read instead of a delete over the same inventory.
+
+## Recommended routing
+
+Both are docs-only findings, not urgent the way the channel-role-authority gap is — neither blocks
+K6/K7/K8 or any near-term build step. Reasonable next step: raise both at whatever session next
+touches S11 (privacy/erasure lands there) or S14 (backup/DR), since both ride the same
+`StoreSpec`/backup infrastructure already being built for other reasons — cheapest to add as a
+sibling of work already in flight rather than as a separate initiative later.

--- a/docs/ideas/moderation-feature-gaps-2026-07-07.md
+++ b/docs/ideas/moderation-feature-gaps-2026-07-07.md
@@ -1,0 +1,63 @@
+# Moderation feature gaps versus competitor bots (researched, most turned out already covered)
+
+> **Status:** `ideas` — capture only, not approved for implementation. Owner-raised 2026-07-07
+> ("I believe we still don't have all the commands and features some other bots have related to
+> [moderation]"), researched against the live bot and `docs/ideas/competitive-teardown-2026-06-10.md`.
+> **Subsystem:** moderation, security
+
+## The honest finding: less of a gap than expected
+
+The live bot already has ban/kick/timeout/warn with an escalation ladder, unban/clearwarnings/
+modlogs (`disbot/cogs/moderation_cog.py`, `disbot/services/moderation_service.py`), automod
+(spam/invite-links/caps/mass-mentions, `disbot/cogs/automod_cog.py`), a prohibited-word filter
+(`disbot/services/prohibited_words_service.py`), AI image moderation
+(`disbot/cogs/image_moderation_cog.py`), raid detection + lockdown + account-age join filtering
+(`disbot/cogs/security_cog.py`, `disbot/services/security_service.py`), full audit/event logging
+(`disbot/cogs/logging_cog.py`), reaction roles, bulk-delete/cleanup, and a staff support-ticket
+system (`disbot/cogs/ticket_cog.py`). All of this is architecturally owned per `docs/architecture.md`.
+An earlier gap-tracking doc (`docs/ideas/server-safety-and-automod-2026-06-12.md`) that once listed
+several of these as missing is now stale — they've since shipped.
+
+**Three things are genuinely absent** — not live, and not captured as an idea anywhere before this
+document:
+
+## 1. Verification/CAPTCHA-style join gate
+
+Today's only join-time defense is an account-age filter (kick/alert if the account is too new) in
+`security_service.py`. There is no "click to verify" / human-acknowledgment gate that holds a new
+member out of normal channels until they actively confirm they're not a bot/raid account — a
+standard feature on Carl-bot/Dyno-class bots for servers that take raid risk seriously. Distinct
+from the existing raid *detection* (which reacts to a burst of joins), this is a *per-member* gate
+applied to every join regardless of burst detection.
+
+## 2. Dedicated ban-appeal / mod-report modmail flow
+
+The existing `ticket_cog.py` is a general staff-support flow (open/claim/close/transcript) — it is
+not specifically a ban-appeal intake or a moderator-facing DM-relay "report a problem to the mod
+team" tool. The only prior mention anywhere in the repo is two one-line rows in the competitive
+teardown table (`competitive-teardown-2026-06-10.md:69-70`, "Modmail/ticket panels" and "Ban appeals
+flow," both scored 3/5, both marked `ideas`, neither designed). Worth deciding whether this should
+be a genuinely separate flow or a specialized ticket *category* on the existing ticket system —
+the latter is probably the smaller build, given the audited ticket machinery already exists.
+
+## 3. Custom trigger→response commands
+
+Keyword-triggered custom auto-replies (Nadeko/ReTrigger-style — an admin configures "when someone
+says X, reply with Y") appear nowhere as a moderation/admin-config feature. It's listed once, in
+passing, in the same competitive-teardown table (row 15) but framed as a general admin-config
+feature alongside game/economy items, not discussed in any moderation-focused doc. Lower priority
+than the two above — closer to a "fun/utility" feature than a moderation gap — but worth naming
+since it's a common request in servers that don't want a full automod rule for a one-off phrase.
+
+## Recommended routing
+
+None of these are foundational/architectural — they're feature-level additions that fit the
+existing moderation/security subsystem ownership and don't need a K0-K10 kernel decision the way the
+channel-role-authority gap does (see
+[`channel-role-scoped-authority-gap-2026-07-07.md`](./channel-role-scoped-authority-gap-2026-07-07.md)).
+Reasonable to route as: (1) the join-verification gate as a small addition to `security_cog.py`'s
+existing join-defense family; (2) ban-appeal as a specialized ticket category rather than a new
+subsystem; (3) trigger→response as a standalone small feature whenever there's appetite, lowest
+priority of the three. None block the rebuild; whoever ports the moderation/security subsystem in
+Sequence C's port bands should decide whether these three port forward as new manifest-declared
+features or stay backlog.


### PR DESCRIPTION
## Summary

Owner asked, in conversation, for a look at (1) website/dashboard oversight tooling, (2) moderation
feature parity against competitor bots, and (3) channel-level role restriction — plus whether there
are other foundational parts of the bot not yet properly considered. Researched all four in parallel
(read-only) and captured the genuine findings as idea docs:

- **[`channel-role-scoped-authority-gap-2026-07-07.md`](docs/ideas/channel-role-scoped-authority-gap-2026-07-07.md)**
  — ⚠ time-sensitive. Neither the live governance stack (`command_access.py`, `command_routing.py`,
  the governance tier model) nor the frozen rebuild K6 authority design (`Lane{CAPABILITY,TIER}` +
  `ChannelAccessDecision`) can express "only role X in channel Y" — confirmed at both layers with
  file:line citations. K6 hasn't been built yet and sits upstream of K7/K8 in the build chain, so
  this is worth deciding before the next K6-touching session rather than filed for later.
- **[`moderation-feature-gaps-2026-07-07.md`](docs/ideas/moderation-feature-gaps-2026-07-07.md)** —
  most suspected moderation gaps turned out already shipped (ban/kick/timeout/warn ladder, automod,
  raid lockdown, audit logging, reaction roles, tickets). Three genuine misses found: a join-time
  verification/CAPTCHA gate, a dedicated ban-appeal/modmail flow distinct from the general ticket
  system, and custom trigger→response commands. Feature-level, not architectural — no rebuild-timing
  urgency.
- **[`guild-config-backup-and-data-export-gap-2026-07-07.md`](docs/ideas/guild-config-backup-and-data-export-gap-2026-07-07.md)**
  — two adjacent misses from a foundational-taxonomy sweep: self-service per-guild settings
  backup/restore (distinct from whole-DB disaster recovery, which is well covered), and the "export"
  half of GDPR-style user data requests (erasure is thoroughly mechanized in the rebuild's privacy
  rubric; export never reappeared after the original idea capture).

The website-oversight question turned out to already have an unbuilt idea covering exactly what the
owner wants (`docs/ideas/dev-site-project-status-donut-2026-06-19.md` — plans/execution grouped by
subsystem, backed by data plumbing that already exists) — no new capture needed, surfaced back to the
owner in conversation instead.

No `disbot/` changes, no edits to frozen/canonical rebuild docs — all three new docs name where they
should land for a future amendment pass rather than editing frozen specs directly.

## Linked issue / plan

New captures, all linked from `docs/ideas/README.md`. The channel-role gap references
`docs/planning/rebuild-canonical-plan-2026-07-06.md` §2.1 (K6) / §5 step 9 as its landing point.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tooling / CI
- [ ] Breaking change

## Checks

- [x] `python3.10 scripts/check_docs.py --strict` passes
- [x] `python3.10 scripts/check_session_gate.py` — no new/modified session card in this PR, not gated
- [x] No secrets, tokens, or credentials added


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5Ka61R9eE1QQrDB4MvYEP)_