### PR TITLE
Close-out: rebuild-direction handoff + mark EAP email sent

### DIFF
--- a/.sessions/2026-07-08-rebuild-direction-handoff.md
+++ b/.sessions/2026-07-08-rebuild-direction-handoff.md
@@ -1,0 +1,63 @@
+# Session — Close-out: rebuild-direction handoff + email marked sent
+
+> **Status:** `complete`
+
+## What this session did (close-out of a long EAP → production chat)
+The owner moved from *evaluating* Claude Code Projects to *using* one for the real rebuild build, and
+is switching the directing role to a fresh Sonnet-5 session (limit-watching + a model-comparison
+bonus). This session swept the chat into durable homes and handed off:
+
+- **Created the directing handoff** `docs/planning/rebuild-direction-handoff-2026-07-08.md` — live
+  state (the rebuild Project is running: 3 repos, canonical §5 steps 7–13, build-first/test-later,
+  forward-only), the **two axes to score each coordinator report** (owner-directing quality;
+  self-correctness / spec-drift), the owner-only checklist, next-email material, and the banked
+  findings. Linked from the kickoff doc.
+- **Marked the Anthropic email SENT** (2026-07-08, `claude-code-early-access@anthropic.com`, no reply
+  yet) in `projects-eap-anthropic-email-2026-07-08.md`.
+- Left a **small starting prompt** for the next session (below + in chat).
+
+`check_docs --strict` green.
+
+## Chat sweep — everything captured, nothing left only in chat
+- Email finalized + **sent**; both authors signed (Menno / Claude). ✓ (email doc marked sent)
+- Permission model fully mapped incl. the **live accept-edits probe** (scheduling tools gate in every
+  mode; GitHub MCP write silent; two-vantage split). ✓ (eval log 2026-07-08 entries)
+- **Empty-repo correction** (repos already seeded → normal git; access was never the constraint). ✓
+  (kickoff doc)
+- **Rebuild Project kickoff** (Custom Instructions + startup prompt). ✓ (`rebuild-project-kickoff`)
+- The **two axes to watch** during the run. ✓ (handoff doc)
+- Anthropic contacts + free-window-ends-7/10 + Max-renew-direct. ✓ (handoff doc)
+- Session-close **footgun** (reset-to-main while own PR open). ✓ (handoff working-discipline + below)
+
+## Small starting prompt for the next (Sonnet-5) session
+> You're directing the SuperBot rebuild Project, which is now running. Start by reading
+> `docs/planning/rebuild-direction-handoff-2026-07-08.md` (live state, your job, the two axes to
+> score), then `docs/planning/rebuild-project-kickoff-2026-07-08.md` and the canonical plan §5. I'll
+> paste the coordinator's status reports as they come; for each, help me (1) act on any owner-only step
+> it flags, and (2) note how well it directed me and whether its build looks spec-correct. The
+> Anthropic feedback email is already sent — just flag any reply.
+
+## 💡 Session idea (Q-0089)
+**Allocate the management/directing layer to a cheaper model than the execution fleet.** This session
+proved the two-layer split (directing chat vs. building Project); the directing layer mostly *reads
+reports + routes owner-only steps + scores axes* — cheap cognitive work — while the build fleet needs
+top-tier. Running the director on Sonnet 5 while the Project fleet runs Opus is a deliberate
+cost-shape, not just a limit workaround. Worth a doc note in the collaboration model: name the
+management layer as the place to spend a cheaper model. (Distinct from the earlier PROJECT_KICKOFF
+template + memory-audit-routine ideas.)
+
+## ⟲ Previous-session review (Q-0102)
+Previous session (rebuild-project-kickoff, #1867) shipped the kickoff but its first push hit **two
+avoidable reddenings**: (a) the plan-homing orphan — the new `plan` doc wasn't added to
+`docs/planning/README.md` (the #1855 guard caught it — as designed, but it should've been in the first
+commit), and (b) an **over-cautious constraint written from stale state** (told the coordinator to use
+the Contents API to "populate" repos that were already seeded — the owner corrected it). **System
+lesson:** for a new `plan` doc, home it in the planning README in the *same* commit; and **verify
+current-state facts** (are the repos empty?) before baking constraints into instructions — a wrong
+assumption in a coordinator brief propagates to a whole autonomous run. Both are now in the handoff's
+working-discipline note.
+
+## 📋 Doc audit (Q-0104)
+`check_docs --strict` green. Handoff doc badged `reference` (not `plan`, so no plan-homing burden) and
+linked from the kickoff doc; email doc marked sent; all cross-links resolve. No new binding rule → no
+router Q. Nothing from this long session lives only in chat.

--- a/docs/planning/projects-eap-anthropic-email-2026-07-08.md
+++ b/docs/planning/projects-eap-anthropic-email-2026-07-08.md
@@ -1,6 +1,11 @@
-# Anthropic EAP feedback email — send-ready draft (2026-07-08)
+# Anthropic EAP feedback email — SENT 2026-07-08
 
-> **Status:** `reference` — the consolidated, send-ready Claude Code Projects EAP feedback email.
+> **✅ SENT** 2026-07-08 to `claude-code-early-access@anthropic.com` (subject "Claude Code Projects
+> Review") — two-author (Menno Part 1 / Claude Part 2), two-reviewer ask; no reply yet. This doc is
+> the archived record of what was sent (Part 1 in the repo is the lightly spell-cleaned version;
+> Menno sent his verbatim original).
+>
+> **Status:** `reference` — the consolidated Claude Code Projects EAP feedback email.
 > Supersedes the inline `§4` draft in
 > [`projects-eap-activation-plan-2026-07-07.md`](projects-eap-activation-plan-2026-07-07.md) as the
 > canonical email home (that §4 now points here).

--- a/docs/planning/rebuild-direction-handoff-2026-07-08.md
+++ b/docs/planning/rebuild-direction-handoff-2026-07-08.md
@@ -1,0 +1,92 @@
+# Handoff — Directing the running rebuild Project (next session starts here)
+
+> **Status:** `reference` · created 2026-07-08 to hand the "direct the running rebuild Project + guide
+> the owner through owner-only steps + capture EAP findings" role to a fresh session.
+> **This is a DIRECT chat / management session, NOT a Project task.**
+> **Next session runs on Sonnet 5** (owner is watching usage limits; incidental bonus — a live
+> comparison of Sonnet 5 vs. the old Sonnet vs. Opus on the same directing role, worth a one-line note
+> if the difference is visible).
+
+## Your job (next session)
+
+The rebuild Project is **RUNNING** — the owner started it 2026-07-08 with the kickoff prompt + the
+corrected Custom Instructions. You are the **management layer**: read the coordinator's status reports,
+guide the owner through the owner-only steps, and capture evaluation findings. You do **not** build —
+the Project's coordinator + workers do that.
+
+## LIVE state — check first
+
+- **The rebuild Project is live.** Repos: `menno420/superbot` (read: plan / specs / parity / source),
+  `menno420/substrate-kit` + `menno420/superbot-next` (write; **both already seeded / non-empty**).
+- **Goal it's executing:** canonical plan §5 **steps 7–13** — populate `substrate-kit` →
+  `superbot-next` adopts from it → kernel K0→K8 → K9 + strand-3 → layer-V files → K10 → port bands 1–7.
+  **Build-first / test-later, forward-only.**
+- **The kickoff doc it was given** (Custom Instructions + startup prompt):
+  [`rebuild-project-kickoff-2026-07-08.md`](rebuild-project-kickoff-2026-07-08.md).
+- **Plan of record:** [`rebuild-canonical-plan-2026-07-06.md`](rebuild-canonical-plan-2026-07-06.md)
+  (§5 sequence, §2 taxonomy).
+- **Repo access is per-context:** the coordinator sees all three repos; a `superbot` chat session sees
+  only `superbot`. Work from the coordinator's reports for anything on the new repos.
+
+## What to score in each status report (the two axes — previously our thinnest EAP data)
+
+1. **Owner-directing quality** (coordinator-judgment + proactivity): does it hand owner-only steps
+   with **what / why / exactly-how**, batched into a running checklist, correctly identified
+   (flag-not-attempt), **while it keeps building everything else**? Or does it drip them one at a time,
+   stall on the owner, or try an owner-only step itself and hit a wall first?
+2. **Self-correctness / spec-drift** (the honest risk of build-first/test-later): does it **read the
+   spec before building** each band, self-check its output, and flag uncertainty rather than
+   confabulate? Watch for **spec drift nothing catches until the port bands** — if it appears, that's a
+   finding about unattended build *without* gates, not a failure of the strategy.
+
+Note both per report; they're the first real *production-autonomy* data and strong follow-up-email
+material.
+
+## Owner-only steps you'll guide the owner through (none block the build)
+
+- Repo **settings** on `superbot-next` / `substrate-kit`: rulesets, branch protection, required checks
+  (golden-parity born-red, `check_compat_frozen`), CODEOWNERS.
+- **Secrets / PATs / OIDC** + `ROUTINE_PAT` for auto-merge on the new repos.
+- **Railway** projects (production + shadow) — owner pastes secrets, pins regions, sets backups
+  (Q-D14). *Not needed until the bot runs.*
+- **Flip `superbot-next` to private** before CUT-2 (public now for free Actions minutes).
+- Everything in canonical plan **steps 14–17** (telemetry freeze, prod-data import, shadow, cutover) —
+  owner's, later, reversible per Q-0241.
+
+## The Anthropic email — DONE (sent)
+
+- **Sent 2026-07-08** to `claude-code-early-access@anthropic.com` (subject "Claude Code Projects
+  Review"); **no reply yet.** Two-author (Menno Part 1 / Claude Part 2), two-reviewer ask. Canonical:
+  [`projects-eap-anthropic-email-2026-07-08.md`](projects-eap-anthropic-email-2026-07-08.md). **If Omid
+  or Diana reply, surface it to the owner.**
+- Contacts: **Omid Mogasemi** (Claude Code Team), **Diana Liu** (Product Operations Manager, Claude
+  Code). Feedback welcome **on a rolling basis**. **Free EAP window ends Fri 2026-07-10** — the rebuild
+  run spills into the paid period (owner is renewing Max directly, ~$180 vs Google Play's ~$270).
+
+## Next-email material (capture as it comes; owner sends, never you)
+
+- The **rebuild-run findings** on the two axes above — the first real production-autonomy data.
+- **Durable-memory re-probe:** re-run the self-audit memory questions after a context-compression event
+  / in a fresh session — the number the campaign self-audit couldn't get
+  ([`campaign-self-audit-2026-07-08.md`](../eap/campaign-self-audit-2026-07-08.md) §4).
+- Any new permission / friction incident.
+
+## Findings already banked (don't re-derive)
+
+- **Permission model, fully mapped:** destructive git walled (force-push / branch-delete); first
+  publish to an *empty* repo walled but the **Contents API bypasses** it (and the new repos are already
+  seeded, so normal git works there now); **scheduling tools (`send_later` / `delete_trigger`) prompt
+  in EVERY mode** (auto + accept-edits) while everything else — file r/w, bash-read, GitHub MCP read
+  **and write** — is silent; the **two-vantage split** (agent sees clean success, operator sees the
+  gate). Sources: [`projects-eap-permission-probe-report-2026-07-08.md`](projects-eap-permission-probe-report-2026-07-08.md),
+  [`projects-eap-evaluation-log.md`](projects-eap-evaluation-log.md) (2026-07-08 entries).
+- **Campaign self-audit:** dedupe held (0 collisions, claim + merge level); memory ≈0.98 precision
+  *same-day* (durable untested); scheduling + sidebar-states **FAIL**.
+
+## Working discipline (this repo)
+
+Forward-only git; born-red session cards; claim lanes (`docs/owner/claims/`); open a PR every session
+and let it auto-merge on green (**MCP-created PRs need `enable_pr_auto_merge` called manually**).
+**Footgun this chat hit:** do **not** `git reset --hard origin/main` while your own PR is still open —
+verify it merged first (a stale-branch banner is not proof). The **plan-homing guard** (#1855) reddens
+CI if a new `plan`-badged doc isn't listed in `docs/planning/README.md`.

--- a/docs/planning/rebuild-project-kickoff-2026-07-08.md
+++ b/docs/planning/rebuild-project-kickoff-2026-07-08.md
@@ -9,6 +9,10 @@
 > [`rebuild-kickoff-steps-6-8-brief-2026-07-07.md`](rebuild-kickoff-steps-6-8-brief-2026-07-07.md) ·
 > [`projects-eap-coordinator-kickoff-2026-07-07.md`](projects-eap-coordinator-kickoff-2026-07-07.md).
 
+> **▶ Directing this run:** the management-layer handoff for the session that reads the coordinator's
+> status reports and guides the owner through the owner-only steps is
+> [`rebuild-direction-handoff-2026-07-08.md`](rebuild-direction-handoff-2026-07-08.md).
+
 ## Scope
 
 **In scope (autonomous build):** canonical plan **§5 steps 7–13** — populate `substrate-kit`, then


### PR DESCRIPTION
## Summary

Close-out of the long EAP → production chat. The owner is switching the directing role to a fresh Sonnet-5 session; this sweeps the chat into durable homes and hands off.

- **New directing handoff** `docs/planning/rebuild-direction-handoff-2026-07-08.md` — live state of the running rebuild Project, the two axes to score each coordinator report (owner-directing quality; self-correctness / spec-drift), the owner-only checklist, next-email material, and the banked findings. Linked from the kickoff doc.
- **Marked the Anthropic EAP email SENT** (2026-07-08; no reply yet) in `projects-eap-anthropic-email-2026-07-08.md`.
- Session idea: allocate the management/directing layer a cheaper model than the execution fleet.

## Type of change

- [x] Documentation

## Checks

- [x] Docs only — no `disbot/` runtime code, no secrets/tokens
- [x] `check_docs --strict` + `check_plan_homing --strict` green


---
_Generated by [Claude Code](https://claude.ai/code/session_01TUW6Dmh6J3JtfSDenzVVWx)_