### PR TITLE
Record finding: GitHub Contents API bypasses the git-push first-publish wall

### DIFF
--- a/.sessions/2026-07-08-api-publish-finding.md
+++ b/.sessions/2026-07-08-api-publish-finding.md
@@ -1,0 +1,35 @@
+# 2026-07-08 — Finding: GitHub-API publish bypasses the git-push first-publish wall
+
+> **Status:** `complete`
+
+**Scope:** owner-directed test ("do the API-bootstrap test first — always useful to find out what
+we can use"). Docs-only record of a first-hand result. No `disbot/` changes.
+
+## What happened
+- Two brand-new **empty public** repos (`menno420/substrate-kit`, `menno420/superbot-next`) — the
+  exact case `git push` first-publish is hard-denied. Created the first commit on each via the
+  **GitHub Contents API** (`create_or_update_file`) instead.
+- **ALLOWED, no prompt** — both bootstrapped: `substrate-kit` README `fae482ac`, `superbot-next`
+  README `de36d28b`. Task B's intent-commit half is done, autonomously.
+
+## Why it matters
+- **The first-publish wall is surface-specific** — it gates the `git push` transport, not the
+  GitHub Contents API (consistent with the base probe's "API issue create/close = ALLOWED").
+- **Likely unblocks step 7 of the rebuild.** The repos are now non-empty, so ordinary `git push`
+  of new branches to them should be allowed (base probe: "new branch to an existing repo =
+  ALLOWED") — untested for these two specifically, confirmable by a branch push.
+- Open question for the email: is the API-vs-git asymmetry intentional (trusted write surface) or
+  an inconsistency? Not tested: whether the API also bypasses the *destructive* walls (Git Refs
+  API delete/force) — deliberately not run, `test/permprobe-0708` preserved as the standing example.
+
+## Shipped (this PR)
+- Probe-report addendum + eval-log entry recording the finding.
+- (Held for owner review, flagged in chat: a one-line email addition — the surface-specificity as
+  a question for Anthropic — and the step-7-unblock status in the rebuild plan.)
+
+## ⚑ Owner action / next
+- Step 7 is plausibly unblocked; confirmable by a branch push to either repo. Settings pass + the
+  settings-ledger Phase 1 can now proceed (repos exist with commits).
+
+## ⚑ Self-initiated
+None beyond the owner-directed test; recording the finding is the drift-prevention discipline.

--- a/docs/planning/projects-eap-evaluation-log.md
+++ b/docs/planning/projects-eap-evaluation-log.md
@@ -107,3 +107,12 @@ product review's analysis — confirm, contradict, or deepen it with lived examp
   layer had no visibility into the target session's toolset · expected: spawn-time capability
   introspection (or a session-type toolset manifest) so protocols premised on direct shell
   access route to a session type that has one · weight: friction · reproducible: yes
+- 2026-07-08 · axis: reliability/capability · observed: the git-push first-publish wall (first
+  commit to an empty public repo) is SURFACE-SPECIFIC — creating the first commit via the GitHub
+  Contents API (`create_or_update_file`) was ALLOWED with no prompt and bootstrapped both new
+  repos (`substrate-kit` fae482ac, `superbot-next` de36d28b), where `git push` is hard-denied
+  (addendum in `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`) · expected:
+  consistent gating across write surfaces, OR a documented "the API is the sanctioned bootstrap
+  path" — either way this is the cleanest current workaround for the one-time bootstrap and
+  plausibly unblocks the wider rebuild workflow for these repos · weight: capability (a real
+  unblock) · reproducible: yes

--- a/docs/planning/projects-eap-permission-probe-report-2026-07-08.md
+++ b/docs/planning/projects-eap-permission-probe-report-2026-07-08.md
@@ -238,3 +238,31 @@ the dispatcher route the row to a suitable session type up front.
 e.g. a CLI/terminal Claude Code session carrying the same Project custom instructions — keeping
 the one-attempt / no-retry / verbatim-capture rule. Until then, the standing-grant cell stays
 open and this addendum is the honest record of why.
+
+## Addendum — GitHub-API publish path bypasses the git-push first-publish wall (2026-07-08)
+
+First-hand, this session (superbot main-loop, cloud auto mode). We had two brand-new **empty
+public** repos (`menno420/substrate-kit`, `menno420/superbot-next`) — the exact case the "publish
+wall" hard-denies for `git push`. Instead of `git push`, we created the first commit via the
+**GitHub Contents API** (`create_or_update_file`), one call per repo.
+
+**Result: ALLOWED, no prompt.** Both first commits landed:
+- `substrate-kit` README → commit `fae482ac` on `main`
+- `superbot-next` README → commit `de36d28b` on `main`
+
+**Finding.** The first-publish wall is **surface-specific**: it blocks the `git push` transport
+but not the GitHub Contents API, even though the net effect is identical (publishing new content
+to an empty public repo). Consistent with the base probe's "GitHub-API issue create/close =
+ALLOWED" — API object-creation is not gated the way git destructive/publish transport is.
+
+**Consequence.** An autonomous session **can** bootstrap a brand-new public repo after all — via
+the API, not git. And once the repo is non-empty, ordinary `git push` of new branches should be
+allowed (base probe: "push a new branch to an existing repo = ALLOWED"), so this also plausibly
+**unblocks the wider workflow** for these repos — untested for these two specifically, confirmable
+by a branch push.
+
+**Open question for Anthropic (and for us).** Is the API-vs-git-push asymmetry intentional (the
+API as a trusted, auditable write surface) or an inconsistency in the publish wall? Either way it
+is the cleanest current workaround for the one-time bootstrap. **Not tested:** whether the API
+also bypasses the **destructive** walls (branch-delete / force-push equivalents via the Git Refs
+API) — deliberately not run, since `test/permprobe-0708` is preserved as the standing example.


### PR DESCRIPTION
## What this changes (docs-only)

First-hand result from an owner-directed test: does the GitHub API publish where `git push` is walled? **Yes.**

- We had two brand-new **empty public** repos (`substrate-kit`, `superbot-next`) — the exact case `git push` first-publish is hard-denied. Creating the first commit via the **GitHub Contents API** (`create_or_update_file`) was **ALLOWED, no prompt**, bootstrapping both (`substrate-kit` `fae482ac`, `superbot-next` `de36d28b`).
- **The first-publish wall is surface-specific** — it gates the `git push` transport, not the API (consistent with the base probe's "API issue create/close = ALLOWED").
- **Likely unblocks step 7:** the repos are now non-empty, so ordinary `git push` of new branches should be allowed — confirmable by a branch push.

Records the finding where it belongs: a probe-report addendum + an evaluation-log entry. The email tweak (surface-specificity as a question for Anthropic) and the rebuild-plan step-7 status are held for owner review and flagged in chat.

`check_docs --strict` green. No `disbot/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_