### PR TITLE
CI: enforce plan homing on the docs-only fast path (closes the #1843 green-by-skip gap)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -82,6 +82,20 @@ jobs:
       - name: Run doc hygiene (check_docs)
         run: python3 scripts/check_docs.py --strict
 
+      # Plan-homing gate — runs on EVERY PR (incl. docs-only), pure stdlib so it needs no
+      # setup, ~1s. Closes the #1843 "green-by-skip" gap: the docs-only fast path skips
+      # pytest, including the live-tree test test_live_repo_plans_are_all_homed — so the one
+      # PR class that can introduce an unhomed plan (docs-only) was exactly the class where
+      # the guard was skipped, and #1843 merged green in 12s then reddened every subsequent
+      # full-CI branch. check_docs above checks *reachability* (≥1 inbound link from
+      # anywhere); this checks *homing* (a live `plan`-badged doc must be linked from a
+      # routing doc — roadmap / current-state / plan index / a folio). See
+      # scripts/check_plan_homing.py and docs/operations/ci-what-runs-where.md §2b.
+      # Q-0194 friction→guard, wired 2026-07-08 (from the PR #1854 archaeology). Disposable
+      # (Q-0105): drop this step if it false-blocks (e.g. deliberately-parked drafts).
+      - name: Plan-homing gate (check_plan_homing)
+        run: python3 scripts/check_plan_homing.py --strict
+
       # Tool-pin drift is a HARD gate (CI-setup redesign PR #1739, decision G4). The pins must match
       # across code-quality.yml / requirements-dev.txt / .pre-commit-config.yaml (CLAUDE.md rule #3); a
       # Dependabot bump of one alone silently desynced them and reached main (#1315). tool-pins.yml runs

--- a/.sessions/2026-07-08-docs-fast-path-plan-homing-gate.md
+++ b/.sessions/2026-07-08-docs-fast-path-plan-homing-gate.md
@@ -1,0 +1,11 @@
+# 2026-07-08 — Docs-only fast path: enforce plan homing (from #1854 finding)
+
+> **Status:** `in-progress`
+
+**Intent:** close the #1843 "green-by-skip" gap — the docs-only fast CI path in
+`code-quality.yml` skips pytest (including the live-tree plan-homing test), so a docs-only PR
+can land an unhomed plan and redden every subsequent full-CI branch. Wire the pure-stdlib
+`scripts/check_plan_homing.py --strict` as an always-run pre-setup step in the required
+`code-quality` job (the `check_docs` pattern), so the fast path enforces plan homing in ~a
+second. Campaign-dispatched (Q-0194 friction→guard, checker/CI tier) from the PR #1854
+§2b archaeology.

--- a/.sessions/2026-07-08-docs-fast-path-plan-homing-gate.md
+++ b/.sessions/2026-07-08-docs-fast-path-plan-homing-gate.md
@@ -1,6 +1,6 @@
 # 2026-07-08 — Docs-only fast path: enforce plan homing (from #1854 finding)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Intent:** close the #1843 "green-by-skip" gap — the docs-only fast CI path in
 `code-quality.yml` skips pytest (including the live-tree plan-homing test), so a docs-only PR
@@ -9,3 +9,67 @@ can land an unhomed plan and redden every subsequent full-CI branch. Wire the pu
 `code-quality` job (the `check_docs` pattern), so the fast path enforces plan homing in ~a
 second. Campaign-dispatched (Q-0194 friction→guard, checker/CI tier) from the PR #1854
 §2b archaeology.
+
+## What shipped (PR #1855)
+
+- `.github/workflows/code-quality.yml` — new always-run pre-setup step **"Plan-homing gate
+  (check_plan_homing)"** right after `check_docs`: `python3 scripts/check_plan_homing.py
+  --strict`. Unconditional (no `if:`), pure stdlib, before Python/pip setup → it runs on the
+  docs-only fast path, which was exactly the PR class where the live-tree guard
+  (`test_live_repo_plans_are_all_homed`) was skipped.
+- `scripts/check_plan_homing.py` — docstring updated: `--strict` is now a per-PR merge gate
+  (was "report-only by design / routine cadence"); Q-0105 reliability header updated with the
+  CI-gating date and a "demote to advisory / delete if noisy" kill-switch.
+- `docs/operations/ci-what-runs-where.md` — §1 row 1 note, §2a new gating row, §2b marked
+  CLOSED-for-plan-homing, §2d annotated (also per-PR gate now).
+
+## Ground-truth proofs (Q-0120)
+
+- **Fails when it should:** induced `docs/planning/zz-scratch-unhomed-plan-proof-2026-07-08.md`
+  (`plan` badge, no routing link) in the working tree only → `--strict` exited 1, named the
+  file. Never committed.
+- **Passes on the live tree:** `check_plan_homing: OK — all 81 live plan docs … are linked
+  from a routing doc`, exit 0, 0.65s wall.
+- **Runs in CI:** this PR touches workflows/scripts → full CI path (expected). A post-merge
+  scratch draft PR (docs-only diff + induced unhomed plan, `do-not-automerge`, closed
+  immediately, branch deleted) demonstrates the fast path executes the gate red — recorded in
+  the coordinator report; result was not known at card-flip time (the workflow change must be
+  on `main` before a docs-only PR can exercise it; a scratch PR carrying the workflow edit
+  would itself take the full path).
+
+## Decisions (decide-and-flag)
+
+- **Shape (b)-adjacent, as its own named step, not folded into `check_docs.py`:** the checker
+  already exists, is stdlib, and a named step gives per-check attribution in the checks UI
+  (the §2b follow-up idea explicitly wants named-step attribution). One workflow step beats
+  editing `check_docs`'s scope.
+- **Unconditional (every PR), not docs-only-gated:** ~1s on full-path PRs is noise, and it
+  gives a fast named failure before the 3-minute pytest run reaches the same live-tree fact.
+- **Docstring/reliability header updated in the same PR** so the script's self-description
+  doesn't contradict its wiring (Q-0120 class).
+
+## Session enders
+
+- **💡 Session idea (Q-0089):** a *fast-path deps-parity test* — extend
+  `tests/unit/scripts/test_workflow_script_flags.py` (or a sibling) to assert every
+  **unconditional** step in `code-quality.yml` (no `if: steps.changes.outputs.code == 'true'`)
+  invokes only scripts whose imports are stdlib (no PyYAML etc.), since pip install hasn't run
+  yet at that point. The failure mode is real: an agent copying the `check_consistency` pattern
+  into the pre-setup block would redden **every docs-only PR** with an ImportError.
+  Dedup-checked: `live-tree-test-culprit-attribution-2026-07-08.md` covers *adding* stdlib
+  guards to the fast path, not *guarding the stdlib-ness* of that block. (Logged here only —
+  campaign scope excludes new `docs/ideas/` files this session.)
+- **⟲ Previous-session review (Q-0102):** the #1854 grooming session's §2b archaeology was
+  exemplary — timestamped run evidence (12s green on `faaa29f`), the exact commits that
+  hand-fixed the drift, and a crisp root-cause class. What it left open: the enforcing guard
+  itself, which Q-0194 wants shipped the same session friction is found — defensible under its
+  docs-only scope, and the workflow *self-corrected* (its finding became this dispatched
+  session within hours). Improvement surfaced: a grooming/docs session that identifies a
+  one-step enforceable guard could name the exact step in its handoff (「add step X after
+  step Y」) so the follow-up session is pure execution — #1854 §2b did nearly that, which is
+  why this session was cheap.
+- **Q-0104 docs audit:** `check_current_state_ledger --strict` green (benign newest-merge lag
+  ≤ marker rules); `check_docs --strict` green; no new owner decision → no router entry; the
+  gate's durable home is `ci-what-runs-where.md` (updated in this PR). Nothing chat-only left.
+- **Provenance:** campaign-dispatched worker session, from the PR #1854 §2b finding
+  (coordinator task, Q-0194 checker/CI tier — free-to-ship lane).

--- a/docs/operations/ci-what-runs-where.md
+++ b/docs/operations/ci-what-runs-where.md
@@ -45,7 +45,7 @@ non-blocking / `continue-on-error`) · **R** = routine (schedule/dispatch, not p
 
 | # | Workflow | Trigger (today) | Class | Required? | Concurrency | Role / notes |
 |---|---|---|---|---|---|---|
-| 1 | `code-quality.yml` | `push:main`, `pull_request:main`, `workflow_dispatch` | **G** | **YES** (`code-quality`) | `code-quality-${ref}`, **cancel:false** | The merge gate. Bundles ruff/black/isort/mypy/pytest + `check_docs` + `check_consistency` + `check_session_gate` (born-red) + `check_stale_claims`. Docs-only fast path skips heavy steps but still reports green. |
+| 1 | `code-quality.yml` | `push:main`, `pull_request:main`, `workflow_dispatch` | **G** | **YES** (`code-quality`) | `code-quality-${ref}`, **cancel:false** | The merge gate. Bundles ruff/black/isort/mypy/pytest + `check_docs` + `check_plan_homing` + `check_consistency` + `check_session_gate` (born-red) + `check_stale_claims`. Docs-only fast path skips heavy steps but still reports green; the pre-setup stdlib gates (`check_docs`, `check_plan_homing`, `check_tool_pins`, `check_workflow_concurrency`) run on it regardless. |
 | 2 | `codeql.yml` | `push:main`, `pull_request:main`, weekly cron | **G** (via ruleset) | **YES** (ruleset, 2026-07-05) | `codeql-${ref}`, **cancel: false** ✓ (#1739) | SAST. Now a merge gate via the **`codeql-merge-protection` ruleset** (Require code scanning results · CodeQL · High+ · Active) — auto-merge waits for CodeQL and blocks on a High+ alert (closes the Q-0238 race). `cancel:false` so the head run isn't dropped. Residual (a CodeQL run that errors/hangs) is now bounded alerting-only by the `ci-rerun-watchdog` stuck-scan leg (#7). |
 | 3 | `auto-merge-enabler.yml` | `pull_request:[opened,reopened,ready_for_review]` | **I** | — | — | Arms native auto-merge on non-draft `claude/*` PRs. Needs `ROUTINE_PAT`. Does **not** fire on MCP-created PRs (arm manually, Q-0127). |
 | 4 | `codex-final-review.yml` | `pull_request:[synchronize,ready_for_review]` | **A** | — | — | Posts `@codex review` when the born-red card flips ready, so Codex sees the final head. |
@@ -78,6 +78,7 @@ on both heavy workflows.
 |---|---|
 | `check_quality.py` | The local CI-mirror; in CI its constituent tools (black/isort/ruff/mypy/pytest) run as explicit steps. |
 | `check_docs.py` `--strict` | Doc-hygiene: Status badges, dead links, read-path refs. Runs on **every** PR incl. docs-only. |
+| `check_plan_homing.py` `--strict` | Plan-homing gate: every live `plan`-badged doc under `docs/planning/` is linked from a routing doc (roadmap / current-state / plan index / folio). Pre-setup, pure stdlib, ~1s — runs on **every** PR incl. docs-only, closing the #1843 green-by-skip gap (§2b). Wired 2026-07-08 (PR #1855). |
 | `check_consistency.py` `--mode strict` | UX/interaction linter (graduated rules only) over `disbot/views/`. |
 | `check_session_gate.py` | The born-red merge hold (PR-only). |
 | `check_stale_claims.py` `--strict` | **Advisory** (`continue-on-error`) — surfaces orphan claim files. |
@@ -121,6 +122,8 @@ subsequent branch containing that merge where pytest actually ran, until paralle
 the plan by hand (roadmap horizon in #1845 commit `75a495a`; plan-index row on the #1846 lane
 `58a2e24`; deduped `0dc13f6`). Root-cause class: **the one PR class that can introduce docs
 drift (docs-only) is exactly the class where the live-tree tests guarding it are skipped.**
+**CLOSED for plan homing 2026-07-08 (PR #1855):** `check_plan_homing.py --strict` is now an
+always-run pre-setup step in `code-quality` (§2a), so the fast path enforces plan homing in ~1s.
 Follow-up idea (named CI step + push-main culprit issue + stdlib docs guards on the fast path):
 [`../ideas/live-tree-test-culprit-attribution-2026-07-08.md`](../ideas/live-tree-test-culprit-attribution-2026-07-08.md).
 
@@ -133,8 +136,8 @@ Follow-up idea (named CI step + push-main culprit issue + stdlib docs guards on 
 ### 2d. Routine (schedule / dispatch / reconciliation set — not per-PR)
 
 `check_reconciliation_due` · `check_reconcile_marker` · `check_ledger_hygiene` ·
-`check_completion_ledger_parity` · `check_plan_code_drift` · `check_plan_homing` ·
-`check_plan_staleness` · `check_sector_map` · `check_sector_next_freshness` ·
+`check_completion_ledger_parity` · `check_plan_code_drift` · `check_plan_homing` (also a per-PR
+gate since 2026-07-08 — §2a) · `check_plan_staleness` · `check_sector_map` · `check_sector_next_freshness` ·
 `check_startability_tags` · `check_bug_book_rootfix_backlog` · `check_plan_backlog` ·
 `check_loop_health` · `check_ci_coverage` (the dropped-`synchronize` watchdog) ·
 `check_codeql_coverage` (the CodeQL stuck-scan watchdog, A10 — shares `lib.owner_alert`).

--- a/docs/owner/claims/claude-docs-fast-path-plan-homing-gate.md
+++ b/docs/owner/claims/claude-docs-fast-path-plan-homing-gate.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/docs-fast-path-plan-homing-gate` · tooling: docs-only fast-path live-tree guard (from #1854 finding) · expected files: `.github/workflows/code-quality.yml`, `scripts/check_plan_homing.py` (docstring), `docs/operations/ci-what-runs-where.md`, session card · 2026-07-08

--- a/docs/owner/claims/claude-docs-fast-path-plan-homing-gate.md
+++ b/docs/owner/claims/claude-docs-fast-path-plan-homing-gate.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/docs-fast-path-plan-homing-gate` · tooling: docs-only fast-path live-tree guard (from #1854 finding) · expected files: `.github/workflows/code-quality.yml`, `scripts/check_plan_homing.py` (docstring), `docs/operations/ci-what-runs-where.md`, session card · 2026-07-08

--- a/scripts/check_plan_homing.py
+++ b/scripts/check_plan_homing.py
@@ -26,15 +26,21 @@ Run::
     python3.10 scripts/check_plan_homing.py --strict   # exit 1 when a live plan is unhomed
     python3.10 scripts/check_plan_homing.py --json      # machine-readable summary
 
-**Report-only by design.** An unhomed plan is a *routing* signal for the reconciliation cadence /
-a planning session, not a per-push merge blocker — so the default exit is 0 and ``--strict`` is the
-opt-in cadence gate (the pattern of ``check_plan_backlog.py``/``check_sector_map.py``). It reasons
-over docs only — never touches runtime code, never runs a bot.
+**Report-only by default; ``--strict`` is a per-PR merge gate since 2026-07-08.** The default
+exit is 0 (a routing readout for a planning session), while ``--strict`` runs as an always-on
+pre-setup step in the required ``code-quality`` job — **including the docs-only fast path**. That
+promotion (PR #1855, Q-0194 friction→guard) closes the #1843 "green-by-skip" gap: the fast path
+skips pytest, so the live-tree test ``test_live_repo_plans_are_all_homed`` never ran on exactly
+the PR class (docs-only) that can introduce an unhomed plan; #1843 merged green in 12s and
+reddened every subsequent full-CI branch until the plan was homed by hand. It reasons over docs
+only — never touches runtime code, never runs a bot.
 
-Reliability (Q-0105): **unverified — added 2026-06-20.** The "routing doc" allow-list and the
-basename link-match are heuristics; confirm the homeless list against the plan index by hand a few
-times across sessions before trusting ``--strict``, and **delete this script if it proves noisy**
-(e.g. flags deliberately-parked Someday drafts) over multiple sessions rather than working around it.
+Reliability (Q-0105): added 2026-06-20; CI-gating since 2026-07-08 (PR #1855). Verified against
+ground truth twice (the 2026-06-19 planning-map orphan set; the #1843 unhomed plan, which it
+flags and the homed fix clears). The "routing doc" allow-list and the basename link-match are
+still heuristics; **demote the CI step back to advisory (or delete this script) if it proves
+noisy** (e.g. flags deliberately-parked Someday drafts) over multiple sessions rather than
+working around it.
 
 → relates ``scripts/check_docs.py`` (reachability) · ``scripts/check_sector_map.py`` (folio homing) ·
 ``scripts/check_plan_backlog.py`` (depth) · ``docs/planning/README.md`` · ``docs/roadmap.md``.


### PR DESCRIPTION
## What

The docs-only fast path in `code-quality.yml` skips pytest — including the live-tree test
`test_live_repo_plans_are_all_homed` — so the one PR class that can introduce docs drift
(docs-only) is exactly where the guard was skipped. PR #1843 merged **green-by-skip** with an
unhomed plan and reddened every subsequent full-CI branch (documented in
`docs/operations/ci-what-runs-where.md` §2b by #1854).

This wires the existing pure-stdlib `scripts/check_plan_homing.py --strict` as an
**always-run pre-setup step** in the required `code-quality` job (the `check_docs` pattern):
no pip install, ~1s, runs on every PR including docs-only. Also updates the checker's
docstring (it is now a per-PR gate, not routine-only) and the ci-what-runs-where map rows.

Q-0194 friction→guard (checker/CI tier); campaign-dispatched from the #1854 finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSotBF7cXww71p3sg9ahow

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSotBF7cXww71p3sg9ahow)_