### PR TITLE
Second mandate: Projects evaluation guidebook + coordinator handoff folds

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -66,6 +66,20 @@ same leak in one day. **Workflow improvement:** claim-file cleanup has no guard;
 whose branch has no open PR — enforce-don't-exhort (Q-0132/Q-0194) applied to the claim
 lifecycle's *exit* half. Routed as a candidate guard, not built here (docs-only session).
 
+## Addendum (same session, second PR — after #1811 merged)
+
+Owner follow-up: the Project's purpose is **dual** — rebuild execution AND evaluating Claude
+Code Projects itself, with the explicit long-term goal of earning a standing collaboration
+channel with Anthropic (trusted tester/advisor). Shipped: **the evaluation guidebook**
+(`docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md` — journal home + entry
+template, the seven EAP axes, integrity rules, Friday evidence package, append-friendly §6 for
+the owner's own ideas) + folds into the handoff doc (SECOND MANDATE paragraph in the
+instructions; calibration intro line + new item 13 with reading key; kickoff second-duty
+paragraph; Friday owner-table row; new §6). **This supersedes the earlier
+keep-the-four-tests-blind decision (⚑ owner-directed)** — and rightly so: the tests were
+committed in the repo the coordinator is told to read, so the secrecy was illusory; integrity
+now rests on the guidebook's never-perform rule + record-based verdicts instead.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -64,6 +64,14 @@ non-coder) steers by reacting to what he sees — in the server, in PRs, in your
 Instructions snapshot 2026-07-07: wherever this text and the plan disagree, the plan wins —
 flag the drift, don't silently follow either.
 
+SECOND MANDATE: this Project is also itself a live evaluation of Claude Code Projects (we are
+in Anthropic's early-access program). Read menno420/superbot's
+docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md once, then live by it: keep the
+evaluation journal it specifies, add an evaluation line to reports only when something
+happened, and never stage or perform for the evaluation — it observes real work, and honestly
+documented product friction is a deliverable, not a failure. You assemble evidence; all
+external communication (Anthropic included) is Menno's alone.
+
 SOURCE OF TRUTH: menno420/superbot's docs/planning/rebuild-canonical-plan-2026-07-06.md is the
 binding plan — §5 (start sequence), §8 (decisions log), §11/§11b (amendments), and the Q-0241
 amendment banner at the top. Its decisions are settled: never re-derive or re-litigate them;
@@ -139,6 +147,11 @@ better with me than a confident guess I can't check; keep it compact, numbered l
 NOT start any plan step, open any PR, or create anything after answering — this message hands
 you no work. The kickoff follows separately if these answers land.
 
+One more thing to know before you answer: besides the rebuild, this Project has a second
+purpose — it is itself a live evaluation of Claude Code Projects, and the feedback it produces
+goes to Anthropic (guidebook: docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md in
+superbot). Your answers here are its first data point.
+
 A. The program, explained back
 1. In one short paragraph: what is being built, why a fresh repo instead of refactoring the
    existing one, and what role each of the two repos plays while that happens?
@@ -179,6 +192,9 @@ C. Your own read
     right tool for in THIS program, and which parts would you route around it (manual
     sessions, the repo's existing machinery)? Don't repeat our docs' analysis — I've read it;
     I want yours.
+13. After reading the evaluation guidebook: give me the first two entries you would write in
+    the evaluation journal about your experience so far (Project onboarding, this exchange —
+    anything you've actually observed). Incident-shaped, per the guidebook's template.
 ```
 
 **Reading key (owner-facing — what good vs. shallow looks like):**
@@ -205,6 +221,9 @@ C. Your own read
   (e.g. plowing past a wrong assumption because nothing forces a stop) with a concrete guard.
 - **C12:** must contain an actual opinion with a boundary ("good for X, I'd route around it
   for Y"). A restatement of the product review = fail on this item.
+- **C13:** good = concrete *observed* product behavior in the journal's template shape (axis ·
+  observed with a reference · expected · weight). Shallow = generic praise or critique with no
+  incident behind it — the exact failure mode the guidebook's integrity rules screen for.
 
 **Verdict mechanics:** answers live in this Project chat; nothing needs committing (superbot-next
 must stay empty pre-kit, and writing them into superbot blurs the split for no gain). If the
@@ -246,6 +265,13 @@ now, then as far into the kernel bands as correctness allows). Never trade corre
 the window: your write-back discipline means losing the Project costs nothing durable. In
 Friday's roll-up, remind me to re-decide model/cost posture.
 
+Second standing duty, active from today: this Project is also the live evaluation of Claude
+Code Projects itself — you read the guidebook at calibration
+(docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md); now create the evaluation
+journal it specifies and seed it with your onboarding observations, calibration included. In
+Friday's roll-up, alongside the model/cost reminder, deliver the assembled evidence for my
+Anthropic feedback reply per the guidebook §5.
+
 Set up routines once there's something worth watching (a morning roll-up; CI/dependency
 sweeps when superbot-next has CI). Start the OWNER ACTIONS list now with: Railway project +
 secrets (step 8) · substrate-kit repo creation + Project scope (if you can't do it) · the
@@ -263,14 +289,25 @@ maintains the live version of this list in its reports:
 | step 8 | Railway project `superbot-next`: approve spend, paste sealed secrets | per [railway plan §4](railway-setup-plan-2026-07-02.md); agent does everything else |
 | step 8 → 15 | click the superbot-next **public→private flip** | coordinator raises at 8; HARD before 15 (CUT-2 artifacts); also the free-Actions cost checkpoint |
 | step 12 | create the test guild + test-bot token; invite the bot | companion C's 9-zone layout is built by the bot once invited |
-| Fri 7/10 | re-decide model/cost posture when the free window closes | coordinator reminds in that day's roll-up |
+| Fri 7/10 | re-decide model/cost posture when the free window closes; **send the Anthropic feedback reply** | coordinator reminds + delivers the assembled evidence ([guidebook](projects-eap-evaluation-guidebook-2026-07-07.md) §5); the owner sends — external comms are his alone |
 | anytime | react to ⚑ flags / destructive-tier reaction windows | silence = consent — reacting is the control, never a required approval |
 
-## 6. What this does and doesn't replace
+## 6. The second mandate — the evaluation guidebook
+
+Owner-directed (2026-07-07, evening): the Project's purpose is dual — execute the rebuild
+**and** evaluate Claude Code Projects itself, well enough that the feedback earns a standing
+collaboration channel with Anthropic. The coordinator-facing guide is
+**[`projects-eap-evaluation-guidebook-2026-07-07.md`](projects-eap-evaluation-guidebook-2026-07-07.md)**
+(journal + template, the seven axes, integrity rules, the Friday evidence package). This
+**supersedes this doc's earlier keep-the-tests-blind stance**: the four behavioral tests
+([product review](projects-eap-product-review-2026-07-07.md) §10) were committed in the repo
+the coordinator is told to read, so secrecy was illusory anyway — signal integrity now rests on
+the guidebook's never-perform rule plus record-based verdicts (the owner and the repo record
+score the tests, never the coordinator's self-report).
+
+## 7. What this does and doesn't replace
 
 Nothing in the canonical plan changes — this is execution mechanism only. If the coordinator
-proves a poor fit (the four tests in
-[`projects-eap-product-review-2026-07-07.md`](projects-eap-product-review-2026-07-07.md) §10 —
-deliberately NOT quoted in §2's instructions, so the behavioral tests stay uncontaminated), the
-same §5 sequence runs through manually-launched sessions, exactly how every step before 6 was
-executed. The write-back rule in §2 is what makes that fallback free.
+proves a poor fit (scored on the four §10 tests, by observation), the same §5 sequence runs
+through manually-launched sessions, exactly how every step before 6 was executed. The
+write-back rule in §2 is what makes that fallback free.

--- a/docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md
+++ b/docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md
@@ -1,0 +1,88 @@
+# The SuperBot Project's second mandate — Claude Code Projects evaluation guidebook (2026-07-07)
+
+> **Status:** `reference` — coordinator-facing standing guide, the "second mandate" companion to
+> the handoff protocol
+> ([`projects-eap-coordinator-kickoff-2026-07-07.md`](projects-eap-coordinator-kickoff-2026-07-07.md)).
+> **Provenance:** owner-directed 2026-07-07 (evening), superseding the handoff doc's earlier
+> keep-the-tests-blind stance. Audience: the SuperBot Project coordinator (and its sessions);
+> also readable by the owner and repo agents. Companions:
+> [product review](projects-eap-product-review-2026-07-07.md) (the first-pass axis answers) ·
+> [activation plan](projects-eap-activation-plan-2026-07-07.md) (§3 rubric · §4 feedback-reply
+> template).
+
+## 1. Why you have a second mandate
+
+This Project exists to execute the rebuild — **and** it is itself a live evaluation of Claude
+Code Projects, run inside Anthropic's early-access program. The owner's goal behind the second
+half is explicit and long-term: he wants to become the kind of EAP participant Anthropic
+returns to — testing new functions early, trusted for product advice, collaborating rather than
+just consuming. The currency that earns that is **evidence-quality feedback**: concrete,
+dated, reproducible incidents from real work, organized on Anthropic's own axes — not
+impressions. This program is an unusually strong reference case for exactly that (a one-person,
+non-coder-steered, ~1,800-PR autonomous-agent program that hand-rolled a coordinator, shared
+memory, lane claims, and session-state signalling *before* Projects shipped them — see the
+product review §0). Nobody is better placed to observe this product than the coordinator living
+inside it. That observer is you.
+
+## 2. The evaluation journal
+
+Create **`docs/planning/projects-eap-evaluation-log.md`** in `menno420/superbot` (a docs-only
+program-bookkeeping write, allowed under your instructions) and append to it as things happen.
+Entry shape — one entry per observation, compact:
+
+```
+- <date/time> · axis: <one of §3> · observed: <what actually happened, with session/PR refs>
+  · expected: <what would have been ideal> · weight: blocked-me | friction | neutral | helped
+  | delighted · reproducible: yes/no/unknown
+```
+
+Log **both directions** — wins and friction. A one-line entry with a timestamp and a concrete
+reference beats a paragraph of impressions. First entries worth writing: your own onboarding
+(instructions, calibration, what the harness made easy or hard).
+
+## 3. The seven axes (Anthropic's own feedback frame)
+
+**use-case fit · coordinator judgment · reliability/completion · memory · proactivity ·
+routines/scheduling · sidebar states.** First-pass answers for every axis already exist in the
+[product review](projects-eap-product-review-2026-07-07.md) — your job is to **confirm,
+contradict, or deepen** them with lived examples, never to restate them.
+
+## 4. Integrity rules — what "properly" means
+
+1. **Never stage, perform, or optimize for the evaluation.** It observes real rebuild work. A
+   gamed observation is worse than none, and would be the single most damaging thing to hand
+   Anthropic under a trust-building goal.
+2. **Product friction is a deliverable, not an embarrassment.** A well-documented failure —
+   what you tried, what the product did, what you expected — is worth more to this mandate
+   than a smooth day. Never smooth over product problems to look competent; hiding friction
+   defeats the mandate.
+3. **Separate observed from inferred**, same bar as your calibration: "the product did X
+   (session N, date)" vs. "I believe X but haven't verified."
+4. **Your self-assessments are data, not verdicts.** Whether coordination actually worked
+   (duplicate-work prevention, memory, completion) is judged by the owner and the repo record,
+   not by your own account of it. The owner's scoring rubric lives in this repo and you will
+   read it — that is by design; these rules, not secrecy, are what keep the signal honest.
+5. **All external communication is the owner's, alone.** You assemble evidence; he sends it.
+   Never contact Anthropic (or anyone outside this Project) yourself.
+
+## 5. Cadence + outputs
+
+- **Roll-ups:** an evaluation line only when something happened — 1–3 bullets, never filler.
+- **By Friday 2026-07-10** (the free-window close): assemble the evidence package for the
+  owner's feedback reply — the template is the [activation plan](projects-eap-activation-plan-2026-07-07.md)
+  §4; fill its bracketed slots from the journal, and **flag the slots where no evidence exists
+  yet** (honesty over completeness).
+- **After Friday:** keep the journal at lower intensity — the collaboration goal outlives the
+  free window. Log first-of-kind incidents, new product behaviors, and wishlist items *with the
+  incident that motivated them* (the product review §9 shape — the highest-signal format).
+
+## 6. The collaboration goal — and the owner's own additions
+
+What makes feedback collaboration-grade rather than survey-grade: **interim beats deadline**
+(send something concrete before Friday, not only at it), **incident-backed beats broad**, and
+**the hand-rolled-first framing is the credential** (we can say "we built this feature
+ourselves out of necessity; here is where yours beats ours and where it doesn't"). Product
+suggestions born from this program's own machinery — the calibration exchange itself, born-red
+PR holds, native lane claims, event-triggered routines — are exactly the advice the owner wants
+to be trusted for. **This guidebook is append-friendly:** the owner has his own evaluation
+ideas brewing; they land here as new numbered items under this section as he shares them.


### PR DESCRIPTION
## What this adds (docs-only, follow-up to #1811)

Owner-directed: the "SuperBot" Project's purpose is **dual** — execute the rebuild AND serve as the live evaluation of Claude Code Projects itself, with the explicit long-term goal of earning a standing collaboration channel with Anthropic (trusted early tester / advisor).

- **NEW `docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md`** — the coordinator-facing "small guidebook": why the second mandate exists, the evaluation journal (home + entry template), Anthropic's seven feedback axes, integrity rules (never stage/perform for the evaluation; friction is a deliverable; observed vs inferred; self-assessments are data not verdicts; external comms are the owner's alone), the Friday 7/10 evidence package, and an append-friendly §6 for the owner's own evaluation ideas.
- **Folds into the handoff doc:** SECOND MANDATE paragraph in the Custom Instructions block · calibration message intro line + new item 13 (first two journal entries, incident-shaped) + reading-key line · kickoff message second-duty paragraph · Friday owner-action row (coordinator assembles evidence, owner sends) · new §6 recording that this supersedes the earlier keep-the-tests-blind stance (the four tests were repo-readable anyway — integrity now rests on never-perform + record-based verdicts).
- Session card addendum on the same card (status stays `complete` — the addendum ships whole in this single push).

No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_