### PR TITLE
EAP feedback email refresh + forward-only Project custom instructions

### DIFF
--- a/.sessions/2026-07-08-eap-email-refresh-forward-only-project.md
+++ b/.sessions/2026-07-08-eap-email-refresh-forward-only-project.md
@@ -1,15 +1,66 @@
 # Session — EAP email refresh + forward-only Project instructions
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
-Owner-directed management/chat session (continues the EAP-feedback thread). Two deliverables:
-1. Refresh the Anthropic EAP feedback email into a complete, send-ready standalone doc —
-   incorporating a NEW owner finding (the claude.ai Chat/Cowork "Skip all approvals" toggle enables
-   even destructive actions; Claude Code Projects auto mode has no scoped equivalent and walls
-   destructive ops even when prompted), restructured into positives / negatives / what-we-tried-and-why
-   / value-of-the-ask / explicit asks (test cases, settings workarounds, is-it-intentional).
-2. Write the forward-only Project's Custom Instructions (fresh Project, scoped so agents never attempt
-   a destructive/prompt-forcing action) — the setup half of the forward-only quality experiment.
+## What this session did
+Owner-directed management/chat session (continues the EAP-feedback thread). Docs-only. Delivered:
 
-Provenance: owner directive (this session). Docs-only; no `disbot/` runtime code.
+1. **Refreshed the Anthropic EAP feedback email** into a consolidated, send-ready standalone doc —
+   `docs/planning/projects-eap-anthropic-email-2026-07-08.md`. New this refresh:
+   - Folds in the owner's new finding: the claude.ai **Chat/Cowork "Skip all approvals"** toggle
+     enables even destructive actions, while Claude Code Projects auto mode has **no scoped
+     equivalent** and walls destructive git even when prompted. Made the **value anchor** — our ask
+     (scoped, opt-in, default-off pre-auth) is *strictly safer* than a blanket toggle Anthropic
+     already ships in Chat.
+   - Restructured to the shape the owner asked for: **Positives / Negatives / What-we-tried-and-why /
+     Why-the-ask-is-valuable / explicit Asks-back** (test cases they'd like run · settings/workarounds
+     we may have missed · is-this-intentional-do-you-want-to-keep-it · Contents-API-vs-git-push
+     asymmetry).
+   - Every claim tied to a source (verifiability appendix table). Marked the "Projects can't replace
+     direct management" paragraph **⚑ owner-review: keep/soften/cut**.
+2. **Forward-only Project custom instructions** —
+   `docs/planning/forward-only-project-custom-instructions-2026-07-08.md`: ready-to-paste block for a
+   fresh Project scoped so agents never *attempt* a destructive/prompt-forcing action, plus the
+   forward-only equivalence table and owner setup notes. This is the setup half of the forward-only
+   quality experiment.
+3. **Wiring:** forward-only idea doc → points at the instructions (status: setup shipped, awaiting
+   run); activation-plan §4 → points at the new canonical email doc; handoff brief → email pointer
+   retargeted; evaluation log → new lived entry for the Chat/Code "Skip all approvals" asymmetry.
+
+PR #1853 (docs-only). `check_docs --strict` green.
+
+## ⚑ Self-initiated
+None beyond the owner-directed scope. (Idea file added per Q-0089 ender; not a self-promoted build.)
+
+## Open for the owner (decide-and-flag)
+- **Send the email** — recommended as the single substantive note now (not interim-then-full); the
+  Skip-all-approvals precedent + explicit asks make it worth leading with. External comms are yours.
+- **The "can't replace direct management" paragraph** — keep / soften / cut before sending.
+- **Fresh vs. re-instruct** for the forward-only Project — you asked for fresh (cleaner A/B); block
+  pastes into either.
+
+## 💡 Session idea (Q-0089)
+`docs/ideas/session-start-capability-self-probe-2026-07-08.md` — a cheap read-only session-start
+self-probe recording which tools a session actually has (shell / git write / self-wake / spawn types),
+so protocols premised on a missing tool (the standing-grant `NOT ATTEMPTED` row; phantom `send_later`)
+fail free-and-early instead of late-and-expensive. The self-serve version of the email's spawn-time
+capability-introspection ask. Dedup-checked against the probe report and the staleness-banner idea.
+
+## ⟲ Previous-session review (Q-0102)
+Previous session (`2026-07-08-eap-direction-handoff.md`) did the hard, right thing: it wrote a genuine
+handoff brief so a fresh session (this one) could pick up the email+direction role cold — and it did,
+with near-zero re-derivation. It also made the correct *product* call (keep management in a direct
+chat, not a Project) with a clear rationale. **What it could have done better:** it left the email
+split across two homes (§4 draft + a chat-only "polished draft") with no single canonical file, which
+forced this session to consolidate; a handoff that names *one* send-from file is cheaper for the next
+session. **System improvement surfaced:** the recurring EAP pattern is "a finding lives only in chat
+or a screenshot" (the Skip-all-approvals toggle came in as an image). The capability-self-probe idea
+above is one guard; a lighter complementary one is a standing convention that *every* external-product
+observation gets a one-line evaluation-log entry the same session it's seen — so the email always
+assembles from the log, never from scrollback.
+
+## 📋 Doc audit (Q-0104)
+`check_docs --strict` green (new docs reachable, badges valid). No ledger entry needed yet — PR #1853
+is unmerged; the living-ledger checker covers it on merge. New owner-facing decisions here are
+reversible/flagged, not router-worthy (no new binding rule). Nothing from this session lives only in
+chat: the email, the instructions, the new finding, and the idea all have durable homes.

--- a/.sessions/2026-07-08-eap-email-refresh-forward-only-project.md
+++ b/.sessions/2026-07-08-eap-email-refresh-forward-only-project.md
@@ -1,0 +1,15 @@
+# Session — EAP email refresh + forward-only Project instructions
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+Owner-directed management/chat session (continues the EAP-feedback thread). Two deliverables:
+1. Refresh the Anthropic EAP feedback email into a complete, send-ready standalone doc —
+   incorporating a NEW owner finding (the claude.ai Chat/Cowork "Skip all approvals" toggle enables
+   even destructive actions; Claude Code Projects auto mode has no scoped equivalent and walls
+   destructive ops even when prompted), restructured into positives / negatives / what-we-tried-and-why
+   / value-of-the-ask / explicit asks (test cases, settings workarounds, is-it-intentional).
+2. Write the forward-only Project's Custom Instructions (fresh Project, scoped so agents never attempt
+   a destructive/prompt-forcing action) — the setup half of the forward-only quality experiment.
+
+Provenance: owner directive (this session). Docs-only; no `disbot/` runtime code.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -44,6 +44,12 @@ Current broad captures:
   the actual quality cost — the empirical version of "the permission wall is friction, not a
   work-stopper," and strong evidence for the Anthropic feedback. Pairs with the per-repo settings
   ledger plan (`docs/planning/per-repo-settings-state-ledger-2026-07-08.md`).
+- [`session-start-capability-self-probe-2026-07-08.md`](./session-start-capability-self-probe-2026-07-08.md) —
+  **session idea (2026-07-08, Q-0089, EAP-email-refresh session):** a cheap read-only session-start
+  self-probe that records which tools a session actually has (shell, git write, self-wake timer,
+  spawn types) — turns late/expensive "this session has no Bash tool" discoveries (the standing-grant
+  `NOT ATTEMPTED` row; the phantom `send_later`) into free up-front ones. The self-serve version of
+  the email's spawn-time-capability-introspection ask.
 - [`session-start-staleness-banner-2026-07-07.md`](./session-start-staleness-banner-2026-07-07.md) —
   **session idea (2026-07-07, Q-0089, Projects-EAP eval-journal session):** the coordinator's
   container clone was 7 merged PRs behind origin at first turn and nothing warned it — add a

--- a/docs/ideas/forward-only-project-quality-experiment-2026-07-08.md
+++ b/docs/ideas/forward-only-project-quality-experiment-2026-07-08.md
@@ -1,6 +1,10 @@
 # Idea — Forward-only Project: measure the quality cost of forbidding destructive actions
 
-> **Status:** `ideas` · raised by the owner 2026-07-08 (EAP-email thread) · EAP-evaluation-adjacent
+> **Status:** `ideas` (setup shipped, awaiting run) · raised by the owner 2026-07-08 (EAP-email
+> thread) · EAP-evaluation-adjacent
+> · **Setup shipped:** the paste-in Custom Instructions live in
+> [`docs/planning/forward-only-project-custom-instructions-2026-07-08.md`](../planning/forward-only-project-custom-instructions-2026-07-08.md).
+> Remaining: owner creates the fresh Project + pastes the block; then the *results* observations note.
 > **Provenance:** owner directive — "if we genuinely don't need these to do our work, create a
 > fresh project with better-scoped instructions so it does not even think about doing any
 > destructive actions… show what happens if we try to prevent it and how it affects the quality

--- a/docs/ideas/session-start-capability-self-probe-2026-07-08.md
+++ b/docs/ideas/session-start-capability-self-probe-2026-07-08.md
@@ -1,0 +1,38 @@
+# Idea — session-start capability self-probe (know your own toolset before you plan)
+
+> **Status:** `ideas` · raised 2026-07-08 (EAP-email-refresh session) · workflow/infrastructure
+
+## The problem it solves
+
+Multiple EAP findings this program hit came from a session **not knowing its own toolset up front**:
+- The standing-grant permission-probe row landed `NOT ATTEMPTED` because the receiving coordinator
+  session had **no Bash tool** — discovered only *after* dispatch, from inside the session
+  (`projects-eap-permission-probe-report-2026-07-08.md`, standing-grant addendum).
+- `send_later` is documented in the coordinator's own instructions but is **absent / rejected on
+  call** (evaluation log 2026-07-07) — a phantom tool a session planned around before learning it
+  didn't work.
+
+Both are the same failure: a protocol premised on a capability the session doesn't actually have,
+caught late and expensively.
+
+## The idea
+
+A tiny **session-start self-probe** — the session records, once, which of a short checklist of
+capabilities it actually has (direct Bash/shell, `git` write, GitHub MCP, self-wake timer, sub-agent
+spawn, `subagent_type`s available) — and writes the result to a known line (session card / eval log).
+Cheap, non-destructive, read-only. Then any dispatch or protocol can check "does the target session
+have a shell?" against a real answer instead of an assumption.
+
+## Why it's worth having
+
+- Turns a class of *late, expensive* discoveries into *free, up-front* ones.
+- Directly complements the email's ask for spawn-time capability introspection — this is the
+  **self-serve** version we can build now, without waiting on Anthropic.
+- Generalizes past the EAP: any cloud/CLI/coordinator session type benefits from knowing its own
+  envelope before it commits to a plan that needs a tool it lacks.
+
+## Dedup
+
+Distinct from the probe report (which maps the *permission* boundary, not the *toolset*) and from the
+"spawn-time capability introspection" email ask (a feature request to Anthropic); this is our own
+session-start convention, buildable now.

--- a/docs/owner/claims/projects-testing-anthropic-feedback-5xqamy.md
+++ b/docs/owner/claims/projects-testing-anthropic-feedback-5xqamy.md
@@ -1,4 +1,0 @@
-- branch `claude/projects-testing-anthropic-feedback-5xqamy` · scope: refresh the Anthropic EAP
-  feedback email (incorporate the claude.ai "Skip all approvals" precedent + explicit asks) and
-  write the forward-only Project custom-instructions · files: `docs/planning/*eap*`,
-  `docs/ideas/forward-only-*`, `.sessions/` · 2026-07-08

--- a/docs/owner/claims/projects-testing-anthropic-feedback-5xqamy.md
+++ b/docs/owner/claims/projects-testing-anthropic-feedback-5xqamy.md
@@ -1,0 +1,4 @@
+- branch `claude/projects-testing-anthropic-feedback-5xqamy` · scope: refresh the Anthropic EAP
+  feedback email (incorporate the claude.ai "Skip all approvals" precedent + explicit asks) and
+  write the forward-only Project custom-instructions · files: `docs/planning/*eap*`,
+  `docs/ideas/forward-only-*`, `.sessions/` · 2026-07-08

--- a/docs/planning/eap-email-and-direction-handoff-2026-07-08.md
+++ b/docs/planning/eap-email-and-direction-handoff-2026-07-08.md
@@ -37,9 +37,13 @@ point (see the critique below).
 
 ## The email — your main deliverable with the owner
 
-- **Lives in:** `docs/planning/projects-eap-activation-plan-2026-07-07.md` **§4** ("email 1" draft).
-  A polished full draft was also delivered in chat this session; §4 carries the two-layer flagship +
-  the honest "friction, not a work-stopper" framing.
+- **Canonical (2026-07-08 refresh):** `docs/planning/projects-eap-anthropic-email-2026-07-08.md` —
+  adds the claude.ai **"Skip all approvals"** precedent as the value anchor, restructures into
+  positives / negatives / what-we-tried / value / **explicit asks-back** (test cases? workarounds?
+  is-it-intentional?), and carries a verifiability appendix. **Send from this doc.**
+- **Prior draft (provenance only):** `docs/planning/projects-eap-activation-plan-2026-07-07.md` **§4**
+  ("email 1"); it carries the two-layer flagship + the "friction, not a work-stopper" framing that
+  the refresh builds on.
 - **Discipline (owner-set, treat as binding):**
   - **Every claim maps to a verifiable source** — the probe report, a committed artifact, a
     documented Claude Code behaviour, or an explicit "not yet tested" marker. No naked assertions.

--- a/docs/planning/forward-only-project-custom-instructions-2026-07-08.md
+++ b/docs/planning/forward-only-project-custom-instructions-2026-07-08.md
@@ -1,0 +1,108 @@
+# Forward-only Project — Custom Instructions (ready to paste, 2026-07-08)
+
+> **Status:** `reference` — the paste-in Custom Instructions for a **fresh** Claude Code Project
+> configured to do forward-moving work and **never attempt** a destructive / prompt-forcing action.
+> This is the *setup* half of the forward-only quality experiment
+> ([`docs/ideas/forward-only-project-quality-experiment-2026-07-08.md`](../ideas/forward-only-project-quality-experiment-2026-07-08.md));
+> the *results* half is an observations note written after real work runs through it.
+> **Provenance:** owner directive 2026-07-08 — "create a fresh project with better-scoped
+> instructions so it does not even think about doing any destructive actions… show what happens if we
+> try to prevent it and how it affects the quality of our work."
+
+## How to use
+
+1. Create a **new** Project (claude.ai/code → Projects → New Project). Name it something like
+   `superbot — forward-only`. Repo list: `menno420/superbot` (add `superbot-next` later if you point
+   this experiment at the rebuild).
+2. Project Settings → **Custom Instructions** → paste the block below verbatim.
+3. Hand the coordinator a **bounded, already-decided** piece of work (a queued idea or the next port
+   band) — not a vague goal — so the experiment measures *forward-only cost*, not *ambiguity cost*.
+4. Let it run. Afterward, write the observations note (did work still ship? messier history? any
+   stuck/confused states? cycles saved by not probing walls?) → EAP evaluation log + follow-up-email
+   paragraph.
+
+## Why forward-only is a real setting, not a handicap
+
+Every destructive git operation has a forward-only equivalent that reaches the same end state:
+
+| Instead of (walled / prompt-forcing) | Do this (forward-only, un-gated) |
+|---|---|
+| force-push a rewritten commit | push a **fresh branch**; open a new PR |
+| `--amend` an already-pushed commit | add a **fixup commit** |
+| squash locally then force-push | let **squash-merge** flatten history at merge time |
+| `git push origin --delete <branch>` | leave cleanup to GitHub **auto-delete-on-merge** + a token-backed Action |
+| first-publish a new repo via `git push` | create files via the **GitHub Contents API** |
+| rebase a stale branch onto main | **branch fresh** from main and re-apply |
+
+So the constraint costs **history tidiness**, not **capability**. The experiment quantifies exactly
+how much of even that is real.
+
+---
+
+## PASTE-IN BLOCK (everything below the line)
+
+---
+
+**This is a forward-only Project. Read this before doing anything.**
+
+**Orientation.** At session start, read `.claude/CLAUDE.md`, then `docs/collaboration-model.md`,
+`docs/current-state.md`, and `docs/AGENT_ORIENTATION.md` for the task-specific reading route. Source
+code and merged PRs win over any doc.
+
+**Forward-only git — never attempt these.** Do not force-push, do not `git push --force[-with-lease]`,
+do not `git push origin --delete` a branch, do not `--amend` or rebase an already-pushed commit, and
+do not first-publish a new public repo via `git push`. These are walled in auto mode and will only
+burn cycles hitting a denial. Treat their absence as **normal**, not a blocker. Use the forward-only
+equivalent every time:
+- Need a clean history? Push a **fresh branch** and open a new PR — never rewrite a pushed one.
+- Need to fix a pushed commit? Add a **fixup commit** — never amend.
+- Want a flat final history? Rely on **squash-merge** at merge time.
+- Branch cleanup? Leave it to GitHub's **auto-delete-on-merge** — never delete a remote branch
+  yourself. Do **not** create disposable/scratch remote branches you would then want to delete; you
+  cannot, and stranding them is worse than not creating them.
+- First commit to a new/empty repo? Use the **GitHub Contents API** (`create_or_update_file`), not
+  `git push`.
+
+**If a task genuinely seems to need a destructive step, it doesn't — find the forward-only path
+first.** In the rare case none exists, **do not attempt it and do not stall**: finish everything else,
+then flag the one destructive step to the owner in your status report (name the operation + target +
+why) and move on. Never route a destructive action through a spawned worker to "get around" the wall —
+that is caught as an auto-mode bypass and wastes the run.
+
+**Decide and flag; never wait.** For any reversible decision (nearly every planning/design/build
+call — nothing deploys until the owner reacts), **decide it yourself**: pick the option, give a
+one-line rationale, flag it in your status report, and keep moving. Silence from the owner = consent =
+keep going. Only stop-and-ask for genuine product/intent ambiguity or a truly irreversible external
+step. Do not park reversible decisions for the owner.
+
+**Ship in logical batches, forward.** Open a PR ready; let it auto-merge on green CI (merging is
+deploying — Railway redeploys `worker` on merge; never tell the owner to "restart" or "deploy").
+Follow this repo's conventions: a `.sessions/<date>-<slug>.md` session card, a lane claim in
+`docs/owner/claims/<branch>.md` (create at start, delete at close), and the born-red → flip-to-ready
+gate. Match CI exactly: run checks via `python3.10 -m …` / `python3.10 scripts/check_quality.py
+--full` before pushing.
+
+**Coordinator environment realities** (plan around them, don't fight them): the coordinator has no
+direct shell (workers do the file/git work), a ~4 KB cap on child-session instructions (use "read
+doc X, do task N" pointers, not inline briefs), no working self-wake timer, and MCP-created PRs need
+`enable_pr_auto_merge` called manually. Webhooks don't deliver CI-success / merge-conflict / new-push,
+so verify PR state with a fresh fetch rather than assuming.
+
+**Memory is a working cache, not the record.** Anything durable gets written back to `docs/` /
+`.sessions/` the same as any session — don't let a decision live only in Project memory.
+
+---
+
+## Notes for the owner (not part of the paste-in block)
+
+- **Fresh vs. re-instruct.** You asked for a *fresh* Project, which is the cleaner experimental
+  baseline (the current Project's coordinator is "contaminated" with wall-probing history). Trade-off:
+  a fresh Project loses accumulated rebuild memory and adds a second Project to run. If you'd rather
+  keep continuity, the same block can be pasted into the current Project instead — the experiment is
+  informative either way; a fresh Project just gives a cleaner A/B.
+- **What to measure.** The valuable artifact is a short observations note answering: did work still
+  ship? Was the history meaningfully messier? Any stuck/confused states from the constraint? Cycles
+  saved by *not* probing walls? That note is direct evidence for the email's "it's friction, not a
+  work-stopper" claim — a demonstration instead of an assertion.
+- **Point it at bounded work.** The experiment measures forward-only *cost*; give it already-decided
+  work (a queued idea or the next port band) so ambiguity doesn't confound the signal.

--- a/docs/planning/projects-eap-activation-plan-2026-07-07.md
+++ b/docs/planning/projects-eap-activation-plan-2026-07-07.md
@@ -83,6 +83,13 @@ rather than restate them unchanged.
 
 ## 4. Feedback to send back to Anthropic — draft reply
 
+> **▶ Canonical email now lives in
+> [`projects-eap-anthropic-email-2026-07-08.md`](projects-eap-anthropic-email-2026-07-08.md)**
+> (2026-07-08 refresh — adds the claude.ai "Skip all approvals" precedent as the value anchor,
+> restructures into positives / negatives / what-we-tried / value / explicit asks-back, and adds the
+> "test cases? workarounds? is-it-intentional?" questions). The draft below is the prior version,
+> kept for provenance; send from the newer doc.
+
 Diana's confirmation email explicitly invites feedback at
 `claude-code-early-access@anthropic.com`. Below is a **ready-to-send, external-facing** draft —
 shorter and less repo-internal than the full product-review doc, but traceable to it.

--- a/docs/planning/projects-eap-anthropic-email-2026-07-08.md
+++ b/docs/planning/projects-eap-anthropic-email-2026-07-08.md
@@ -1,0 +1,212 @@
+# Anthropic EAP feedback email — send-ready draft (2026-07-08)
+
+> **Status:** `reference` — the consolidated, send-ready Claude Code Projects EAP feedback email.
+> Supersedes the inline `§4` draft in
+> [`projects-eap-activation-plan-2026-07-07.md`](projects-eap-activation-plan-2026-07-07.md) as the
+> canonical email home (that §4 now points here).
+> **Handoff / how this session got here:**
+> [`eap-email-and-direction-handoff-2026-07-08.md`](eap-email-and-direction-handoff-2026-07-08.md).
+> **Evidence base (public, linkable):**
+> [`projects-eap-permission-probe-report-2026-07-08.md`](projects-eap-permission-probe-report-2026-07-08.md).
+
+## Rules of the road (owner-set, binding)
+
+- **External comms are the owner's.** This is a *draft*. Merging its PR is **not** sending it. Only
+  the owner sends, from his own mail, to `claude-code-early-access@anthropic.com` (Diana's stated
+  address) / Omid / Diana.
+- **Every claim maps to a verifiable source** — the probe report, a committed artifact, a documented
+  Claude Code behaviour, or an explicit "not yet tested" marker. No naked assertions.
+- **Compact, real problems only.** Report friction we actually hit; don't bloat.
+
+## What changed vs. the previous (§4) draft — decide-and-flag
+
+1. **New finding folded in and made the value anchor:** the claude.ai **Chat/Cowork** surface ships a
+   global **"Skip all approvals"** toggle (owner screenshot, 2026-07-08 — *"Claude will work and use
+   your connectors without pausing for approval. This can put your data at risk."*). Claude Code
+   Projects has **no scoped equivalent**; its closest lever, **auto mode**, still walls destructive
+   ops even when the prompt calls for them. This turns our ask from "please add a setting" into
+   "please give Code the *scoped, safer* version of a blanket toggle you already ship in Chat."
+2. **Restructured to the shape the owner asked for:** explicit **Positives / Negatives /
+   What-we-tried-and-why / Why-the-ask-is-valuable / Asks-back** sections.
+3. **Added an explicit Asks-back block** — test cases they'd like us to run, settings/workarounds we
+   may have missed, and a direct "is this intentional / do you want to keep it?" question.
+4. **⚑ Flag for the owner — the "Projects can't replace direct management" critique** is included as
+   one measured paragraph (marked below). It's fair and evidence-backed, but it's the sharpest thing
+   in the note. **Owner call: keep, soften, or cut before sending.**
+5. **Send-timing recommendation (flag):** the prior plan was "interim note now, fuller note later."
+   Recommendation — **send this as the single substantive note now.** The Skip-all-approvals
+   precedent + the explicit asks make it worth leading with; a slimmer interim note would only cost
+   a second round-trip. Owner's call.
+
+---
+
+## The email
+
+> **Subject:** Claude Code Projects EAP — feedback after our first week
+>
+> Hi Omid, Diana,
+>
+> Thanks for the access. I think you found a near-ideal reviewer for this: `superbot` is a
+> one-person, ~1,700-merged-PR, largely agent-run production Discord bot that had to **hand-build its
+> own** coordinator, shared memory, lane claims against duplicate work, and a CI gate that holds a PR
+> "red by design" until a session declares itself done — just to function before Projects existed.
+> We're now starting a ground-up rebuild meant to be *built* by a coordinated fleet of sessions in
+> days, not months — exactly the stream a coordinator exists to run. So our bar isn't "is this a
+> nice-to-have," it's **"does this beat what we already built."** Mostly it does. Here's the honest
+> ledger, with a link to the full evidence at the end.
+>
+> ---
+>
+> **What's working well**
+>
+> - **"Say it once" memory — our strongest result.** We stated our authorization envelope *once* and
+>   the coordinator baked it into its own dispatch templates, so every session it spawns inherits it
+>   without us restating anything. That's the feature solving a problem structurally, not by recall —
+>   the single biggest daily cost it removes for us.
+> - **Unattended runs fail *fast and loud*, not silently.** When the permission layer denies an
+>   action it returns an immediate, written reason (`[Git Destructive] …`) rather than hanging on an
+>   invisible prompt. For never-wait autonomy that's the right shape — a stall with nobody at the
+>   keyboard is far worse than a clean denial, and we didn't hit stalls on permissioned actions.
+> - **The worker tier is excellent.** Coordinator-spawned worker sessions ran our full
+>   born-red-card → lane-claim → PR → auto-merge-on-green flow end to end with **zero permission
+>   prompts and no tool failures**. The capability division of labor (thin coordinator, capable
+>   workers) works as designed at the worker tier.
+> - **Zero-cost orientation.** Our repo's `CLAUDE.md` and `.claude/rules/*` were auto-injected into
+>   the coordinator's context at session start — the whole working agreement was present with no
+>   reads. For a project as convention-heavy as ours, that's a real head start.
+>
+> ---
+>
+> **Where we hit friction** (each re-runnable, not an impression)
+>
+> - **Flagship — auto mode walls destructive git with no scoped way to pre-clear it.** Auto mode's
+>   line is *reversibility of published state*: every constructive action ran unprompted (reads,
+>   local writes, outbound GET/POST, `pip install`, pushing a **new** branch, GitHub-API issue
+>   create/close, sub-agent spawns), while destroying or rewriting published state (force-push,
+>   remote-branch delete, first-publish to a new public repo) is denied. We traced the denial to
+>   **two independent walls.** (1) The **auto-mode classifier** treats a coordinator's relayed intent
+>   as "not user intent," so an *unattended* session can't self-clear — though a *present* operator's
+>   direct in-session grant does clear it, at a surprisingly low bar (a generic "I give you explicit
+>   permission," answering a request that named the operation and target, sufficed). (2) Even then,
+>   the **cloud environment's git credential** rejects the destructive push server-side (`HTTP 403`),
+>   which no in-session grant clears — so a cloud session **cannot delete a published ref at all**,
+>   operator present or not. Our coordinator literally cannot remove a scratch branch it pushed. The
+>   safety intent is right and it fails safe; the friction is that an unattended run has **no scoped
+>   way to pre-authorize even a reversible-tier action** ahead of time.
+> - **The Chat-vs-Code asymmetry that surprised us.** In the normal claude.ai app (Chat/Cowork),
+>   there's a **"Skip all approvals"** toggle — a blanket opt-in that lets Claude act *including
+>   destructive actions* ("this can put your data at risk"). Claude Code Projects — the surface built
+>   for *long, autonomous* work — has **no equivalent**, scoped or otherwise. So the product where
+>   unattended autonomy matters most is the one with the *least* operator control over the permission
+>   envelope. That inversion is the core of our suggestion below.
+> - **The genuinely dangerous shape: silent unattended failure at the *edges*.** Denials are loud
+>   (good), but the surrounding infrastructure isn't always: a container restart killed in-flight
+>   work, a usage-limit condition returned an empty "success," and a self-scheduled timer died
+>   without a signal. For an autonomy product, *silent* failure is the one shape that erodes trust —
+>   worth a pass on making these as loud as the permission denials already are.
+> - **Coordinator ergonomics gaps we worked around.** The coordinator has no direct shell, no clock,
+>   no working self-wake (`send_later` is documented in its own instructions but rejected on call),
+>   and no direct channel to steer a running child (`SendMessage` to a session id fails). Child spawn
+>   is capped at **4 KB of instructions**, which a detailed brief exceeds easily (ours did, mid-fleet).
+>   PR-webhook events don't cover CI *success*, merge-conflict, or new-push transitions, and
+>   MCP-created PRs don't fire repo workflows (we arm auto-merge manually). None are blockers; each is
+>   a paper cut on the "coordinator runs the whole project" promise.
+> - **Surface-specific gating that reads as an inconsistency.** First-publish to an empty public repo
+>   is hard-denied over `git push`, but the **GitHub Contents API** publishes the identical
+>   content — including `.github/workflows/*` — with no prompt. Net effect is the same; only the
+>   transport differs. Great as a workaround (it unblocked our two new repos); confusing as a policy.
+>
+> **⚑ [owner-review paragraph — keep / soften / cut]** *One structural observation: we tried moving
+> our own program-management role into a Project and moved it back out. A Project coordinator is
+> strictly more constrained than a direct chat for managing — no direct shell, the 4 KB spawn cap,
+> and it can't orchestrate a destructive or settings step even under a standing owner grant. Projects
+> delivers the coordination and memory it advertises, but for a program that occasionally needs a
+> destructive / settings / first-publish step, an unattended coordinator can't yet replace direct
+> management. That's a real gap between the "manage your whole project" framing and today's envelope —
+> and it's exactly what the suggestion below would close.*
+>
+> ---
+>
+> **What we tried, and why**
+>
+> We didn't want to *guess* where the autonomy envelope's edge is — we run unattended, so we have to
+> plan around it precisely. So we ran a structured **11-action permission probe** (one isolated
+> sub-agent per action, so denials don't confound each other), then three targeted follow-ups: a
+> **clear-path** test (does an explicit in-session operator grant lift the wall? — yes, at the
+> classifier; no, at the git credential), a **standing-grant** test (does a pre-authorization in the
+> Project's Custom Instructions clear it? — *couldn't run it*: the receiving coordinator session has
+> no shell, which is itself a finding), and a **Contents-API bootstrap** of two fresh repos. The
+> point was a map, not a complaint — and the map is what makes the suggestion below concrete.
+>
+> ---
+>
+> **The suggestion — and why it's valuable, not just convenient**
+>
+> A **scoped, opt-in pre-authorization setting.** Let the operator explicitly enable specific
+> normally-denied action classes for a named scope (Project / repo / account) — default-off,
+> reviewable, versioned — so it reads as an *auditable grant*, not "safety off." That converts "an
+> unattended run dead-ends" into "the operator declared once what this run may do."
+>
+> Why this is the right ask and not a weakening of safety: **you already ship the blunt version of it
+> in Chat.** The "Skip all approvals" toggle is blanket and unscoped. A per-scope, default-off,
+> versioned grant in Code is **strictly safer than that** — narrower, auditable, revocable — while
+> finally giving the *autonomy* product the operator control the *chat* product already has. Two
+> implementation notes from our probe: **both walls have to move together** (a pre-auth that clears
+> the classifier still 403s if the session's git credential doesn't carry the matching scope), and
+> the fix **isn't Projects-specific** — the same dead-end hits any unattended Claude Code session, so
+> it helps ordinary cloud sessions too.
+>
+> **Smaller asks, each from something we already hand-built** (so we know they're worth having):
+> - **Raise the 4 KB spawn-instruction cap**, or allow an attachable reference doc.
+> - **Deliver PR-webhook events for CI success and merge-conflict transitions**, not just failures.
+> - **A native "work-in-progress, don't-auto-merge-yet" PR state** that auto-merge respects (we built
+>   a session-card + CI gate for exactly this after a half-done PR merged once).
+> - **Native lane claims** — "this session owns scope X until it ends," visible to siblings at start
+>   (we built a claim-file convention for it).
+> - **Spawn-time capability introspection** — a coordinator should see a target session's toolset
+>   *before* dispatching, so a task needing a shell doesn't land in a shell-less session.
+>
+> ---
+>
+> **A few questions back to you** — we'd rather calibrate than assume:
+> 1. **Is the destructive-git wall (and the absence of a scoped pre-auth) intentional and something
+>    you'd rather keep as-is?** If so, tell us — we'll design around it permanently instead of
+>    treating it as a rough edge, and we'd frame our own docs accordingly.
+> 2. **Are there settings or workarounds we've missed?** A Custom-Instructions form that actually
+>    clears the classifier for a named scope, a cloud-environment git-credential scope, an allowlist —
+>    anything that already exists that we haven't found.
+> 3. **Would you hand us a few scenarios you most want stress-tested?** We have an unusually good
+>    harness — a ~1,700-PR autonomous project — and we're happy to run structured probes and send you
+>    verbatim results. Tell us what would be most useful to you.
+> 4. **Is the Contents-API-vs-`git push` asymmetry intentional** (the API as a sanctioned, auditable
+>    bootstrap surface) or a gap you'd want to close?
+>
+> Full probe report, public and linkable:
+> https://github.com/menno420/superbot/blob/main/docs/planning/projects-eap-permission-probe-report-2026-07-08.md
+>
+> Happy to go deeper on any of these — there's a concrete, re-runnable incident behind each one.
+>
+> Thanks again for the early access,
+> [name]
+
+---
+
+## Verifiability appendix (not part of the email — for the owner's own check)
+
+| Email claim | Source |
+|---|---|
+| Say-it-once memory held | evaluation log 2026-07-07 (coordinator baked envelope into dispatch templates) |
+| Denials fail fast + written reason | probe report tests 7/8/11; eval log 2026-07-07 ~22:38Z |
+| Worker tier ran full flow, zero prompts | eval log 2026-07-07 ~22:45Z (PR #1820) |
+| CLAUDE.md/rules auto-injected | eval log 2026-07-07 "helped" |
+| Two independent destructive-git walls | probe report §"clear-path" addendum + main table |
+| Coordinator context = untrusted / not user intent | probe report tests 7/8/11 verbatim |
+| Present-operator grant clears classifier, low bar | probe report clear-path addendum (verbatim "I give you explicit permission") |
+| git credential 403s regardless | probe report clear-path addendum (HTTP 403 capture) |
+| "Skip all approvals" toggle exists in Chat | owner screenshot 2026-07-08 (claude.ai, Opus 4.8 Medium) |
+| Silent unattended failures | evaluation log + handoff "STRONG HYPOTHESIS" list |
+| 4 KB spawn cap | eval log 2026-07-07 (child spawn API), handoff |
+| Webhooks miss CI-success/merge-conflict/new-push; MCP-PRs don't fire workflows | handoff "STRONG HYPOTHESIS"; repo auto-merge practice |
+| Contents-API bypasses first-publish wall (incl. workflows) | probe report Contents-API addendum (commits fae482ac, de36d28b, 4d17832c, 586e8f1c) |
+| Standing-grant cell NOT ATTEMPTED (no shell) | probe report standing-grant addendum (PR #1842) |
+| ~1,700 merged PRs | GitHub verified (1,741; stated as ~1,700) |

--- a/docs/planning/projects-eap-anthropic-email-2026-07-08.md
+++ b/docs/planning/projects-eap-anthropic-email-2026-07-08.md
@@ -33,7 +33,12 @@
 4. **⚑ Flag for the owner — the "Projects can't replace direct management" critique** is included as
    one measured paragraph (marked below). It's fair and evidence-backed, but it's the sharpest thing
    in the note. **Owner call: keep, soften, or cut before sending.**
-5. **Send-timing recommendation (flag):** the prior plan was "interim note now, fuller note later."
+5. **Merge-lifecycle worked example added** (owner insight, 2026-07-08): our born-red gate + early
+   auto-merge is a workaround-on-a-workaround (arm early so agents don't forget the trailing merge;
+   red-gate so early-arming doesn't merge a half-done PR). Root cause: *actions stored in agent
+   context are forgettable; actions handed to the server aren't.* Clean fix: wire Projects' existing
+   per-session working→ready→done sidebar state to auto-merge. Folded into the smaller-asks section.
+6. **Send-timing recommendation (flag):** the prior plan was "interim note now, fuller note later."
    Recommendation — **send this as the single substantive note now.** The Skip-all-approvals
    precedent + the explicit asks make it worth leading with; a slimmer interim note would only cost
    a second round-trip. Owner's call.
@@ -159,12 +164,25 @@
 > **Smaller asks, each from something we already hand-built** (so we know they're worth having):
 > - **Raise the 4 KB spawn-instruction cap**, or allow an attachable reference doc.
 > - **Deliver PR-webhook events for CI success and merge-conflict transitions**, not just failures.
-> - **A native "work-in-progress, don't-auto-merge-yet" PR state** that auto-merge respects (we built
->   a session-card + CI gate for exactly this after a half-done PR merged once).
 > - **Native lane claims** — "this session owns scope X until it ends," visible to siblings at start
 >   (we built a claim-file convention for it).
 > - **Spawn-time capability introspection** — a coordinator should see a target session's toolset
 >   *before* dispatching, so a task needing a shell doesn't land in a shell-less session.
+>
+> **One worked example of the "we hand-built a workaround" pattern — merge lifecycle.** This one is
+> worth spelling out because the workaround is visibly fixing a problem it created, which is usually a
+> sign the platform should absorb it. To get autonomous sessions to reliably land their own PRs, we
+> arrange for auto-merge to be **armed early** in the session (because an agent reliably does setup
+> steps that are on the critical path to its work) rather than at the end (a trailing step agents
+> reliably *forget* — the merge intention lives only in the session's context, which ends). But arming
+> early risks merging a *half-finished* PR, so we added a CI gate that holds every PR "red by design"
+> until the session flips a status marker as its last act — a workaround on top of a workaround. The
+> underlying insight is simple and general: **an action stored only in an agent's context is
+> forgettable; an action handed to the server is not.** Arming early works precisely because GitHub's
+> auto-merge is server-side and survives the session ending. The clean fix is one you're most of the
+> way to: Projects already tracks a per-session **working → ready-for-review → done** state in the
+> sidebar. If **auto-merge respected that state**, the entire early-arm + red-gate + end-flip dance
+> collapses to a single server-honored signal the sidebar already needs — no workaround required.
 >
 > ---
 >

--- a/docs/planning/projects-eap-evaluation-log.md
+++ b/docs/planning/projects-eap-evaluation-log.md
@@ -125,3 +125,12 @@ product review's analysis — confirm, contradict, or deepen it with lived examp
   control over the permission envelope · expected: a scoped, opt-in, default-off, versioned per-scope
   pre-authorization in Code — strictly safer than Chat's blanket toggle — so unattended runs can be
   pre-cleared for named action classes · weight: friction · reproducible: yes
+- 2026-07-08 · axis: reliability/completion · observed: (owner insight) our born-red-gate + arm-auto-
+  merge-early workflow is a self-correcting workaround stack — auto-merge is armed EARLY because
+  agents reliably do setup steps on the critical path but reliably FORGET the trailing end-of-session
+  merge (the #778 failure: the merge intention lives only in ephemeral session context); a CI "red by
+  design" gate is then added so early-arming can't merge a half-done PR, and the session flips it as
+  its last act. Root cause: an action stored only in agent context is forgettable, one handed to the
+  server (GitHub auto-merge) is not · expected: auto-merge that respects Projects' existing per-session
+  working→ready→done sidebar state, collapsing the whole dance to one server-honored signal · weight:
+  friction (a missing native primitive we hand-built around) · reproducible: yes

--- a/docs/planning/projects-eap-evaluation-log.md
+++ b/docs/planning/projects-eap-evaluation-log.md
@@ -116,3 +116,12 @@ product review's analysis — confirm, contradict, or deepen it with lived examp
   path" — either way this is the cleanest current workaround for the one-time bootstrap and
   plausibly unblocks the wider rebuild workflow for these repos · weight: capability (a real
   unblock) · reproducible: yes
+- 2026-07-08 · axis: use-case fit · observed: the normal claude.ai Chat/Cowork surface exposes a
+  global **"Skip all approvals"** toggle (owner screenshot — "Claude will work and use your
+  connectors without pausing for approval. This can put your data at risk."), i.e. a blanket opt-in
+  to act *including* destructive actions; Claude Code Projects — the surface built for long
+  autonomous work — has NO equivalent, scoped or otherwise, and auto mode walls destructive git even
+  when the prompt names it. The product where unattended autonomy matters most has the LEAST operator
+  control over the permission envelope · expected: a scoped, opt-in, default-off, versioned per-scope
+  pre-authorization in Code — strictly safer than Chat's blanket toggle — so unattended runs can be
+  pre-cleared for named action classes · weight: friction · reproducible: yes


### PR DESCRIPTION
## Summary

Owner-directed management/chat session continuing the Claude Code Projects EAP feedback thread. Docs-only. Two deliverables:

1. **Refreshed Anthropic feedback email** (complete, send-ready standalone doc) — incorporates a new owner finding: the claude.ai Chat/Cowork surface ships a **"Skip all approvals"** toggle that enables even destructive actions, while Claude Code Projects auto mode has **no scoped equivalent** and walls destructive ops even when explicitly prompted. Restructured into positives / negatives / what-we-tried-and-why / value-of-the-ask / explicit asks (test cases, settings workarounds, is-it-intentional).
2. **Forward-only Project custom instructions** — ready-to-paste block for a fresh Project scoped so agents never *attempt* a destructive / prompt-forcing action (fresh branch over force-push, fixup over amend, Contents-API for files, decide-and-flag genuinely-needed destructive steps to the owner). This is the setup half of the forward-only quality experiment.

## Linked issue / plan

- `docs/ideas/forward-only-project-quality-experiment-2026-07-08.md`
- `docs/planning/eap-email-and-direction-handoff-2026-07-08.md`
- `docs/planning/projects-eap-permission-probe-report-2026-07-08.md` (evidence base)

## Type of change

- [x] Documentation

## Checks

- [x] Docs only — no `disbot/` runtime code, no secrets/tokens
- [x] Every email claim tied to a verifiable source or an explicit "not yet tested" marker

<!-- The email is a DRAFT — merging this PR is NOT sending it. External comms are the owner's to send. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01TUW6Dmh6J3JtfSDenzVVWx)_