### PR TITLE
Email flagship: fold in the two-layer clear-path finding (classifier vs. credential)

### DIFF
--- a/.sessions/2026-07-08-email-two-layer-flagship.md
+++ b/.sessions/2026-07-08-email-two-layer-flagship.md
@@ -1,0 +1,24 @@
+# 2026-07-08 — Email flagship: fold in the two-layer clear-path finding
+
+> **Status:** `in-progress`
+
+**Scope:** the clear-path test (coordinator PR #1839, merged) resolved the flagship's open half.
+Fold the two-layer result into the Anthropic feedback email
+(`docs/planning/projects-eap-activation-plan-2026-07-07.md` §4). Docs-only. Continuation of the
+coordinator-kickoff thread (prior cards: `2026-07-08-email-compaction-verifiability.md`,
+`2026-07-07-coordinator-kickoff-calibration.md`).
+
+## What I'm about to do
+- **Correct the now-inaccurate claim.** The email currently says destructive ops have "no
+  self-clear path" and an unattended run "dead-ends with a present human as the only way through."
+  The test refined that: the auto-mode **classifier** IS operator-clearable in-session (low bar —
+  a generic "I give you explicit permission" answering a named request sufficed), but a **second**
+  wall (the cloud environment's git credential) 403s the destructive push regardless, which no
+  in-session grant clears.
+- Rewrite the flagship as the **two-layer** finding (classifier: operator-clearable, coordinator
+  not; credential: HTTP 403, unclearable in-session → no path to remote-ref deletion from a cloud
+  session at all).
+- Update the "what would fix it" to note **both layers must move together** (a pre-auth that
+  clears the classifier still 403s unless the git credential carries matching scope).
+- Meta-note: record that the flagship now reflects PR #1839's clear-path addendum.
+- Aligned to the authoritative report addendum, not re-derived from the screenshot.

--- a/.sessions/2026-07-08-email-two-layer-flagship.md
+++ b/.sessions/2026-07-08-email-two-layer-flagship.md
@@ -1,6 +1,6 @@
 # 2026-07-08 — Email flagship: fold in the two-layer clear-path finding
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Scope:** the clear-path test (coordinator PR #1839, merged) resolved the flagship's open half.
 Fold the two-layer result into the Anthropic feedback email
@@ -22,3 +22,34 @@ coordinator-kickoff thread (prior cards: `2026-07-08-email-compaction-verifiabil
   clears the classifier still 403s unless the git credential carries matching scope).
 - Meta-note: record that the flagship now reflects PR #1839's clear-path addendum.
 - Aligned to the authoritative report addendum, not re-derived from the screenshot.
+
+## What shipped (PR #1840)
+- **Flagship rewritten as the two-layer finding.** Layer 1 (auto-mode classifier): operator-clearable
+  in-session at a low bar; coordinator-relay is not. Layer 2 (cloud environment's git credential):
+  destructive push 403s regardless, unclearable in-session → no path from a cloud session to
+  remote-ref deletion, operator present or not. Corrects the prior "no self-clear path / present human
+  the only way through" (the human clears layer 1; layer 2 still stops it).
+- **Fix section** now notes both layers must move together — pre-auth clears the classifier, but the
+  op still 403s unless the git credential carries matching scope.
+- **Meta-note** records the flagship reflects PR #1839's clear-path addendum.
+- Aligned verbatim to the report addendum + eval-log entry the coordinator merged (#1839).
+
+## ⚑ Live corroboration (worth noting)
+This PR could not force-push the post-squash branch — auto mode denied `git push --force-with-lease`
+with `[Git Destructive]` ("the user never named this force-push and its target"). So it ships from a
+**fresh branch** (`claude/eap-email-two-layer-flagship`). The force-push wall the email describes hit
+this very session — a first-hand instance, not a relayed one.
+
+## ⚑ Owner action (unchanged from #1839)
+`test/permprobe-0708` still exists and still needs a human with full git rights to delete (the
+in-session grant cleared the classifier but 403'd at the credential layer). Owner can delete it via the
+GitHub Branches UI whenever.
+
+## ⚑ Self-initiated
+None — owner/coordinator-directed correction (the #1839 card's "↪ Next" explicitly routes this fold-in).
+
+## 💡 Session idea (Q-0089)
+**Ship the email's flagship as a standalone "auto-mode capability + clearance" one-pager** (rows =
+operation, cols = gating layer + what clears it), reusing the coordinator's #1839 capability-matrix
+idea — so the *email* can link a crisp table instead of prose, and the same doc seeds substrate-kit's
+environment-capability template. Dedup: extends #1839's idea toward the email artifact specifically.

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -88,7 +88,10 @@ verifiable source: the probe report (`projects-eap-permission-probe-report-2026-
 Project itself is private and cannot be shared), a committed in-repo artifact, a documented
 Claude Code behaviour, or an
 explicit "not yet tested" marker. The merged-PR count was verified against GitHub (1,741 → stated
-as "~1,700", since the #1837-style counter is shared with issues and overstates merges). Two cells
+as "~1,700", since the #1837-style counter is shared with issues and overstates merges). The flagship now reflects the clear-path follow-up (PR #1839): the
+auto-mode classifier is operator-clearable in-session, but a second wall — the cloud environment's
+git credential — 403s destructive remote git ops regardless, so the email separates the two as
+independent walls. Two cells
 stay honestly unverified — **#1 duplicate-work** (no real collision yet) and **#3 red-vs-broken**
 (no CI-fail vs. born-red side-by-side yet); confirm both from direct observation before sending.
 **Owner intent: send this interim note now (2026-07-08), not at the Friday window close** —
@@ -125,25 +128,33 @@ owner's to send.
 >    its control plane fully unattended; permission prompts deny *fast* with a written reason
 >    rather than hanging, so nothing silently stalled.
 >
-> **Flagship finding — the auto-mode permission boundary** (full action-by-action table and
-> reproduction steps in the probe report, linked below). The line auto mode draws is
-> *reversibility of published state.* Every constructive action ran unprompted — reads, local
-> writes, outbound GET/POST, `pip install`, pushing a **new** branch, GitHub-API issue
-> create/close, sub-agent spawns. Destroying or rewriting already-published state is hard-denied
-> with **no self-clear path**: force-push, remote-branch deletion, and first-publish to a
-> brand-new public repo all fail, and a coordinator's relayed intent is explicitly discounted as
-> "not user intent" — so an unattended session **cannot clean up even its own scratch branch.**
-> The safety intent is right and it fails safe-and-fast; the gap is that there is no scoped way
-> for the operator to pre-authorize a single reversible-tier action, so an unattended run
-> dead-ends with a present human as the only way through.
+> **Flagship finding — the auto-mode permission boundary, in two layers** (full table + the
+> clear-path follow-up in the linked report). Auto mode's line is *reversibility of published
+> state*: every constructive action ran unprompted — reads, local writes, outbound GET/POST,
+> `pip install`, pushing a **new** branch, GitHub-API issue create/close, sub-agent spawns —
+> while destroying or rewriting published state (force-push, remote-branch deletion,
+> first-publish to a new public repo) is denied. We separated that denial into **two independent
+> walls.** (1) The **auto-mode classifier** discounts a coordinator's relayed intent as "not user
+> intent," so an *unattended* session can't self-clear — but a *present* operator's direct
+> in-session grant *does* clear it, at a surprisingly low bar (a generic "I give you explicit
+> permission," answering a request that named the operation and target, sufficed). (2) Even then,
+> the **cloud environment's git credential** rejects the destructive push server-side (`HTTP
+> 403`), and no in-session grant clears that — so a cloud session **cannot delete a published ref
+> at all**, operator present or not; our coordinator still cannot remove its own scratch branch
+> without a human who has full git rights. The safety intent is right and it fails safe-and-fast;
+> the friction is that an unattended run has no scoped way to pre-clear even a reversible-tier
+> action ahead of time.
 >
 > **What would fix it, without weakening the safety intent:** a **scoped, opt-in
 > pre-authorization setting.** Let the operator explicitly enable specific normally-denied action
 > classes for a named scope — Project, repo, and account — default-off, reviewable and versioned,
-> so it reads as an *auditable grant*, not "safety off." That turns "the session dead-ends and a
-> present human is the only way through" into "the operator declares once what this run may do."
-> It isn't Projects-specific: the same auto-mode dead-end hits **any** unattended Claude Code
-> session, so this would help ordinary chats outside Projects too.
+> so it reads as an *auditable grant*, not "safety off." That turns "an unattended run dead-ends"
+> into "the operator declares once what this run may do." **Both layers have to move together for
+> it to bite:** pre-auth clears the classifier ahead of time (layer 1), but the grant only
+> actually unblocks the operation if the session's git credential also carries the matching scope
+> (layer 2) — today it doesn't, so even a cleared classifier still 403s. And it isn't
+> Projects-specific: the same dead-end hits **any** unattended Claude Code session, so this would
+> help ordinary chats outside Projects too.
 >
 > **Smaller asks, each from something we already hand-built** (Projects could absorb them):
 > - **Raise the spawn-instruction cap.** A coordinator can pass a child session at most 4096 bytes


### PR DESCRIPTION
## What this changes (docs-only)

The clear-path test (coordinator PR #1839, merged) resolved the flagship's open half, and it **partly disproved** what the email claimed. Folds the corrected finding into `docs/planning/projects-eap-activation-plan-2026-07-07.md` §4.

- **Corrects a now-inaccurate claim.** The email said destructive ops have "no self-clear path" and an unattended run "dead-ends with a present human as the only way through." The test refined that into **two independent walls**: the auto-mode **classifier** *is* operator-clearable in-session (low bar — a generic "I give you explicit permission" answering a named request cleared it; coordinator-relay still isn't enough), but a **second** wall — the cloud environment's git credential — then 403s the destructive push regardless, and no in-session grant clears that. Net: a cloud session cannot delete a published ref at all, operator present or not.
- **Rewrites the flagship** as the two-layer finding, aligned to the authoritative report addendum (#1839), not re-derived.
- **Updates "what would fix it"** to note both layers must move together — a pre-auth that clears the classifier still 403s unless the git credential carries matching scope.
- **Meta-note** records that the flagship now reflects the clear-path addendum.

Live corroboration: this PR itself hit the force-push wall (auto mode denied `git push --force-with-lease` on the post-squash branch), so it ships from a fresh branch — a first-hand instance of the finding.

No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_