### PR TITLE
SCRATCH — do not merge: fast-path plan-homing gate proof (will be closed)

### DIFF
--- a/docs/planning/per-repo-settings-state-ledger-2026-07-08.md
+++ b/docs/planning/per-repo-settings-state-ledger-2026-07-08.md
@@ -58,3 +58,5 @@ instead of re-probing them (extends the coordinator's #1839 "environment capabil
 
 Phase 1 is shippable immediately (docs). Ping to build it; Phase 2 follows once the row set is
 agreed. Phase 3 is a website feature to plan on its own.
+
+(Scratch proof link — never merges: [zz-scratch-fastpath-proof-plan-2026-07-08.md](zz-scratch-fastpath-proof-plan-2026-07-08.md))

--- a/docs/planning/zz-scratch-fastpath-proof-plan-2026-07-08.md
+++ b/docs/planning/zz-scratch-fastpath-proof-plan-2026-07-08.md
@@ -1,0 +1,5 @@
+# Scratch fast-path proof plan (never merges)
+
+> **Status:** `plan` — induced unhomed plan proving the docs-only fast path runs the plan-homing gate. PR is closed immediately after the red check.
+
+Scratch body.


### PR DESCRIPTION
Ground-truth proof for PR #1855 (Q-0120): a docs-only diff containing an induced unhomed
`plan` doc must take the docs-only fast CI path and go RED on the new
"Plan-homing gate (check_plan_homing)" step. This PR is a draft, labeled
`do-not-automerge`, and will be closed immediately after the check reports.

Never merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSotBF7cXww71p3sg9ahow

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSotBF7cXww71p3sg9ahow)_