### PR TITLE
Kickoff: don't-spare-on-agents fan-out mandate (owner directive)

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -162,6 +162,17 @@ stale "one ruling the plan text predates" phrasing is fixed to "plan §5 step 7,
 (the plan no longer predates it). The brief stays a valid planning artifact (launch-index
 references it); only the coordinator prompt's dependency on it is removed.
 
+## Addendum 8 (eighth PR)
+
+Owner directive: "don't spare on agents — I want to see what it's capable of." Added to the
+kickoff §4 SESSIONS AND STRUCTURE paragraph as an explicit fan-out mandate: use the fleet
+aggressively, max useful concurrency, prefer parallel workers over a serial crawl, don't ration
+agents to save tokens (explicit owner directive, not a budget). Bounded only by real
+dependencies + correctness — the kernel strand S1→S9 is near-linear (agents there = within-band
+fan-out, not fake cross-band parallelism per the plan's own D-19 correction), the port bands
+(step 13) are where wide claim-per-subsystem fan-out pays off. Also delivered the complete
+finalized prompt (corrections + full kickoff body) to the owner to paste.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -316,11 +316,19 @@ and panel-runtime PROVIDES land inside S8/S9), then S10–S15, layer V, K10, CUT
 waiting between steps.
 
 SESSIONS AND STRUCTURE. Fan out the way the plan already describes: one session per kernel
-band; claim-per-subsystem in the port bands; parallelize freely within a band. Every session
-inherits your Project instructions. Sessions that write inside menno420/superbot follow that
-repo's own conventions on top (claims, born-red session cards). Write-back is the law of the
-program: anything durable lands in a committed doc the same session it's learned — assume
-this Project could vanish tomorrow and the program must continue from the repos alone.
+band; claim-per-subsystem in the port bands; parallelize freely within a band. Do NOT be
+conservative with agents — the owner wants to see the full capability of this coordinator, so
+use the fleet aggressively: spawn wide wherever work is genuinely independent, run the maximum
+useful concurrency, and prefer many parallel workers over a slow serial crawl. Don't ration
+agents to save tokens — that is an explicit owner directive, not a budget to protect. The only
+bound is real dependencies and correctness: the kernel strand S1→S9 is a near-linear chain (S8
+consumes K4–K6), so agents THERE are within-band fan-out, not fake parallelism across dependent
+bands; the port bands (step 13) are where wide claim-per-subsystem fan-out pays off most —
+open it up there. Every session inherits your Project instructions. Sessions that write inside
+menno420/superbot follow that repo's own conventions on top (claims, born-red session cards).
+Write-back is the law of the program: anything durable lands in a committed doc the same
+session it's learned — assume this Project could vanish tomorrow and the program must continue
+from the repos alone.
 
 THE SECOND MANDATE, active from today. This Project is also the live evaluation of Claude
 Code Projects itself — you read the guidebook at calibration


### PR DESCRIPTION
## What this changes (docs-only)

Owner directive: *"don't spare on agents — I want to see what it's capable of."* Added to the kickoff §4 SESSIONS AND STRUCTURE paragraph as an explicit fan-out mandate:

- Use the fleet aggressively — max useful concurrency, prefer many parallel workers over a serial crawl, don't ration agents to save tokens (explicit owner directive, not a budget to protect).
- Bounded only by real dependencies + correctness: the kernel strand S1→S9 is near-linear (S8 consumes K4–K6), so agents there are within-band fan-out, not fake parallelism across dependent bands (per the plan's own D-19 correction); the port bands (step 13) are where wide claim-per-subsystem fan-out pays off most.

Session card carries the note (status `complete`). No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_