### PR TITLE
Two EAP findings (secrets-field exposure + auto-mode dead-end); correct consent-wall model

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -245,6 +245,29 @@ fix, and a non-coder can't tell how/whether to pre-authorize. Safety behavior co
 discoverability + scoping are the gap. Owner action: add `Bash(git push:*)` in the step-7 session's
 Settings → Permissions (or Project-level if available), reply "retry".
 
+## Addendum 13 (thirteenth PR — two serious EAP findings; consent-wall model corrected again)
+
+Owner opened "Edit environment" (per my wrong permissions guess) and hit two things:
+1. **SECURITY (urgent):** the env-var field holds real credentials (GitHub PAT, DATABASE_URL,
+   OpenAI key) in a box the UI itself warns is "visible to anyone using this environment — don't
+   add secrets." Flagged to the owner: rotate all three (coordinate with the live consumers so
+   prod doesn't break), the PAT is likely removable (integration auth + plan bans PAT-in-env), no
+   secret VALUES recorded anywhere. Captured as an activation-plan §4 feedback bullet
+   (structural finding only, zero values).
+2. **AUTO-MODE DEAD-END:** confirmed via claude-code-guide + owner — cloud Projects are
+   **auto-mode-only** (no prompting-mode switch), there is **no permissions UI** (Edit-environment =
+   Name/Network/EnvVars/SetupScript; Project settings = General/Repositories), and the committed
+   `.claude/settings.json` allow-rule is session-start-only + may be classifier-overridden. So the
+   first-publish push wall may be **un-self-clearable in cloud** → Anthropic escalation. This
+   **falsified my prior §8 "Settings → Permissions allow rule is the lever" correction** — fixed
+   §8 again to the accurate picture + practical unblocks (`/permissions` attempt · local
+   CLI/Remote-Control push · escalate). Both findings sharpened into activation-plan §4 (the
+   auto-mode one reframed as the single highest-signal finding).
+
+Lesson for me: I guessed the UI twice and was wrong twice — should have used claude-code-guide
+before sending the owner clicking (which is how they landed on the secrets screen). Verify
+product-UI claims before directing a non-coder.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -125,16 +125,28 @@ follow at the window close.
 >   invisible without polling.
 > - A native "work-in-progress, don't auto-merge yet" PR state that auto-merge respects — we
 >   built this ourselves (a session-card + CI gate) after a half-done PR merged once.
-> - A declarative, per-Project pre-authorization manifest for tool permissions — runtime
->   permission prompts are the single most common way an unattended session stalls, and the
->   bigger problem underneath is that **granting a permission correctly is not self-explanatory.**
->   Concrete incident (our coordinator's first repo publish): an in-chat owner "go ahead" was
->   denied, the GitHub-API route was denied *as a bypass attempt*, and the actual lever — a
->   `Bash(git push:*)` allow rule under Settings → Permissions — was undiscoverable from the UI,
->   with its scope (per-session vs. per-Project) still unclear. A non-coder owner running auto
->   mode currently cannot tell how, or whether it's even possible, to pre-authorize an action the
->   safety layer keeps denying — and the denial messages don't point at the fix. The safety
->   *behavior* is correct; the **discoverability and scoping of the authorization** are the gap.
+> - **A discoverable, scoped way to authorize an action auto mode blocks — right now there may be
+>   none, and this is our single highest-signal finding.** Auto mode is meant to let sessions run
+>   unattended *without* prompts; but its safety layer *hard-denies* some actions (a first `git
+>   push` publishing to a public repo) rather than prompting — and cloud Projects offer **no switch
+>   to a prompting mode, no discoverable permission-rule UI** (the session's "Edit environment" has
+>   only Name / Network / Environment variables / Setup script; Project settings only General /
+>   Repositories), and the documented `.claude/settings.json` allow-rule (`Bash(git push:*)`) is
+>   read only at session start and, per your own docs, may be overridden by the auto classifier
+>   anyway. Concrete incident (our coordinator's first repo publish): in-chat "go ahead" denied,
+>   GitHub-API route denied as a bypass, no mode to switch to, no settings pane to add a rule — an
+>   autonomous session hit a wall it **could not self-clear**, and a non-coder owner could not find
+>   any way to grant the one action. The safety *behavior* is right; the missing piece is a
+>   **discoverable, scoped pre-authorization** (a per-Project allow-list) so auto mode runs
+>   unattended *and* can be told "these specific actions are fine."
+> - **The environment's only env-var field forces credential exposure.** The cloud environment's
+>   "Environment variables" box is the sole place to set the vars a real setup needs (database URL,
+>   API keys), yet it warns "these are visible to anyone using this environment — don't add secrets
+>   or credentials" with no secure alternative surfaced. So an operator is pushed to either break
+>   their setup or paste live credentials into a field the product itself flags as unsafe —
+>   readable by every autonomous session in the Project, i.e. exactly the surface a prompt-injection
+>   through untrusted content would target. A sealed/reference-variable mechanism (write-only,
+>   masked at rest, unreadable by the session that consumes it) is the missing piece.
 > - Native lane claims ("this session owns scope X until it ends," visible to siblings at
 >   session start) — we built a claim-file convention for exactly this.
 >

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -505,22 +505,25 @@ every `DECIDED:` as *also commit it to a doc*, not chat-only.
   stuck. No need to open sessions to audit. It labels red-by-design vs. broken every report;
   unlabeled red = a coordinator miss, call it. Cheapest owner habit: one same-day visit on a ⚠ +
   the 09:00 roll-up.
-- **▸ Consent walls (the one latency-critical thing).** Auto mode's safety layer walls
-  *destructive* or *new-external-publish* actions (a `git push` publishing first content to a
-  public repo; a branch delete). **Corrected 2026-07-07 — the step-7 wall falsified the earlier
-  "an in-chat owner go-ahead clears it" model:** a chat "go ahead" is **not** sufficient; the
-  classifier denied the push *and* the GitHub-API route as a bypass. The real authorization lever
-  is a **Settings → Permissions allow rule** (for pushes: `Bash(git push:*)`). Consent hierarchy
-  observed: plan docs < coordinator dispatch < in-chat owner "yes" < **a settings rule** — only
-  the last actually authorizes. **Tempo fix:** set the rule at **Project level** if that scope
-  exists, so every future session inherits it — otherwise each kernel-band session walls one by
-  one. An allow-rule beats switching auto mode off (keeps every other guardrail up); the broad
-  push-allow is bounded by branch protection on `main` (step 8) + the session's repo scope + the
-  PR/CI merge gates, so allowing push ≠ allowing merge-to-prod. **Still open:** whether that rule
-  scopes per-session or per-Project (owner sets it and reports). This whole
-  discover-the-permission friction is a flagged Anthropic-feedback item (activation-plan §4):
-  granting a permission correctly is not self-explanatory. Treat ⚠ consent lines as the sole
-  moments the owner's absence is the critical path.
+- **▸ Consent walls (a real EAP limitation, not just latency).** Auto mode's safety layer
+  *hard-denies* certain actions — a `git push` publishing first content to a public repo, a
+  branch delete — and cloud Projects run **auto-mode-only with no switch to a prompting mode**, so
+  there is **no in-session way to approve**: not a chat "go ahead" (denied — it also denied the
+  GitHub-API route as a bypass), not a mode toggle (doesn't exist in cloud). **Corrected twice
+  (2026-07-07) — earlier notes claiming an in-chat go-ahead or a "Settings → Permissions" UI clears
+  it were both wrong:** there is **no permissions UI** in the web app (the session's "Edit
+  environment" holds only Name / Network / Environment variables / Setup script; Project settings
+  only General / Repositories). The only documented lever is a committed **`.claude/settings.json`
+  `permissions.allow: ["Bash(git push:*)"]`** — but it's read at *session start* (useless to an
+  already-running session) and per Claude Code's docs **the auto classifier may override it
+  anyway**. So a first-publish push can be a wall an autonomous cloud session **cannot self-clear**
+  — an Anthropic-escalation item and the program's single strongest feedback finding
+  (activation-plan §4). Practical unblocks: (a) the coordinator tries `/permissions` in-session
+  (may not be wired in web); (b) do the one-time initial push from a **local** Claude Code session
+  (CLI / Remote Control *does* have a prompting mode); (c) escalate. Once repos are populated +
+  branch-protected, routine branch+PR pushes pass — it's specifically *first-publish* and
+  *destructive* verbs that wall. Treat ⚠ consent lines as the sole moments the owner's absence is
+  the critical path.
 - **▸ Load.** Scales on clean-ownership sessions (claims + self-describing PRs + write-back), not
   on head-only state. Overload tells: stale checklist · generic replies · misattributed work ·
   growing wake latency. A second Project is for a separate *decision rhythm* (the trading repo


### PR DESCRIPTION
## What this changes (docs-only)

Opening "Edit environment" to hunt for permission settings surfaced two real issues, both captured for the Anthropic feedback and one requiring a doc correction.

**1. Security finding (activation-plan §4).** The cloud environment's "Environment variables" field is the only place to set setup vars, yet it warns "visible to anyone using this environment — don't add secrets" with no secure alternative — forcing credential exposure readable by every autonomous session (the exact prompt-injection surface). Captured as a feedback bullet — **structural finding only, no secret values recorded anywhere.** (Owner advised separately to rotate the exposed credentials.)

**2. Auto-mode dead-end (activation-plan §4 + kickoff §8 correction).** Confirmed via the claude-code-guide agent + owner inspection: cloud Projects run **auto-mode-only** (no prompting-mode switch), there is **no permissions UI** (Edit-environment = Name/Network/EnvVars/SetupScript; Project settings = General/Repositories), and the documented `.claude/settings.json` allow-rule is read only at session start and may be classifier-overridden. So a first-publish push can be a wall an autonomous cloud session **cannot self-clear** → Anthropic-escalation, reframed as the single highest-signal feedback finding.

This **falsified my prior "Settings → Permissions allow rule is the lever" correction** — the kickoff §8 consent-wall bullet is fixed again to the accurate picture plus practical unblocks (`/permissions` attempt · local CLI/Remote-Control push · escalate). Session card notes the lesson (verify product-UI claims via claude-code-guide before directing a non-coder).

No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_