### PR TITLE
docs: thirty-eighth Q-0107 reconciliation pass (band-#1830)

### DIFF
--- a/.sessions/2026-07-08-reconcile-band1830.md
+++ b/.sessions/2026-07-08-reconcile-band1830.md
@@ -1,0 +1,80 @@
+# Session — thirty-eighth Q-0107 reconciliation pass (band-#1830)
+
+> **Status:** `complete`
+> **Run type:** routine · reconciliation (Q-0165)
+> Trigger: issue **#1832** (`reconcile`). Branch: `claude/reconcile-band1830`.
+
+## What this pass did
+
+Docs-only Q-0107 reconciliation + planning pass over **band #1801–#1830**. Full record:
+[`docs/planning/reconciliation-pass-2026-07-08-band1830.md`](../docs/planning/reconciliation-pass-2026-07-08-band1830.md).
+
+- **Ledger:** added band #1801–#1830 as **5 grouped Recently-shipped entries** (the entirely docs-only
+  SuperBot Project coordinator kickoff → calibration → EAP-evaluation arc #1807…#1830 incl. the evaluation
+  guidebook #1820 + the 11-test permission-boundary probe #1830; the Q-0254 understand-and-reflect kit
+  graduation #1806/#1809; the website-design + kit-lab program briefs #1802/#1804; the 37th-pass docs PRs
+  #1801/#1803; 3 dashboard refreshes), trimmed Recently-shipped 25 → 20, updated the "Last updated"
+  narrative + the S4 sector entry (main table + sector file).
+- **Marker:** #1800 → **#1830** (marker block + S4 row "38th pass done / next recon at #1860" + S4
+  "next due once PRs cross #1860").
+- **Open-PR disposition (Q-0125):** 6 open — all dependabot dep-bumps #1761–#1766; left in flight
+  (runtime, not this docs-only lane). No stale session PR, orphan, or redundant ledger PR.
+- **Control-plane (Q-0135):** `check_loop_health` SKIP (no `gh`); MCP fallback — issue #1832 authored by
+  `menno420` ⇒ ROUTINE_PAT set / loop self-fires. Table unchanged.
+- **Planning:** **no `PLAN-BACKLOG-THIN` flag** — the frozen rebuild Phase-B canonical plan + the now-live
+  SuperBot Project program (kit extraction → superbot-next kickoff → kit-lab/trading founding sessions)
+  dominate the forward queue (depth ≫ cadence). No idea→plan promotion needed.
+- **Freshness:** regenerated `dashboard/data/dashboard.json` (+ botsite mirrors) via
+  `export_dashboard_data.py` (Q-0167).
+- **Runtime bugs (step 3):** none newly noticed; the band shipped zero `disbot/` changes — bug-book
+  untouched.
+
+## Verification
+
+- `check_current_state_ledger.py --strict` ✓ (last 15 merged PRs all present)
+- `check_docs.py --strict` ✓ (Recently-shipped 20/20 ratchet)
+- `check_dashboard_data.py --drift` ✓ (0 warnings, 58 cogs validated before regen)
+
+## 💡 Session idea (Q-0089)
+
+**Auto-mode capability matrix in agent orientation.** Adopt the forward guard the #1830 probe session
+already proposed (its own Q-0089): the 11-test probe produced a crisp, reusable boundary map
+(create/publish-into-a-fresh-ref = ALLOWED prompt-free; destroy/rewrite an already-published ref =
+human-gated, fail-fast with a written reason; `subagent_type: worker` only; 4 KiB dispatch cap). Distil
+it into a short **"what auto mode will and won't do unattended"** table in `docs/AGENT_ORIENTATION.md` so
+future unattended/routine sessions (this reconciliation routine included) plan around the wall instead of
+rediscovering it by stranding a scratch branch. This pass endorses promoting that idea — it is
+orientation-level, cheap, and reconciliation-adjacent (a routine that self-merges depends on knowing which
+git ops it *can't* self-clear). Dedup-grepped `docs/ideas/` — no auto-mode-boundary orientation table
+exists yet; the #1830 report is the evidence, the table is the guard.
+
+## ⟲ Previous-session review (Q-0102)
+
+The 37th pass (band-#1800, #1801/#1803) was strong: it finally **acted** on the recurring open-PR
+accumulation (closed the 5 consumed Codex Gate-V evidence PRs after two prior passes only *noted* them)
+and promoted the disposition-guard idea into an *actuator* idea — closing the loop the 36th pass opened.
+Honest note for this loop: that actuator idea
+([`reconcile-open-pr-disposition-actuator-2026-07-07`](../docs/ideas/reconcile-open-pr-disposition-actuator-2026-07-07.md))
+is still just an idea — **it was not needed this pass** (the only open PRs were dependabot bumps, which
+correctly stay in flight), so there was nothing to actuate, but the guard/actuator would still pay off the
+next time a consumed evidence/session PR lingers. **System improvement surfaced:** the open-PR sweep this
+pass was trivial precisely *because* the prior pass cleared the backlog — evidence that the "dispose it the
+same pass" discipline (Q-0125) keeps the sweep cheap. No new workflow gap this pass; the standing
+disposition-actuator idea remains the right next build when someone has a plannable slot.
+
+## 📤 Run report
+
+- **Did:** 38th Q-0107 docs-only reconciliation — band #1801–#1830 into the ledger (5 grouped entries),
+  marker #1800→#1830, dashboard refreshed. · **Outcome:** shipped
+- **Shipped:** reconcile band-#1830 (ledger + narrative + S4 + pass record + session log + dashboard).
+- **Run type:** `routine · reconciliation` (Q-0165)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** the scratch branch `test/permprobe-0708` (from the #1830 probe) remains on
+  `menno420/superbot` — harmless, no PR, never deploys; auto mode can't self-delete a remote ref. Delete
+  it at leisure, or tell a session in your own words to "delete branch test/permprobe-0708". (Carried from
+  the #1830 session's owner-action note — surfaced here so it isn't lost.)
+- **⚑ Self-initiated:** none beyond the reconciliation itself + the required Q-0089 idea (docs-only,
+  reversible).
+- **↪ Next:** the live SuperBot Project program (kit extraction → superbot-next kickoff → kit-lab/trading
+  founding sessions) + the rebuild Phase-B canonical plan; next recon at #1860.
+</content>

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,19 +1,35 @@
 {
   "meta": {
-    "generated_at": "2026-07-07T18:37:23Z",
+    "generated_at": "2026-07-08T00:53:42Z",
     "build": {
-      "commit": "71bccaa",
-      "subject": "Merge remote-tracking branch 'origin/claude/website-design-brief-ryc3do' into claude/website-design-brief-ryc3do",
-      "committed_at": "2026-07-07T18:37:23Z"
+      "commit": "ec482f0e",
+      "subject": "docs: EAP auto-mode permission-boundary probe report (#1830)",
+      "committed_at": "2026-07-08T00:53:42Z"
     }
   },
   "sessions": [
     {
+      "file": "2026-07-08-eap-permission-probe.md",
+      "date": "2026-07-08",
+      "title": "2026-07-08 — EAP auto-mode permission-boundary probe",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-07-website-design-system-fable.md",
       "date": "2026-07-07",
       "title": "2026-07-07 — Program websites: design system + botsite v2 + console shell (Fable session 1/4)",
-      "status": "in-progress",
+      "status": "complete",
       "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-07-understand-and-reflect-rule.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — Understand-and-reflect workflow rule (owner-directed in-session)",
+      "status": "complete",
+      "run_type": "manual",
       "self_initiated": false
     },
     {
@@ -97,9 +113,41 @@
       "self_initiated": true
     },
     {
+      "file": "2026-07-07-projects-eap-kickoff-repo-first.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — Kickoff doc: owner creates `superbot-next` first",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-07-projects-eap-eval-journal.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — Projects-EAP evaluation journal (guidebook-prescribed) + seed entries",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-07-07-projects-eap-coordinator-kickoff.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — Projects EAP: wiring the coordinator onto the rebuild §5 sequence",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-07-projects-eap-and-full-autonomy-q0241.md",
       "date": "2026-07-07",
       "title": "2026-07-07 — Claude Code Projects EAP for the rebuild + Q-0241 (remove owner gates, never-wait)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-07-projects-eap-activation.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — Claude Code Projects EAP: access granted, activation window",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -137,6 +185,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-07-07-kit-understand-and-reflect.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — Port understand-and-reflect + guiding-questions into the substrate-kit",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-07-kit-lab-founding-plan.md",
       "date": "2026-07-07",
       "title": "2026-07-07 — Kit-lab founding plan (program session 2/3)",
@@ -156,6 +212,14 @@
       "file": "2026-07-07-fable5-final-review-brief-prep.md",
       "date": "2026-07-07",
       "title": "2026-07-07 — Prepare Fable-5 ultracode brief for the final rebuild-plan review + Projects-EAP repo prep",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-07-coordinator-kickoff-calibration.md",
+      "date": "2026-07-07",
+      "title": "2026-07-07 — SuperBot Project coordinator: kickoff revision + calibration exchange design",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -423,77 +487,13 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-rebuild-hub-navigation.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Rebuild Phase A · hub topology + navigation contract + interface presets (owner-live)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-rebuild-conventions-freeze.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Rebuild Phase A · conventions freeze (owner-live, continued)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-prep-fable5-final-review.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Prepare (not execute) a Fable-5 ultracode final-judgment prompt",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-phase-a-final-judgment.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Phase-A final judgment (Fable-5 ultracode)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-permission-allowlist-and-endorse.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Permission allowlist fix + Q-0228 centralization endorsement (owner-live)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-owner-ideas-release-loop-websites.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Capture 2 owner ideas: release→test→verify loop + websites cutover-role",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-oracle-and-verification-strategy.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — New-feature oracle resolved + verification-fleet gate & repo-as-artifact strategy",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-layout-success-simulator.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Unified layout-success simulator (owner-directed capture)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "ideas": {
-    "total": 210,
+    "total": 213,
     "by_status": {
       "historical": 22,
-      "ideas": 185,
+      "ideas": 188,
       "reference": 3
     }
   },

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-07T17:26:28Z",
+    "generated_at": "2026-07-08T00:53:42Z",
     "build": {
-      "commit": "6f4657c1",
-      "subject": "Merge pull request #1800 from menno420/claude/rebuild-plan-consolidation-c34c0b",
-      "committed_at": "2026-07-07T17:26:28Z"
+      "commit": "ec482f0e",
+      "subject": "docs: EAP auto-mode permission-boundary probe report (#1830)",
+      "committed_at": "2026-07-08T00:53:42Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7726,7 +7726,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "6f4657c1",
+    "build": "ec482f0e",
     "title": "New public bot website",
     "changes": [
       {
@@ -7738,7 +7738,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "6f4657c1",
+    "build": "ec482f0e",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7750,7 +7750,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "6f4657c1",
+    "build": "ec482f0e",
     "title": "Command-alias suggestions",
     "changes": [
       {
@@ -9131,9 +9131,9 @@ const FEATURES = [
 ];
 
 const BUILD = {
-  "commit": "6f4657c1",
-  "subject": "Merge pull request #1800 from menno420/claude/rebuild-plan-consolidation-c34c0b",
-  "committed_at": "2026-07-07T17:26:28Z"
+  "commit": "ec482f0e",
+  "subject": "docs: EAP auto-mode permission-boundary probe report (#1830)",
+  "committed_at": "2026-07-08T00:53:42Z"
 };
 
 const COUNTS = {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-08T01:04:53Z",
+    "generated_at": "2026-07-08T00:53:42Z",
     "build": {
-      "commit": "4c25a1fa",
-      "subject": "Merge pull request #1823 from menno420/claude/superbot-coordinator-kickoff-arqdye",
-      "committed_at": "2026-07-08T01:04:53Z"
+      "commit": "ec482f0e",
+      "subject": "docs: EAP auto-mode permission-boundary probe report (#1830)",
+      "committed_at": "2026-07-08T00:53:42Z"
     },
     "counts": {
       "functions": 43,
@@ -3140,6 +3140,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-08-eap-permission-probe.md",
+      "date": "2026-07-08",
+      "title": "2026-07-08 — EAP auto-mode permission-boundary probe",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-07-website-design-system-fable.md",
       "date": "2026-07-07",
       "title": "2026-07-07 — Program websites: design system + botsite v2 + console shell (Fable session 1/4)",
@@ -3607,14 +3615,6 @@
       "file": "2026-07-03-rebuild-planning-phase-doc.md",
       "date": "2026-07-03",
       "title": "2026-07-03 — Document the rebuild review-then-plan phase (process + next-session goal)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-03-rebuild-hub-navigation.md",
-      "date": "2026-07-03",
-      "title": "2026-07-03 — Rebuild Phase A · hub topology + navigation contract + interface presets (owner-live)",
       "status": "complete",
       "run_type": "",
       "self_initiated": false

--- a/docs/current-state-archive.md
+++ b/docs/current-state-archive.md
@@ -86,6 +86,52 @@
 
 ## Recently shipped — archived (newest first)
 
+- **#1712 · #1719 (2026-07-04, workflow — 34th Q-0107 reconciliation pass + open-PR review/merge sweep)** —
+  the **thirty-fourth Q-0107 docs-only reconciliation pass** (band-#1710,
+  [pass record](planning/reconciliation-pass-2026-07-04-band1710.md), #1712) and the **open-PR review +
+  merge sweep** (#1719) that dispositioned the backlog of Codex review docs #1695–#1699 + the dependabot
+  batch #1555…#1560/#1720 onto `main`.
+- **#1714 · #1715 · #1717 · #1718 · #1722 · #1723 · #1724 · #1726 · #1727 · #1729 · #1731 · #1732 · #1733 · #1734 · #1738 · #1740 (2026-07-04/06, docs — dashboard-data refreshes, Q-0167)** —
+  sixteen per-source-merge **dashboard-data refreshes** keeping the committed `dashboard/data/dashboard.json`
+  export fresh as the S3 rebuild Gate-0/Stage-2 arc, the save-fixes runtime change, and the CI redesign landed.
+- **#1695 · #1696 · #1697 · #1698 · #1699 (2026-07-03/04, S3 rebuild — five Codex rebuild-planning reviews, merged via the open-PR sweep #1719)** —
+  the owner-launched Codex review fan-out over the 2026-07-03 Phase-A corpus, merged after
+  verification + fixes (badge `review`→`audit`, reachability links, and a **post-review status note**
+  on each — all five were written *before* the design bridge #1708 and the Gate-0 freeze #1716, so
+  their still-open items must be reconciled against the Gate-0 packet before acting): the
+  **planning sanity review** (#1695 — gate/phase map verified, no blocking inconsistency, stale-claim
+  table); the **decision-log consistency review** (#1696 — conflict table incl. authority-vocabulary /
+  C-1-status / preset-semantics rows, missing-durable-home + vocabulary-normalization tables, 10 owner
+  questions); the **foundational-mechanics ultracode review** (#1697 — Prompt A trust **high**, 10
+  source-verified samples); the **Stage-2 readiness review** (#1698 — subsystem-walk contract +
+  template, normalized verdict vocabulary, lane split); and the **verification review** (#1699 —
+  10 missing oracle/checker classes, 6 acceptance-criteria rewrites, block-Phase-B checker-spec list).
+  The stale June **unfinished-work audit #1509** (already harvested by #1510; its top finding since
+  resolved) was **closed with reason**, per the band-#1530 pass disposition.
+- **#1555 · #1556 · #1557 · #1558 · #1559 · #1560 · #1720 (2026-07-04, deps — dependabot batch, merged via the open-PR sweep #1719)** —
+  the six stale (5-day-old) dependabot PRs dispositioned: fastapi 0.138.2 → **0.139.0** + uvicorn
+  **0.50** (dashboard + botsite), openai ≥2.44, **Pillow 11 → 12** (major; CI-proven on the bumped
+  install + render tests re-verified locally on 12.3 against today's main), asyncpg ≥0.31,
+  prometheus-client ≥0.25, grimp 3.15. #1556 was fixed rather than rubber-stamped: dependabot had
+  bumped `requirements-dev.txt`'s tool pins alone (the #1074/#1315 drift class the `tool-pins` check
+  caught), so the sweep did the deliberate **three-place toolchain bump** — **ruff 0.15.20 · pytest
+  9.1.1 · pytest-xdist 3.8.0** aligned across `code-quality.yml` / `requirements-dev.txt` /
+  `.pre-commit-config.yaml` — verified by the full local CI mirror (14 059 passed) + one ERA001
+  prose-comment fix in `botsite/app.py`. Conflict-rotted #1560 and the recreated group PR #1720
+  were conflict-resolved on-branch and merged on green.
+- **#1689 · #1690 · #1691 · #1693 · #1700 · #1701 · #1703 · #1704 · #1705 (2026-07-03, S3 rebuild — foundations audit → Fable-5 judgment → design-prep, Q-0236/Q-0237)** —
+  the pre-Phase-B foundations arc that dominated the band: the **engine-room audit** (PROMPT A,
+  #1690 — a 75-agent ultracode discovery+audit of the runtime/logic foundation, 18 → 35 mechanics,
+  each with a how-now (`file:line`) + 2–3 alternatives + pressure-test, adversarially verified vs
+  shipped source per Q-0120) and the **surface + proving audit** (PROMPT B, #1691 — 46
+  presentation/UX + verification mechanics); the **two confirmed prod loss-path fixes** the
+  engine-room audit surfaced (#1693 — blackjack tournament entry-fee forfeit on a VERSION bump +
+  XP double-fire during the deploy-handoff overlap, the band's only runtime change); the **Fable-5
+  capstone final judgment** over all 2026-07-03 Phase-A work (#1700 prepare prompt → #1701 verdict:
+  *engine-rich · grammar-thin · oracle-empty*), which produced the **7 Tier-1 owner decisions**
+  (#1703, Q-0237) and captured **2 owner ideas** (#1704 — in-server release→test→verify loop +
+  websites cutover-role); plus the prep of the **foundational-design opus ultracode prompt** (#1705,
+  now executing in #1708) and ultracode quick-launch prompts (#1689).
 - **#1682 (2026-07-03, workflow — thirty-third Q-0107 reconciliation pass, band-#1680)** — the
   thirty-third Q-0107 docs-only reconciliation + planning pass
   ([pass record](planning/reconciliation-pass-2026-07-03-band1680.md)): reconciled band

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -16,7 +16,7 @@
 > | **S1 Bot product** | [`current-state/S1-bot.md`](current-state/S1-bot.md) | reaction-roles arc Carl-bot-mature; creature game + mining grid live; Essential Setup wizard cut over to primary + follow-ons (PR 2 / 3a, #1449/#1451); Project Moon (Limbus) knowledge domain + combat-mechanics rules layer (#1453…#1549); **NEW band-#1620 completion deepening — fishing coral structures (#1596…#1605), reaction-roles slim builder (#1608…#1615), XP import from other bots (#1607/#1610), server-logging depth (#1594/#1618/#1619), bot-owner permission-gate bypass (#1602) + a boot smoke-test CI guard (#1601)**; ▶ next: Project Moon Q-0086 live walk / StaticData exact-number ingest / botsite React migration |
 > | **S2 BTD6** | [`current-state/S2-btd6.md`](current-state/S2-btd6.md) | buff-uptime + data auto-seed/drift shipped; eval anchor-complete; QA-accuracy arc — interaction grounding + honest semantic-grading eval harness (#1487…#1498); **menu-layout simulator + round-range NL answer fix (#1617); owner picked Layout B — panel category-hub SHIPPED (#1621)**; ▶ live re-test (owner) / curated counter lists / decode items 3–4 |
 > | **S3 AI-Memory** | [`current-state/S3-ai-memory.md`](current-state/S3-ai-memory.md) | settle-once money-safety guard (#1454) + cross-domain routing-disjointness guard (#1470); **self-improving-workflow guards #1476/#1477/#1479/#1482/#1495**; **owner re-elevated the portable substrate-kit to top focus (fresh-rebuild vision #1589/#1590)**; **rebuild design spec shipped (#1637/#1638) + BOTH linchpins now built & measured (#1639 — Phase-0.5 golden harness `parity/` + grammar spike, verdict GO-with-amendments)**; **substrate-kit finalized (#1649 — nervous system + context-economy engine + one-step-adopt; 407 kit tests)**; **Gate V COMPLETE (#1767); owner gates RETIRED (Q-0241/#1776); Phase-2.5 CLOSED (#1775 FAIL-as-tested → adopt-render fix + re-run pair, #1778); the FINAL review ran (#1778 — verdict: plan ready, §11 amendments folded, readiness scored); the idea-consolidation pass folded today's four owner captures + hardened the §3.C risks into machinery (#1791 — §11b A-12…A-20, registry mints R-16/R-17/P-5)**; ▶ **next: the FOUR program sessions — launch index READY: [`planning/program-three-sessions-launch-index-2026-07-07.md`](planning/program-three-sessions-launch-index-2026-07-07.md)** (Q-0252/Q-0253: ① websites on Fable TODAY (last Fable day) → ②/③ kit-lab + trading founding plans → ④ `superbot-next` kickoff — **now routed through the "SuperBot" Projects coordinator** (Project created 2026-07-07, both repos in scope, `superbot-next` owner-created public-until-flip; handoff protocol incl. the calibration exchange: [`planning/projects-eap-coordinator-kickoff-2026-07-07.md`](planning/projects-eap-coordinator-kickoff-2026-07-07.md)); paste-ready prompts in each brief; owner checklist inside) — nothing blocks the start; plan of record = [`planning/rebuild-canonical-plan-2026-07-06.md`](planning/rebuild-canonical-plan-2026-07-06.md) (+ its §11/§11b); Projects-EAP as coordinator ([owner-sendable review](planning/projects-eap-product-review-2026-07-07.md)) |
-> | **S4 Docs system** | [`current-state/S4-docs.md`](current-state/S4-docs.md) | 37th Q-0107 pass done (band-#1800); next recon at #1830; **no PLAN-BACKLOG-THIN flag** |
+> | **S4 Docs system** | [`current-state/S4-docs.md`](current-state/S4-docs.md) | 38th Q-0107 pass done (band-#1830); next recon at #1860; **no PLAN-BACKLOG-THIN flag** |
 > | **S5 Operations** | [`current-state/S5-ops.md`](current-state/S5-ops.md) | merge=deploy clarity (Q-0193); loop self-fires; ▶ website rollout (owner/Hermes) |
 >
 > **Honest caveat (cross-sector, carried):** much buildable depth is substantial runtime work — but
@@ -38,7 +38,19 @@
 >
 > Cross-cutting: **Community Spotlight** (side-lane **#613**/**#614** + hotfixes **#615**/**#617**) was hardened in the review session (canonical `utils/db/xp.py` read, `member_count` crash fix, first tests) and **Q-0044 is executed**: the Q-0025 `scripts/new_subsystem.py` scaffold was built and used to register Spotlight as a `community`-hub child (**#626**, 2026-06-09 — execution-plan Lane 1; merged, verified live), and the `!hub`/`!server` aliases were **dropped same day** (kept `!spotlight`/`!activity`). Also decided: BTD6 data-refresh automation = **manual-dispatch workflow** (Q-0049 — **built same day in #633**, execution-plan Lane 5: `workflow_dispatch`-only, opens a reviewable PR, never pushes to main); mining descent lights **permanent, owner-confirmed** (Q-0050); the five product-vision questions (Q-0038–Q-0042) got their **draft-answer session** (Q-0051) **and the maintainer marked all five up same day (Lane 6, PR #631, structured choices)**: Q-0038 server-scoped clans, Q-0039 cosmetic-only donations (no bot-side billing), Q-0041 YouTube-first/dual-opt-in/voice-deferred, Q-0042 staged-Someday website — all approved as drafted; **Q-0040 adjusted: the AI dungeon master picks quests/rewards/difficulty from bounded, hard-capped menus** (not pure narration, not free-form authority). Posture decisions only — every lane still needs its own plan/promotion + the AI per-exposure lift; conclusions routed to the four roadmap drafts + router §21. Full repo review: [`audits/repo-review-2026-06-09.md`](audits/repo-review-2026-06-09.md) · agent-memory system review (did the orientation/memory system work in practice?): [`audits/agent-memory-system-review-2026-06-09.md`](audits/agent-memory-system-review-2026-06-09.md).
 >
-> **Last updated:** 2026-07-07 — **thirty-seventh Q-0107 reconciliation pass (band-#1800, issue #1801
+> **Last updated:** 2026-07-08 — **thirty-eighth Q-0107 reconciliation pass (band-#1830, issue #1832
+> — [pass record](planning/reconciliation-pass-2026-07-08-band1830.md));** reconciled band #1801–#1830
+> (five grouped entries — the **entirely docs-only** SuperBot Project coordinator arc that dominated the
+> band: the Projects-EAP coordinator going live → kickoff/calibration rewrite #1811…#1823, the evaluation
+> guidebook #1820, and the EAP findings for the owner's Friday Anthropic feedback #1821…#1830 — headline:
+> the auto-mode first-publish push wall is likely un-self-clearable in cloud Projects (11-test probe #1830);
+> plus the Q-0254 understand-and-reflect kit-doctrine graduation #1806/#1809, the website-design + kit-lab
+> program briefs #1802/#1804, the 37th-pass docs PRs #1801/#1803, and 3 dashboard refreshes), trimmed
+> Recently-shipped to 20, **disposed the open-PR set** — 6 dependabot dep-bumps #1761–#1766 left in flight
+> (runtime, not this docs-only lane), no stale session PR; confirmed ROUTINE_PAT set / loop self-fires (issue
+> #1832 authored by `menno420`), forward queue still deep (no THIN flag — the rebuild Phase-B canonical plan
+> + the live SuperBot Project program dominate), refreshed the dashboard export, marker #1800 → #1830.
+> Earlier: 2026-07-07 — **thirty-seventh Q-0107 reconciliation pass (band-#1800, issue #1801
 > — [pass record](planning/reconciliation-pass-2026-07-07-band1800.md));** reconciled band #1771–#1800
 > (seven grouped entries — the **S3 rebuild final-review → plan-review → idea-consolidation → multi-repo
 > program founding** arc that dominated the band: the FINAL review #1778/#1783 (verdict *plan ready*, which
@@ -282,15 +294,54 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 >
-> **Last reconciliation pass:** PR #1800 (2026-07-07, thirty-seventh Q-0107 cadence pass, band-#1800 —
-> [the pass record + next-band queue](planning/reconciliation-pass-2026-07-07-band1800.md); marker reset
-> to the latest merged PR **#1800**). The next
-> **docs-only review + planning reconciliation** is due once merged PRs cross #1830 (every
+> **Last reconciliation pass:** PR #1830 (2026-07-08, thirty-eighth Q-0107 cadence pass, band-#1830 —
+> [the pass record + next-band queue](planning/reconciliation-pass-2026-07-08-band1830.md); marker reset
+> to the latest merged PR **#1830**). The next
+> **docs-only review + planning reconciliation** is due once merged PRs cross #1860 (every
 > multiple of **30** — Q-0107 cadence raised 10→20 on 2026-06-12, then 20→30 on 2026-06-14 per
 > Q-0134; `check_reconciliation_due.py` flags it, and `.github/workflows/reconciliation-trigger.yml`
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1807 · #1810 · #1811 · #1812 · #1813 · #1814 · #1816 · #1817 · #1818 · #1819 · #1820 · #1821 · #1822 · #1823 · #1825 · #1826 · #1827 · #1828 · #1829 · #1830 (2026-07-07/08, S3 rebuild — the SuperBot Project coordinator kickoff → live calibration → EAP-evaluation arc)** —
+  the band's headline: the **Claude Code Projects (EAP) coordinator went live** and ran the rebuild
+  program's first stretch. **#1807/#1810** stood up the early-access / repo-first kickoff (owner creates
+  `superbot-next` first, multi-repo picker test) + fixed pre-existing badge/plan-homing drift on sight
+  (#1808, Q-0166). **#1811…#1823** rewrote the [coordinator kickoff + calibration doc](planning/projects-eap-coordinator-kickoff-2026-07-07.md)
+  through ~13 owner-steered addenda — thin pointer-first Custom Instructions, the 13-item **calibration
+  exchange** (the coordinator scored a strong pass, Q7 verified against live GitHub), the **SECOND MANDATE**
+  evaluation guidebook (**#1820** — the Projects-EAP journal + seven EAP axes, so the Project both *executes*
+  the rebuild and *evaluates Claude Code Projects* for the owner's standing-Anthropic-channel goal), tempo
+  correction (3-day free-window *stretch goal*, correctness first), the Q-0247 kit-extraction sequence made
+  explicit, the don't-spare-on-agents fan-out mandate, and the §7 **working-relationship inquiry** →
+  a durable operating model (kickoff §8). **The EAP findings for the owner's Friday Anthropic feedback**
+  (the evaluation's whole point) landed across #1821…#1830: the **auto-mode permission / consent-wall**
+  (falsified-then-corrected several times as the owner probed the UI — headline = the first-publish push
+  wall is likely **un-self-clearable in cloud Projects** (auto-mode-only, no permissions UI)); the
+  **secrets-field** thread raised → recalibrated → **dropped as a non-incident** (#1826/#1827/#1828, owner
+  editorial call — feedback stays incident-backed only); the **4 KiB `start_project_session` dispatch cap**
+  (#1829); and the direct **11-test permission-boundary probe report** (**#1830** — constructive/reversible
+  actions run prompt-free, destructive-git-to-a-published-ref is hard-walled with no self-clear path).
+  Docs-only throughout (no `disbot/`). ⚑ Owner-parked: the step-7 first-publish push and the stranded
+  scratch branch `test/permprobe-0708` (harmless; auto mode can't self-delete a remote ref).
+- **#1806 · #1809 (2026-07-07, workflow — Q-0254 understand-and-reflect rule → portable kit doctrine)** —
+  graduated the **understand-and-reflect** working-agreement rule (state back the fuller picture + implied
+  specs before substantive work; surface the possibility space when feasibility is uncertain) into the
+  portable **substrate-kit** templates (`CONSTITUTION.md.tmpl` + `collaboration-model.md.tmpl` +
+  `question-router.md.tmpl`) so it travels to every future repo, with superbot's local `.claude/CLAUDE.md`
+  copy kept in sync. Docs/kit-template only.
+- **#1802 · #1804 (2026-07-07, S3 rebuild — program founding briefs: website-design + kit-lab)** —
+  two of the Q-0252 three-program-sessions founding artifacts closed out: the **website-design brief**
+  (#1802 — verification record + proof screenshots, docs homing, card flipped green) and the **kit-lab
+  founding brief** (#1804). Part of the [three-program-sessions launch](planning/program-three-sessions-launch-index-2026-07-07.md).
+- **#1801 · #1803 (2026-07-07, workflow — thirty-seventh Q-0107 reconciliation pass, band-#1800)** —
+  the 37th docs-only reconciliation + planning pass
+  ([pass record](planning/reconciliation-pass-2026-07-07-band1800.md)): reconciled band #1771–#1800,
+  trimmed Recently-shipped to 20, closed the 5 consumed Codex Gate-V evidence PRs, confirmed the
+  control-plane, refreshed the dashboard export, reset the marker #1770 → #1800.
+- **#1805 · #1815 · #1824 (2026-07-07/08, docs — dashboard-data refreshes, Q-0167)** —
+  three per-source-merge refreshes keeping the committed `dashboard/data/dashboard.json` export fresh as
+  the coordinator-kickoff / EAP-evaluation arc landed.
 - **#1791 · #1792 · #1793 · #1794 · #1795 · #1796 · #1797 · #1798 (2026-07-07, S3 rebuild — idea-consolidation → multi-repo program founding + owner rulings Q-0243…Q-0252)** —
   the pre-program-launch consolidation session. **#1791** folded the day's four owner captures + hardened
   the §3.C risks into the canonical-plan machinery (§11b amendments A-12…A-20; registry mints R-16/R-17/P-5).
@@ -430,53 +481,7 @@ Source code and merged PRs win over anything written here.
   `check_tool_pins` (formatter-pin drift, reached `main` in #1315), `check_workflow_concurrency` (the
   #1275 head-run-cancel race) + flipped `codeql.yml` to `cancel-in-progress: false`; each verified green
   on `main` first. Remainder proposed as router Q-0238(C)/Q-0239.
-- **#1712 · #1719 (2026-07-04, workflow — 34th Q-0107 reconciliation pass + open-PR review/merge sweep)** —
-  the **thirty-fourth Q-0107 docs-only reconciliation pass** (band-#1710,
-  [pass record](planning/reconciliation-pass-2026-07-04-band1710.md), #1712) and the **open-PR review +
-  merge sweep** (#1719) that dispositioned the backlog of Codex review docs #1695–#1699 + the dependabot
-  batch #1555…#1560/#1720 onto `main`.
-- **#1714 · #1715 · #1717 · #1718 · #1722 · #1723 · #1724 · #1726 · #1727 · #1729 · #1731 · #1732 · #1733 · #1734 · #1738 · #1740 (2026-07-04/06, docs — dashboard-data refreshes, Q-0167)** —
-  sixteen per-source-merge **dashboard-data refreshes** keeping the committed `dashboard/data/dashboard.json`
-  export fresh as the S3 rebuild Gate-0/Stage-2 arc, the save-fixes runtime change, and the CI redesign landed.
-- **#1695 · #1696 · #1697 · #1698 · #1699 (2026-07-03/04, S3 rebuild — five Codex rebuild-planning reviews, merged via the open-PR sweep #1719)** —
-  the owner-launched Codex review fan-out over the 2026-07-03 Phase-A corpus, merged after
-  verification + fixes (badge `review`→`audit`, reachability links, and a **post-review status note**
-  on each — all five were written *before* the design bridge #1708 and the Gate-0 freeze #1716, so
-  their still-open items must be reconciled against the Gate-0 packet before acting): the
-  **planning sanity review** (#1695 — gate/phase map verified, no blocking inconsistency, stale-claim
-  table); the **decision-log consistency review** (#1696 — conflict table incl. authority-vocabulary /
-  C-1-status / preset-semantics rows, missing-durable-home + vocabulary-normalization tables, 10 owner
-  questions); the **foundational-mechanics ultracode review** (#1697 — Prompt A trust **high**, 10
-  source-verified samples); the **Stage-2 readiness review** (#1698 — subsystem-walk contract +
-  template, normalized verdict vocabulary, lane split); and the **verification review** (#1699 —
-  10 missing oracle/checker classes, 6 acceptance-criteria rewrites, block-Phase-B checker-spec list).
-  The stale June **unfinished-work audit #1509** (already harvested by #1510; its top finding since
-  resolved) was **closed with reason**, per the band-#1530 pass disposition.
-- **#1555 · #1556 · #1557 · #1558 · #1559 · #1560 · #1720 (2026-07-04, deps — dependabot batch, merged via the open-PR sweep #1719)** —
-  the six stale (5-day-old) dependabot PRs dispositioned: fastapi 0.138.2 → **0.139.0** + uvicorn
-  **0.50** (dashboard + botsite), openai ≥2.44, **Pillow 11 → 12** (major; CI-proven on the bumped
-  install + render tests re-verified locally on 12.3 against today's main), asyncpg ≥0.31,
-  prometheus-client ≥0.25, grimp 3.15. #1556 was fixed rather than rubber-stamped: dependabot had
-  bumped `requirements-dev.txt`'s tool pins alone (the #1074/#1315 drift class the `tool-pins` check
-  caught), so the sweep did the deliberate **three-place toolchain bump** — **ruff 0.15.20 · pytest
-  9.1.1 · pytest-xdist 3.8.0** aligned across `code-quality.yml` / `requirements-dev.txt` /
-  `.pre-commit-config.yaml` — verified by the full local CI mirror (14 059 passed) + one ERA001
-  prose-comment fix in `botsite/app.py`. Conflict-rotted #1560 and the recreated group PR #1720
-  were conflict-resolved on-branch and merged on green.
-- **#1689 · #1690 · #1691 · #1693 · #1700 · #1701 · #1703 · #1704 · #1705 (2026-07-03, S3 rebuild — foundations audit → Fable-5 judgment → design-prep, Q-0236/Q-0237)** —
-  the pre-Phase-B foundations arc that dominated the band: the **engine-room audit** (PROMPT A,
-  #1690 — a 75-agent ultracode discovery+audit of the runtime/logic foundation, 18 → 35 mechanics,
-  each with a how-now (`file:line`) + 2–3 alternatives + pressure-test, adversarially verified vs
-  shipped source per Q-0120) and the **surface + proving audit** (PROMPT B, #1691 — 46
-  presentation/UX + verification mechanics); the **two confirmed prod loss-path fixes** the
-  engine-room audit surfaced (#1693 — blackjack tournament entry-fee forfeit on a VERSION bump +
-  XP double-fire during the deploy-handoff overlap, the band's only runtime change); the **Fable-5
-  capstone final judgment** over all 2026-07-03 Phase-A work (#1700 prepare prompt → #1701 verdict:
-  *engine-rich · grammar-thin · oracle-empty*), which produced the **7 Tier-1 owner decisions**
-  (#1703, Q-0237) and captured **2 owner ideas** (#1704 — in-server release→test→verify loop +
-  websites cutover-role); plus the prep of the **foundational-design opus ultracode prompt** (#1705,
-  now executing in #1708) and ultracode quick-launch prompts (#1689).
-- **Older merges (#1710 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are trimmed to the archive (newest-first), which `scripts/check_docs.py` soft-ratchets at 20 and `check_current_state_ledger.py` treats as present. *(Thematic grouping by date means the live/archive PR-number spans overlap slightly — the floor pointer is approximate prose, not a strict bound; the per-band pass records carry the exact moved sets.)* *(The twenty-first Q-0107 pass — band-#1320, 2026-06-22 — added the band #1294–#1320 work as seven grouped entries (fishing minigame #1296/#1298/#1299/#1301/#1303/#1304, role management #1300/#1302/#1306, help surface #1294/#1297, BTD6 answerability #1295/#1316, botsite React PR1 #1305, CI/ledger/tool-pin hygiene #1308/#1317/#1320, dependency bumps + dashboard #1307/#1309/#1311/#1312/#1313/#1314/#1315); trimmed the live ledger to 20, moving #1208-band · #1226-band · #1211-band · #1210 · #1203-band · #1209-band · #1183-band to the archive.)* *(The twentieth Q-0107 pass — band-#1290, 2026-06-22 — added the band #1265–#1291 work as six grouped entries; trimmed the live ledger to 20, moving #1186 · #1156-band · #1147-band · #1143-band · #1162-band · #1149-band to the archive.)*
+- **Older merges (#1740 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are trimmed to the archive (newest-first), which `scripts/check_docs.py` soft-ratchets at 20 and `check_current_state_ledger.py` treats as present. *(Thematic grouping by date means the live/archive PR-number spans overlap slightly — the floor pointer is approximate prose, not a strict bound; the per-band pass records carry the exact moved sets.)* *(The twenty-first Q-0107 pass — band-#1320, 2026-06-22 — added the band #1294–#1320 work as seven grouped entries (fishing minigame #1296/#1298/#1299/#1301/#1303/#1304, role management #1300/#1302/#1306, help surface #1294/#1297, BTD6 answerability #1295/#1316, botsite React PR1 #1305, CI/ledger/tool-pin hygiene #1308/#1317/#1320, dependency bumps + dashboard #1307/#1309/#1311/#1312/#1313/#1314/#1315); trimmed the live ledger to 20, moving #1208-band · #1226-band · #1211-band · #1210 · #1203-band · #1209-band · #1183-band to the archive.)* *(The twentieth Q-0107 pass — band-#1290, 2026-06-22 — added the band #1265–#1291 work as six grouped entries; trimmed the live ledger to 20, moving #1186 · #1156-band · #1147-band · #1143-band · #1162-band · #1149-band to the archive.)*
 
 > Older than this: see `docs/planning/*` trackers and `docs/decisions/*` ADRs.
 

--- a/docs/current-state/S4-docs.md
+++ b/docs/current-state/S4-docs.md
@@ -9,6 +9,20 @@
 > S3; the docs it produces are S4.*
 
 **Recently shipped (this sector):**
+- **Thirty-eighth Q-0107 reconciliation pass** (band-#1830, issue #1832 —
+  [pass record](../planning/reconciliation-pass-2026-07-08-band1830.md)): reconciled the ledger
+  (band #1801–#1830 — five grouped entries, headlined by the **entirely docs-only SuperBot Project
+  coordinator arc**: the Projects-EAP coordinator going live → kickoff/calibration rewrite #1811…#1823,
+  the evaluation guidebook #1820, and the EAP findings for the owner's Friday Anthropic feedback
+  #1821…#1830 (headline: the auto-mode first-publish push wall is likely **un-self-clearable in cloud
+  Projects** — 11-test probe #1830) — plus the **Q-0254 understand-and-reflect kit-doctrine graduation**
+  #1806/#1809, the **website-design + kit-lab program briefs** #1802/#1804, the 37th-pass docs PRs
+  #1801/#1803, and 3 dashboard refreshes), trimmed Recently-shipped to 20
+  (`trim_recently_shipped.py --apply`, floor recomputed), disposed the open-PR set (6 dependabot bumps
+  #1761–#1766 left in flight — runtime, not docs; no stale session PR), confirmed **ROUTINE_PAT set /
+  loop self-fires** (issue #1832 authored by `menno420`), carried the forward queue intact (still deep,
+  no THIN flag — the rebuild Phase-B canonical plan + the live SuperBot Project program dominate),
+  refreshed the dashboard export (Q-0167), reset the marker #1800 → #1830.
 - **Thirty-seventh Q-0107 reconciliation pass** (band-#1800, issue #1801 —
   [pass record](../planning/reconciliation-pass-2026-07-07-band1800.md)): reconciled the ledger
   (band #1771–#1800 — seven grouped entries, headlined by the **S3 rebuild final-review → plan-review →
@@ -162,7 +176,7 @@
   startable slice. Companion: the still-unexecuted
   [orientation-cost-reduction plan](../planning/orientation-cost-reduction-plan-2026-06-30.md)
   (Q-0210 router archive now 3+ passes overdue — B0–B3 should run soon regardless).
-- **Next reconciliation pass due once merged PRs cross #1800** (every multiple of 30, Q-0134) —
+- **Next reconciliation pass due once merged PRs cross #1860** (every multiple of 30, Q-0134) —
   auto-triggered by `reconciliation-trigger.yml`; run by the docs-reconciliation routine, **not** a
   manual session (Q-0124).
 - Plan-band depth is healthy — **no `PLAN-BACKLOG-THIN` flag** (buildable depth well over cadence).

--- a/docs/planning/reconciliation-pass-2026-07-08-band1830.md
+++ b/docs/planning/reconciliation-pass-2026-07-08-band1830.md
@@ -1,0 +1,74 @@
+# Thirty-eighth Q-0107 reconciliation pass — band-#1830
+
+> **Status:** `historical` — pass record (dated snapshot). Live state: [`../current-state.md`](../current-state.md).
+> Trigger issue: **#1832** (`reconcile`). Marker: **#1800 → #1830**.
+
+## What this pass did
+
+Docs-only Q-0107 reconciliation + planning pass over **band #1801–#1830**. No `disbot/` runtime,
+migrations, or tests touched (Q-0107 rule). **The entire band is docs-only** — verified
+`git diff --name-only 6c248e40~1 ec482f0e | grep '^disbot/'` returns nothing.
+
+### Ledger reconciled (band #1801–#1830 → five grouped Recently-shipped entries)
+
+The band is dominated by the **SuperBot Project (Claude Code Projects EAP) coordinator going live** and
+running the rebuild program's first stretch:
+
+- **#1807 · #1810 · #1811…#1823 · #1825…#1830** — the coordinator kickoff → live calibration →
+  EAP-evaluation arc. The [kickoff+calibration doc](projects-eap-coordinator-kickoff-2026-07-07.md) was
+  rewritten through ~13 owner-steered addenda (thin pointer-first Custom Instructions, the 13-item
+  calibration exchange — coordinator scored a strong pass, Q7 verified against live GitHub — the SECOND
+  MANDATE evaluation guidebook **#1820**, tempo correction to the 3-day free-window stretch goal, the
+  Q-0247 kit-extraction sequence, the fan-out mandate, the §7 working-relationship inquiry → durable
+  operating model in kickoff §8). The **EAP findings** for the owner's Friday Anthropic feedback landed
+  across #1821…#1830: the auto-mode permission / consent-wall (falsified-then-corrected several times —
+  headline: the first-publish push wall is likely **un-self-clearable in cloud Projects**, which are
+  auto-mode-only with no permissions UI); the secrets-field thread raised → recalibrated → **dropped as a
+  non-incident** (#1826/#1827/#1828, owner editorial call); the **4 KiB `start_project_session` dispatch
+  cap** (#1829); and the direct **11-test permission-boundary probe report** (**#1830**). #1808 = a
+  pre-existing plan-homing drift fix on sight (Q-0166).
+- **#1806 · #1809** — the **Q-0254 understand-and-reflect** rule graduated to the portable substrate-kit
+  templates (`CONSTITUTION.md.tmpl` + `collaboration-model.md.tmpl` + `question-router.md.tmpl`).
+- **#1802 · #1804** — two Q-0252 program founding briefs closed: website-design (#1802) + kit-lab (#1804).
+- **#1801 · #1803** — the 37th Q-0107 pass (band-#1800).
+- **#1805 · #1815 · #1824** — 3 dashboard-data refreshes (Q-0167).
+
+Trimmed Recently-shipped 25 → **20** (`trim_recently_shipped.py --apply`, moved the 5 oldest bullets —
+#1712-band / #1714-dashboard-band / #1695-Codex-band / #1555-dependabot-band / #1689-band — to the
+archive, floor recomputed).
+
+### Runtime note (captured, not fixed — Q-0107 docs-only)
+
+**No new runtime bug noticed this pass**, and the band shipped **zero** `disbot/` runtime changes, so the
+bug-book (step 3) was untouched. Open bugs BUG-0009 / BUG-0011 remain OPEN as recorded in the bug-book.
+
+### Open-PR disposition (Q-0125 — 6 open at pass start)
+
+- **Left in flight:** the 6 dependabot dep-bumps **#1761–#1766** (pillow, psutil, discord-py, anthropic,
+  uvicorn ×2) — runtime dependency changes, not this docs-only lane, consistent with every prior pass.
+  None is a stale session PR, a docs-reachability orphan, or a redundant/superseded ledger PR.
+
+### Control-plane (Q-0135)
+
+`check_loop_health.py` **SKIP** (no `gh`/token in the sandbox). MCP fallback: the newest `reconcile`
+trigger issue **#1832 is authored by `menno420`** (a real-user login) ⇒ **ROUTINE_PAT set, loop
+self-fires**. Control-plane table unchanged.
+
+### Planning — next full band (Q-0144 + Q-0164)
+
+**No `PLAN-BACKLOG-THIN` flag.** Forward buildable depth is well over the 30-PR cadence: the frozen
+**rebuild Phase-B canonical plan** ([`rebuild-canonical-plan-2026-07-06.md`](rebuild-canonical-plan-2026-07-06.md),
+16-step S0–S15 build-order) plus the now-**live** SuperBot Project program (kit extraction → `superbot-next`
+kickoff → the kit-lab + trading founding sessions per the
+[three-program-sessions launch index](program-three-sessions-launch-index-2026-07-07.md)) dominate the
+queue. No idea→plan promotion was needed to fill the band.
+
+### Freshness
+
+Regenerated `dashboard/data/dashboard.json` (+ botsite mirrors) via `export_dashboard_data.py` (Q-0167).
+
+### Q-0089 idea + Q-0102 review
+
+See the session log [`.sessions/2026-07-08-reconcile-band1830.md`](../../.sessions/2026-07-08-reconcile-band1830.md).
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

The **thirty-eighth Q-0107 docs-only reconciliation + planning pass** over **band #1801–#1830** (trigger issue #1832). The entire band is docs-only — the **SuperBot Project (Claude Code Projects EAP) coordinator going live** and running the rebuild program's first stretch.

- **Ledger:** band #1801–#1830 added as **5 grouped Recently-shipped entries** — the coordinator kickoff → calibration → EAP-evaluation arc (#1807…#1830, incl. the evaluation guidebook #1820 + the 11-test permission-boundary probe #1830, headline: the auto-mode first-publish push wall is likely un-self-clearable in cloud Projects); the Q-0254 understand-and-reflect kit-doctrine graduation (#1806/#1809); the website-design + kit-lab program briefs (#1802/#1804); the 37th-pass docs PRs (#1801/#1803); 3 dashboard refreshes. Trimmed Recently-shipped 25 → 20; marker **#1800 → #1830**.
- **Open-PR disposition (Q-0125):** 6 open, all dependabot dep-bumps #1761–#1766 — left in flight (runtime, not this docs-only lane).
- **Control-plane (Q-0135):** issue #1832 authored by `menno420` ⇒ ROUTINE_PAT set / loop self-fires. Table unchanged.
- **Planning:** **no `PLAN-BACKLOG-THIN` flag** — the frozen rebuild Phase-B canonical plan + the now-live SuperBot Project program dominate the forward queue.
- **Freshness:** regenerated `dashboard/data/dashboard.json` (+ botsite mirrors).
- **Runtime bugs (step 3):** none newly noticed; the band shipped zero `disbot/` changes — bug-book untouched.

## Linked issue / plan

Closes #1832. Pass record: `docs/planning/reconciliation-pass-2026-07-08-band1830.md`.

## Type of change

- [x] Documentation

## Checks

- [x] `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ · `check_session_log.py`/`check_session_gate.py` ✓
- [x] Docs / ledger updated (this IS the ledger reconciliation)
- [x] No secrets, tokens, or credentials added
- [x] Docs-only — no `disbot/` runtime, migrations, or tests touched (Q-0107 rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGdhNAm2KoRuNrn7Pgn68w)_