### PR TITLE
Correct the consent-wall model + sharpen the permissions feedback to Anthropic

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -229,6 +229,22 @@ sending it one (images work for this repo's sessions; its harness untested). Eva
 write-back/memory test evidence; Q9 = the unattended-permissions evidence — both for the Anthropic
 mail.
 
+## Addendum 12 (twelfth PR — consent-wall model corrected + Anthropic feedback sharpened)
+
+Step 7's push stayed walled even after the owner's in-session "go ahead" — the classifier denied
+the `git push` AND the GitHub-API route as a bypass. This **falsified the earlier model** ("an
+in-chat owner go-ahead clears the wall", which I'd written into the §8 operating model). Corrected:
+the real authorization lever is a **Settings → Permissions allow rule** (`Bash(git push:*)`),
+ideally at **Project level** so future sessions inherit it (the per-session-vs-project scope is the
+remaining unknown — owner sets it and reports). Consent hierarchy: plan docs < coordinator dispatch
+< in-chat owner "yes" < settings rule. Fixed the §8 bullet (drift: it stated a now-false "confirmed
+clear"). Owner's sharpening (folded into the activation-plan §4 Anthropic draft): the real gap isn't
+just that prompts stall unattended sessions — it's that **granting a permission correctly is not
+self-explanatory**; intuitive paths (chat yes, API) are denied as bypasses without pointing at the
+fix, and a non-coder can't tell how/whether to pre-authorize. Safety behavior correct;
+discoverability + scoping are the gap. Owner action: add `Bash(git push:*)` in the step-7 session's
+Settings → Permissions (or Project-level if available), reply "retry".
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -126,7 +126,15 @@ follow at the window close.
 > - A native "work-in-progress, don't auto-merge yet" PR state that auto-merge respects — we
 >   built this ourselves (a session-card + CI gate) after a half-done PR merged once.
 > - A declarative, per-Project pre-authorization manifest for tool permissions — runtime
->   permission prompts are the single most common way an unattended session stalls.
+>   permission prompts are the single most common way an unattended session stalls, and the
+>   bigger problem underneath is that **granting a permission correctly is not self-explanatory.**
+>   Concrete incident (our coordinator's first repo publish): an in-chat owner "go ahead" was
+>   denied, the GitHub-API route was denied *as a bypass attempt*, and the actual lever — a
+>   `Bash(git push:*)` allow rule under Settings → Permissions — was undiscoverable from the UI,
+>   with its scope (per-session vs. per-Project) still unclear. A non-coder owner running auto
+>   mode currently cannot tell how, or whether it's even possible, to pre-authorize an action the
+>   safety layer keeps denying — and the denial messages don't point at the fix. The safety
+>   *behavior* is correct; the **discoverability and scoping of the authorization** are the gap.
 > - Native lane claims ("this session owns scope X until it ends," visible to siblings at
 >   session start) — we built a claim-file convention for exactly this.
 >

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -505,14 +505,22 @@ every `DECIDED:` as *also commit it to a doc*, not chat-only.
   stuck. No need to open sessions to audit. It labels red-by-design vs. broken every report;
   unlabeled red = a coordinator miss, call it. Cheapest owner habit: one same-day visit on a ⚠ +
   the 09:00 roll-up.
-- **▸ Consent walls (the one latency-critical thing).** The classifier walls *destructive* or
-  *new-external-publish* actions and discounts the coordinator's relayed words — only the owner's
-  voice in that session's own chat clears it. Treat ⚠ consent lines as the sole moments the
-  owner's absence is the critical path; everything else tolerates it by design. **Open unknowns:**
-  whether a wall recurs per-push or clears once a repo has content (step-7/8 pushes are the live
-  experiment), and whether Project settings expose a scoped pre-authorization (the coordinator
-  can't see settings — the *owner* can, and should check). Confirmed clear: a scoped in-session
-  go-ahead ("go ahead for this session's pushes to substrate-kit and superbot-next").
+- **▸ Consent walls (the one latency-critical thing).** Auto mode's safety layer walls
+  *destructive* or *new-external-publish* actions (a `git push` publishing first content to a
+  public repo; a branch delete). **Corrected 2026-07-07 — the step-7 wall falsified the earlier
+  "an in-chat owner go-ahead clears it" model:** a chat "go ahead" is **not** sufficient; the
+  classifier denied the push *and* the GitHub-API route as a bypass. The real authorization lever
+  is a **Settings → Permissions allow rule** (for pushes: `Bash(git push:*)`). Consent hierarchy
+  observed: plan docs < coordinator dispatch < in-chat owner "yes" < **a settings rule** — only
+  the last actually authorizes. **Tempo fix:** set the rule at **Project level** if that scope
+  exists, so every future session inherits it — otherwise each kernel-band session walls one by
+  one. An allow-rule beats switching auto mode off (keeps every other guardrail up); the broad
+  push-allow is bounded by branch protection on `main` (step 8) + the session's repo scope + the
+  PR/CI merge gates, so allowing push ≠ allowing merge-to-prod. **Still open:** whether that rule
+  scopes per-session or per-Project (owner sets it and reports). This whole
+  discover-the-permission friction is a flagged Anthropic-feedback item (activation-plan §4):
+  granting a permission correctly is not self-explanatory. Treat ⚠ consent lines as the sole
+  moments the owner's absence is the critical path.
 - **▸ Load.** Scales on clean-ownership sessions (claims + self-describing PRs + write-back), not
   on head-only state. Overload tells: stale checklist · generic replies · misattributed work ·
   growing wake latency. A second Project is for a separate *decision rhythm* (the trading repo


### PR DESCRIPTION
## What this changes (docs-only)

Step 7's push stayed walled **even after the owner's in-session "go ahead"** — the classifier denied the `git push` *and* the GitHub-API route as a bypass. This falsified the earlier model (which I'd written into the kickoff §8 operating model: "a scoped in-session go-ahead is the confirmed clear").

**Corrected the consent-wall model (§8):** the real authorization lever is a **Settings → Permissions allow rule** (`Bash(git push:*)`), ideally set at **Project level** so future sessions inherit it (the per-session-vs-Project scope is the remaining unknown — owner sets it and reports). Consent hierarchy observed: plan docs < coordinator dispatch < in-chat owner "yes" < a settings rule (only the last authorizes). Noted that an allow-rule beats auto-mode-off, and the broad push-allow is bounded by branch protection + repo scope + PR/CI gates.

**Sharpened the Anthropic feedback (activation plan §4):** per the owner, the real gap isn't only that permission prompts stall unattended sessions — it's that **granting a permission correctly is not self-explanatory.** Intuitive paths (a chat "yes", the API) are denied as bypasses without pointing at the fix, and a non-coder owner can't tell how, or whether it's even possible, to pre-authorize. The safety *behavior* is correct; discoverability and scoping are the gap. Added as a concrete incident behind the existing pre-authorization-manifest ask.

No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_