### PR TITLE
Email currency pass: fill the four test cells + add the "what would fix it" section

### DIFF
--- a/.sessions/2026-07-07-coordinator-kickoff-calibration.md
+++ b/.sessions/2026-07-07-coordinator-kickoff-calibration.md
@@ -333,6 +333,21 @@ step-7 feasibility signal (both are no-go classes). Did NOT run the Q-0124 recon
 #1833 already ran it). Meta-lesson (3rd correction of this bullet): stop hand-summarizing a moving
 target — point at the instrument's report and let it be canonical.
 
+## Addendum 18 (eighteenth PR — email currency pass + "what would fix it" section)
+
+Owner: review the email for currency + add a small "what would fix this" section (project-level
+pre-authorization setting, also useful for chats outside Projects) + send the full email in chat.
+Done: (1) filled the four bracketed test cells from first-day reality (#2 memory = strongest
+result: envelope baked into dispatch templates; #4 unattended = held, prompts fail-fast not hang;
+#1 dedupe + #3 red-vs-broken = honestly marked not-yet-stress-tested, flagged for owner to verify
+from direct observation); (2) permission bullet already current from the probe report (PR #1834);
+(3) added the **"What we think would fix the biggest one"** section — a scoped opt-in
+pre-authorization setting (project + per-repo + per-account), default-off, auditable, and
+explicitly **also useful for non-Project Claude Code sessions** (the auto-mode dead-end isn't
+Projects-specific); (4) refreshed the meta-note (brackets filled; attach the probe report; two
+cells owner-verify; send interim now). Full email pasted in chat for the owner to send (external
+comms are his).
+
 ## Docs audit (Q-0104)
 
 `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ (exit 0; #1802/#1804/

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -81,12 +81,16 @@ rather than restate them unchanged.
 
 Diana's confirmation email explicitly invites feedback at
 `claude-code-early-access@anthropic.com`. Below is a **ready-to-send, external-facing** draft —
-shorter and less repo-internal than the full product-review doc, but traceable to it. Fill in
-the bracketed examples from what actually happened — the coordinator's evaluation journal
-([guidebook](projects-eap-evaluation-guidebook-2026-07-07.md) §2/§5) feeds them. **Owner
-intent (2026-07-07 evening): send ~tomorrow, after first real coordinator use** — interim,
-incident-backed feedback beats waiting for the Friday deadline; a second, fuller note can
-follow at the window close.
+shorter and less repo-internal than the full product-review doc, but traceable to it.
+**Updated 2026-07-08 after the first day of real use:** the four-tests section is filled from
+what actually happened, and the permission finding is now the mapped, reproducible boundary from
+the probe (`projects-eap-permission-probe-report-2026-07-08.md` — **attach or link it**), plus a
+"what would fix it" section (the scoped pre-authorization setting). Two cells are inferred from
+the coordinator's reports rather than a clean pre-registered run — **#1 duplicate-work** (no real
+collision occurred yet) and **#3 red-vs-broken** (no CI-fail vs. born-red side-by-side yet); the
+owner should confirm/tweak both from direct observation before sending. **Owner intent: send this
+interim note now (2026-07-08), not at the Friday window close** — incident-backed feedback lands
+harder early; a fuller note can follow. External comms are the owner's to send.
 
 > Subject: Re: Claude Code Projects EAP — feedback after first activation
 >
@@ -109,14 +113,25 @@ follow at the window close.
 > declares itself done — our bar is "does this beat what we already built," not "is this a
 > nice-to-have."
 >
-> **Four things we're specifically checking, and what we found:**
-> 1. *Duplicate-work prevention* — [what happened when two sessions/tasks overlapped]
-> 2. *Write-back / "say it once" memory* — [whether a requirement stated once actually carried
->    into a fresh session without restating]
-> 3. *Distinguishing "intentionally incomplete" from "broken"* — [what the sidebar/coordinator
->    showed for a deliberately in-progress PR vs. a CI failure]
-> 4. *Surviving genuinely unattended stretches* — [whether a session ran 20+ minutes with no one
->    at the keyboard without stalling on a permission prompt]
+> **Four things we're specifically checking, and what we found so far (~first day of real use):**
+> 1. *Duplicate-work prevention* — not yet stress-tested: the coordinator ran an 11-agent probe
+>    fleet, but by design each agent owned a disjoint action, so no genuine collision occurred.
+>    Our claim-file discipline carried over and the coordinator kept a single owned work-list.
+>    We'll report the first real overlap.
+> 2. *Write-back / "say it once" memory* — **held, and it's our strongest result.** We stated the
+>    working-authorization envelope once; the coordinator committed it into its own dispatch
+>    templates, so every session it spawns inherits it without us restating — it solved "say it
+>    once" structurally rather than leaning on recall.
+> 3. *Distinguishing "intentionally incomplete" from "broken"* — the coordinator labels "red by
+>    design" vs. "broken" explicitly in every report, and its born-red PRs held red-until-complete
+>    as intended. We haven't yet caught a real CI failure and a born-red hold side by side to
+>    stress how the *sidebar* itself distinguishes them, but the coordinator's narration never
+>    conflated the two.
+> 4. *Surviving genuinely unattended stretches* — **held well.** The coordinator ran the probe
+>    fleet and drafted the control plane fully unattended, and permission prompts fail *fast*
+>    (deny with a written reason) rather than hanging — nothing silently stalled. The only hard
+>    stops were genuine safety walls (below), not hung prompts, which is the right failure shape
+>    for unattended work.
 >
 > **Cross-cutting asks, not specific to Projects** (things that would help any autonomous Claude
 > Code session, ours included):
@@ -150,6 +165,21 @@ follow at the window close.
 >   spawn, would remove a real orchestration bottleneck.
 > - Native lane claims ("this session owns scope X until it ends," visible to siblings at
 >   session start) — we built a claim-file convention for exactly this.
+>
+> **What we think would fix the biggest one.** The permission dead-end has a clean solution that
+> keeps the safety intent fully intact: a **scoped, opt-in pre-authorization setting**. At the
+> Project level (and, ideally, per-repo and per-account), let the operator explicitly enable
+> specific normally-denied action classes for a named scope — e.g. "allow force-push", "allow
+> branch deletion", "allow first-publish to a new public repo", limited to repos X and Y. Default
+> off, so auto mode stays safe-by-default; reviewable and versioned (a settings pane, or a
+> committed allow-list), so it's an *auditable grant*, not a blanket "turn safety off". That one
+> addition turns "an unattended session dead-ends and a present human is the only way through"
+> into "the operator pre-declares, once, what this autonomous run is allowed to do." Crucially it
+> isn't Projects-specific — the same auto-mode dead-end hits **any** unattended Claude Code session,
+> so a general pre-authorized-actions setting (account / repo / session scope) would help every
+> auto-mode user, ordinary chats outside Projects included. It's the natural complement to auto
+> mode: auto mode decides what's safe *by default*; a pre-auth list lets the operator safely widen
+> that, in scope, on purpose.
 >
 > Happy to go deeper on any of these — we have concrete incidents behind each one.
 >


### PR DESCRIPTION
## What this changes (docs-only)

Owner asked to review the Anthropic feedback email for currency and add a proposed-fix section, then send the full email.

- **Filled the four pre-registered test cells** from first-day reality: #2 memory (strongest result — the coordinator baked the authorization envelope into its dispatch templates, so it persists without restating), #4 unattended (held; prompts fail-fast rather than hang). #1 duplicate-work and #3 red-vs-broken are honestly marked *not yet stress-tested* and flagged for the owner to verify from direct observation (they're inferred from the coordinator's reports, not a clean pre-registered run).
- **Permission finding** is already the mapped, reproducible probe boundary (from PR #1834).
- **Added "What we think would fix the biggest one"** — a scoped, opt-in pre-authorization setting (Project + per-repo + per-account, default-off, auditable, not a blanket "safety off"), explicitly noting it would also help **non-Project** Claude Code sessions since the auto-mode dead-end isn't Projects-specific.
- Refreshed the meta-note: attach the probe report, owner-verify two cells, send the interim note now.

The full email is delivered to the owner in chat. No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_