### PR TITLE
Recalibrate the secrets feedback after owner correction

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -268,6 +268,21 @@ Lesson for me: I guessed the UI twice and was wrong twice — should have used c
 before sending the owner clicking (which is how they landed on the secrets screen). Verify
 product-UI claims before directing a non-coder.
 
+## Addendum 14 (fourteenth PR — recalibrate the secrets feedback after owner correction)
+
+Owner corrected my over-warning: "I will not rotate the tokens, sessions are meant to see and
+use these." Correct — env vars for a running bot's DB/API access are normal, not a misuse; I
+pattern-matched on the "don't add secrets" label without accounting for the fact that the bot
+needs its credentials reachable. Dropped the rotation ask. Recalibrated the activation-plan §4
+feedback bullet: removed the overstated "forces exposure" + the incoherent "unreadable by the
+session that consumes it" (a session must read a value to use it). Accurate framing: the real gap
+is the absence of a **sealed/masked secret option** (injected into the runtime but hidden in
+UI/logs), not "don't store credentials." Residual point kept as awareness only (not an action):
+autonomous sessions + live creds + untrusted input = injection-exfil risk, mitigated by
+least-privilege scoping (DB perms, OpenAI spend cap, fine-grained PAT), not by removal. Lesson:
+the owner is the authority on his own setup; don't escalate a security warning past what the
+evidence supports.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -139,14 +139,17 @@ follow at the window close.
 >   any way to grant the one action. The safety *behavior* is right; the missing piece is a
 >   **discoverable, scoped pre-authorization** (a per-Project allow-list) so auto mode runs
 >   unattended *and* can be told "these specific actions are fine."
-> - **The environment's only env-var field forces credential exposure.** The cloud environment's
->   "Environment variables" box is the sole place to set the vars a real setup needs (database URL,
->   API keys), yet it warns "these are visible to anyone using this environment — don't add secrets
->   or credentials" with no secure alternative surfaced. So an operator is pushed to either break
->   their setup or paste live credentials into a field the product itself flags as unsafe —
->   readable by every autonomous session in the Project, i.e. exactly the surface a prompt-injection
->   through untrusted content would target. A sealed/reference-variable mechanism (write-only,
->   masked at rest, unreadable by the session that consumes it) is the missing piece.
+> - **No masked/sealed secret option — one plainly-visible env-var field for everything.** A real
+>   setup's environment needs live credentials (database URL, API keys) so sessions can use them —
+>   that's expected and correct, not a misuse. The gap is that the *only* place to put them is an
+>   "Environment variables" box the UI labels "visible to anyone using this environment — don't add
+>   secrets," with no **sealed** alternative (a value injected into the runtime but masked in the
+>   UI/logs and not plainly readable or shareable). So credentials that must exist for the bot to
+>   run are also *displayed* as plaintext the product itself tells you not to trust. For an
+>   autonomous program whose sessions also process untrusted content, a masked secret store —
+>   usable by code, not surfaced to humans or easily echoed back — would shrink the exfiltration
+>   surface without breaking the legitimate use. (The ask is a sealed-secret mechanism, not "don't
+>   store credentials" — storing them is unavoidable.)
 > - Native lane claims ("this session owns scope X until it ends," visible to siblings at
 >   session start) — we built a claim-file convention for exactly this.
 >


### PR DESCRIPTION
## What this changes (docs-only)

The owner corrected an over-warning of mine: env vars for a running bot's DB/API access are normal and intended ("sessions are meant to see and use these"), not a misuse. I pattern-matched on the field's "don't add secrets" label without accounting for the fact that the bot needs its credentials reachable.

- **Dropped the rotation ask** — it's the owner's call and a reasonable one.
- **Fixed the activation-plan §4 feedback bullet** so the Anthropic mail stays credible: removed the overstated "forces credential exposure" and the incoherent "unreadable by the session that consumes it" (a session must read a value to use it). Reframed to the accurate, defensible gap: there's no **sealed/masked secret option** (a value injected into the runtime but hidden in the UI/logs), only one plainly-visible field — the ask is a sealed-secret mechanism, not "don't store credentials."
- Kept the residual point as **awareness only** (not an action): autonomous sessions + live credentials + untrusted input = an injection-exfil surface, mitigated by least-privilege scoping (DB perms, OpenAI spend cap, fine-grained PAT), not by removal.

No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_