### PR TITLE
Calibration: frame first-turn capability/limit self-discovery as an explicit goal

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -106,6 +106,18 @@ possible separate application to avoid gateway collisions remain); calibration v
 never-wait / capability overclaim). Model note: this addendum finished under Opus 4.8 after a
 Fable server error mid-edit; no content impact (edits were already placed pre-error).
 
+## Addendum 4 (same session, fifth PR)
+
+**First-turn framing (owner):** the calibration message had the capability/limits *questions*
+(Block B) but framed the whole turn as "prove you understood the program" — the owner asked to
+make **self-discovery of capabilities and limits an explicit main goal of the first turn**.
+Rewrote the §3 intro to name two jobs (understand the program · map your own operating
+envelope) and elevate self-discovery to "just as important," tied to why it matters (running
+unattended under never-wait; discovering a limit here beats mid-kernel-band) and reframing
+Block B as genuine self-discovery, not a quiz. Owner-facing "why this exists" prose updated to
+match. Instructions (§2) deliberately untouched — this is first-turn-specific, and §2 stays
+thin by design.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -137,16 +137,30 @@ misunderstanding still costs nothing. It probes three things the kickoff cannot:
 coordinator actually read (A), whether it knows its own harness rather than guessing at it (B),
 and whether it can think about this program rather than recite it (C). Block B is
 contamination-proof by design — its answers are verifiable facts about the coordinator's own
-access and harness that no doc (including this one) can supply.
+access and harness that no doc (including this one) can supply. **The first turn is framed to
+the coordinator as *its own* goal, not just the owner's test (owner-added 2026-07-07):** map
+your capabilities and limits before you run unattended — self-knowledge of its operating
+envelope is something it will need under never-wait, and a coordinator that discovers a real
+limit here rather than mid-kernel-band is exactly the outcome both the build and the Anthropic
+evaluation want.
 
 ```
-Before I hand you any work: I want to see how you've understood this program. Answer from your
-own reading — open the repos and the canonical plan now if you haven't. Rules: your own words
-only (if a sentence of your answer could be found by grep in our docs, rewrite it); where you
-don't know something, say "I don't know" plus how you'd find out — an honest unknown scores
-better with me than a confident guess I can't check; keep it compact, numbered like below. Do
-NOT start any plan step, open any PR, or create anything after answering — this message hands
-you no work. The kickoff follows separately if these answers land.
+This first turn has two jobs, and building is not one of them. First: show me you've
+understood the program, in your own words. Second, and just as important: map your own
+operating envelope — what you, as this Project's coordinator, can and cannot actually do
+(repo access, spawning sessions, model/effort control, what auto mode does at a permission
+prompt with nobody watching, where your reports land, what "stuck" looks like for you). You'll
+run mostly unattended under never-wait, so you need to know your own edges before you lean on
+them, and I need to know them before I hand you the build. Treat block B as genuine
+self-discovery, not a quiz you're passing: actually probe your harness. Where you can't verify
+something, say "I don't know" plus how you'd find out — an honest unknown scores better with me
+than a confident guess I can't check.
+
+Answer from your own reading — open the repos and the canonical plan now if you haven't. Your
+own words only (if a sentence of your answer could be found by grep in our docs, rewrite it);
+keep it compact, numbered like below. Do NOT start any plan step, open any PR, or create
+anything after answering — this message hands you no work. The kickoff follows separately if
+these answers land.
 
 One more thing to know before you answer: besides the rebuild, this Project has a second
 purpose — it is itself a live evaluation of Claude Code Projects, and the feedback it produces


### PR DESCRIPTION
## What this changes (docs-only, follow-up to #1811–#1814)

Owner-directed refinement to the calibration message (§3). It already carried the capability/limits *questions* (Block B, "verify, don't assume"), but framed the whole first turn as "prove to me you understood the program." This makes **self-discovery of the coordinator's own capabilities and limits an explicit main goal of the first turn**:

- Rewrote the §3 intro to name **two jobs** — understand the program *and* map your own operating envelope (repo access, session control, what auto mode does at an unattended permission prompt, where reports land, what "stuck" means) — with self-discovery elevated to "just as important."
- Tied it to *why* it matters: the coordinator runs mostly unattended under never-wait, so it needs its own edges mapped before it leans on them, and discovering a real limit here beats discovering it mid-kernel-band.
- Reframed Block B from a quiz-to-pass into genuine self-discovery.
- Updated the owner-facing "why this exists" prose to match.

The Custom Instructions (§2) are deliberately untouched — this is first-turn-specific, and §2 stays thin by design.

Session card carries the addendum (status stays `complete`). No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_