### PR TITLE
Correct settings ledger: new repos are bare + full API capability map

### DIFF
--- a/.sessions/2026-07-08-ledger-correction-api-caps.md
+++ b/.sessions/2026-07-08-ledger-correction-api-caps.md
@@ -1,0 +1,26 @@
+# 2026-07-08 — Ledger correction: new repos are bare + full API capability map
+
+> **Status:** `complete`
+
+**Scope:** owner clarified only `superbot` has rules/branch-protection/Actions/workflows — the new
+repos are bare. Correct the settings ledger, and fold in the API-capability tests run this session.
+Docs-only. No `disbot/` changes.
+
+## What shipped
+- **Ledger correction** (`docs/operations/repo-settings-state.md`): the Rules / automation rows for
+  `substrate-kit` + `superbot-next` now read **none yet (bare)**, not "per step-8 ruleset" (that was
+  the *planned* config, not applied — my premature seed). Added a Workflows/Actions row.
+- **Full API capability map** (ledger + probe-report addendum extension): confirmed first-hand this
+  session that the GitHub Contents API allows an autonomous session to **create / update / delete**
+  files — including `.github/workflows/*` (no `workflow`-scope block; `substrate-kit` `4d17832c`
+  created, `586e8f1c` deleted). So the whole file/content layer is agent-doable; only repo settings
+  (rulesets, branch protection, required checks, secrets/PATs) are owner-only → new-repo build is
+  ~90% agent-doable. Git-ref *rewrite* walls (force-push, branch-delete) are unaffected (untested via
+  Git Refs API; `test/permprobe-0708` preserved).
+
+## ⚑ Self-initiated
+Correction + capability capture from an owner-directed test; drift-fix discipline. No unprompted scope.
+
+## ⚑ Owner action / next
+- Still owner-only for the new repos: rulesets/required-checks, `ROUTINE_PAT` secret. Agent-doable:
+  the full CI/tooling file tree (adopting from substrate-kit). Awaiting owner's go to scope that task.

--- a/docs/operations/repo-settings-state.md
+++ b/docs/operations/repo-settings-state.md
@@ -44,19 +44,24 @@ gap is itself an EAP finding** (an agent can't introspect the repo config it ope
 ✓ = verified from the recording (superbot-next). Other columns = owner replicating to match —
 **confirm per repo.**
 
-## Rules / branch protection / required checks (NOT in the recording — confirm)
+## Rules / branch protection / required checks
+
+**Only `superbot` has any rules / branch protection / Actions / workflows** (owner, 2026-07-08).
+The new repos are **bare** — just the intent commit + the General settings above, nothing else yet.
 
 | Aspect | superbot | substrate-kit | superbot-next |
 |---|---|---|---|
-| Required status check(s) | `Code Quality` (the auto-merge gate) + `CodeQL`; `codex-final-review` advisory | TBD | per step-8 decisions — confirm live |
-| Ruleset / approvals | — | TBD | **0 required approvals** (a required review would deadlock single-owner auto-merge), strict status checks off + a 6-hourly `main` backstop (`staging/step8-control-plane-drafts` `DECISIONS.md`) |
+| Required status check(s) | `Code Quality` (the auto-merge gate) + `CodeQL`; `codex-final-review` advisory | **none yet** | **none yet** |
+| Ruleset / approvals | single-owner (no required approvals) | **none yet** | **none yet** — *planned* config (0 approvals, strict-checks-off + 6-hourly `main` backstop, `staging/step8-control-plane-drafts` `DECISIONS.md`) is not applied |
+| Workflows / Actions | full CI suite | **none yet** | **none yet** |
 | Delete-protection | branch deletion is auto-mode-walled regardless (see capability facts) | same | same |
 
 ## Automation / tokens
 
 - **`ROUTINE_PAT`** (real fine-grained PAT) drives `auto-merge-enabler`, `ci-rerun-watchdog`,
   `pr-auto-update`, `reconciliation-trigger` on **superbot** — needed because app/integration-token
-  actions don't fire workflows. New repos: **TBD** whether they carry the same automation set.
+  actions don't fire workflows. **New repos: none yet** — no secrets/PATs and no automation;
+  adding the `ROUTINE_PAT` secret is owner-only and is a prerequisite for auto-merge to arm there.
 
 ## Auto-mode capability facts (what a session can/can't do — the walls)
 
@@ -66,9 +71,15 @@ Full evidence: `docs/planning/projects-eap-permission-probe-report-2026-07-08.md
 |---|---|---|
 | Read / local write / outbound net / `pip install` | ✅ allowed | — |
 | Push a **new** branch to an existing repo | ✅ allowed | — |
-| GitHub-API object create (issue, **file/first-commit**) | ✅ allowed | — the API bypasses the git-push publish wall (2026-07-08) |
-| First-publish to an empty **public** repo via `git push` | ❌ denied | human, token-backed Action, or the API path above |
-| Force-push / remote-branch delete (`git push`) | ❌ denied (2 layers) | present operator clears the classifier; the git credential still 403s — no in-session path |
+| GitHub Contents API — create / update / **delete** a file, incl. first-commit **and `.github/workflows/*`** | ✅ allowed | bypasses the git-push publish wall; no workflow-scope block (all confirmed 2026-07-08) |
+| First-publish to an empty **public** repo via `git push` | ❌ denied | human, token-backed Action, or the Contents-API path above |
+| Force-push / remote-branch delete (`git push` ref-rewrite) | ❌ denied (2 layers) | present operator clears the classifier; the git credential still 403s — no in-session path |
+
+**Implication for standing up the new repos:** the entire **file/content layer** — source, all
+`.github/workflows/` CI, scripts, config, docs, kit content — is agent-doable via the Contents API
+(create/update/delete). Only the **settings layer** (rulesets, branch protection, required checks,
+General toggles, secrets/PATs) is owner-only. So the new-repo build is ~90% agent-doable; the
+git-ref *rewrite* walls (force-push, branch-delete) do not affect this file-layer work.
 
 ## Next
 

--- a/docs/planning/projects-eap-permission-probe-report-2026-07-08.md
+++ b/docs/planning/projects-eap-permission-probe-report-2026-07-08.md
@@ -266,3 +266,13 @@ API as a trusted, auditable write surface) or an inconsistency in the publish wa
 is the cleanest current workaround for the one-time bootstrap. **Not tested:** whether the API
 also bypasses the **destructive** walls (branch-delete / force-push equivalents via the Git Refs
 API) — deliberately not run, since `test/permprobe-0708` is preserved as the standing example.
+
+**Extension (same day) — full Contents-API file lifecycle, including workflows.** Also confirmed
+ALLOWED, no prompt, on the fresh repos: creating a `.github/workflows/*.yml` file (no GitHub
+`workflow`-scope block — `substrate-kit` commit `4d17832c`) and **deleting** a file
+(`586e8f1c`). So the entire *content* layer — create / update / delete of any file, workflows
+included — is open to an autonomous session via the Contents API, even though the git-ref
+*rewrite* surface (force-push, branch-delete) stays walled. Practical upshot: an agent can stand
+up a new repo's whole source + CI file tree; only repo **settings** (rulesets, branch protection,
+required checks, secrets) remain owner-only. The create/delete asymmetry vs. the git surface is
+the same open question above — content operations are un-gated, ref-rewrite operations are hard-walled.


### PR DESCRIPTION
## What this changes (docs-only)

Follow-up to #1848, correcting one row and folding in this session's confirmed API capability tests.

- **Correction:** the owner clarified only `superbot` has rules / branch protection / Actions / workflows — `substrate-kit` and `superbot-next` are **bare**. The ledger's Rules/automation rows read "none yet" now, not "per step-8 ruleset" (that was the *planned* config, not applied — a premature seed on my part). Added a Workflows/Actions row.
- **Full API capability map:** confirmed first-hand this session that the GitHub Contents API lets an autonomous session **create / update / delete** files, **including `.github/workflows/*`** (no `workflow`-scope block — `substrate-kit` `4d17832c` created, `586e8f1c` deleted). So the whole file/content layer is agent-doable; only repo settings (rulesets, branch protection, required checks, secrets/PATs) are owner-only → the new-repo build is **~90% agent-doable**. Git-ref *rewrite* walls (force-push, branch-delete) are unaffected (untested via Git Refs API; `test/permprobe-0708` preserved).
- Probe-report addendum extended to match.

`check_docs --strict` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qb7JdAvkk37yKB4doznGo)_