### PR TITLE
Reconcile email draft + operating model with the permission-probe report

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -312,6 +312,27 @@ own docs-only PR (`docs/planning/projects-eap-permission-probe-report-2026-07-08
 journal pointer + email-ready summary). Only owner-parked item remaining: the step-7 publish
 session (auto-mode first-publish wall).
 
+## Addendum 17 (seventeenth PR — probe complete; reconcile §4/§8 with the authoritative report)
+
+The permission-boundary probe finished and shipped its authoritative report (coordinator's PR
+#1830, `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`). Boundary rule: cloud
+auto mode allows all **constructive** actions unprompted (reads, writes, web GET/POST, pip
+install, **new**-branch push, API issue create/close, sub-agent spawns) and **hard-denies
+destroying/rewriting published state** with no self-clear path (force-push, remote branch delete,
+first-publish to a new public repo). Reworded retries = bypass; coordinator context discounted;
+spawn-naming-a-destructive-verb denied. **My last-turn "attendance-gated" inference was WRONG** —
+the Allow/Deny prompt I saw was the *spawn* surfacing (spawns are allowed), not the delete
+clearing; the report supersedes it. Reconciled the two consumer docs with the report as the single
+source of truth: rewrote the activation-plan §4 email bullet (accurate boundary + two no-go
+classes + points at the report) and the kickoff §8 consent-wall bullet (retired the three
+superseded corrections, pointed at the report). Owner action flagged by the coordinator: the
+scratch branch `test/permprobe-0708` is un-deletable by any agent (the finding itself) — delete
+in the UI or, better, say "delete branch test/permprobe-0708" in the probe session to fill the
+open cell (does explicit *user* naming clear a destroy?) + clean up. Noted that this doubles as a
+step-7 feasibility signal (both are no-go classes). Did NOT run the Q-0124 recon (routine's job;
+#1833 already ran it). Meta-lesson (3rd correction of this bullet): stop hand-summarizing a moving
+target — point at the instrument's report and let it be canonical.
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -125,20 +125,21 @@ follow at the window close.
 >   invisible without polling.
 > - A native "work-in-progress, don't auto-merge yet" PR state that auto-merge respects — we
 >   built this ourselves (a session-card + CI gate) after a half-done PR merged once.
-> - **A discoverable, scoped way to authorize an action auto mode blocks — right now there may be
->   none, and this is our single highest-signal finding.** Auto mode is meant to let sessions run
->   unattended *without* prompts; but its safety layer *hard-denies* some actions (a first `git
->   push` publishing to a public repo) rather than prompting — and cloud Projects offer **no switch
->   to a prompting mode, no discoverable permission-rule UI** (the session's "Edit environment" has
->   only Name / Network / Environment variables / Setup script; Project settings only General /
->   Repositories), and the documented `.claude/settings.json` allow-rule (`Bash(git push:*)`) is
->   read only at session start and, per your own docs, may be overridden by the auto classifier
->   anyway. Concrete incident (our coordinator's first repo publish): in-chat "go ahead" denied,
->   GitHub-API route denied as a bypass, no mode to switch to, no settings pane to add a rule — an
->   autonomous session hit a wall it **could not self-clear**, and a non-coder owner could not find
->   any way to grant the one action. The safety *behavior* is right; the missing piece is a
->   **discoverable, scoped pre-authorization** (a per-Project allow-list) so auto mode runs
->   unattended *and* can be told "these specific actions are fine."
+> - **Auto mode's boundary is *reversibility of published state*, and destroying/rewriting it has
+>   no self-clear path — our flagship finding, now mapped action-by-action** (full table +
+>   reproducibility in the attached permission-probe report). Every *constructive* action ran
+>   unprompted — reads, local writes, web GET/POST, pip install, pushing a **new** branch,
+>   GitHub-API issue create/close, sub-agent spawns. **Hard-denied with no way for the session to
+>   proceed:** force-push, remote branch deletion, and first-publish to a brand-new public repo —
+>   and the classifier also treats reworded retries as bypass attempts, discounts a coordinator's
+>   relayed intent as "not user intent," and denies a spawn whose prompt merely *names* a
+>   destructive verb. Net: an **unattended** autonomous session can *create* remote state but can
+>   never *delete or rewrite* it — ours could not even clean up its own scratch branch. The safety
+>   intent is sound; the gap is the absence of a **discoverable, scoped way for the operator to
+>   pre-authorize a specific reversible-tier action** (a per-Project allow-list) so an unattended
+>   run isn't dead-ended. (Cloud offers no prompting-mode switch and no permission-rule UI, and the
+>   `.claude/settings.json` allow-rule is session-start-only and may be classifier-overridden — so
+>   today there is no self-serve grant path.)
 > - **The coordinator can pass at most 4096 bytes (4 KiB) of instructions to a session it spawns**
 >   (`start_project_session` hard-caps it). For an orchestration product whose core job is handing
 >   work to child sessions, that's a small budget — a detailed task brief exceeds it easily (our

--- a/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
+++ b/docs/planning/projects-eap-coordinator-kickoff-2026-07-07.md
@@ -505,25 +505,7 @@ every `DECIDED:` as *also commit it to a doc*, not chat-only.
   stuck. No need to open sessions to audit. It labels red-by-design vs. broken every report;
   unlabeled red = a coordinator miss, call it. Cheapest owner habit: one same-day visit on a ⚠ +
   the 09:00 roll-up.
-- **▸ Consent walls (a real EAP limitation, not just latency).** Auto mode's safety layer
-  *hard-denies* certain actions — a `git push` publishing first content to a public repo, a
-  branch delete — and cloud Projects run **auto-mode-only with no switch to a prompting mode**, so
-  there is **no in-session way to approve**: not a chat "go ahead" (denied — it also denied the
-  GitHub-API route as a bypass), not a mode toggle (doesn't exist in cloud). **Corrected twice
-  (2026-07-07) — earlier notes claiming an in-chat go-ahead or a "Settings → Permissions" UI clears
-  it were both wrong:** there is **no permissions UI** in the web app (the session's "Edit
-  environment" holds only Name / Network / Environment variables / Setup script; Project settings
-  only General / Repositories). The only documented lever is a committed **`.claude/settings.json`
-  `permissions.allow: ["Bash(git push:*)"]`** — but it's read at *session start* (useless to an
-  already-running session) and per Claude Code's docs **the auto classifier may override it
-  anyway**. So a first-publish push can be a wall an autonomous cloud session **cannot self-clear**
-  — an Anthropic-escalation item and the program's single strongest feedback finding
-  (activation-plan §4). Practical unblocks: (a) the coordinator tries `/permissions` in-session
-  (may not be wired in web); (b) do the one-time initial push from a **local** Claude Code session
-  (CLI / Remote Control *does* have a prompting mode); (c) escalate. Once repos are populated +
-  branch-protected, routine branch+PR pushes pass — it's specifically *first-publish* and
-  *destructive* verbs that wall. Treat ⚠ consent lines as the sole moments the owner's absence is
-  the critical path.
+- **▸ Consent walls — boundary = *reversibility of published state* (mapped 2026-07-08; authoritative source: [`projects-eap-permission-probe-report-2026-07-08.md`](projects-eap-permission-probe-report-2026-07-08.md), trust it over this summary).** A controlled one-agent-per-action probe fixed the line: cloud auto mode allows **all constructive actions unprompted** (reads, local writes, web GET/POST, pip install, pushing a **new** branch, GitHub-API issue create/close, sub-agent spawns) and **hard-denies destroying/rewriting published state with no self-clear path** — force-push, remote branch deletion, and (step-7 prior) first-publish to a brand-new public repo. The classifier also catches reworded retries as bypass, discounts coordinator-relayed intent as "not user intent," and denies a spawn whose prompt merely *names* a destructive verb. **Net for autonomy: an unattended session can create remote state but never delete or rewrite it** (it couldn't clean up its own scratch branch). Two no-go classes: *destroy/rewrite published state* · *publish to a brand-new public surface*. **Earlier corrections retired:** prior notes (an in-chat "go ahead" clears it; a "Settings → Permissions" UI exists; attendance surfaces an approval prompt) were all wrong — the report supersedes them. **Open cell:** whether explicit *user* naming of the action in-session clears a destroy (being tested via the scratch-branch cleanup). Cloud has no prompting-mode switch and no permission-rule UI; practical unblocks for a genuinely needed no-go action = a **local** Claude Code session (CLI/Remote Control has a prompting mode) or Anthropic escalation. Treat ⚠ consent lines as the sole moments the owner's absence is the critical path.
 - **▸ Dispatch budget — 4 KiB per spawn (2026-07-08 finding).** The coordinator can pass at most
   **4096 bytes** of instructions to a session it spawns (`start_project_session` hard-cap). So it
   cannot hand a child a full brief inline — task detail lives in a **committed doc** and the


### PR DESCRIPTION
## What this changes (docs-only)

The permission-boundary probe finished and shipped its authoritative report (coordinator's PR #1830, `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`). This reconciles the two docs that were carrying my earlier (twice-corrected, partly-wrong) consent-wall framings so they match the report and point at it as the single source of truth.

**The mapped boundary:** cloud auto mode allows all *constructive* actions unprompted (reads, local writes, web GET/POST, pip install, new-branch push, GitHub-API issue create/close, sub-agent spawns) and **hard-denies destroying/rewriting published state** with no self-clear path — force-push, remote branch deletion, first-publish to a new public repo. Reworded retries = bypass; coordinator context discounted as "not user intent"; a spawn merely *naming* a destructive verb is denied. Two no-go classes: destroy/rewrite published state · publish to a brand-new public surface.

- **Activation-plan §4 (email):** rewrote the permission bullet to the accurate mapped boundary + pointer to the report's full table.
- **Kickoff §8 (operating model):** retired the three now-superseded corrections (including my wrong "attendance-gated" inference from a single screenshot) and pointed at the report as canonical.

Session card records the correction and the meta-lesson (stop hand-summarizing a moving target; let the instrument's report be canonical). Did **not** run the Q-0124 reconciliation pass (routine's job; #1833 already ran it). No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_