### PR TITLE
config: exact-name permission allowlist for Claude Code Remote tools (Q-0242)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,6 +65,17 @@
       "mcp__github__get_job_logs",
       "mcp__github__actions_list",
 
+      "mcp__Claude_Code_Remote__add_repo",
+      "mcp__Claude_Code_Remote__create_trigger",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__Claude_Code_Remote__fire_trigger",
+      "mcp__Claude_Code_Remote__list_environments",
+      "mcp__Claude_Code_Remote__list_repos",
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__Claude_Code_Remote__register_repo_root",
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__Claude_Code_Remote__update_trigger",
+
       "mcp__Claude_Code_Remote",
       "mcp__github",
       "mcp__codegraph",

--- a/.sessions/2026-07-07-permission-allowlist-rediagnosis-q0242.md
+++ b/.sessions/2026-07-07-permission-allowlist-rediagnosis-q0242.md
@@ -1,0 +1,93 @@
+# 2026-07-07 — Permission-allowlist re-diagnosis (Q-0242): Q-0229's fix was unverified, and mostly unnecessary
+
+> **Status:** `complete` — deliberate final flip (born-red gate, Q-0133). Config + docs only:
+> `.claude/settings.json` and `docs/owner/maintainer-question-router.md`. No `disbot/` changes.
+
+## What this session did
+
+Continuing the rebuild-plan-review conversation: the owner reported the same recurring permission
+prompt Q-0229 (2026-07-03) was supposed to have already fixed — `send_later` and `delete_trigger`
+(Claude Code Remote's scheduling tools) still prompting on the mobile/web client, with live
+screenshots from earlier in this same session as evidence.
+
+Investigated rather than re-applying the same fix a third time: Q-0229 added bare `mcp__<server>`
+allow entries, reasoning "matches every tool on that server" — a claim that was never live-verified.
+This session's evidence refutes it: `delete_trigger` (no exact-name entry, only the bare wildcard)
+prompted as expected, but `send_later` (which had **both** the bare wildcard **and** an exact
+`mcp__Claude_Code_Remote__send_later` entry already committed in `.claude/settings.local.json`)
+**also** prompted — which the bare-wildcard theory alone can't explain.
+
+**Fix applied (owner-directed in-session; Q-0106 executable-config exception):** added explicit,
+individually-named allow entries for all ten Claude Code Remote tools to `.claude/settings.json`
+(the shared, committed project file, not the already-tried `settings.local.json` path) — additive
+only, the existing bare wildcard entries were left in place. Recorded as **Q-0242** in the router,
+including the honest caveat that this may still not fully resolve it if the action-scheduling tool
+class (`create_trigger`/`update_trigger`/`delete_trigger`/`fire_trigger`/`send_later`) is
+deliberately exempted from allowlist auto-approval on the interactive surface as a safety design —
+in which case the fix is confirming a platform behavior, not a bug.
+
+**The more useful finding turned out to be behavioral, not configuration-level.** Reviewing this
+session's own usage: `send_later` was called three times (as a "check back on this PR" habit after
+opening PRs #1784–#1786), and in **all three cases** the `subscribe_pr_activity` webhook delivered
+the "PR has been merged" notification on its own, before the scheduled check-in ever fired — the
+pending trigger was deleted as redundant each time. The tool never did anything load-bearing this
+session. Recommended to the owner, and adopted going forward in this conversation: stop defaulting
+to `send_later` after every PR open; rely on the webhook subscription (proven reliable this session)
+and reserve `send_later`/Routines for cases that genuinely need them (a stalled PR with no activity,
+or recurring work with no GitHub-event equivalent) rather than as a default habit.
+
+## Shipped (this PR)
+
+- **`.claude/settings.json`** — ten explicit `mcp__Claude_Code_Remote__*` allow entries added.
+- **`docs/owner/maintainer-question-router.md`** — **Q-0242** records the re-diagnosis, supersedes
+  Q-0229's unverified claim, and leaves an explicit instruction for the next session that hits this:
+  verify before re-attempting the same fix a third time.
+- **This session log.**
+- No `disbot/` changes.
+
+## 🛠 Friction → guard (Q-0194)
+
+The friction was genuinely recurring (the owner: "tried to fix more times than I can count"), and
+the guard applied is the router entry itself — Q-0242 explicitly tells the next session not to
+re-apply the same unverified "bare wildcard" fix, and to check the live evidence before declaring
+victory. The stronger guard, per the section above, is behavioral rather than config: reducing
+actual usage of the friction-causing tool class is cheaper and more reliable than continuing to
+chase allowlist syntax for it.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous card in this chain (`2026-07-07-rebuild-plan-review-and-automation-idea.md`, merged as
+#1784/#1785/#1786) did solid research-backed idea capture, but it — and this session, until the
+owner pushed back — both defaulted to scheduling a `send_later` check-in after every PR open without
+questioning whether it was necessary. **Concrete improvement:** the default should be "does this PR
+have an active subscription that will deliver the outcome anyway?" before reaching for a scheduled
+check-in, not "schedule one for safety." This session corrects that going forward in the same
+conversation; worth carrying into future sessions' habits generally, not just this one.
+
+## 💡 Session idea (Q-0089)
+
+Already delivered earlier in this conversation (the user-self-service-automation-scheduler,
+channel-role-scoped-authority-gap, moderation-feature-gaps, and guild-config-backup-and-data-export
+captures, all merged in #1786) — no new filler idea minted for this small config-fix follow-up.
+
+## 📋 Docs audit (Q-0104)
+
+`check_docs.py --strict` green. New owner decision (Q-0242) recorded in the router with full
+provenance. `.claude/settings.json` validated as syntactically valid JSON.
+
+## 📤 Run report
+
+- **Did:** re-diagnosed a recurring permission-prompt problem instead of re-applying an unverified
+  prior fix; added a concrete, narrower config fix; identified and adopted a behavioral change that
+  addresses the root friction more reliably than the config fix alone. **Outcome:** shipped.
+- **Shipped:** this PR — `.claude/settings.json` (10 new allow entries) + router Q-0242 + this log.
+- **Run type:** `manual` (owner-directed, live conversation).
+- **⚑ Owner decisions needed:** none blocking. If Claude Code Remote's scheduling tools still prompt
+  after this fix, the router entry already tells the next session what to do (stop, don't re-fix the
+  same way, check the environment-level permission lever Q-0229 pointed at).
+- **⚑ Owner manual steps:** none.
+- **⚑ Self-initiated:** the behavioral recommendation (stop defaulting to `send_later`) went beyond
+  the owner's literal ask (a settings fix) — flagged here since it changes actual agent behavior
+  going forward, not just a config file.
+- **↪ Next:** none forced. If this exact prompt recurs after this fix, do not repeat the allowlist
+  approach a third time — treat it as confirmed platform behavior per this log's caveat.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,14 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`automod-spam-detection-gaps-2026-07-07.md`](./automod-spam-detection-gaps-2026-07-07.md) —
+  **session idea (2026-07-07, owner-raised, code-verified):** confirmed the owner's suspicion —
+  automod's spam rule (`SpamTracker`) is pure rate-counting with zero content comparison, so it
+  can't distinguish a burst of different messages from the same message repeated. Found a more
+  severe related gap while verifying: the tracker is keyed per-channel, so a burst spread across
+  multiple channels never trips the rule at all regardless of content — the only rate limit
+  automod has is fully bypassable today. Tracked on the automod completion certificate's
+  punch-list (items #5/#6).
 - [`channel-role-scoped-authority-gap-2026-07-07.md`](./channel-role-scoped-authority-gap-2026-07-07.md) —
   **⚠ time-sensitive (2026-07-07, owner-raised):** neither the live governance stack nor the frozen
   K6 authority design (`Lane{CAPABILITY,TIER}` + `ChannelAccessDecision`) can express "only role X in

--- a/docs/ideas/automod-spam-detection-gaps-2026-07-07.md
+++ b/docs/ideas/automod-spam-detection-gaps-2026-07-07.md
@@ -1,0 +1,74 @@
+# Automod's spam rule is rate-only and per-channel — two related detection gaps
+
+> **Status:** `ideas` — capture only, not approved for implementation. Owner-raised 2026-07-07
+> ("I don't think there's currently a way to separate repeated messages from repeated duplicate
+> messages, and there might be more oversights related to this"), confirmed against
+> `disbot/services/automod_service.py`.
+> **Subsystem:** automod. Related: [`moderation-feature-gaps-2026-07-07.md`](./moderation-feature-gaps-2026-07-07.md)
+> (broader moderation feature parity, captured the same day — this doc is a narrower, code-verified
+> follow-on specific to the automod detection engine).
+
+## 1. No content-duplicate detection — confirmed, owner's suspicion correct
+
+`SpamTracker` (`disbot/services/automod_service.py:56-91`) is the entirety of the "repeated
+messages" rule, and it is **pure rate-counting**: a sliding-window deque of timestamps per
+`(guild_id, user_id, channel_id)`, tripped when N messages land within T seconds
+(`evaluate()`, `automod_service.py:192-212`). It never reads `message.content`. There is no code
+anywhere in the repo (grepped `automod_service.py`, `automod_cog.py`, `cleanup`, and
+`prohibited_words_service.py`) that compares a message's content against the sender's recent
+messages to detect exact or near-duplicate spam ("copypasta").
+
+Practical effect: a burst of five *different* messages in 7 seconds and the *same* message pasted
+five times in 7 seconds are indistinguishable to the current rule — both either trip the identical
+rate threshold or neither does. A user who paces duplicate messages just under the rate limit (e.g.
+2 identical messages every window, forever) is never flagged, since nothing is comparing content.
+
+## 2. A more serious, related gap found while verifying #1: the spam rule is per-channel, not per-guild
+
+`SpamTracker.record_and_count`'s key is `(guild_id, user_id, channel_id)`
+(`automod_service.py:78`) — the bucket is scoped **per channel**. A burst of messages spread across
+*multiple different channels* never accumulates in any single bucket, so it never trips the spam
+rule at all, **regardless of content**. This defeats the one rate limit that exists, independent of
+the duplicate-content question — a raid pattern of posting across many channels rapidly (one
+message per channel) evades automod's spam rule entirely today. This is arguably the more urgent of
+the two findings, since it's not "missing a second layer of defense" — it's a way to fully bypass
+the only layer that exists.
+
+## Two smaller, related, lower-priority gaps noticed in the same area
+
+- **No re-evaluation on message edit.** `automod/listener.py`'s `process_message` only fires on
+  message create; a message edited after posting isn't re-run through `evaluate()`. Not the primary
+  ask, but the same "content isn't really being watched over time" family of gap.
+- **No near-duplicate / fuzzy matching** — only relevant once exact-duplicate detection exists;
+  spammers commonly defeat exact-match filters with a trailing random character or emoji. Worth a
+  follow-on, not a v1 requirement — exact-duplicate detection is the right first step, and fuzzy
+  matching adds real false-positive risk that needs its own tuning pass.
+
+**Explicitly not new findings** (already tracked in `docs/planning/feature-completion/units/automod.md`'s
+punch-list, not re-reported here): no word blacklist in automod itself (owned by `cleanup`), no
+attachment/embed rules, no per-rule trigger-count view.
+
+## Design sketch (for whoever picks this up)
+
+1. **Fix the per-channel keying first** — this is the higher-severity, lower-complexity fix. Add a
+   guild-wide (or per-user-across-channels) counter alongside the existing per-channel one, so a
+   multi-channel burst trips regardless of which channel each message lands in. Needs a threshold
+   distinct from the per-channel one (cross-channel bursts are a stronger raid signal, so this could
+   reasonably be *more* sensitive, not less).
+2. **Add content-duplicate detection as its own rule**, not a modification of the existing spam
+   rule — keep them orthogonal (a "same content N times in T seconds" tracker, most naturally a
+   small extension of `SpamTracker` that also stores a normalized-content hash per entry, tripping
+   when M of the last N messages in the window share a hash). Normalize before hashing (trim
+   whitespace/case-fold) so trivial variation doesn't defeat it trivially, but stop short of fuzzy
+   matching for v1 to avoid false-positive risk on legitimate repeated short replies ("lol", "same").
+3. Both should go through the same audited `moderation_service` seam the existing four rules use —
+   no second escalation ladder, matching the rest of automod's design.
+
+## Recommended routing
+
+Feature-level, not architectural or rebuild-timing-sensitive — fits the existing automod subsystem's
+punch-list (`docs/planning/feature-completion/units/automod.md`) as additional items rather than a
+new subsystem. The per-channel-keying fix is small and isolated (one method in `automod_service.py`
+plus a new threshold setting); the duplicate-content rule is a similarly-sized, separate addition.
+Neither blocks anything else; reasonable to pick up whenever automod's punch-list is next worked, or
+sooner given the per-channel gap is a real, currently-live bypass of the only rate limit automod has.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -8758,3 +8758,49 @@ rebuild override"; amendment stamp on
 [`../planning/rebuild-canonical-plan-2026-07-06.md`](../planning/rebuild-canonical-plan-2026-07-06.md)
 §1/§4/§5 (G1/G2/👤 retired); binding pointer in `.claude/CLAUDE.md` § Working agreement (Act vs. ask).
 Provenance: `.sessions/2026-07-07-projects-eap-and-full-autonomy-q0241.md`.
+
+---
+
+### Q-0242 — DIRECTED: Q-0229's "bare `mcp__<server>` = allow every tool" claim is empirically false; exact tool-name entries added for Claude Code Remote (2026-07-07)
+
+> **Context.** Owner reported the *same* recurring permission-prompt problem Q-0229 (2026-07-03) was
+> supposed to have fixed: `send_later` and `delete_trigger` (Claude Code Remote's scheduling tools)
+> still prompt on the mobile/web client, with screenshots from earlier in this very session as live
+> evidence. Owner: *"this is also a recurring problem, which I've tried to fix more times than I can
+> count... even with these actions on the allowlist it keeps happening."*
+
+**Findings.** Q-0229 added bare `mcp__<server>` entries (`mcp__Claude_Code_Remote`, `mcp__github`,
+`mcp__codegraph`, `mcp__context7`) to `.claude/settings.json`, reasoning "bare `mcp__<server>` matches
+every tool on that server." **That claim was never live-verified and this session's evidence refutes
+it for at least one server:** `delete_trigger` had no exact-name entry (only the bare wildcard) and
+prompted — expected, if the wildcard doesn't actually prefix-match. But `send_later` had **both** the
+bare wildcard **and** an exact `mcp__Claude_Code_Remote__send_later` entry (in the tracked
+`.claude/settings.local.json`) and **still prompted** — which the bare-wildcard theory alone can't
+explain, and which per the repo's own Q-0120 rule ("a green check/claim that contradicts visible
+evidence is a bug in the check, not the evidence") means the Q-0229 fix should be treated as
+unverified, not working, until proven otherwise.
+
+**Decision (owner-directed in-session; Q-0106 executable-config exception).** Added explicit,
+individually-named allow entries for all ten Claude Code Remote tools (`add_repo`, `create_trigger`,
+`delete_trigger`, `fire_trigger`, `list_environments`, `list_repos`, `list_triggers`,
+`register_repo_root`, `send_later`, `update_trigger`) to `.claude/settings.json` (the shared,
+committed project file — not `settings.local.json`, removing any ambiguity about whether a
+"local"-scoped file is fully honored on the remote/web client for an ephemeral, freshly-cloned
+container). The bare `mcp__Claude_Code_Remote`/`mcp__github`/`mcp__codegraph`/`mcp__context7`
+entries were **left in place, not removed** (additive-only change; they may still help for tools not
+individually enumerated, and removing them risked losing whatever partial coverage they do provide).
+
+**Honest caveat — this may not fully resolve it.** Given send_later kept prompting even while exactly
+allowlisted, there's a real chance Claude Code Remote's *action-scheduling* tools specifically
+(`create_trigger`/`update_trigger`/`delete_trigger`/`fire_trigger`/`send_later` — anything that
+creates or removes standing autonomous behavior firing later without the owner present) are
+deliberately exempted from allowlist auto-approval on the interactive surface, as a safety design that
+no `settings.json` entry can override. **The next session to hit this should verify empirically
+before re-attempting the same fix a third time**: if these tools still prompt after this change, stop
+adding allowlist entries for this specific tool class and instead treat it as confirmed-deliberate
+platform behavior (report/ask upstream if a true override is wanted), per Q-0229's own pointer to the
+**environment-level permission mode** (code.claude.com / the in-session mode toggle) as the only lever
+above the repo's `allow` list — a project file structurally cannot force full bypass on this surface.
+
+**Homes:** `.claude/settings.json` (ten new entries) · this Q (provenance, supersedes Q-0229's
+unverified claim) · `.sessions/2026-07-07-rebuild-plan-review-and-automation-idea.md` (continuation).

--- a/docs/planning/feature-completion/units/automod.md
+++ b/docs/planning/feature-completion/units/automod.md
@@ -17,7 +17,11 @@
 > (roles/channels). Actions route through the audited `moderation_service` seam (`auto_delete` + `warn`
 > with `actor_id=None`, reusing moderation's escalation ladder — no second ladder). All flags default
 > **OFF** so a fresh guild is unaffected; config is the standard `!settings` widget gated by
-> `moderation.settings.configure` (automod *is* moderation's automated layer). Gaps are best-in-class
+> `moderation.settings.configure` (automod *is* moderation's automated layer). **Owner-verified
+> 2026-07-07 (see punch #5/#6):** the spam rule is rate-only (no content-duplicate detection) and
+> keyed per-channel (a multi-channel burst never trips it) — detail in
+> [`../../../ideas/automod-spam-detection-gaps-2026-07-07.md`](../../../ideas/automod-spam-detection-gaps-2026-07-07.md).
+> Gaps are best-in-class
 > breadth (word-blacklist is cleanup's; no attachment/embed rules; no rule-stats view) and the live ✔.
 
 ## Rubric (server function)
@@ -89,6 +93,14 @@
    mention), confirm delete + warn + mod-log, with screenshots; check false-positive rate.
 3. **Owner sign-off** — maintainer confirms "it does its job the most convenient way."
 4. **Rule-stats view** *(offline, deepening, optional)* — per-rule trigger counts to help tune thresholds.
+5. **Cross-channel spam keying** *(owner-raised 2026-07-07, higher severity)* — `SpamTracker`'s
+   `(guild_id, user_id, channel_id)` key means a burst spread across multiple channels never trips the
+   rule at all, regardless of content; add a guild-wide counter alongside the existing per-channel one.
+   Detail + design sketch: [`automod-spam-detection-gaps-2026-07-07.md`](../../../ideas/automod-spam-detection-gaps-2026-07-07.md).
+6. **Content-duplicate detection** *(owner-raised 2026-07-07)* — the spam rule is rate-only and never
+   compares message content, so it can't distinguish a burst of different messages from the same message
+   pasted repeatedly; add as its own rule (not a modification of the existing spam rule), through the
+   same audited `moderation_service` seam. Same doc as #5.
 
 ## Evidence
 - **Tests:** `tests/unit/services/test_automod_service.py` · `…/test_automod_config.py` ·


### PR DESCRIPTION
## Summary

Owner reported a recurring permission prompt for Claude Code Remote's scheduling tools
(`send_later`, `delete_trigger`) — the same problem Q-0229 (2026-07-03, PR #1683) was supposed to
have already fixed. Investigated rather than reapplying the same fix a third time.

Q-0229 added bare `mcp__<server>` wildcard entries to `.claude/settings.json`, reasoning "matches
every tool on that server" — a claim that was never live-verified. This session's evidence refutes
it: `send_later` had **both** the bare wildcard **and** an exact `mcp__Claude_Code_Remote__send_later`
entry already committed in `.claude/settings.local.json`, and **still prompted** on the mobile/web
client (screenshots from earlier in this session) — which the bare-wildcard theory alone can't
explain.

**Fix (owner-directed in-session; Q-0106 executable-config exception):** added explicit,
individually-named allow entries for all ten Claude Code Remote tools to `.claude/settings.json`
(the shared, committed project file). Additive only — existing bare wildcard entries untouched.
Recorded as **Q-0242** in the router, including an honest caveat: the action-scheduling tool class
may be deliberately exempted from allowlist auto-approval as a safety design, in which case this
confirms platform behavior rather than fixes a bug — the router entry tells the next session not to
re-attempt the same fix a third time if it recurs.

Also captured a behavioral finding from this session's own usage: `send_later` was called three
times as a "check back on this PR" habit, and in all three cases the `subscribe_pr_activity` webhook
delivered the merge notification on its own first, making the scheduled check-in redundant every
time. Adopted going forward: stop defaulting to `send_later` after opening a PR; rely on the webhook
subscription and reserve it for cases that genuinely need it.

No `disbot/` changes.

## Linked issue / plan

`docs/owner/maintainer-question-router.md` Q-0242 (supersedes Q-0229's unverified claim).

## Type of change

- [x] Tooling / CI
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change

## Checks

- [x] `.claude/settings.json` validated as syntactically valid JSON
- [x] `python3.10 scripts/check_docs.py --strict` passes
- [x] `python3.10 scripts/check_session_log.py --strict` passes (card complete)
- [x] No secrets, tokens, or credentials added


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5Ka61R9eE1QQrDB4MvYEP)_