### PR TITLE
Q-0250: trading repo starts stocks-first (US large-cap tech; point-in-time universe; API-broker paper lane; DEGIRO = manual venue)

### DIFF
--- a/.sessions/2026-07-07-trading-market-ruling.md
+++ b/.sessions/2026-07-07-trading-market-ruling.md
@@ -1,17 +1,28 @@
 # 2026-07-07 — Trading-repo market ruling (Q-0250: stocks-first)
 
-> **Status:** `in-progress`
-> **Branch:** `claude/rebuild-plan-consolidation-c34c0b` (restarted from main after #1795)
+> **Status:** `complete`
+> **Branch:** `claude/rebuild-plan-consolidation-c34c0b` (restarted from main after #1795) · **PR:** #1796
 > **Continues:** the 2026-07-07 consolidation conversation (PRs #1791–#1795)
 
-## What is about to happen
+## What happened
 
-The owner answered the trading repo's "which market first" fork: he trades **stocks only**
-(DEGIRO; mostly US large-cap tech — Intel, Nvidia), doesn't want back into crypto. Record
-**Q-0250** (stocks-first; point-in-time universe rule as the selection-bias guard; paper lane via
-an API broker since DEGIRO has no official API; DEGIRO stays the owner's manual venue, integrated
-read-only via transaction-export ingestion at the tracker) + update the capture doc's open fork.
+Recorded **Q-0250** — the owner's answer to the trading repo's "which market first" fork:
 
-## Close-out
+- **Stocks-first, US large-cap tech** (his actual domain: DEGIRO, Intel/Nvidia-class); the crypto
+  proving-ground suggestion is withdrawn — owner preference wins and the technical case supports
+  it (mega-cap data is cheap/clean; survivorship bias is a broad-universe problem; the
+  falsification ladder proves out fine on liquid large caps).
+- Three binding riders: **point-in-time universe rule** (never "the stocks I hold now" — the
+  selection-bias guard; his picks become watchlist inputs, not the universe); the **automated
+  paper lane rides an API broker** (DEGIRO has no official API; unofficial clients are
+  ToS-violating and brittle); **DEGIRO integrates read-only at the tracker** via transaction
+  export — the owner's real portfolio becomes a benchmark lane beside the strategies' paper
+  portfolios.
+- Capture-doc fork closed (only the distant live-cap numbers remain open there).
 
-_(to be written at close)_
+Checks: `check_docs --strict` ✓.
+
+## Session enders
+
+Same conversation as the main consolidation session — enders live in
+`.sessions/2026-07-07-rebuild-idea-consolidation.md`.

--- a/.sessions/2026-07-07-trading-market-ruling.md
+++ b/.sessions/2026-07-07-trading-market-ruling.md
@@ -1,0 +1,17 @@
+# 2026-07-07 — Trading-repo market ruling (Q-0250: stocks-first)
+
+> **Status:** `in-progress`
+> **Branch:** `claude/rebuild-plan-consolidation-c34c0b` (restarted from main after #1795)
+> **Continues:** the 2026-07-07 consolidation conversation (PRs #1791–#1795)
+
+## What is about to happen
+
+The owner answered the trading repo's "which market first" fork: he trades **stocks only**
+(DEGIRO; mostly US large-cap tech — Intel, Nvidia), doesn't want back into crypto. Record
+**Q-0250** (stocks-first; point-in-time universe rule as the selection-bias guard; paper lane via
+an API broker since DEGIRO has no official API; DEGIRO stays the owner's manual venue, integrated
+read-only via transaction-export ingestion at the tracker) + update the capture doc's open fork.
+
+## Close-out
+
+_(to be written at close)_

--- a/docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md
+++ b/docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md
@@ -182,8 +182,12 @@ ships as kit-planted templates that each repo instantiates.
   telemetry + a ~2-month observation window first; security rails (scoped credentials, the
   trading real-money brake) stand regardless.** Still open: which extra work surfaces to
   provision first (bot token vs website vs both).
-- Trading: which market/asset class first (the data-vendor and broker-API choice hangs on it),
-  and the initial live-execution caps when that distant gate arrives.
+- ~~Trading: which market/asset class first (the data-vendor and broker-API choice hangs on it)~~
+  **RULED (Q-0250, 2026-07-07): stocks-first — US large-cap tech (the owner's domain; crypto
+  suggestion withdrawn); point-in-time universe rule (never the owner's current holdings); paper
+  lane on an API broker (DEGIRO has no official API); DEGIRO integrates read-only at the tracker
+  as the owner's manual benchmark lane.** Still open: the initial live-execution caps when that
+  distant gate arrives.
 - Whether the trading repo's autonomy runs under the same never-wait model from day one or
   starts owner-gated until the falsification ladder has proven itself on paper trades.
 

--- a/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
+++ b/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/rebuild-plan-consolidation-c34c0b` (restarted from main post-#1795) · record Q-0250 (trading repo: stocks-first, US large-cap tech; point-in-time universe rule; API-broker paper lane; DEGIRO = manual venue integrated read-only) + capture-doc fork update · expected files: `docs/owner/maintainer-question-router.md`, `docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md`, `.sessions/` · 2026-07-07

--- a/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
+++ b/docs/owner/claims/claude-rebuild-plan-consolidation-c34c0b.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/rebuild-plan-consolidation-c34c0b` (restarted from main post-#1795) · record Q-0250 (trading repo: stocks-first, US large-cap tech; point-in-time universe rule; API-broker paper lane; DEGIRO = manual venue integrated read-only) + capture-doc fork update · expected files: `docs/owner/maintainer-question-router.md`, `docs/ideas/multi-repo-program-kit-lab-trading-2026-07-07.md`, `.sessions/` · 2026-07-07

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -8986,3 +8986,36 @@ caps + kill switch) stand regardless, because they guard irreversibility, not sp
 
 **Homes:** this Q · the capture doc (open-forks + part-2 rails updated) · the kickoff brief §2
 step 8 (no Railway caps; telemetry instead).
+
+### Q-0250 — DECIDED: the trading repo starts stocks-first (US large-cap tech); DEGIRO stays the owner's manual venue; the crypto proving-ground suggestion is withdrawn (2026-07-07)
+
+**Context.** The multi-repo capture left "which market/asset class first" as an open fork; the
+outside-the-box sweep suggested crypto as a cheap rigor proving ground (free complete data, 24/7,
+trivial paper trading). The owner answered: he trades **stocks only**, on **DEGIRO**, mostly US
+large-cap tech (Intel, Nvidia); he has no way — and no desire — to trade crypto, though he'd
+accept it if genuinely best "since most of it will not be done by me."
+
+**Decision (owner preference wins; the technical case supports it).** **Stocks-first, US
+large-cap tech as the initial scope.** Rationale: for liquid mega-caps the usual data killers are
+weak (survivorship bias is a broad-universe problem; large-cap daily/intraday data with
+documented splits/dividends is cheap and good; spreads are tight so cost modeling stays honest) —
+and the falsification ladder proves out fine there, so crypto's data-cheapness advantage isn't
+worth building where the owner's interest and ground truth aren't. Three binding riders:
+
+1. **Point-in-time universe rule — the selection-bias guard.** The backtest universe is defined
+   by a dated rule (e.g. "top-N US tech by market cap as of each rebalance date"), **never** "the
+   stocks the owner holds/likes today" — NVDA is one of history's best performers, and a universe
+   chosen on hindsight makes any long-biased strategy look brilliant. The owner's picks are
+   welcome as *watchlist/priority inputs*, not as the universe definition.
+2. **The automated lane rides an API broker, not DEGIRO.** DEGIRO has **no official public API**
+   (unofficial reverse-engineered clients violate its terms and break routinely — not a
+   foundation). Paper trading runs on an API-native broker (IBKR-class, EU-available, real paper
+   environments; Alpaca-class for US-stock paper). The eventual capped-live gate (if ever) uses
+   the same API broker, under the standing real-money brake.
+3. **DEGIRO integrates read-only at the tracker.** DEGIRO supports transaction/portfolio export;
+   the tracking website ingests those exports so the owner's *real* portfolio appears next to the
+   strategies' paper portfolios — his manual trading becomes a benchmark lane, not an execution
+   dependency.
+
+**Homes:** this Q · the capture doc's open-forks + Part 3 (fork closed) · the future trading-repo
+founding brief (this Q is its market-scope input).


### PR DESCRIPTION
## What

Records the owner's answer to the trading repo's open "which market first" fork (same conversation as #1791–#1795):

- **Q-0250** — stocks-first (US large-cap tech, the owner's actual domain); the crypto-proving-ground suggestion is withdrawn (owner preference wins; the rigor ladder proves out fine on liquid mega-caps). Universe defined by a **point-in-time rule**, never "the stocks I hold now" (the selection-bias guard). Automated paper lane rides an **API broker** (DEGIRO has no official API — its unofficial libraries are ToS-violating and brittle); **DEGIRO stays the owner's manual venue**, integrated read-only via transaction-export ingestion so the tracker shows his real portfolio next to the strategies' paper portfolios.
- Capture-doc fork updated to point at the ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBHekm7vi2Sio9fLg2iQeJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBHekm7vi2Sio9fLg2iQeJ)_