### PR TITLE
Capture: multi-repo program (repo-start mechanics, substrate-kit self-improvement lab, trading research repo)

### DIFF
--- a/.sessions/2026-07-07-multi-repo-program-capture.md
+++ b/.sessions/2026-07-07-multi-repo-program-capture.md
@@ -1,19 +1,36 @@
 # 2026-07-07 — Multi-repo program capture (kit lab + trading repo + repo-start mechanics)
 
-> **Status:** `in-progress`
-> **Branch:** `claude/rebuild-plan-consolidation-c34c0b` (restarted from main after #1793)
+> **Status:** `complete`
+> **Branch:** `claude/rebuild-plan-consolidation-c34c0b` (restarted from main after #1793) · **PR:** #1794
 > **Continues:** the 2026-07-07 consolidation conversation (PRs #1791/#1792/#1793)
 
-## What is about to happen
+## What happened
 
-The owner dropped a program-level vision live: (0) how should the new-repo session actually start
-(clone the old repo like the btd6-mod-helper pattern, or better?); (1) `superbot-next` as planned;
-(2) a dedicated **substrate-kit repo** whose only goal is autonomous self-improvement (complete
-freedom, Railway access, own work surfaces — a bot token, deployable websites; ideas as testable
-output); (3) a dedicated **stock-market research + trading repo** (strategy discovery, backtesting,
-paper/live trading, tracking website). Capture the strengthened design as one idea doc; the chat
-reply is the discussion, the doc is the durable home.
+Captured the owner's program-level vision drop as
+`docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md` (+ README index entry), with the
+strengthening he asked for:
 
-## Close-out
+- **Part 0 — repo-start mechanics answered:** fresh-from-kit + old repo attached read-only as the
+  oracle (the btd6-mod-helper *session* pattern, not the clone-as-base pattern); what crosses over
+  is the pinned artifact list (goldens, compat artifacts, frozen specs by reference, CUT-2 data),
+  never code — behavior continuity without code continuity.
+- **Part 2 — kit repo = self-improvement lab:** extraction at the step-7 second-consumer moment
+  (Q-0219 logic at repo scale); fitness functions not vibes (Phase-2.5 A/B as standing benchmark —
+  its unproven cold-start benefit is the lab's founding challenge; ideas-that-ship-and-survive as
+  the idea-output metric); work surfaces (own bot token, capped Railway project, deployable
+  sites); "complete freedom" shaped as Q-0241 rails (reversible, budgeted, scoped credentials,
+  cold-session self-measurement).
+- **Part 3 — trading repo:** backtest-decides-strategy as the sim-decides-design twin; the
+  falsification promotion ladder (in-sample → OOS → walk-forward → paper → capped live); the
+  rigor list (point-in-time data, multiple-testing correction, pessimistic costs, regime
+  walk-forward); the real-money brake as the program's one ask-first tier.
+- **Sequencing ⚑:** superbot-next now → kit extraction at step 7 → trading third; rail before
+  scale.
 
-_(to be written at close)_
+The chat reply is the discussion; the doc is the durable home. No plan edits (part 1 IS the plan).
+
+## Session enders
+
+Same conversation as the main consolidation session — enders live in
+`.sessions/2026-07-07-rebuild-idea-consolidation.md`. This capture is itself the Q-0015-style
+grooming act for the drop (raw → captured + routed same hour).

--- a/.sessions/2026-07-07-multi-repo-program-capture.md
+++ b/.sessions/2026-07-07-multi-repo-program-capture.md
@@ -1,0 +1,19 @@
+# 2026-07-07 — Multi-repo program capture (kit lab + trading repo + repo-start mechanics)
+
+> **Status:** `in-progress`
+> **Branch:** `claude/rebuild-plan-consolidation-c34c0b` (restarted from main after #1793)
+> **Continues:** the 2026-07-07 consolidation conversation (PRs #1791/#1792/#1793)
+
+## What is about to happen
+
+The owner dropped a program-level vision live: (0) how should the new-repo session actually start
+(clone the old repo like the btd6-mod-helper pattern, or better?); (1) `superbot-next` as planned;
+(2) a dedicated **substrate-kit repo** whose only goal is autonomous self-improvement (complete
+freedom, Railway access, own work surfaces — a bot token, deployable websites; ideas as testable
+output); (3) a dedicated **stock-market research + trading repo** (strategy discovery, backtesting,
+paper/live trading, tracking website). Capture the strengthened design as one idea doc; the chat
+reply is the discussion, the doc is the durable home.
+
+## Close-out
+
+_(to be written at close)_

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -1287,8 +1287,16 @@ Current broad captures:
   first (no approval needed), extract later. → **GRADUATED 2026-06-13 to an approved executable
   plan:** [`../planning/portable-substrate-kit-extraction-2026-06-13.md`](../planning/portable-substrate-kit-extraction-2026-06-13.md)
   (10 review rounds + owner approval; entry point PR 1a).
-- [`autonomous-improvement-loop-vision-2026-06-12.md`](./autonomous-improvement-loop-vision-2026-06-12.md) —
-  **maintainer vision (2026-06-12, voice):** the north-star — agents continuously improve
+- [`multi-repo-program-kit-lab-trading-2026-07-07.md`](./multi-repo-program-kit-lab-trading-2026-07-07.md) —
+  **maintainer vision (2026-07-07, live drop, captured strengthened):** the program frame above
+  the rebuild — three repos on one substrate: `superbot-next` (the plan of record) · **the
+  substrate-kit as its own repo = the autonomous self-improvement lab** (fitness functions —
+  the Phase-2.5 A/B as standing benchmark, ideas-that-ship as the acceptance metric; own work
+  surfaces: test-bot token, Railway project with caps, deployable sites) · **a trading-research
+  repo** (backtest-decides-strategy, falsification promotion ladder, real-money brake). Also
+  answers repo-start mechanics: fresh-from-kit + old repo attached read-only as the oracle,
+  never clone-as-base. Kit extraction rides the step-7 second-consumer moment → **discuss/plan
+  lane** (the step-6–8 kickoff session reads this and decides the extraction fork ⚑).
   the bot, chain session→session autonomously (idea → revised plan → implement), gate
   agent-*generated* features behind correctness (bugs/UX first), and use **Hermes as the
   independent reviewer** (a non-Claude "different mind" that critiques plans + implementations,

--- a/docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md
+++ b/docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md
@@ -1,0 +1,181 @@
+# The multi-repo program: superbot-next · the substrate-kit self-improvement lab · the trading research repo
+
+> **Status:** `ideas` — owner-dropped live 2026-07-07 (the consolidation conversation, after
+> PRs #1791–#1793), captured same day with the strengthening the owner asked for ("use your
+> advanced reasoning to strengthen my ideas"). This is a **program-level** capture: it frames
+> three repos and answers the repo-start-mechanics question. Nothing here changes the canonical
+> rebuild plan ([`rebuild-canonical-plan-2026-07-06.md`](../planning/rebuild-canonical-plan-2026-07-06.md))
+> — part 1 *is* that plan; parts 2–3 are new program surface.
+> **Subsystem:** none (agent-workflow / program architecture).
+
+## The owner's vision, in his words (condensed)
+
+1. **Repo-start mechanics:** "should the new session in the new repo just clone the old repo
+   first and work from there, kind of like how we did it with the btd6 mod helper repo, or is
+   there a better way?"
+2. **Multiple repos:** one for the bot and everything that belongs with it; **one dedicated to
+   the memory-system kit, with the only goal of self-improvement and nothing else** — it could
+   also produce ideas as its testable output; "create a system that optimises itself by
+   independently working through all possible ideas they can come up with while having complete
+   freedom"; Railway access; extra work surfaces where possible (a separate bot token, websites
+   they can independently get online, view, and improve).
+3. **A repo dedicated to stock-market research and trading** — "find, discover, create the best
+   possible trading strategies and backtest them through simulations, real-time trades," possibly
+   with a website to keep track of everything.
+4. "How does the current substrate kit relate to these ideas?"
+
+## Part 0 — Repo-start mechanics: fresh-from-kit, old repo attached as the ORACLE (never clone-as-base)
+
+The canonical plan already decides this, and the reasoning survives re-examination:
+
+- **The new repo starts empty + `dist/bootstrap.py adopt`** (plan §5 steps 6–7). It is *born*
+  from the kit, not from the old code.
+- **The old repo is attached to the build session read-only, alongside** — the btd6-mod-helper
+  *session* pattern (both repos visible in one session) is right; the *clone-as-base* pattern is
+  not. The build sessions read the old source freely (it is the oracle and the reference), but
+  nothing is copied wholesale.
+- **What crosses over is a pinned artifact list, not code:** the frozen specs + Gate-0 grammar
+  (by reference — they live in the old repo as the what/why/how record), the **465+ parity
+  goldens** (pinned outside the new repo's write reach — the behavioral contract the new bot must
+  reproduce), the **compat artifacts** (`custom_id` lists, event literals, subsystem keys, audit
+  payload shapes — gate 6 diffs against them), and at CUT-2 the **data** via the manifest-driven
+  importer. Behavioral continuity comes from goldens, not from carried code.
+- **Why not clone:** a clone imports the disease the rebuild exists to cure (the smeared files,
+  ~47k dead-classified symbols, the tracked layer violations), drags the full git history into a
+  repo whose whole point is clean provenance, and makes "what is new-bot truth?" ambiguous from
+  day one. The rebuild's premise is *behavior continuity with zero code continuity*, enforced by
+  red-until-parity.
+
+## Part 1 — `superbot-next` (already the plan of record)
+
+Nothing new to capture — plan §5 steps 6–17, ready to start. Listed here only so the program
+frame is complete: this is repo #1 and the kit's **second consumer** (see part 2 — that matters).
+
+## Part 2 — The substrate-kit repo: the self-improvement lab
+
+### Why a dedicated repo is the kit's natural destiny
+
+The kit was *designed* portable (nervous system + context-economy engine + one-step adopt;
+stdlib-only; 432 tests). Today it has exactly **one consumer** (this repo), which means kit
+quality and superbot idiosyncrasy are indistinguishable — nobody can tell whether a kit
+convention works *in general* or merely *here*. The moment `superbot-next` adopts (plan step 7),
+the kit has two consumers and the same logic as the repo's own **Q-0219 second-consumer rule**
+fires at repo scale: shared machinery with ≥2 consumers earns its own home. **Extract the kit to
+its own repo at that moment** — consumers adopt *versioned* kit releases via `bootstrap.py`
+(the adopt/upgrade discipline already exists), so a kit change can never silently break a
+consumer.
+
+### The lab: strengthened
+
+The owner's core idea — a repo whose autonomous loop has one goal, *make the system better*, with
+complete freedom — is sound, and it already has a founding document
+([`autonomous-improvement-loop-vision-2026-06-12.md`](autonomous-improvement-loop-vision-2026-06-12.md)).
+The strengthening it needs is **fitness functions, not vibes**:
+
+1. **A standing, measurable benchmark.** The Phase-2.5 A/B protocol
+   ([companion D](../planning/rebuild-phase-2.5-procedure-2026-07-06.md)) is exactly this and
+   already exists: cold-start paired sessions on throwaway repos, measured orientation footprint,
+   wrong-turn count, task completion, judge-scored. The lab re-runs it per kit release. **Its
+   founding challenge is already known and honest:** the 2026-07-07 re-run left the kit's
+   cold-start *benefit* claim unproven (ON arms read more and shipped no better; twice failed to
+   end cleanly; never wrote back to kit surfaces). A lab whose first measurable win is "make the
+   A/B flip" starts with a real, falsifiable goal instead of ceremony.
+2. **Ideas as *testable* output — with an acceptance metric.** "Produce ideas" is only a real
+   output if it's scored: ideas that get *implemented in a consumer repo and survive* (not
+   reverted, not worked around) within N sessions count; unbuilt or reverted ones don't. The
+   idea-lifecycle machinery (capture → route → build → review) already exists to ride.
+3. **Work surfaces = observable outputs.** The owner's instinct is exactly right: give the lab
+   its own **test bot token** (the Galaxy-Bot pattern), its own **Railway project** with a spend
+   cap, and **deployable websites** it can put online and iterate on end-to-end without the owner
+   in the loop. Each surface makes an improvement *externally verifiable* — the difference
+   between "the loop says it improved" and "you can click the thing it improved."
+4. **Cross-repo friction reports close the loop.** Consumer repos (superbot-next, trading) file
+   kit-friction deltas (the context-delta pattern from the collaboration model); the lab consumes
+   them as its inbound work queue; fixes ship as versioned kit releases; consumers upgrade and
+   the A/B + friction rate say whether it worked. That triangle — lab improves, consumers adopt,
+   metrics arbitrate — is the whole design.
+5. **"Complete freedom" gets the Q-0241 shape, not literal absence of rails:** reversible by
+   default, budget caps (tokens + Railway spend), **scoped credentials only** (the lab never
+   holds another repo's prod secrets or the live bot's token), everything audited, owner reads
+   outputs and vetoes reactively. One structural guard matters more than all others:
+   **the lab must measure itself on cold sessions and throwaway repos** — Phase-2.5's deepest
+   lesson is that a warm session cannot evaluate its own substrate; a self-improvement loop that
+   grades itself on its own warm context will optimize the grade, not the system.
+
+## Part 3 — The trading research repo
+
+### Understood as: a strategy-research *platform*, not a stock-picking bot
+
+Data ingestion → strategy generation → backtesting → paper trading → (eventually) capped live
+execution → a tracking website. The repo's existing DNA maps onto it almost one-to-one:
+
+| SuperBot discipline | Trading twin |
+|---|---|
+| Sim-decides-design (V-3, Q-0243) | **Backtest-decides-strategy** — no strategy ships on narrative |
+| Golden parity / drift pins | **Pinned point-in-time data snapshots + fully reproducible backtest runs** (a backtest that can't be replayed byte-identically doesn't count) |
+| Decide-and-flag + gates | **A promotion ladder with machine-checked gates**: in-sample → out-of-sample → walk-forward → paper → small-capped live; a strategy is *promoted*, never declared |
+| Adversarial verify (the workflow pattern) | **Falsification-first**: a great backtest is a *candidate for refutation* (overfitting hunt), not a result |
+| Q-0213 destructive brake | **The real-money brake** (below) |
+| botsite / dashboard export | The tracking website — generated from the strategy registry + results store, agent-deployable |
+
+### The rigor that must be designed in from day one (cheap now, ruinous to retrofit)
+
+- **Point-in-time data** — survivorship-bias-free universes, no look-ahead (fundamentals as they
+  were known, not as later restated). This is the #1 silent killer of retail backtests.
+- **Multiple-testing correction** — an autonomous loop that searches thousands of strategies
+  *will* find spectacular backtests by chance; the promotion ladder must price that in (holdout
+  embargo periods, deflated performance metrics, strict out-of-sample discipline).
+- **Pessimistic cost modeling** — commissions, spread, slippage, borrow costs; a strategy that
+  dies under pessimistic costs was never alive.
+- **Regime honesty** — walk-forward evaluation across regimes, never one heroic full-history fit.
+- **The real-money brake:** paper trading is fully autonomous (broker paper environments, e.g.
+  Alpaca-class APIs); **live orders sit behind owner-set hard caps** (per-trade, per-day, total
+  exposure) **+ a kill switch**, keys scoped to a small account. This is the one genuinely
+  irreversible-money surface in the whole program — it keeps the ask-first tier even under
+  never-wait, exactly like CUT-3's data tier kept its reversibility rider.
+- **Honest goal-setting:** the measurable objective is "strategies that survive falsification and
+  beat costs out-of-sample," never promised returns. The lab's value is the *platform* — the
+  discipline, reproducibility, and search capacity — which is real regardless of whether any
+  single strategy is an edge.
+
+## How the substrate kit relates to all of it (the connective answer)
+
+The kit is the **shared substrate of the whole program** — that was its founding purpose
+("portable"). Concretely: every repo adopts it for orientation/journal/guards/session-workflow;
+the kit repo is its home *and* its lab; `superbot-next` and the trading repo are consumers #2 and
+#3. Multi-repo is not just compatible with the kit — **it is what finally makes the kit's value
+measurable**, because improvements must generalize across three very different consumers (a
+Discord bot port, a greenfield research platform, and the lab itself) instead of fitting one
+repo's habits. The workflow layer above the kit (claims, question router, routines, CI guards)
+ships as kit-planted templates that each repo instantiates.
+
+## Recommended sequencing (decide-and-flag; ⚑ vetoable)
+
+1. **Now:** `superbot-next` per plan §5 steps 6–8 — unchanged, ready.
+2. **At step 7 (the second-consumer moment):** extract the kit to its own repo; superbot-next
+   adopts *from the kit repo* rather than from the in-tree copy; this repo's `substrate-kit/`
+   becomes a consumer pin too. The lab starts small: the A/B benchmark as a routine + the
+   friction-report inbox — not a fleet of loops on day one.
+3. **Third:** the trading repo, adopting the kit (consumer #3) — data + backtest engine + paper
+   trading first; the website next; capped live execution last, behind the real-money brake.
+4. **Rail before scale:** each repo's autonomy loop gets its guardrails (budgets, scoped
+   credentials, benchmark) proven before the next repo launches — three unproven autonomy loops
+   in one week is how a program loses observability.
+
+## Open forks for the owner (flag, not blockers)
+
+- Kit-repo timing: extract at step 7 (recommended) vs immediately vs after the port completes.
+- The lab's Railway budget cap + which extra work surfaces to provision first (bot token vs
+  website vs both).
+- Trading: which market/asset class first (the data-vendor and broker-API choice hangs on it),
+  and the initial live-execution caps when that distant gate arrives.
+- Whether the trading repo's autonomy runs under the same never-wait model from day one or
+  starts owner-gated until the falsification ladder has proven itself on paper trades.
+
+## Recommended routing
+
+Program-level; touches the rebuild plan only at the step-7 extraction note. Next concrete moves:
+(1) this doc is the durable capture; (2) when the step-6–8 kickoff session runs, it should read
+this doc and decide the kit-extraction fork in-flight (⚑); (3) the trading repo gets its own
+founding brief (a `docs/planning/` plan in this repo, or the first doc of the new repo) when the
+owner says go — its rigor list above is the skeleton.

--- a/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
+++ b/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/rebuild-plan-consolidation-c34c0b` (restarted from main post-#1793) · capture the owner's multi-repo program drop (repo-start mechanics + kit self-improvement lab + trading research repo) as an idea doc with the strengthened design · expected files: `docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md`, `docs/ideas/README.md` (index if needed), `.sessions/` · 2026-07-07

--- a/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
+++ b/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/rebuild-plan-consolidation-c34c0b` (restarted from main post-#1793) · capture the owner's multi-repo program drop (repo-start mechanics + kit self-improvement lab + trading research repo) as an idea doc with the strengthened design · expected files: `docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md`, `docs/ideas/README.md` (index if needed), `.sessions/` · 2026-07-07


### PR DESCRIPTION
## What

Captures the owner's program-level vision drop (same conversation as #1791–#1793) as a durable idea doc with the strengthened design:

- **Part 0** — how the new-repo session actually starts: fresh-from-kit + old repo attached read-only as the oracle, never clone-as-base (with the pinned-artifact import list).
- **Part 1** — `superbot-next` (already the canonical plan; cross-referenced).
- **Part 2** — the **substrate-kit as its own repo = the self-improvement lab**: fitness functions instead of vibes, the second-consumer extraction moment, work surfaces (own bot token, Railway project, deployable sites), safety rails for "complete freedom," and the unproven cold-start benefit as its founding challenge.
- **Part 3** — the **trading research repo**: backtest-decides-strategy as the sim-decides-design twin, the falsification-gate promotion ladder (in-sample → out-of-sample → walk-forward → paper → capped live), the real-money brake, and the tracking website.
- How the kit relates to all three + recommended sequencing + the open owner forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBHekm7vi2Sio9fLg2iQeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBHekm7vi2Sio9fLg2iQeJ)_