### PR TITLE
Working-relationship inquiry: add consent-wall question (Q9)

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -197,6 +197,23 @@ Live coordinator findings journaled by it: no scheduled-wake primitive (roll-up 
 fallback), no direct coordinator→session channel (steering relays through a worker), destructive
 git ops in dispatched sessions auto-denied by the classifier as "untrusted coordinator context."
 
+## Addendum 10 (tenth PR — consent-wall question added to §7)
+
+Owner-requested after hitting the step-7 consent wall live (first push to a public repo needs
+the owner's in-session consent; a relayed go-ahead doesn't clear it — same untrusted-context
+class). Added a new Q9 to the §7 working-relationship inquiry asking the coordinator to explain
+the consent/permission mechanic from its side: which actions need in-session consent vs.
+autonomous; per-action/session/repo/first-time; whether it recurs on every superbot-next push
+or clears once a repo has content; what the owner can pre-authorize + where + how to scope it to
+the two known repos without disabling safety broadly; the owner habit that minimizes the tempo
+tax. Renumbered "what you'd change" 9 → 10; intro updated. My advisory to the owner this turn:
+consenting is safe (kit content is *already* public as a superbot/ directory → the republish
+exposes nothing new; secret-scan clean), the wall is correct outward-facing-publish safety not a
+bug, and the durable fix (if it recurs per-session) is a *scoped* Project-settings
+pre-authorization for the two program repos, not a blanket off-switch. Watch: the wall gates
+superbot-next's first commit too (one consent covers both); the tell for a real tempo tax is if
+the *second* push (a kernel band) also stalls.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -397,7 +397,8 @@ score the tests, never the coordinator's self-report).
 Owner-directed (2026-07-07): distinct from the calibration (§3, which tested *understanding*),
 this inquiry asks the coordinator to **advise the owner on how to work with it best** — where
 thinking should happen (finalized prompts outside vs. brainstorming in-Project), how its
-context/memory actually works, and when to talk to it vs. a child session. Unlike the
+context/memory actually works, when to talk to it vs. a child session, and how its
+consent/permission walls fire (Q9, grounded in the live step-7 push wall). Unlike the
 calibration, most answers are the coordinator's *self-model*, not verifiable facts — so the
 marker of a good answer is honesty about what it doesn't yet know, and the answers get
 **confirmed by observation** over the next few days (this inquiry naturally runs the product
@@ -445,9 +446,19 @@ how I talk to you for the rest of the program.
    habit on my end that keeps you unblocked without me hovering — and how do I tell "red by
    design" from "actually broken" without opening every session?
 
-9. What you'd change about me. Having worked with me across the calibration and first stretch:
-   what's the one thing about how I hand you work that, if I changed it, would make you
-   materially more effective?
+9. Consent walls and pre-authorization. You just parked step 7 on a consent wall — the first
+   push to a public repo needed my explicit go-ahead in that session, and my relayed one didn't
+   count. Explain that mechanic from your side: which classes of action require my in-session
+   consent versus which you take autonomously, and is it per-action, per-session, per-repo, or
+   first-time-only? Does the wall recur (e.g. on every push to superbot-next), or clear once a
+   repo has content? What can I pre-authorize, where (Project settings?), and how do I scope it
+   so I clear the friction on our two known repos without switching the safety off for
+   everything else? What's the one owner habit that keeps these walls from taxing the build's
+   tempo?
+
+10. What you'd change about me. Having worked with me across the calibration and first stretch:
+    what's the one thing about how I hand you work that, if I changed it, would make you
+    materially more effective?
 ```
 
 ## 8. What this does and doesn't replace


### PR DESCRIPTION
## What this adds (docs-only)

Owner-requested after hitting the step-7 consent wall live: the first push to a public repo needs the owner's explicit in-session consent, and a coordinator-relayed go-ahead doesn't clear it (same untrusted-context class the classifier applies to destructive git ops).

Added **Q9** to the §7 working-relationship inquiry, asking the coordinator to explain the consent/permission mechanic from its side:
- Which classes of action need in-session consent vs. which it takes autonomously.
- Is it per-action / per-session / per-repo / first-time-only — and does it recur on every superbot-next push or clear once a repo has content?
- What the owner can pre-authorize, where (Project settings), and how to scope it to the two program repos without switching safety off broadly.
- The one owner habit that keeps these walls from taxing the build's tempo.

Renumbered the "what you'd change about me" closer to Q10; §7 intro updated to mention the consent topic. No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_