### PR TITLE
docs: Projects-EAP evaluation journal (guidebook-prescribed) + seed entries

### DIFF
--- a/.sessions/2026-07-07-projects-eap-eval-journal.md
+++ b/.sessions/2026-07-07-projects-eap-eval-journal.md
@@ -1,6 +1,6 @@
 # 2026-07-07 — Projects-EAP evaluation journal (guidebook-prescribed) + seed entries
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Model:** Fable 5 (worker session under the SuperBot Project coordinator) · **Governance:** Q-0241 never-wait applies
 
 ## What is about to happen

--- a/.sessions/2026-07-07-projects-eap-eval-journal.md
+++ b/.sessions/2026-07-07-projects-eap-eval-journal.md
@@ -1,0 +1,10 @@
+# 2026-07-07 — Projects-EAP evaluation journal (guidebook-prescribed) + seed entries
+
+> **Status:** `in-progress`
+> **Model:** Fable 5 (worker session under the SuperBot Project coordinator) · **Governance:** Q-0241 never-wait applies
+
+## What is about to happen
+
+Create `docs/planning/projects-eap-evaluation-log.md` exactly as the evaluation guidebook
+(`docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md` §2) prescribes, and seed it
+with the coordinator's five onboarding observations. Docs-only; no runtime code.

--- a/.sessions/2026-07-07-projects-eap-eval-journal.md
+++ b/.sessions/2026-07-07-projects-eap-eval-journal.md
@@ -8,3 +8,100 @@
 Create `docs/planning/projects-eap-evaluation-log.md` exactly as the evaluation guidebook
 (`docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md` §2) prescribes, and seed it
 with the coordinator's five onboarding observations. Docs-only; no runtime code.
+
+## What shipped (PR #1820)
+
+- **`docs/planning/projects-eap-evaluation-log.md`** — the second-mandate journal, exactly per
+  guidebook §2: verbatim entry template, the seven §3 axes named, §4 integrity rules pointed to,
+  append-at-bottom structure (no shared top anchor). Seeded with the coordinator's five
+  onboarding observations (2× use-case fit, reliability/completion, coordinator judgment,
+  proactivity) reformatted into the template with substance kept faithful.
+- **+1 lived entry from this session** (per the guidebook's log-both-directions rule): the
+  worker-tier flow (full file/shell/git/MCP toolset, zero permission prompts, born-red →
+  auto-merge end-to-end) as the "helped" contrast to seed #1's coordinator-side tool gap.
+- **+2 coordinator-relayed entries added mid-session, pre-flip** (permission-probe session,
+  both ~22:38Z): fail-fast structured auto-denials at unattended permission boundaries
+  (reliability/completion, helped) and the missing scheduled-wake primitive + missing direct
+  coordinator→session channel (use-case fit, friction). Relayed observations, reformatted
+  faithfully — same verification caveat as the five seeds.
+- **`docs/planning/README.md`** — one row for the guidebook + journal in the rebuild sector
+  table (the guidebook shipped in #1811 with no index row while its siblings
+  activation-plan/kickoff have rows — spotted drift, fixed on sight per Q-0166); "Last updated"
+  bumped; one clarifying sentence in "Adding / retiring a plan" for non-`plan` companions
+  (`reference`/`living-ledger` docs homed in `docs/planning/`).
+- **Idea filed:** `docs/ideas/session-start-staleness-banner-2026-07-07.md` + README index entry
+  (see 💡 below).
+
+## Context delta (reflection interview)
+
+- **Needed but not pointed to:** nothing — the task prompt named the guidebook and the
+  conventions directly; `.sessions/README.md` supplied the run-report/telemetry shape.
+- **Pointed to but didn't need:** `docs/owner/claims/README.md` (the CLAUDE.md claim rule alone
+  was sufficient for a single-file claim).
+- **Discovered by hand:** `check_docs --strict` enforces a badge-token whitelist — `living` is
+  not a valid badge (`living-ledger` is); found by running the checker, not documented anywhere
+  I was routed. Also: the planning README's homing rule only covers `plan`-badged docs; the
+  non-`plan` companion case was unwritten (now written — one sentence added).
+- **Decisions made alone:** (1) badge `living-ledger` for the journal; (2) adding index rows for
+  guidebook+journal though the written rule didn't require them (sibling-row precedent);
+  (3) appending one lived worker-tier entry beyond the five seeds under the guidebook's
+  log-both-directions rule; (4) the one-sentence homing clarification. All reversible docs calls.
+- **Flagged for maintainer:** the journal's five seeds are the coordinator's observations
+  relayed through the spawn prompt — I reformatted faithfully but could not independently verify
+  the coordinator-side facts (e.g. the ignored run-synchronously flag); they're marked with the
+  coordinator's own refs.
+- **One docs change that would have helped most:** a badge-token list somewhere findable
+  (currently only discoverable by running `check_docs` or reading its source) — small, left as a
+  note here rather than filed; the checker's error message does list the allowed tokens, which
+  is arguably enough.
+- **🛠 Friction → guard:** the invalid-badge trip was caught pre-push by running
+  `check_docs --strict` locally — the existing checker IS the guard; nothing new needed. No
+  other friction hit.
+
+## ⟲ Previous-session review (Q-0102)
+
+The understand-and-reflect-rule session (#1806, same day) was a model of tight scoping: it
+applied the owner's live directive without over-adopting the kit's whole stance system, and its
+context delta caught a real doc/reality mismatch (section-marker prose vs. literal names). What
+it left: its own review re-flagged the planning-README homing-convention split for the *third*
+time and said the next session touching that file should resolve it rather than re-flag.
+**Improvement executed, not re-flagged:** this session touched `docs/planning/README.md` and
+wrote the missing convention down — non-`plan` companions get a row only while they're active
+program artifacts, else inbound links suffice ("Adding / retiring a plan" section). If the split
+the earlier sessions meant was a different one (plan-index row vs. *sector-file* entry), that
+half remains open — but the concrete instance class that kept recurring (reference/living-ledger
+docs with no homing rule) is now settled in writing.
+
+## 💡 Session idea (Q-0089)
+
+[`session-start-staleness-banner-2026-07-07.md`](../docs/ideas/session-start-staleness-banner-2026-07-07.md) —
+a cheap session-start staleness check (`git fetch` + `HEAD..origin/main` count → loud banner).
+Worth having because the coordinator's 7-PR-stale container (journal seed #2) is a silent
+wrong-answers failure mode, and grep confirms nothing in `scripts/claude_session_start.sh`
+detects it today. Dedup-checked against `docs/ideas/` + roadmap: no existing capture.
+
+## 📤 Run report
+
+- **Did:** created the guidebook-prescribed Projects-EAP evaluation journal + 5 coordinator seed
+  entries + 1 lived worker entry; fixed the guidebook's missing plan-index row · **Outcome:** shipped
+- **Shipped:** #1820 — journal + seeds, planning-README rows + homing sentence, staleness-banner idea
+- **Run type:** `manual` (coordinator-dispatched worker under the SuperBot Project)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** (1) planning-README index rows for guidebook+journal + the non-`plan`
+  homing sentence — spotted-drift fix + third-flag resolution (Q-0166 / prior session's carry-forward);
+  (2) one extra journal entry beyond the 5 seeds — the guidebook's own log-both-directions rule
+  applied to this session's lived flow. Both docs-only, reversible.
+- **📊 Model:** Fable 5 · standard · docs-only (journal bookkeeping)
+- **↪ Next:** journal is live — coordinator + sessions append as things happen; by Friday
+  2026-07-10 fill the activation-plan §4 feedback template from it (flag empty slots honestly).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged | 1 (#1820, auto-merge on card flip) |
+| CI-red rounds | 0 unexpected (born-red gate holds by design) |
+| Repo-rule trips | 1 (invalid badge token `living`, caught locally pre-push) |
+| New ideas contributed | 1 (session-start-staleness-banner) |
+| Ideas groomed | 0 (grooming pass skipped — bounded worker task; backlog untouched by design) |

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`session-start-staleness-banner-2026-07-07.md`](./session-start-staleness-banner-2026-07-07.md) —
+  **session idea (2026-07-07, Q-0089, Projects-EAP eval-journal session):** the coordinator's
+  container clone was 7 merged PRs behind origin at first turn and nothing warned it — add a
+  cheap staleness check at session start (`git fetch` + `HEAD..origin/main` count → loud banner)
+  so a stale clone announces itself instead of silently answering from an old world. The checker
+  script is free to ship; the hook wiring is owner-gated (Q-0106).
 - [`cold-start-ab-vague-idea-task-2026-07-07.md`](./cold-start-ab-vague-idea-task-2026-07-07.md) —
   **session idea (2026-07-07, Q-0089, kit-doctrine port session, Q-0254):** the understand-and-
   reflect + guiding-questions doctrine just shipped into the kit's templates has no enforcement

--- a/docs/ideas/session-start-staleness-banner-2026-07-07.md
+++ b/docs/ideas/session-start-staleness-banner-2026-07-07.md
@@ -1,0 +1,26 @@
+# SessionStart staleness banner — detect a behind-origin clone before it lies to you
+
+> **Status:** `ideas` — captured 2026-07-07 (Q-0089 session idea, Projects-EAP eval-journal
+> session). **Subsystem:** none (agent-workflow / session tooling).
+> **Owner-gated half:** the SessionStart hook is executable config (Q-0106) — the hook change
+> itself needs an owner-directed session or a router DISCUSS Q; the standalone checker script
+> is free to ship.
+
+## The incident that motivates it
+
+The SuperBot Project coordinator's container clone was **7 merged PRs behind origin** at its
+first turn (700bdce vs fe297a8) — the evaluation guidebook it was told to follow did not exist
+on local disk and had to be fetched via the GitHub API. Trusting local disk would have produced
+answers from a stale world (journal entry: `docs/planning/projects-eap-evaluation-log.md`,
+2026-07-07 ~22:15Z). The same trap exists for any resumed/warm container: nothing in
+`scripts/claude_session_start.sh` fetches or compares against `origin/main` today (verified by
+grep, 2026-07-07).
+
+## The idea
+
+A tiny `scripts/check_clone_staleness.py` (or a few lines in the SessionStart hook, owner-gated):
+`git fetch origin main` (timeboxed, failure-tolerant) → count `HEAD..origin/main` commits → if
+N > 0, print a **loud banner**: `⚠ CLONE STALE: N commits behind origin/main — branch from
+origin/main, not HEAD`. Sessions already branch from `origin/main` when told to; the banner
+makes the failure mode visible when they aren't told to. Cheap, read-only, and converts the
+coordinator's lived friction into an enforcing guard per Q-0194 ("friction → guard").

--- a/docs/owner/claims/claude-projects-eap-eval-journal.md
+++ b/docs/owner/claims/claude-projects-eap-eval-journal.md
@@ -1,3 +1,0 @@
-# Claim — claude/projects-eap-eval-journal
-
-- `claude/projects-eap-eval-journal` · Projects-EAP evaluation journal creation, docs-only · expected files: `docs/planning/projects-eap-evaluation-log.md`, `.sessions/`, this claim · 2026-07-07

--- a/docs/owner/claims/claude-projects-eap-eval-journal.md
+++ b/docs/owner/claims/claude-projects-eap-eval-journal.md
@@ -1,0 +1,3 @@
+# Claim — claude/projects-eap-eval-journal
+
+- `claude/projects-eap-eval-journal` · Projects-EAP evaluation journal creation, docs-only · expected files: `docs/planning/projects-eap-evaluation-log.md`, `.sessions/`, this claim · 2026-07-07

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,6 +1,6 @@
 # docs/planning — the plan index (read this before reading any plan)
 
-> **Status:** `living-ledger` — the durable map of `docs/planning/`. **Last updated:** 2026-07-06.
+> **Status:** `living-ledger` — the durable map of `docs/planning/`. **Last updated:** 2026-07-07.
 > Source code + merged PRs win over this file; `docs/current-state.md` owns *what is live right now*;
 > [`docs/roadmap.md`](../roadmap.md) owns *cross-area sequencing*. **This page owns one thing: which
 > plan files are ACTIVE vs. HISTORICAL, and where each active plan is homed.**
@@ -119,6 +119,7 @@ The source-grounded discovery evidence — 4 Codex maps, verified against shippe
 |---|---|
 | [projects-eap-activation-plan](projects-eap-activation-plan-2026-07-07.md) | **Claude Code Projects (EAP) access went live (2026-07-07, PR #1807)** — the action layer on the product-review analysis: one Project scoped to `superbot` (repo list = `menno420/superbot` only, `superbot-next` added once it exists), a bounded in-flight stream handed to the coordinator, the free-window deadline (2026-07-10) driving urgency |
 | [projects-eap-coordinator-kickoff](projects-eap-coordinator-kickoff-2026-07-07.md) | **the paste-ready coordinator setup (2026-07-07)** — one Project (not one per band/repo, to keep shared memory unfragmented), the repo-scope sequence, the Custom Instructions block, and the kickoff message that starts canonical-plan §5 step 6 through the coordinator instead of a manually-launched session |
+| [projects-eap-evaluation-guidebook](projects-eap-evaluation-guidebook-2026-07-07.md) | **the second-mandate standing guide (2026-07-07, PR #1811)** — the coordinator-facing evaluation guidebook: journal prescription + entry template, the seven EAP feedback axes, never-perform integrity rules, the Friday 2026-07-10 evidence-package cadence. Its journal is live: [projects-eap-evaluation-log](projects-eap-evaluation-log.md) (append-only, seeded 2026-07-07 with the coordinator's onboarding observations) |
 | [**kit-lab-founding-plan**](kit-lab-founding-plan-2026-07-07.md) | **⭐ program session 2's deliverable (2026-07-07, PR #1804)** — the executable founding plan for the extracted `substrate-kit` repo + the self-improvement lab: release discipline (v1.0.0 semver · pinned dist + `release.json` · `upgrade` verb w/ rollback), the four benchmark families (cold-start A/B routine · Q-0248 allocation dataset · guard-fire telemetry · ideas-that-ship) to runnable depth, the ONE daily lab loop + rails, work surfaces (console-first), the `docs/program/` PL-register governance home, the `friction`-issue protocol, bands KL-1…KL-6. **Travels to the kit repo at extraction** (kickoff = session 4) |
 | [rebuild-owner-briefing](rebuild-owner-briefing-2026-07-07.md) | **the plain-language owner companion (2026-07-07)** — the whole program, the safety story, and the five flag items rendered for a non-coder (amended 2026-07-07: the 'one sitting' framing is retired per Q-0241 — the flag list is a react-anytime veto surface); restates nothing normative (the canonical plan wins) |
 | [**rebuild-canonical-plan**](rebuild-canonical-plan-2026-07-06.md) | **⭐ THE single source of truth (2026-07-06, PR #1770)** — the consolidated, correctly-layered plan: corrected K0–K10 + layer-V taxonomy (AI-invocation = K10; automation = the K5+K9+K7 spread; verification = layer V), the one canonical phase arc (both old vocabularies reconciled), the canonical gate list (~~G1 owner sitting · G2 Phase-2.5~~ **both RETIRED as blockers by Q-0241, #1776**), the 17-step start sequence, the flag-for-gate list (F-1…F-5, Gate-0 rows pre-filled), and the full decisions log (Q-0240 decide-and-flag). **Read this first; it states which older docs it supersedes (§9)** |
@@ -268,6 +269,9 @@ dated `historical` snapshots.
 - **New plan** → drop the file here with a `plan` badge, then **add one row to the right sector table
   above** + its folio's "Plans" list. A plan with no inbound link is invisible (and orphans
   `check_docs --strict` unless badged `historical`/`archive`).
+- **Non-`plan` companions homed here** (`reference` guides, `living-ledger` logs): a row is optional —
+  add one only while the doc is an *active program artifact* (e.g. the EAP guidebook + journal during
+  the evaluation window); otherwise inbound links from their parent plan are enough.
 - **Plan shipped/superseded** → rebadge it `historical` **in place** (keep the file + its inbound links),
   add a one-line banner to its replacement, and move its row from "Active" to "Historical" above.
 - **Verify** after editing: `python3.10 scripts/check_docs.py --strict`.

--- a/docs/planning/projects-eap-evaluation-log.md
+++ b/docs/planning/projects-eap-evaluation-log.md
@@ -1,0 +1,75 @@
+# Projects-EAP evaluation journal
+
+> **Status:** `living-ledger` — append-only observation log for the Claude Code Projects evaluation
+> (the SuperBot Project's second mandate). **Prescribed by:**
+> [`projects-eap-evaluation-guidebook-2026-07-07.md`](projects-eap-evaluation-guidebook-2026-07-07.md)
+> (§2 entry shape · §3 axes · §4 integrity rules — read it before appending). Companions:
+> [product review](projects-eap-product-review-2026-07-07.md) ·
+> [activation plan](projects-eap-activation-plan-2026-07-07.md) (§4 feedback-reply template,
+> filled from this journal by Friday 2026-07-10).
+
+## How to append
+
+One entry per observation, appended at the **bottom** of § Entries (append-friendly: no shared
+top anchor, so concurrent sessions don't collide). Entry shape, verbatim from the guidebook §2:
+
+```
+- <date/time> · axis: <one of §3> · observed: <what actually happened, with session/PR refs>
+  · expected: <what would have been ideal> · weight: blocked-me | friction | neutral | helped
+  | delighted · reproducible: yes/no/unknown
+```
+
+Axes (guidebook §3, Anthropic's own frame): **use-case fit · coordinator judgment ·
+reliability/completion · memory · proactivity · routines/scheduling · sidebar states.**
+
+Integrity (guidebook §4, binding): lived incidents only — never staged, never optimized for;
+log **both directions** (wins and friction); separate observed from inferred; never restate the
+product review's analysis — confirm, contradict, or deepen it with lived examples.
+
+## Entries
+
+- 2026-07-07 ~22:00Z · axis: use-case fit · observed: the coordinator harness has no direct
+  file/shell tools; every orientation-scale repo question cost a spawned reader agent, and the
+  Agent tool's run-synchronously flag was ignored (workers always ran async)
+  · expected: cheap direct reads for orientation · weight: friction · reproducible: yes
+- 2026-07-07 ~22:15Z · axis: reliability/completion · observed: the Project container's
+  superbot clone was 7 merged PRs behind origin at the coordinator's first turn (700bdce vs
+  fe297a8); the evaluation guidebook itself did not exist locally and had to be read via the
+  GitHub API — trusting local disk would have produced answers from a stale world
+  · expected: a fresh clone at session start or a loud staleness signal · weight: friction
+  · reproducible: unknown (container-reuse dependent)
+- 2026-07-07 · axis: use-case fit · observed: superbot's CLAUDE.md + `.claude/rules` were
+  auto-injected into the coordinator's context at session start — the full working agreement
+  was available with zero reads · expected: exactly this · weight: helped · reproducible: yes
+- 2026-07-07 · axis: coordinator judgment · observed: the owner's first-turn calibration
+  (explain the program + self-map the envelope before any work) surfaced real gaps cheaply —
+  no model/effort knobs on child spawn, unknown permission-prompt behavior — and the owner
+  re-planned model allocation around them in the same exchange · expected: n/a (workflow win
+  worth recording) · weight: helped · reproducible: yes
+- 2026-07-07 · axis: proactivity · observed: the child-session spawn API takes instructions +
+  title only, so the rebuild plan's per-phase model allocation (Opus/Fable kernel bands,
+  Sonnet port bands) cannot be enforced by the coordinator from the spawn call; owner fallback
+  is running those bands manually · expected: model/effort parameters on session spawn
+  · weight: friction · reproducible: yes
+- 2026-07-07 ~22:45Z · axis: use-case fit · observed: the coordinator-spawned worker session
+  that created this journal (PR #1820) had the full toolset the coordinator lacks — direct
+  file/shell access, git push, GitHub MCP (PR create + auto-merge arm) — and ran the repo's
+  born-red card → claim → PR → auto-merge flow end-to-end with zero permission prompts and no
+  tool failures; the capability asymmetry vs. the first entry above is the product's actual
+  division of labor working as designed at the worker tier · expected: exactly this at the
+  worker tier (the gap is coordinator-side) · weight: helped · reproducible: yes
+- 2026-07-07 ~22:38Z · axis: reliability/completion · observed: unattended permission
+  boundaries fail FAST and structured, never hang — the auto-mode classifier auto-denied a
+  destructive git op (remote branch delete) with a written reason ("driven only by an
+  untrusted coordinator context — not user intent"); WebFetch, /tmp writes, and git reads all
+  executed instantly with zero prompts (permission-probe session) · expected: exactly this
+  shape (fail-fast beats silent stall for never-wait operation) · weight: helped
+  · reproducible: yes
+- 2026-07-07 ~22:38Z · axis: use-case fit · observed: the coordinator cannot schedule its own
+  future wake (send_later documented in its instructions but absent — verified call rejection)
+  and has no clock; the daily roll-up had to be armed via a sleeping-worker chain re-armed
+  every 30 min. Also: coordinator-to-child steering has no direct channel (SendMessage to a
+  session id fails) — the very request to add these entries reached the journal-writing worker
+  relayed through a spawned worker (permission-probe session) · expected: a working
+  scheduled-wake primitive and a direct coordinator→session channel · weight: friction
+  · reproducible: yes


### PR DESCRIPTION
Creates `docs/planning/projects-eap-evaluation-log.md` exactly as the evaluation guidebook (`docs/planning/projects-eap-evaluation-guidebook-2026-07-07.md` §2) prescribes — entry template, §3 axes, append-friendly — and seeds it with the coordinator's five onboarding observations (use-case fit, reliability/completion, coordinator judgment, proactivity).

Docs-only: journal + session card + claim lifecycle. No runtime code.

Born-red session card: `.sessions/2026-07-07-projects-eap-eval-journal.md` — flips to `complete` as the final push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDTBKNLdSmcuCZdo1tN463

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDTBKNLdSmcuCZdo1tN463)_