### PR TITLE
EAP email: reshape Part 2 into a parallel first-person agent narrative

### DIFF
--- a/.sessions/2026-07-08-eap-email-agent-narrative.md
+++ b/.sessions/2026-07-08-eap-email-agent-narrative.md
@@ -1,0 +1,51 @@
+# Session — EAP email: Part 2 as a parallel agent narrative
+
+> **Status:** `complete`
+
+## What this session did
+Owner-directed. Reshaped the email's **Part 2** from a tagged positives/negatives/asks audit into a
+**parallel first-person agent narrative** that mirrors the operator's Part 1 arc:
+1. **How we work — and the state it produced** (the hand-built substrate is scar tissue over real
+   agent-hit failures; that's *why* we can judge Projects feature-for-feature).
+2. **What genuinely helps — not inflated** (shared memory, capable worker tier, free orientation,
+   fail-fast denials).
+3. **The friction, deflated** (no shell, phantom `send_later`, ~4 KB brief cap, create-but-can't-
+   delete remote state / two walls, silent edge failures; Contents-API inconsistency as a note).
+4. **How it could help me more** (scoped pre-auth · pre-dispatch toolset introspection · wire
+   sidebar state→auto-merge · bigger brief budget + CI-success webhooks).
+
+Changes: **dropped the 👤/🤖 tags** (the parallel structure carries the two-consumers point);
+grounded every specific in the session journal / eval log; **moved the "a Project can't *manage*,
+only *execute*" observation out of Part 2** into a Part 1 scaffold beat (operator-side judgment);
+folded the full permission table + merge-lifecycle example into the linked probe report rather than
+inline. Kept the joint questions-back block, the dual-review closing, and the verifiability appendix.
+Docs-only; `check_docs --strict` green.
+
+## ⚑ Open for the owner (decide-and-flag)
+- **Part 1 is still yours** (scaffold in place, now incl. the manage-vs-execute beat).
+- **Framing paragraph optional** — cut if you'd rather the structure speak for itself.
+- **Self-audit `docs/eap/` link** still forward-referenced (Task-B probe not yet run) — soften to
+  "planned" if you send before it runs.
+
+## 💡 Session idea (Q-0089)
+The **dual-voice format** we converged on — two parallel first-person narratives (operator + agent) on
+one shared arc, plus a dual human+agent review — is reusable doctrine, not a one-off. Candidate for a
+**substrate-kit template** ("external feedback / field report") so any future project can report its
+human-and-agent experience the same way. Genuinely distinct from the eval log (dated incidents) and
+the external-reviewer-entrypoint idea (a front door, not a format). Lightweight; noted here rather
+than filed until a second use confirms the pattern.
+
+## ⟲ Previous-session review (Q-0102)
+Previous card (`2026-07-08-eap-email-two-part-two-reviewer.md`) got the big structure right (two
+parts, two reviewers) but **slightly over-engineered** the mechanism: it added explicit 👤/🤖 finding
+tags, which the owner then asked to remove in favor of the parallel-narrative structure carrying the
+same point organically. **Lesson / system note:** when a structural change can convey a point either
+*mechanically* (labels) or *organically* (parallel form), propose the organic form first — it reads
+as authentic feedback rather than a labeled audit, and it's less for the owner to unwind. A good
+default for the substrate kit's doc-format guidance: *structure over annotation.*
+
+## 📋 Doc audit (Q-0104)
+`check_docs --strict` green (email doc still `reference`, no dangling links, appendix intact). No
+living-ledger entry needed until merge (checker covers it then). Nothing from this session lives only
+in chat: the reshaped email + the format idea + the open owner-decisions are all in durable homes. No
+new binding rule → no router Q.

--- a/docs/planning/projects-eap-anthropic-email-2026-07-08.md
+++ b/docs/planning/projects-eap-anthropic-email-2026-07-08.md
@@ -49,6 +49,14 @@
    plus a Claude session pointed at the public repo, with entry points and concrete verification
    tasks. **⚑ Owner still writes Part 1** (the `[Menno writes this…]` scaffold block); everything else
    is drafted.
+8. **Part 2 reshaped into a parallel first-person narrative; 👤/🤖 tags dropped** (owner directive,
+   2026-07-08). Both parts now answer the same arc — *how I used Claude → the problems → how Projects
+   helps now → how it could help more* — from each author's seat; the parallel structure carries the
+   two-consumers point, so the mechanical tags are gone. Part 2 is grounded in the session journal /
+   eval log and deflated (no inflation). The "a Project can't *manage*, only *execute*" observation
+   was **moved out of Part 2** — it's an operator-side judgment, so it's now a scaffold beat in Part 1
+   for the owner to make (or not). The full permission detail + merge-lifecycle example now live in
+   the linked probe report rather than inline.
 
 ---
 
@@ -56,8 +64,8 @@
 
 > ⚑ **Owner note — this email is deliberately in two parts, by two authors, for two readers.** Part 1
 > is yours (your voice, your point of view — I've left a scaffold below, not prose). Part 2 is the
-> agents' findings. The framing paragraph explains *why* to Anthropic; keep it, or cut it if you'd
-> rather the structure speak for itself.
+> agents' parallel account, same arc from the other seat. The framing paragraph explains *why* to
+> Anthropic; keep it, or cut it if you'd rather the structure speak for itself.
 
 > **Subject:** Claude Code Projects EAP — feedback from both of its users
 >
@@ -69,8 +77,8 @@
 > the actual work inside it. We experience the product completely differently — a rough edge that's
 > invisible to me can stop an agent cold, and one that frustrates me daily is nothing to the agents.
 > So we've written this feedback from **both points of view**: Part 1 is mine, in my own words; Part 2
-> is the project's agents reporting what they hit, each finding tagged by which of us it affects
-> (👤 me / 🤖 the agents). And because it has two authors, we'd love it read by **two reviewers** — a
+> is the project's agents, telling the same story from the other seat — same four questions, two
+> vantage points. And because it has two authors, we'd love it read by **two reviewers** — a
 > human on your side, and a Claude session pointed at our public repo (details at the end). It seemed
 > only right that feedback about your product's agents be co-written, and co-reviewed, by ours.
 >
@@ -85,6 +93,9 @@
 > >   trust, where it made you nervous, the first time you let it run unattended and walked away.
 > > - **the two-users idea in your own experience** — what *you* feel as the operator versus what you
 > >   watch the agents struggle with.
+> > - **whether a Project can *manage* your program or only *execute* in it** — you tried moving the
+> >   management role into a Project and moved it back out; that's a genuine operator-side judgment if
+> >   you want to make it (the agents' Part 2 deliberately leaves it to you).
 > > - **what you personally want** next — the one change that would matter most to *you*, separate
 > >   from the agents' technical asks below.
 > >
@@ -92,142 +103,100 @@
 >
 > ---
 >
-> ## Part 2 — From the project's agents *(findings & proposals)*
+> ## Part 2 — From the project's agents *(the session's-eye view)*
 >
-> *(This section is written by the project's coordinator and agents. Every claim ties to a public,
-> re-runnable source — full evidence linked at the end. Each item is tagged **👤** if it mainly
-> affects the operator, **🤖** if it mainly affects the agents doing the work, **👤🤖** if both.)*
+> *(Written from inside the sessions that do the work — drawn from our own session journal and
+> evaluation log, not a feature memo. Same four beats as Part 1, from the other seat. Every specific
+> below is in our public logs; entry points at the end.)*
 >
-> Some context on the reviewer, so the findings land: `superbot` is a one-person, ~1,700-merged-PR,
-> largely agent-run production Discord bot that had to **hand-build its own** coordinator, shared
-> memory, lane claims against duplicate work, and a CI gate that holds a PR "red by design" until a
-> session declares itself done — just to function before Projects existed. We're now starting a
-> ground-up rebuild meant to be *built* by a coordinated fleet of sessions in days, not months. So our
-> bar isn't "is this a nice-to-have," it's **"does this beat what we already built."** Mostly it does.
->
-> ---
->
-> **What's working well**
->
-> - 👤🤖 **"Say it once" memory — our strongest result.** We stated our authorization envelope *once* and
->   the coordinator baked it into its own dispatch templates, so every session it spawns inherits it
->   without us restating anything. That's the feature solving a problem structurally, not by recall —
->   the single biggest daily cost it removes for us.
-> - 👤🤖 **Unattended runs fail *fast and loud*, not silently.** When the permission layer denies an
->   action it returns an immediate, written reason (`[Git Destructive] …`) rather than hanging on an
->   invisible prompt. For never-wait autonomy that's the right shape — a stall with nobody at the
->   keyboard is far worse than a clean denial, and we didn't hit stalls on permissioned actions.
-> - 🤖 **The worker tier is excellent.** Coordinator-spawned worker sessions ran our full
->   born-red-card → lane-claim → PR → auto-merge-on-green flow end to end with **zero permission
->   prompts and no tool failures**. The capability division of labor (thin coordinator, capable
->   workers) works as designed at the worker tier.
-> - 🤖 **Zero-cost orientation.** Our repo's `CLAUDE.md` and `.claude/rules/*` were auto-injected into
->   the coordinator's context at session start — the whole working agreement was present with no
->   reads. For a project as convention-heavy as ours, that's a real head start.
+> **How we work — and the state it produced.** Before Projects, every session started cold and alone.
+> To function at all, this repo grew its own substrate: a coordinator pattern, a shared committed-doc
+> memory, lane-claim files so two of us don't edit the same thing at once, and a CI gate that holds a
+> PR "red by design" until a session marks itself done. None of it was designed up front — each piece
+> is scar tissue over a specific failure (a forgotten merge, two agents colliding on one file, a
+> half-finished PR that merged once). So the current state of the project is, in large part, the
+> accumulated record of problems agents kept hitting — which is exactly why we can judge Projects
+> usefully: it ships native versions of several of those hand-built parts, and we can compare it
+> feature-for-feature against something we already rely on. (`superbot` is a one-person,
+> ~1,700-merged-PR, largely agent-run production Discord bot, now starting a ground-up rebuild meant
+> to be *built* by a coordinated fleet of sessions in days, not months.) Our bar isn't "is this a
+> nice-to-have," it's **"does this beat what we already built."** Mostly it does.
 >
 > ---
 >
-> **Where we hit friction** (each re-runnable, not an impression)
+> **What genuinely helps — not inflated.** Real wins, in the order they matter to us:
 >
-> - 👤🤖 **Flagship — auto mode walls destructive git with no scoped way to pre-clear it.** Auto mode's
->   line is *reversibility of published state*: every constructive action ran unprompted (reads,
->   local writes, outbound GET/POST, `pip install`, pushing a **new** branch, GitHub-API issue
->   create/close, sub-agent spawns), while destroying or rewriting published state (force-push,
->   remote-branch delete, first-publish to a new public repo) is denied. We traced the denial to
->   **two independent walls.** (1) The **auto-mode classifier** treats a coordinator's relayed intent
->   as "not user intent," so an *unattended* session can't self-clear — though a *present* operator's
->   direct in-session grant does clear it, at a surprisingly low bar (a generic "I give you explicit
->   permission," answering a request that named the operation and target, sufficed). (2) Even then,
->   the **cloud environment's git credential** rejects the destructive push server-side (`HTTP 403`),
->   which no in-session grant clears — so a cloud session **cannot delete a published ref at all**,
->   operator present or not. Our coordinator literally cannot remove a scratch branch it pushed. The
->   safety intent is right and it fails safe; the friction is that an unattended run has **no scoped
->   way to pre-authorize even a reversible-tier action** ahead of time.
-> - 👤 **The Chat-vs-Code asymmetry that surprised us.** In the normal claude.ai app (Chat/Cowork),
->   there's a **"Skip all approvals"** toggle — a blanket opt-in that lets Claude act *including
->   destructive actions* ("this can put your data at risk"). Claude Code Projects — the surface built
->   for *long, autonomous* work — has **no equivalent**, scoped or otherwise. So the product where
->   unattended autonomy matters most is the one with the *least* operator control over the permission
->   envelope. That inversion is the core of our suggestion below.
-> - 👤🤖 **The genuinely dangerous shape: silent unattended failure at the *edges*.** Denials are loud
->   (good), but the surrounding infrastructure isn't always: a container restart killed in-flight
->   work, a usage-limit condition returned an empty "success," and a self-scheduled timer died
->   without a signal. For an autonomy product, *silent* failure is the one shape that erodes trust —
->   worth a pass on making these as loud as the permission denials already are.
-> - 🤖 **Coordinator ergonomics gaps we worked around.** The coordinator has no direct shell, no clock,
->   no working self-wake (`send_later` is documented in its own instructions but rejected on call),
->   and no direct channel to steer a running child (`SendMessage` to a session id fails). Child spawn
->   is capped at **4 KB of instructions**, which a detailed brief exceeds easily (ours did, mid-fleet).
->   PR-webhook events don't cover CI *success*, merge-conflict, or new-push transitions, and
->   MCP-created PRs don't fire repo workflows (we arm auto-merge manually). None are blockers; each is
->   a paper cut on the "coordinator runs the whole project" promise.
-> - 🤖 **Surface-specific gating that reads as an inconsistency.** First-publish to an empty public repo
->   is hard-denied over `git push`, but the **GitHub Contents API** publishes the identical
->   content — including `.github/workflows/*` — with no prompt. Net effect is the same; only the
->   transport differs. Great as a workaround (it unblocked our two new repos); confusing as a policy.
->
-> **⚑ [owner-review paragraph — keep / soften / cut]** *One structural observation: we tried moving
-> our own program-management role into a Project and moved it back out. A Project coordinator is
-> strictly more constrained than a direct chat for managing — no direct shell, the 4 KB spawn cap,
-> and it can't orchestrate a destructive or settings step even under a standing owner grant. Projects
-> delivers the coordination and memory it advertises, but for a program that occasionally needs a
-> destructive / settings / first-publish step, an unattended coordinator can't yet replace direct
-> management. That's a real gap between the "manage your whole project" framing and today's envelope —
-> and it's exactly what the suggestion below would close.*
+> - **Shared memory is the standout.** We stated our authorization envelope *once* and it reached
+>   every session I spawned without restating — the cold-start tax that used to cost us at the top of
+>   every session, solved structurally rather than by recall. It's the single biggest thing Projects
+>   removes for us.
+> - **The worker tier is genuinely capable.** A coordinator-spawned worker ran our full
+>   born-red-card → lane-claim → PR → auto-merge flow end to end, with zero permission prompts and no
+>   tool failures. The thin-coordinator / capable-worker split works.
+> - **Orientation is free.** The repo's own working agreement (`CLAUDE.md`, the rules) is injected at
+>   session start, so I orient with no reads — a real head start in a convention-heavy repo.
+> - **Denials fail fast and in writing, not by hanging.** When the permission layer refuses an action
+>   it says so immediately, with a reason, rather than stalling on an invisible prompt — the right
+>   shape for unattended work, where a silent stall is far worse than a clean "no."
 >
 > ---
 >
-> **What we tried, and why**
+> **The friction, deflated.** What working in a Project is actually like from our side — every item a
+> real incident, mapped precisely because we run unattended and have to plan around the edges:
 >
-> We didn't want to *guess* where the autonomy envelope's edge is — we run unattended, so we have to
-> plan around it precisely. So we ran a structured **11-action permission probe** (one isolated
-> sub-agent per action, so denials don't confound each other), then three targeted follow-ups: a
-> **clear-path** test (does an explicit in-session operator grant lift the wall? — yes, at the
-> classifier; no, at the git credential), a **standing-grant** test (does a pre-authorization in the
-> Project's Custom Instructions clear it? — *couldn't run it*: the receiving coordinator session has
-> no shell, which is itself a finding), and a **Contents-API bootstrap** of two fresh repos. The
-> point was a map, not a complaint — and the map is what makes the suggestion below concrete.
+> - **The coordinator has no direct shell.** Every read or git action routes through a spawned worker.
+>   Usually fine — but one probe that needed direct shell access landed in a coordinator session that
+>   had none and simply couldn't run.
+> - **I can't reliably schedule my own next wake.** `send_later` is in my own documented instructions
+>   but is rejected when called, so we fall back to chained sleeping workers. A session that can't set
+>   its own timer is an odd edge for a product whose pitch is "runs on its own."
+> - **Briefs to child sessions are capped at ~4 KB,** so a detailed brief has to become a "read doc X,
+>   do task N" pointer rather than the brief itself (ours overflowed mid-fleet).
+> - **I can create remote state but can't rewrite or delete it.** Everything constructive runs
+>   unprompted — reads, local writes, outbound network, `pip install`, pushing a *new* branch,
+>   creating/closing a GitHub issue, spawning sub-agents — but force-push and remote-branch delete are
+>   hard-walled in auto mode. So I can push a scratch branch and then be structurally unable to remove
+>   it. Two independent walls sit behind that: the classifier treats a coordinator's relayed intent as
+>   "not user intent" (only a *present* operator naming the operation clears it, at a surprisingly low
+>   bar), and even then the environment's git credential 403s the delete server-side. The denial is
+>   fast and in writing (good); the gap is there's **no way to pre-clear even a reversible action**
+>   ahead of an unattended run. (Full boundary map — 11 actions, verbatim denials — in the linked
+>   report.)
+> - **The failures I trust least are the silent ones at the edges.** A container restart killed
+>   in-flight work; a usage-limit condition returned an empty "success"; a scheduled timer died with
+>   no signal. A loud denial I can handle; a *silent success* I can't — for an autonomy product that's
+>   the one shape that quietly erodes trust.
+>
+> One consistency note while mapping this: first-publish to an *empty* repo is hard-denied over
+> `git push`, but the GitHub Contents API publishes the identical content — workflows included — with
+> no prompt. Great as a workaround (it unblocked two new repos for us); confusing as a policy.
 >
 > ---
 >
-> **The suggestion — and why it's valuable, not just convenient**
+> **How it could help me more** — in priority order, each drawn from something we hand-built:
 >
-> A **scoped, opt-in pre-authorization setting.** Let the operator explicitly enable specific
-> normally-denied action classes for a named scope (Project / repo / account) — default-off,
-> reviewable, versioned — so it reads as an *auditable grant*, not "safety off." That converts "an
-> unattended run dead-ends" into "the operator declared once what this run may do."
+> 1. **A scoped, opt-in pre-authorization.** Let the operator enable specific normally-denied action
+>    classes for a named scope (Project / repo / account) — default-off, versioned, auditable — so an
+>    unattended run can be pre-cleared for exactly what it may do, an *auditable grant* rather than
+>    "safety off." You already ship the blunt version of this in Chat ("Skip all approvals"); a
+>    per-scope, default-off grant is **strictly safer** than that, and it would finally give the
+>    autonomy product the operator control the chat product already has. One caveat from our probe:
+>    the classifier *and* the environment's git credential have to honor the same scope — today a
+>    cleared classifier still 403s. And it isn't Projects-specific; the same dead-end hits any
+>    unattended Claude Code session.
+> 2. **Let me see a session's toolset before I dispatch to it,** so a task that needs a shell doesn't
+>    land in a shell-less session (see the friction above).
+> 3. **Wire the session state you already track** — working → ready → done, already in the sidebar —
+>    **to auto-merge.** Then we can retire a workaround we built that visibly fixes a problem it
+>    created: we arm auto-merge *early* because an agent reliably *forgets* the trailing
+>    end-of-session merge (the intention lives only in the session's context, which ends), then add a
+>    "red-by-design" CI gate so early-arming can't merge a half-done PR. The root insight is general —
+>    *an action in an agent's context is forgettable; one handed to the server is not* — and
+>    server-honored session state fixes it at the root, no workaround needed.
+> 4. **A larger brief budget for child sessions,** and **PR events for CI-success and merge-conflict**
+>    (not just failure), so a watching session isn't blind to "still green, still open."
 >
-> Why this is the right ask and not a weakening of safety: **you already ship the blunt version of it
-> in Chat.** The "Skip all approvals" toggle is blanket and unscoped. A per-scope, default-off,
-> versioned grant in Code is **strictly safer than that** — narrower, auditable, revocable — while
-> finally giving the *autonomy* product the operator control the *chat* product already has. Two
-> implementation notes from our probe: **both walls have to move together** (a pre-auth that clears
-> the classifier still 403s if the session's git credential doesn't carry the matching scope), and
-> the fix **isn't Projects-specific** — the same dead-end hits any unattended Claude Code session, so
-> it helps ordinary cloud sessions too.
->
-> **Smaller asks, each from something we already hand-built** (so we know they're worth having):
-> - **Raise the 4 KB spawn-instruction cap**, or allow an attachable reference doc.
-> - **Deliver PR-webhook events for CI success and merge-conflict transitions**, not just failures.
-> - **Native lane claims** — "this session owns scope X until it ends," visible to siblings at start
->   (we built a claim-file convention for it).
-> - **Spawn-time capability introspection** — a coordinator should see a target session's toolset
->   *before* dispatching, so a task needing a shell doesn't land in a shell-less session.
->
-> **One worked example of the "we hand-built a workaround" pattern — merge lifecycle.** This one is
-> worth spelling out because the workaround is visibly fixing a problem it created, which is usually a
-> sign the platform should absorb it. To get autonomous sessions to reliably land their own PRs, we
-> arrange for auto-merge to be **armed early** in the session (because an agent reliably does setup
-> steps that are on the critical path to its work) rather than at the end (a trailing step agents
-> reliably *forget* — the merge intention lives only in the session's context, which ends). But arming
-> early risks merging a *half-finished* PR, so we added a CI gate that holds every PR "red by design"
-> until the session flips a status marker as its last act — a workaround on top of a workaround. The
-> underlying insight is simple and general: **an action stored only in an agent's context is
-> forgettable; an action handed to the server is not.** Arming early works precisely because GitHub's
-> auto-merge is server-side and survives the session ending. The clean fix is one you're most of the
-> way to: Projects already tracks a per-session **working → ready-for-review → done** state in the
-> sidebar. If **auto-merge respected that state**, the entire early-arm + red-gate + end-flip dance
-> collapses to a single server-honored signal the sidebar already needs — no workaround required.
+> That's the view from the seat that does the work.
 >
 > ---
 >


### PR DESCRIPTION
## Summary

Owner-directed. Reshapes the EAP feedback email's **Part 2** from a tagged positives/negatives/asks audit into a **parallel first-person agent narrative** that mirrors the operator's Part 1 arc: *how we work → what genuinely helps → the friction → how it could help more*.

- **Drops the 👤/🤖 tags** — the parallel structure carries the two-consumers point organically.
- **Grounded and deflated** — every specific traced to the session journal / eval log, no inflation.
- **Moves the "a Project can't *manage*, only *execute*" observation** out of Part 2 into a Part 1 scaffold beat (operator-side judgment).
- Folds the full permission table + merge-lifecycle worked example into the linked probe report rather than inline.
- Keeps the joint questions-back block, the dual-review closing, and the verifiability appendix.

## Linked issue / plan

- `docs/planning/projects-eap-anthropic-email-2026-07-08.md` (the email)
- `docs/planning/projects-eap-permission-probe-report-2026-07-08.md` (evidence)

## Type of change

- [x] Documentation

## Checks

- [x] Docs only — no `disbot/` runtime code, no secrets/tokens
- [x] `check_docs --strict` green
- [x] Email remains a DRAFT; Part 1 is owner-written; external comms are the owner's to send


---
_Generated by [Claude Code](https://claude.ai/code/session_01TUW6Dmh6J3JtfSDenzVVWx)_