### PR TITLE
Capture: forward-only Project experiment (idea) + per-repo settings ledger (plan)

### DIFF
--- a/.sessions/2026-07-08-forward-only-and-settings-plan.md
+++ b/.sessions/2026-07-08-forward-only-and-settings-plan.md
@@ -1,0 +1,31 @@
+# 2026-07-08 — Capture: forward-only Project experiment + per-repo settings ledger
+
+> **Status:** `complete`
+
+**Scope:** owner-directed idea capture ("before I forget") from the EAP-email finalization
+thread. Two durable artifacts, docs-only:
+1. `docs/ideas/forward-only-project-quality-experiment-2026-07-08.md` — reconfigure a Project to
+   never attempt destructive git, run it, and measure the quality cost (empirical version of
+   "friction not blockage"; feeds the Anthropic email).
+2. `docs/planning/per-repo-settings-state-ledger-2026-07-08.md` — a plan for a durable,
+   ideally auto-generated per-repo settings ledger so future sessions read the state instead of
+   guessing (optionally surfaced on the dev website).
+
+Also corrected in-thread: "first push must be the owner personally" was imprecise — it's the
+auto-mode wall on an unattended session's first-publish-to-a-new-public-repo, clearable by any
+non-walled path (human, token-backed Action, or the untested private-first trick).
+
+## What shipped (PR)
+- `docs/ideas/forward-only-project-quality-experiment-2026-07-08.md` + ideas-README index entry.
+- `docs/planning/per-repo-settings-state-ledger-2026-07-08.md` (phased: capture → auto-generate →
+  dashboard).
+- Both reachable, `check_docs --strict` green.
+
+## ⚑ Self-initiated
+Owner-directed capture — no unprompted scope. Execution of either (run the forward-only Project;
+build the settings ledger) awaits the owner's go.
+
+## 💡 Session idea (Q-0089)
+The per-repo settings ledger's "auto-mode capability facts" row is the natural home for the
+coordinator's #1839 environment-capability-matrix idea — one doc that tells every future session
+which actions are walled and what clears each, so nobody re-probes. (Captured inside the plan.)

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`forward-only-project-quality-experiment-2026-07-08.md`](./forward-only-project-quality-experiment-2026-07-08.md) —
+  **owner-raised (2026-07-08, EAP-email thread):** configure a Project's instructions so agents
+  never *attempt* destructive git (forward-only by design), run real work through it, and measure
+  the actual quality cost — the empirical version of "the permission wall is friction, not a
+  work-stopper," and strong evidence for the Anthropic feedback. Pairs with the per-repo settings
+  ledger plan (`docs/planning/per-repo-settings-state-ledger-2026-07-08.md`).
 - [`session-start-staleness-banner-2026-07-07.md`](./session-start-staleness-banner-2026-07-07.md) —
   **session idea (2026-07-07, Q-0089, Projects-EAP eval-journal session):** the coordinator's
   container clone was 7 merged PRs behind origin at first turn and nothing warned it — add a

--- a/docs/ideas/forward-only-project-quality-experiment-2026-07-08.md
+++ b/docs/ideas/forward-only-project-quality-experiment-2026-07-08.md
@@ -1,0 +1,55 @@
+# Idea — Forward-only Project: measure the quality cost of forbidding destructive actions
+
+> **Status:** `ideas` · raised by the owner 2026-07-08 (EAP-email thread) · EAP-evaluation-adjacent
+> **Provenance:** owner directive — "if we genuinely don't need these to do our work, create a
+> fresh project with better-scoped instructions so it does not even think about doing any
+> destructive actions… show what happens if we try to prevent it and how it affects the quality
+> of our work."
+
+## The concept
+
+We established (this session) that destructive git (force-push, remote-branch delete, history
+rewrite, first-publish-to-a-new-public-repo) is **friction, not a work-stopper** — every use has a
+forward-only alternative. This idea turns that claim into an **experiment**: configure a Project's
+Custom Instructions so agents *never attempt* destructive actions — forward-only by design — then
+run real work through it and record the **actual quality cost**.
+
+Two payoffs:
+1. **Practical.** Agents stop wasting cycles hitting walls they can't clear (the coordinator spent
+   real effort probing/relaying denied destructive ops this session). Forward-only-by-instruction
+   removes that waste.
+2. **Email evidence.** Instead of *asserting* "it's only friction," we **demonstrate** the cost
+   empirically — the strongest possible version of that argument for the Anthropic feedback.
+
+## What "forward-only instructions" say (draft)
+
+> This Project never performs destructive or history-rewriting git. Do not force-push, delete
+> remote branches, rebase-and-force, `--amend` an already-pushed commit, or first-publish to a new
+> public repo from a session. Instead: a fresh branch instead of rewriting a stale one; a fixup
+> commit instead of an amend; let squash-merge flatten history; leave branch cleanup to GitHub's
+> auto-delete-on-merge + a token-backed Action; route any genuinely-needed destructive step to the
+> owner via decide-and-flag. Treat the absence of these operations as normal, not a blocker.
+
+## How to run it (fork to decide)
+
+- **Re-instruct the current Project** — continuity (keeps rebuild state + coordinator memory), but
+  the coordinator is already "contaminated" with wall-probing history, so it's a less clean
+  baseline.
+- **A fresh Project** — clean baseline for the experiment and separates it from the rebuild, but
+  loses accumulated memory and adds a second Project to run.
+
+Recommendation: **re-instruct the current Project** unless we specifically want a clean A/B; the
+experiment is informative either way, and a fresh Project fragments the rebuild.
+
+## Deliverable when run
+
+An observations note (work still shipped? messier history? any stuck/confused states? cycles
+saved?) → the EAP evaluation log + a follow-up-email paragraph. Needs run-time, so the **results**
+are follow-up-email material; email 1 can preview it ("we're now quantifying the constraint's
+cost").
+
+## Dedup
+
+No existing `docs/ideas/` entry proposes an instruction-level forward-only configuration or a
+quality-cost measurement of the permission constraint; this is distinct from the permission-probe
+report (which maps *what* is walled, not the *cost of avoiding* it).

--- a/docs/planning/per-repo-settings-state-ledger-2026-07-08.md
+++ b/docs/planning/per-repo-settings-state-ledger-2026-07-08.md
@@ -1,0 +1,60 @@
+# Plan — Per-repo settings state ledger (so sessions read the state, don't guess)
+
+> **Status:** `plan` · raised by the owner 2026-07-08 (EAP-email thread)
+> **Provenance:** owner directive — "create a good plan to see how we have all the settings per
+> repo and a way to properly document that so future sessions know the state and don't have to
+> guess; maybe add that to the developer website."
+
+## Problem
+
+Sessions repeatedly *guess* at repo configuration and pay for it: which check is the required one,
+is auto-merge armed, is "auto-delete head branches" on, what does the ruleset require, which token
+fires workflows, is the repo public or private, and — new this session — which git actions the
+auto-mode wall blocks. This state is scattered across workflows, journal entries, and tribal
+memory. A session should **read** the current state, not reconstruct it.
+
+## Goal
+
+A durable, **current**, per-repo settings ledger, ideally **auto-generated** (so it can't drift),
+that sessions read at orientation — covering `superbot`, and `superbot-next` + `substrate-kit`
+once they exist. Optionally surfaced on the dev website.
+
+## What it records (per repo)
+
+- Visibility (public/private) + default branch
+- Branch protection / **rulesets** (required checks, required reviews, restrict-deletions, etc.)
+- Auto-merge config + **which check is the merge gate** (Code Quality)
+- "Automatically delete head branches" on/off
+- Which token/PAT applies to which automation (`ROUTINE_PAT` and why — the app-token
+  workflow-trigger gap)
+- **Auto-mode capability facts** — the walled git actions (force-push, remote-branch delete,
+  first-publish-to-public) + what clears each (nothing / present-operator / human-with-full-rights),
+  cross-linked to `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`
+
+## Phases
+
+**Phase 1 — Capture (docs, ship now).** `docs/operations/repo-settings-state.md` seeded from what
+we know + a one-shot GitHub-API read (repo settings, branch list, any reachable ruleset). Manual is
+fine for v1; the value is one source of truth existing at all.
+
+**Phase 2 — Auto-generate (dev tool, avoids drift).** `scripts/generate_repo_settings_state.py`
+queries the GitHub API and regenerates the doc; wire it into a routine or CI so it stays current.
+Known gap to document, not hide: **rulesets / branch-protection / OIDC aren't exposed by the
+standard GitHub MCP tools** (coordinator-kickoff §5), so mark which rows are API-fetchable vs.
+must-be-hand-confirmed. Ship lazy-imported + `pytest.importorskip` per the dev-dep rule.
+
+**Phase 3 — Surface on the dev website (optional, bigger).** The botsite already has a
+`dashboard/data/*.json` → panel pipeline; add a `repo-settings` data source + a read-only panel.
+Plan separately once Phases 1–2 prove the data.
+
+## Why this belongs to the workflow, not just the bot
+
+This is orientation infrastructure — the same class as the claim files and the session cards. It
+directly reduces the "guess the repo state" friction that has bitten multiple sessions, and it's
+the natural home for the auto-mode capability facts so future sessions plan around the walls
+instead of re-probing them (extends the coordinator's #1839 "environment capability matrix" idea).
+
+## Next
+
+Phase 1 is shippable immediately (docs). Ping to build it; Phase 2 follows once the row set is
+agreed. Phase 3 is a website feature to plan on its own.


### PR DESCRIPTION
## What this changes (docs-only)

Durable capture of two owner-raised threads from the EAP-email finalization discussion ("before I forget"). No `disbot/` changes.

- **`docs/ideas/forward-only-project-quality-experiment-2026-07-08.md`** — configure a Project's instructions so agents never *attempt* destructive git (forward-only by design), run real work through it, and measure the actual quality cost. The empirical version of the "friction, not a work-stopper" finding, and strong evidence for the Anthropic feedback. Includes a draft of the forward-only instruction block and the fresh-vs-current-Project fork. Indexed in the ideas README.
- **`docs/planning/per-repo-settings-state-ledger-2026-07-08.md`** — a phased plan for a durable, ideally auto-generated per-repo settings ledger (visibility, rulesets, required checks, auto-merge, auto-delete-branches, which PAT, and the auto-mode capability facts) so future sessions read the state instead of guessing. Phase 1 docs → Phase 2 generator script → Phase 3 optional dashboard panel.

`check_docs --strict` green (both reachable + correctly badged).

Both are captured, not executed — running the forward-only Project and building the ledger await the owner's go.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_