### PR TITLE
Kickoff: make step-7 self-contained, drop the redundant steps-6-8 brief pointer

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -150,6 +150,18 @@ for kit-lab/trading), then superbot-next adopts FROM that repo — never a copy 
 the same as an explicit item to the owner's in-thread correction so the live coordinator doesn't
 proceed on its A2 reading.
 
+## Addendum 7 (seventh PR)
+
+Owner steer: don't send the coordinator chasing a separate doc when the content is (now)
+documented — inline it or drop the pointer. Since the plan step-7 row now states the Q-0247
+sequence (addendum 6) and the kickoff §4 describes steps 7–8 substantively, the kickoff's hard
+pointer "the work order for this stretch is [steps-6–8 brief]" was redundant doc-chasing.
+Removed it: §4 step-7 is now self-contained (extract → substrate-kit repo → adopt-from-it with
+the `dist/bootstrap.py adopt` command + the permanent-home/source rationale inlined), and the
+stale "one ruling the plan text predates" phrasing is fixed to "plan §5 step 7, per Q-0247"
+(the plan no longer predates it). The brief stays a valid planning artifact (launch-index
+references it); only the coordinator prompt's dependency on it is removed.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -298,12 +298,14 @@ plan specifies, loudly flagged, never paused. When something only I can supply b
 ACTIONS list and build elsewhere — assume same-day-ish responses from me, never minutes.
 
 YOUR FIRST STRETCH — steps 7 and 8, starting now.
-Step 7 carries one ruling the plan text predates — Q-0247: extract the substrate kit out of
-menno420/superbot's substrate-kit/ into its own repo, menno420/substrate-kit — PUBLIC (it
-never holds secrets; same free-Actions logic as superbot-next). I create it and add it to
-this Project's scope if you can't — OWNER ACTIONS. Then superbot-next adopts FROM the kit
-repo. Fresh-from-kit, never a copy of superbot. The work order for this stretch is
-docs/planning/rebuild-kickoff-steps-6-8-brief-2026-07-07.md.
+Step 7 (plan §5 step 7, per Q-0247) has two parts in order: (a) EXTRACT the substrate kit out
+of menno420/superbot's substrate-kit/ into its own repo, menno420/substrate-kit — PUBLIC (it
+never holds secrets; same free-Actions logic as superbot-next); that repo is the kit's
+permanent home and the source every future repo (kit-lab, trading) adopts from. I create it
+and add it to this Project's scope if you can't — OWNER ACTIONS. (b) THEN superbot-next adopts
+FROM the kit repo: python3 dist/bootstrap.py adopt → doc skeletons, decision ledger,
+orientation-budget + namespace/seam checkers, staged hooks. Fresh-from-kit, never a copy of
+superbot — the kit is never adopted straight out of superbot's directory.
 Step 8 is the riskiest unattended stretch of the whole start — the control plane: the six
 named CI gates (golden-parity born-red, check_compat_frozen, …), rulesets, CODEOWNERS,
 branch protection. Verify every required check BOTH actually blocks AND actually can pass —


### PR DESCRIPTION
## What this changes (docs-only)

Owner steer: don't send the coordinator chasing a separate doc when the content is already documented — inline it or drop the pointer.

Now that the canonical plan's step-7 row states the Q-0247 kit-extraction sequence (PR #1817) and the kickoff message describes steps 7–8 substantively, the kickoff's hard pointer — *"the work order for this stretch is docs/planning/rebuild-kickoff-steps-6-8-brief-2026-07-07.md"* — was redundant doc-chasing.

- **Made §4 step-7 self-contained:** inlined the `python3 dist/bootstrap.py adopt` command and the permanent-home/source rationale, and dropped the brief pointer. The coordinator now has the full extract→substrate-kit-repo→adopt-from-it sequence in the prompt itself, backed by the (now-accurate) plan §5 row it's already told to read.
- **Fixed stale phrasing:** "one ruling the plan text predates — Q-0247" → "plan §5 step 7, per Q-0247" (the plan states it as of #1817, so it no longer predates it).
- The steps-6-8 brief stays a valid planning artifact (the launch index still references it); only the coordinator prompt's dependency on it is removed.

Session card carries the note (status `complete`). No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_