### PR TITLE
EAP finding: 4 KiB cap on spawned-session instructions

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -296,6 +296,22 @@ native lane claims. Net lesson across addenda 13→15: I escalated a security wa
 evidence, then over-corrected into a tangent bullet; the owner cut it. Feedback stays incident-
 backed only.
 
+## Addendum 16 (sixteenth PR — 4 KiB dispatch-instruction cap finding + probe fleet running)
+
+New EAP finding, flagged convergently by me (from the owner's screenshot) and the coordinator
+(from dispatching the permission-probe): **`start_project_session` caps a spawned session's
+instructions at 4096 bytes.** The permission-probe directive exceeded it; the coordinator
+compressed it (all 11 tests + rails + taxonomy + report spec preserved, only prose squeezed) and
+dispatched successfully. For an orchestration product whose job is handing briefs to child
+sessions, 4 KiB is tight — it forces the repo-as-context model (detail in committed docs, terse
+"read X do task N" dispatches) as a hard limit, not a preference. Captured as an activation-plan
+§4 email bullet + a kickoff §8 operating-model "▸ Dispatch budget" note. The permission-probe
+fleet is running (manifest-by-number, scratch-branch-only, cleanup-as-data-point, gotcha-last-
+isolated, six priors cited not re-triggered); its report lands separately as the coordinator's
+own docs-only PR (`docs/planning/projects-eap-permission-probe-report-2026-07-08.md` + evaluation-
+journal pointer + email-ready summary). Only owner-parked item remaining: the step-7 publish
+session (auto-mode first-publish wall).
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -139,6 +139,14 @@ follow at the window close.
 >   any way to grant the one action. The safety *behavior* is right; the missing piece is a
 >   **discoverable, scoped pre-authorization** (a per-Project allow-list) so auto mode runs
 >   unattended *and* can be told "these specific actions are fine."
+> - **The coordinator can pass at most 4096 bytes (4 KiB) of instructions to a session it spawns**
+>   (`start_project_session` hard-caps it). For an orchestration product whose core job is handing
+>   work to child sessions, that's a small budget — a detailed task brief exceeds it easily (our
+>   permission-probe spec hit the cap mid-fleet). It's survivable via the repo-as-context model —
+>   put the detail in a committed file and dispatch a terse "read doc X, do task N" pointer — but
+>   that forces a fetch-from-repo indirection for anything non-trivial and quietly caps how richly
+>   a coordinator can direct a child in-band. A larger cap, or a way to attach a reference doc to a
+>   spawn, would remove a real orchestration bottleneck.
 > - Native lane claims ("this session owns scope X until it ends," visible to siblings at
 >   session start) — we built a claim-file convention for exactly this.
 >

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -524,6 +524,13 @@ every `DECIDED:` as *also commit it to a doc*, not chat-only.
   branch-protected, routine branch+PR pushes pass — it's specifically *first-publish* and
   *destructive* verbs that wall. Treat ⚠ consent lines as the sole moments the owner's absence is
   the critical path.
+- **▸ Dispatch budget — 4 KiB per spawn (2026-07-08 finding).** The coordinator can pass at most
+  **4096 bytes** of instructions to a session it spawns (`start_project_session` hard-cap). So it
+  cannot hand a child a full brief inline — task detail lives in a **committed doc** and the
+  dispatch is a terse pointer ("read X, do task N"). This is *why* briefs must be committed and the
+  coordinator points children at the plan rather than restating it (it reinforces the
+  repo-as-context model, but as a hard limit, not a preference); an over-long dispatch simply
+  fails. Also an activation-plan §4 feedback item.
 - **▸ Load.** Scales on clean-ownership sessions (claims + self-describing PRs + write-back), not
   on head-only state. Overload tells: stale checklist · generic replies · misattributed work ·
   growing wake latency. A second Project is for a separate *decision rhythm* (the trading repo


### PR DESCRIPTION
## What this adds (docs-only)

New EAP finding, flagged convergently from the owner's screenshot and by the coordinator while dispatching the permission-probe: **`start_project_session` caps a spawned session's instructions at 4096 bytes (4 KiB).** The permission-probe directive exceeded it; the coordinator compressed it (all 11 tests + rails + taxonomy + report spec preserved) and dispatched successfully.

- **Activation-plan §4 (Anthropic feedback):** added as an incident-backed bullet — for an orchestration product whose core job is handing work to child sessions, 4 KiB is a small budget; survivable via the repo-as-context model (detail in a committed file, terse "read doc X, do task N" dispatch) but a real bottleneck; a larger cap or an attach-a-reference-doc mechanism would fix it.
- **Kickoff §8 operating model:** added a "▸ Dispatch budget — 4 KiB per spawn" note, since it explains *why* the coordinator points children at committed docs rather than inlining briefs (a hard limit, not a preference).

The permission-probe fleet itself is running and lands as the coordinator's own separate docs-only PR (`projects-eap-permission-probe-report-2026-07-08.md`). No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_