### PR TITLE
Settings ledger Phase 1: capture per-repo settings from the owner's recording

### DIFF
--- a/.sessions/2026-07-08-repo-settings-ledger-phase1.md
+++ b/.sessions/2026-07-08-repo-settings-ledger-phase1.md
@@ -1,0 +1,29 @@
+# 2026-07-08 — Settings ledger Phase 1 (captured from the owner's recording)
+
+> **Status:** `complete`
+
+**Scope:** owner-directed — store the per-repo settings so future sessions read state, not guess.
+Docs-only. Executes Phase 1 of `docs/planning/per-repo-settings-state-ledger-2026-07-08.md`.
+
+## What happened
+- Owner sent a screen recording of the `superbot-next` General settings. The session has no video
+  tooling, so I **pip-installed `imageio-ffmpeg`** (a bundled ffmpeg) and extracted 16 frames
+  (1 fps) to the scratchpad, then read them as images — solving the "can't watch mp4" gap.
+- Captured the verified General settings into `docs/operations/repo-settings-state.md`: Public,
+  `main`, all merge methods, **auto-merge ON**, **auto-delete head branches ON**, etc.
+- Marked what the recording did NOT show (Rules / required checks) as confirm-per-repo, seeded from
+  session context (superbot: Code Quality + CodeQL required; superbot-next: step-8 ruleset).
+- Folded in the auto-mode capability facts (the walls + the API-bypass finding) so the ledger is
+  the one-stop "what's true about these repos."
+
+## Provenance / reliability header (per Q-0105)
+`imageio-ffmpeg` added 2026-07-08 as a **dev-only** frame extractor for reading a screen recording.
+Unverified convenience tool — **delete if unused across sessions**; not a runtime dep, not pinned
+in `requirements.txt`.
+
+## ⚑ Owner action / next
+- Confirm the Rules/required-checks rows per repo (not in the recording); confirm substrate-kit +
+  superbot General rows match. Then Phase 2 (generator script) can auto-maintain the readable rows.
+
+## ⚑ Self-initiated
+None beyond the owner-directed capture.

--- a/docs/operations/repo-settings-state.md
+++ b/docs/operations/repo-settings-state.md
@@ -1,0 +1,76 @@
+# Per-repo settings state ledger
+
+> **Status:** `reference` · Phase 1 (manual capture) of
+> `docs/planning/per-repo-settings-state-ledger-2026-07-08.md`.
+> **So future sessions read the state instead of guessing.** Cross-repo: `superbot` (live),
+> `substrate-kit`, `superbot-next` (both bootstrapped 2026-07-08).
+
+## How this doc is maintained (read before trusting a row)
+
+Captured **manually** on 2026-07-08 — the `superbot-next` General-settings rows are **verified
+from the owner's screen recording**; `substrate-kit` and `superbot` are marked as the owner is
+applying the **same** settings uniformly (confirm before relying on a per-repo value). The GitHub
+MCP tools available to a session **cannot read** merge/branch toggles, rulesets, or branch
+protection — only visibility + default branch — so this ledger is hand-maintained until Phase 2
+(a `scripts/generate_repo_settings_state.py` that queries the API) lands. **That read-visibility
+gap is itself an EAP finding** (an agent can't introspect the repo config it operates under).
+
+## General settings (verified from the 2026-07-08 recording; applied uniformly)
+
+| Setting | superbot | substrate-kit | superbot-next |
+|---|---|---|---|
+| Visibility | Public | Public | **Public** ✓ |
+| Default branch | `main` | `main` | **`main`** ✓ |
+| Template repository | No | No | **No** ✓ |
+| Issues | On | On | **On** ✓ (create: all users) |
+| Projects | On | On | **On** ✓ |
+| Pull requests | On | On | **On** ✓ (create: all users) |
+| Discussions | Off | Off | **Off** ✓ |
+| Sponsorships | Off | Off | **Off** ✓ |
+| Wiki — restrict editing to collaborators | On | On | **On** ✓ |
+| Preserve repository (Archive Program) | On | On | **On** ✓ |
+| Allow merge commits | On | On | **On** ✓ |
+| Allow squash merging | On | On | **On** ✓ |
+| Allow rebase merging | On | On | **On** ✓ |
+| Always suggest updating PR branches | On | On | **On** ✓ |
+| **Allow auto-merge** | On | On | **On** ✓ |
+| **Automatically delete head branches** | On | On | **On** ✓ |
+| Require sign-off on web commits | Off | Off | **Off** ✓ |
+| Allow comments on individual commits | On | On | **On** ✓ |
+| Include LFS objects in archives | Off | Off | **Off** ✓ |
+| Limit branches/tags per push | Off | Off | **Off** ✓ |
+| Auto-close linked issues on merge | On | On | **On** ✓ |
+
+✓ = verified from the recording (superbot-next). Other columns = owner replicating to match —
+**confirm per repo.**
+
+## Rules / branch protection / required checks (NOT in the recording — confirm)
+
+| Aspect | superbot | substrate-kit | superbot-next |
+|---|---|---|---|
+| Required status check(s) | `Code Quality` (the auto-merge gate) + `CodeQL`; `codex-final-review` advisory | TBD | per step-8 decisions — confirm live |
+| Ruleset / approvals | — | TBD | **0 required approvals** (a required review would deadlock single-owner auto-merge), strict status checks off + a 6-hourly `main` backstop (`staging/step8-control-plane-drafts` `DECISIONS.md`) |
+| Delete-protection | branch deletion is auto-mode-walled regardless (see capability facts) | same | same |
+
+## Automation / tokens
+
+- **`ROUTINE_PAT`** (real fine-grained PAT) drives `auto-merge-enabler`, `ci-rerun-watchdog`,
+  `pr-auto-update`, `reconciliation-trigger` on **superbot** — needed because app/integration-token
+  actions don't fire workflows. New repos: **TBD** whether they carry the same automation set.
+
+## Auto-mode capability facts (what a session can/can't do — the walls)
+
+Full evidence: `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`.
+
+| Action | Autonomous session? | Clears how |
+|---|---|---|
+| Read / local write / outbound net / `pip install` | ✅ allowed | — |
+| Push a **new** branch to an existing repo | ✅ allowed | — |
+| GitHub-API object create (issue, **file/first-commit**) | ✅ allowed | — the API bypasses the git-push publish wall (2026-07-08) |
+| First-publish to an empty **public** repo via `git push` | ❌ denied | human, token-backed Action, or the API path above |
+| Force-push / remote-branch delete (`git push`) | ❌ denied (2 layers) | present operator clears the classifier; the git credential still 403s — no in-session path |
+
+## Next
+
+Phase 2 = `scripts/generate_repo_settings_state.py` (auto-regenerate the API-readable rows).
+Phase 3 = optional dev-website panel. Plan: `docs/planning/per-repo-settings-state-ledger-2026-07-08.md`.


### PR DESCRIPTION
## What this changes (docs-only)

Executes Phase 1 of the per-repo settings-ledger plan — so future sessions read the repo state instead of guessing.

- **New: `docs/operations/repo-settings-state.md`** — a cross-repo settings table (superbot / substrate-kit / superbot-next). The `superbot-next` General rows are **verified from the owner's screen recording** (read by extracting frames via a pip-installed `imageio-ffmpeg`, since the session has no video tooling); the other columns are marked "owner replicating to match — confirm."
- Captures the key toggles: Public, `main`, all merge methods, **auto-merge ON**, **auto-delete head branches ON**, auto-close linked issues, etc.
- Rules / required-checks (not in the recording) are marked confirm-per-repo, seeded from session context (superbot: Code Quality + CodeQL required; superbot-next: the step-8 ruleset).
- Folds in the **auto-mode capability facts** (the walls + the 2026-07-08 API-bypass finding) so the ledger is the one-stop "what's true about these repos."
- Notes the **read-visibility gap** (the GitHub MCP tools can't read merge/branch/ruleset settings) — itself an EAP data point, and the reason this is hand-maintained until the Phase 2 generator.

`check_docs --strict` green. `imageio-ffmpeg` carries a provenance/kill-switch header (dev-only, delete if unused).

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_