### PR TITLE
Drop the secrets item from the Anthropic feedback (owner call — keep it incident-backed)

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -283,6 +283,19 @@ least-privilege scoping (DB perms, OpenAI spend cap, fine-grained PAT), not by r
 the owner is the authority on his own setup; don't escalate a security warning past what the
 evidence supports.
 
+## Addendum 15 (fifteenth PR — drop the secrets item from the feedback entirely)
+
+Owner's final call on the secrets thread: *"I don't think the feedback should mention that at
+all, it's unrelated and not a problem, we should focus on actual problems we encounter with the
+Project like the permission gap."* Correct editorial judgment — the sealed-secret item was a
+generic infra observation, not a problem the program actually hit, and padding the Anthropic
+feedback with a non-issue dilutes the real, incident-backed findings. **Removed the §4 sealed-
+secret bullet outright** (not just re-softened). The feedback draft now carries only lived
+problems: the auto-mode permission gap (headline), CI-webhook event gaps, the born-red PR hold,
+native lane claims. Net lesson across addenda 13→15: I escalated a security warning past the
+evidence, then over-corrected into a tangent bullet; the owner cut it. Feedback stays incident-
+backed only.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -139,17 +139,6 @@ follow at the window close.
 >   any way to grant the one action. The safety *behavior* is right; the missing piece is a
 >   **discoverable, scoped pre-authorization** (a per-Project allow-list) so auto mode runs
 >   unattended *and* can be told "these specific actions are fine."
-> - **No masked/sealed secret option — one plainly-visible env-var field for everything.** A real
->   setup's environment needs live credentials (database URL, API keys) so sessions can use them —
->   that's expected and correct, not a misuse. The gap is that the *only* place to put them is an
->   "Environment variables" box the UI labels "visible to anyone using this environment — don't add
->   secrets," with no **sealed** alternative (a value injected into the runtime but masked in the
->   UI/logs and not plainly readable or shareable). So credentials that must exist for the bot to
->   run are also *displayed* as plaintext the product itself tells you not to trust. For an
->   autonomous program whose sessions also process untrusted content, a masked secret store —
->   usable by code, not surfaced to humans or easily echoed back — would shrink the exfiltration
->   surface without breaking the legitimate use. (The ask is a sealed-secret mechanism, not "don't
->   store credentials" — storing them is unavoidable.)
 > - Native lane claims ("this session owns scope X until it ends," visible to siblings at
 >   session start) — we built a claim-file convention for exactly this.
 >


### PR DESCRIPTION
## What this changes (docs-only)

Per the owner: the secrets/env-var observation is unrelated and not a problem the program actually encountered — the feedback should focus on real problems like the permission gap. That's the right editorial call; a generic infra observation dilutes the incident-backed findings.

**Removed the sealed-secret bullet from the activation-plan §4 Anthropic feedback draft outright.** The draft now carries only lived problems:
- The auto-mode permission gap (the headline — a first-publish push an autonomous cloud session can't self-clear).
- CI-webhook event gaps (success/merge-conflict not delivered).
- The born-red "work-in-progress, don't auto-merge yet" PR hold.
- Native lane claims.

No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_