### PR TITLE
Grooming: route PR #1846 follow-ons (supersede-checker) to their doc homes

### DIFF
--- a/.sessions/2026-07-08-groom-pr1846-followons.md
+++ b/.sessions/2026-07-08-groom-pr1846-followons.md
@@ -1,7 +1,85 @@
 # 2026-07-08 — Grooming: PR #1846 follow-ons (Wave-2, coordinator-dispatched)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
+> **Run type:** grooming-only, docs-only · Branch `claude/groom-pr1846-followons` · PR **#1854**.
 
 **Intent:** docs-only grooming pass routing the four follow-on items surfaced by merged
 PR #1846 (supersede-banner integrity checker) into their correct documentation homes per
 the `docs/ideas/README.md` lifecycle. No code/checker changes.
+
+## Routing decisions (one-line rationale each)
+
+| Item | Home | State | Rationale |
+|---|---|---|---|
+| **A** `--strict` promotion | [`docs/ideas/supersede-banner-integrity-checker-2026-07-06.md`](../docs/ideas/supersede-banner-integrity-checker-2026-07-06.md) § Follow-ups | tracked note, trigger: *~5 sessions/passes of clean warn output (Q-0105 proving period)* | Future-conditional on the idea's own artifact → its lifecycle home, not a new file. |
+| **B** culprit-attribution for live-tree tests | [`docs/ideas/live-tree-test-culprit-attribution-2026-07-08.md`](../docs/ideas/live-tree-test-culprit-attribution-2026-07-08.md) + README index entry | new idea file | Genuinely new (dedup-grepped ideas + roadmap: no hit); promotes the #1846 card's deliberately card-only Q-0089 flag into the backlog where grooming can find it. |
+| **C** how did #1843 "merge red"? | [`docs/operations/ci-what-runs-where.md`](../docs/operations/ci-what-runs-where.md) §2b, dated note | inline answer (cheap — one check-runs API call + git log) | It merged **green-by-skip**: docs-only fast path skipped pytest (12 s green run on head `faaa29f`), so the live-tree homing test never ran on the PR that introduced the unhomed plan; the CI-coverage map is where that gap class is catalogued. |
+| **D** extend checker to `.sessions/` + mid-doc banners | same § Follow-ups as A | tracked note, trigger: *warn-period output shows real drift in `.sessions/` or mid-doc banners* | Same artifact, same future-conditional shape as A; checker header explicitly scopes these out today, so extension must be evidence-driven. |
+
+**Item C full answer (also in the ci-what-runs-where note):** PR #1843's required
+`code-quality` check ran green in 12 seconds (11:06:56→11:07:08Z) on head `faaa29f` because the
+workflow's docs-only fast path skips ruff/mypy/pytest; `check_docs --strict` (which does run on
+docs-only PRs) checks reachability/badges, not plan homing. #1843 added
+`docs/planning/per-repo-settings-state-ledger-2026-07-08.md` without a routing-doc link, so
+`test_live_repo_plans_are_all_homed` — a live-tree test validating the checked-out tree, not
+the diff — failed on every subsequent full-CI branch until parallel sessions homed the plan
+(#1845 `75a495a`, #1846-lane `58a2e24`, dedup `0dc13f6`). Not a stale-base race, not a red
+merge: the required check passed legitimately under its fast path; the test it would have
+failed was skipped by design on exactly the PR class that introduces this drift.
+
+## ⚑ Self-initiated
+
+Coordinator-dispatched grooming (Wave-2, PR #1846 follow-ons) — the four routings above are the
+dispatched scope; no un-dispatched promotions. The one judgment call: answering item C inline
+(it was cheap) instead of filing a router Q-block.
+
+## Backlog grooming (Q-0015)
+
+This session **is** a grooming pass: it moved one implemented idea's follow-ups into tracked
+trigger-conditioned notes (A/D), promoted one card-only Q-0089 flag into a real backlog idea
+file (B), and closed one open question inline (C).
+
+## 💡 Session idea (Q-0089)
+
+**Warn-first proving-period evidence trail.** Item A's promotion trigger ("~5 sessions of clean
+warn output") is currently uncheckable — nothing records how many times a Q-0105 warn-first
+checker has run clean, so promotion/deletion decisions rest on vibes and archaeology. Idea: the
+session-close skill (or `check_docs`' soft-check summary) writes one greppable line per
+warn-first checker into the session card (`warn-checker: check_supersede_integrity=0 findings`),
+so "N clean sessions" is answerable with one grep over `.sessions/`. Dedup-checked:
+`warn-first-checker-authoring-kit-2026-07-06` scaffolds *new* checkers,
+`sim-assumption-telemetry-loop-2026-06-22` is the same self-verifying instinct for sims — neither
+tracks proving-period outcomes. Card-flag capture (small, protocol-level); worth an idea file if
+a second consumer appears.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed: the Wave-1 lane B session (PR #1846). Genuinely strong — it verified its checker's
+detection was non-vacuous against ground truth (Q-0120 discipline: 6 banners + 5 rows detected,
+0 findings), fixed the #1843 homing drift on sight (Q-0166), and yielded cleanly to the parallel
+#1848 homing fix instead of duplicating the index row. One miss / concrete workflow improvement:
+its Q-0089 idea was deliberately left as a **card-only flag** ("campaign rails route follow-ons
+to Wave-2 grooming") — which worked only because a coordinator actually dispatched this Wave-2
+pass. A card-only 💡 flag is invisible to `groom-ideas` (which browses `docs/ideas/`), so an
+undispatched follow-on would rot. Improvement: campaign rails should have EXECUTE lanes still
+write the one-paragraph idea *file* (cheap, ~2 min) and let grooming enrich it later — or
+`groom-ideas` should also grep recent `.sessions/` cards for 💡 flags that lack a matching idea
+file.
+
+## Docs audit (Q-0104)
+
+- `python3.10 scripts/check_current_state_ledger.py --strict` — see verification below.
+- `python3.10 scripts/check_docs.py --strict` — see verification below.
+- New idea file reachable via the README index; follow-ups live on the idea's own artifact;
+  item C's answer is in the CI-coverage map with a link back to the new idea. Nothing
+  chat-only left unhomed.
+
+## Verification
+
+- `python3.10 scripts/check_current_state_ledger.py --strict` ✓ (exit 0; 19 PRs newer than
+  marker #1830 = benign newest-merge lag, next reconciliation pass records them)
+- `python3.10 scripts/check_docs.py --strict` ✓ (all checks passed; new idea file reachable)
+- `python3.10 scripts/check_supersede_integrity.py` ✓ (web intact after the follow-ups edit)
+- `python3.10 scripts/check_plan_homing.py` ✓ (81/81 homed — item C's drift confirmed fixed)
+- No visible docs drift found beyond what this session was dispatched to route (Q-0166 sweep:
+  the ledger lag above is the allowed benign class).

--- a/.sessions/2026-07-08-groom-pr1846-followons.md
+++ b/.sessions/2026-07-08-groom-pr1846-followons.md
@@ -1,0 +1,7 @@
+# 2026-07-08 — Grooming: PR #1846 follow-ons (Wave-2, coordinator-dispatched)
+
+> **Status:** `in-progress`
+
+**Intent:** docs-only grooming pass routing the four follow-on items surfaced by merged
+PR #1846 (supersede-banner integrity checker) into their correct documentation homes per
+the `docs/ideas/README.md` lifecycle. No code/checker changes.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,14 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`live-tree-test-culprit-attribution-2026-07-08.md`](./live-tree-test-culprit-attribution-2026-07-08.md) —
+  **grooming capture (2026-07-08, PR #1846 follow-on pass):** live-tree ground-truth tests
+  (plan homing etc.) fail on innocent fresh branches whenever an earlier merge shipped tree
+  drift — observed three times, hand-bisected each time (#1843 being the latest: a docs-only
+  PR skipped pytest entirely, then reddened every full-CI branch). Proposes a named CI step
+  ("tree drift, probably not your diff"), a `push:main` leg that opens a culprit issue (a
+  push-main failure names its own culprit — no bisect), and running the stdlib live-tree docs
+  guards on the docs-only fast path to close the introduction vector.
 - [`claim-remote-visibility-scan-2026-07-08.md`](./claim-remote-visibility-scan-2026-07-08.md) —
   **session idea (2026-07-08, Q-0089, grooming wave-1 lane C, #1845):** claims only become visible
   to siblings via the open PR — `check_lane_overlap.py` reads the *local* claims dir, so a claim on

--- a/docs/ideas/live-tree-test-culprit-attribution-2026-07-08.md
+++ b/docs/ideas/live-tree-test-culprit-attribution-2026-07-08.md
@@ -1,0 +1,56 @@
+# Culprit attribution for live-tree ground-truth tests (2026-07-08)
+
+> **Status:** `ideas` — capture only, not a plan, not approval.
+> **Subsystem:** none (agent-workflow / CI tooling).
+> *(Grooming capture, 2026-07-08, from the PR #1846 follow-on pass — Wave-2,
+> coordinator-dispatched. Promotes the Q-0089 flag on the Wave-1 lane B session card,
+> `.sessions/2026-07-08-wave1-lane-b-supersede-checker.md`, which deliberately left the
+> capture card-only per campaign rails "route follow-ons to Wave-2 grooming".)*
+
+## The problem
+
+Live-tree ground-truth tests (`test_check_plan_homing.py::test_live_repo_plans_are_all_homed`,
+and siblings that assert a property of the **checked-out tree**, not the diff) have a built-in
+attribution gap: when one fails on a fresh branch, the failure is almost never *caused by that
+branch's diff* — it inherits drift some earlier merge shipped to `main`. Observed repeatedly:
+
+- **PR #1843 (2026-07-08):** a docs-only PR added a `docs/planning/` plan without a routing-doc
+  link. Its own `code-quality` ran green in 12 s (the docs-only fast path skips pytest), so the
+  live-tree homing test never ran on it — and then failed on every subsequent full-CI branch
+  until two parallel sessions homed the plan by hand. (Full archaeology:
+  `docs/operations/ci-what-runs-where.md` §2b, dated note 2026-07-08.)
+- **Band-#1800 reconciliation (2026-07-07):** the same test was red for every open PR because
+  three kit-lab plans were homed only from a sibling index, and the pass had to detective the
+  culprit by hand.
+- **Band-#1230 (2026-06-21):** same class — doc edits removed the last routing links.
+
+Each time, an innocent session burns time proving "not my diff" and then bisecting `main` by
+hand. Nothing attributes the breakage to the merge that caused it.
+
+## The idea
+
+1. **Named CI step.** Run the live-tree ground-truth tests as their own named step (e.g.
+   `live-tree ground truth`) inside `code-quality`, separate from the general pytest blob — so
+   a red is *immediately legible* as "the tree drifted; probably not your diff" instead of an
+   anonymous pytest failure the session debugs as its own.
+2. **Post-merge culprit issue.** A `push:main` leg runs the same tests on `main` itself; on
+   failure it opens (or updates) a **culprit issue** naming the merge that flipped main red —
+   which on a push-triggered run is precisely the commit being tested, so attribution is free,
+   no bisect needed. The issue is the durable handoff: the next session fixes the drift at the
+   root instead of every open PR independently rediscovering it.
+3. **Companion root fix** (smaller, arguably first): the docs-only fast path is the one PR
+   class that can *introduce* this drift while skipping the test that guards it. Running the
+   cheap live-tree docs guards (`check_plan_homing.py --strict` at minimum — stdlib, no deps)
+   on the docs-only path too closes the introduction vector; culprit attribution then handles
+   whatever still slips through (e.g. semantic merges of two individually-green PRs).
+
+## Why it's worth having
+
+Friction → guard (Q-0194): the by-hand archaeology this idea mechanizes has now been done at
+least three times (band-#1230, band-#1800, and the #1843 pass that produced this capture). The
+live-tree test family is growing (plan homing, session-slug uniqueness, ledger parity …), and
+every new member widens the "innocent branch inherits main's drift" window. Attribution is the
+cheap half — a push-main failure names its own culprit.
+
+Workflow edits are owner-gated (Q-0194 split) — the checker/step design is free to plan; the
+`.github/workflows/` wiring ships owner-directed or via a router DISCUSS Q.

--- a/docs/ideas/supersede-banner-integrity-checker-2026-07-06.md
+++ b/docs/ideas/supersede-banner-integrity-checker-2026-07-06.md
@@ -36,3 +36,20 @@ doc that actually carries the banner. Warn-first (Q-0105 header, disposable), pr
 "Enforce, don't exhort" (Q-0132/Q-0194) applied to the one docs-drift class that reconciliation
 passes keep re-finding by hand. The supersede convention is now load-bearing — the canonical plan
 is only "the single source of truth" while the losers visibly point at it.
+
+## Follow-ups (tracked 2026-07-08, grooming pass on PR #1846)
+
+Two future-conditional follow-ons from the implementing session, recorded here (the idea's
+lifecycle home) with explicit triggers so a later session can act on evidence, not memory:
+
+- **Promote to `--strict`.** *Trigger:* after **~5 sessions / reconciliation passes of clean
+  warn output** (the Q-0105 proving period — no false positives, and no Q-0120 false-green
+  where visible banner drift passed). Then: run `check_supersede_integrity.py --strict` in the
+  `check_docs --strict` session-close/CI path and drop the "unverified" header clause. If the
+  warn period instead shows noise, the header's own instruction applies — delete the checker.
+- **Extend scope to `.sessions/` and mid-doc banners.** *Trigger:* **if warn-period output (or
+  a reconciliation pass) shows real supersede drift in `.sessions/` cards or in mid-doc
+  section-level banners** — both intentionally out of scope today (see the checker header:
+  only header-block banners under `docs/` count). Don't extend speculatively: mid-doc
+  `SUPERSEDED` markers (e.g. `docs/btd6/`) are section-level by convention and a naive
+  extension would be all noise.

--- a/docs/operations/ci-what-runs-where.md
+++ b/docs/operations/ci-what-runs-where.md
@@ -109,6 +109,21 @@ Still local/routine-only (candidates for a verified follow-up, not yet gating):
 | `check_dashboard_data.py` | routine | Belongs on the dashboard leg (drift shipped to main: #988/#1020/#1023). |
 | dashboard / botsite / design-system `mypy`+`pytest` | advisory app-CI | Yes — promote to gating on their (path-filtered) legs. |
 
+**The docs-only fast path skips the live-tree ground-truth tests — verified case, 2026-07-08
+(PR #1843 archaeology).** #1843 did not merge red; it merged **green-by-skip**. It was
+docs-only, so its required `code-quality` run on head `faaa29f` completed green in **12 s**
+(11:06:56→11:07:08Z): the fast path (§1 row 1) skipped ruff/mypy/**pytest**, and the doc-hygiene
+gate that *does* run on docs-only PRs (`check_docs --strict` — reachability/badges) does **not**
+check plan homing. The PR added `docs/planning/per-repo-settings-state-ledger-2026-07-08.md`
+with no routing-doc link, so `test_check_plan_homing.py::test_live_repo_plans_are_all_homed` — a
+**live-tree** test that validates the checked-out tree, not the diff — failed on every
+subsequent branch containing that merge where pytest actually ran, until parallel sessions homed
+the plan by hand (roadmap horizon in #1845 commit `75a495a`; plan-index row on the #1846 lane
+`58a2e24`; deduped `0dc13f6`). Root-cause class: **the one PR class that can introduce docs
+drift (docs-only) is exactly the class where the live-tree tests guarding it are skipped.**
+Follow-up idea (named CI step + push-main culprit issue + stdlib docs guards on the fast path):
+[`../ideas/live-tree-test-culprit-attribution-2026-07-08.md`](../ideas/live-tree-test-culprit-attribution-2026-07-08.md).
+
 ### 2c. Advisory (correctly non-blocking — a session may legitimately be *fixing* the thing)
 
 `check_current_state_ledger` · `check_migration_collision` · `check_permission_overlap` ·

--- a/docs/owner/claims/claude-groom-pr1846-followons.md
+++ b/docs/owner/claims/claude-groom-pr1846-followons.md
@@ -1,0 +1,3 @@
+# Claim
+
+- claude/groom-pr1846-followons · grooming-only: PR #1846 follow-ons · docs/ideas + docs/owner + .sessions · 2026-07-08

--- a/docs/owner/claims/claude-groom-pr1846-followons.md
+++ b/docs/owner/claims/claude-groom-pr1846-followons.md
@@ -1,3 +1,0 @@
-# Claim
-
-- claude/groom-pr1846-followons · grooming-only: PR #1846 follow-ons · docs/ideas + docs/owner + .sessions · 2026-07-08


### PR DESCRIPTION
## What

Docs-only grooming pass (Wave-2, coordinator-dispatched) routing the four follow-on items
surfaced by merged PR #1846 (supersede-banner integrity checker) into their documentation
homes per the `docs/ideas/README.md` lifecycle:

- **A. `--strict` promotion** (future-conditional) → tracked follow-ups note with an explicit trigger.
- **B. Culprit-attribution for live-tree ground-truth tests** → new idea file + README index entry (dedup-checked).
- **C. How did PR #1843 merge red?** → answered inline from CI/merge-timeline archaeology if cheap, else a router Q-block.
- **D. Extend checker to `.sessions/` + mid-doc banners** (future-conditional) → tracked note with explicit trigger, same home as A.

## Scope

Docs-only — no `disbot/`, `scripts/`, `tests/`, or `.github/` changes. Forward-only git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fC9vzCuTgd2sup4qT4UAK

---
_Generated by [Claude Code](https://claude.ai/code/session_016fC9vzCuTgd2sup4qT4UAK)_