### PR TITLE
Correct EAP fleet scope: kit-lab governs real repos, trim today's launch to kit-lab + 2

### DIFF
--- a/.sessions/2026-07-09-eap-fleet-sequencing-correction.md
+++ b/.sessions/2026-07-09-eap-fleet-sequencing-correction.md
@@ -1,0 +1,72 @@
+# 2026-07-09 — EAP fleet sequencing correction: kit-lab governs real repos, test fleet trimmed to 2
+
+> **Status:** `complete`
+
+## What I did
+
+The previous session's fleet plan (`docs/planning/eap-project-fleet-2026-07-09.md`, PR #1877)
+treated kit-lab as one of 11 roughly co-launched Projects. Owner correction, live in this
+session: kit-lab is not a peer of the domain-breadth test fleet — it's the long-term manager of
+the **real production repos** (superbot, superbot-next, botsite), per the already-decided
+founding plan (`kit-lab-founding-plan-2026-07-07.md`, KF-1…KF-11), unchanged. The
+domain-breadth fleet (games/bots/research/coding/design/personal/wildcard) is a separate,
+throwaway EAP capability-eval exercise that kit-lab does not govern.
+
+Owner's sequencing: launch kit-lab first (per its existing provisioning checklist), then launch
+**2** test-fleet projects to run independently alongside it — not all 11 — and revisit tomorrow
+whether to add more. Owner picked the coding-tool task run on **Fable 5 and Opus 4.8** (not the
+originally-suggested Sonnet 5) as the 2 — i.e. collapse the 3-model comparison to the two
+higher-tier models, dropping Sonnet 5 from today's launch.
+
+Updated `docs/planning/eap-project-fleet-2026-07-09.md` with a "Corrected launch scope" section:
+kit-lab launches alone first via its existing §7.2 checklist and keeps its original mandate
+(manage the real program repos, unchanged); the domain-breadth test fleet is a separate,
+throwaway eval that kit-lab does not govern; today's actual launch list is trimmed to kit-lab +
+2 coding-tool-lab Projects (`codetool-lab-fable5`, `codetool-lab-opus48` — Sonnet 5 arm dropped
+for today), with the remaining 5 domain rows + the Sonnet arm explicitly deferred to a
+tomorrow capacity decision rather than pre-committed. No repos were created and no Projects were
+launched in this session — those are owner UI/portal actions per the existing checklists; this
+was docs-only.
+
+## Context delta
+
+- **Needed but not pointed to:** none beyond what the fleet doc already had — the correction was
+  a scope/sequencing clarification from the owner, not a missing-doc gap.
+- **Pointed to but didn't need:** n/a.
+- **Discovered by hand:** n/a — this was a direct owner correction in-chat, recorded verbatim
+  rather than reverse-engineered.
+- **Decisions made alone:** picked the coding-tool row (over games/design/wildcard) as the
+  "most important" 2-project pick was the owner's explicit call, not mine — I only proposed the
+  menu via AskUserQuestion and recorded the answer (Fable 5 + Opus 4.8, dropping Sonnet 5).
+- **Flagged for maintainer:** the original fleet doc's 7-row menu and model-comparison section
+  are left intact as the reference menu for tomorrow's decision — only the "what launches today"
+  framing changed. If tomorrow's session wants a genuinely different subset than "coding twice,"
+  it should feel free to deviate; nothing here locks that in.
+- **One docs/tooling change that would have most helped:** none identified this session — the
+  fix was a two-paragraph doc edit, no tooling gap surfaced.
+- **Friction → guard:** none — no workflow friction hit this session (pure planning-doc
+  clarification, no code/CI surface touched).
+
+## 💡 Session idea
+
+None new this session — the work was a scope correction on an already-planned fleet, not fresh
+ground; forcing a filler idea would violate the "no ceremony" bar (Q-0089).
+
+## ⟲ Previous-session review
+
+The previous session (PR #1877, fleet plan authoring) did good, honest work — it explicitly
+flagged "11 is a lot to monitor" as the owner's call rather than silently picking a subset, which
+is exactly what let this session's correction land cleanly. What it could have done better: it
+conflated kit-lab (a permanent, real-repo-governing Project) with the 7 throwaway domain
+evals into one undifferentiated "fleet of 11," which is what needed unwinding today. Concrete
+system improvement this surfaces: when a planning doc mixes a **permanent infrastructure
+Project** with **throwaway eval Projects** in the same table/count, it should say so explicitly
+in the doc's own framing (a one-line "kit-lab is not a fleet peer" caveat in the original doc
+would have caught this before it reached chat) — noted here rather than turned into a new
+checker, since this is a one-off planning-doc pattern, not a recurring mechanical failure mode.
+
+## Documentation audit
+
+`docs/current-state.md` does not need a new entry — no PR has merged from this session yet and
+no runtime/code changed; the fleet plan doc itself is the durable home for this decision, and it
+now carries the correction in place rather than needing a pointer elsewhere.

--- a/docs/planning/eap-project-fleet-2026-07-09.md
+++ b/docs/planning/eap-project-fleet-2026-07-09.md
@@ -1,8 +1,9 @@
 # EAP Project fleet — broad capability + model-comparison test plan (2026-07-09)
 
-> **Status:** `plan` — prep artifact for a **dedicated next session** that creates the repos and
-> launches this fleet. Not executed yet; this doc is the refined plan + ready-to-paste materials
-> so that session is pure execution.
+> **Status:** `plan` — prep artifact for a **dedicated next session** that
+> creates the repos and launches this fleet. This doc is the refined plan + ready-to-paste
+> materials; **§ "Corrected launch scope" below (same day) supersedes the original "launch all
+> 11" execution checklist** — read that section first, it changes what actually launches today.
 > **Provenance:** owner directive 2026-07-09 (directing-session chat) — run several Claude Code
 > Projects in parallel across varied domains as an extensive capability eval, plus a dedicated
 > model-comparison sub-experiment, plus the already-planned substrate-kit self-improvement lab.
@@ -12,6 +13,42 @@
 > §5). Today (Thursday) is the last day to get autonomous fleet runtime in *before* that
 > deadline, though nothing here stops mattering after — the collaboration goal outlives the free
 > window (same doc §5).
+
+## Corrected launch scope (owner correction, same day)
+
+The original framing below (§ "Why a fleet") and its execution checklist treated kit-lab as one
+of 11 roughly co-launched Projects, and floated kit-lab acting as a reviewing "mastermind" over
+the domain-breadth test fleet itself. Both are wrong:
+
+- **Kit-lab is not a peer of the test fleet and does not govern it.** Kit-lab's job (unchanged,
+  [`kit-lab-founding-plan-2026-07-07.md`](kit-lab-founding-plan-2026-07-07.md), KF-1…KF-11) is to
+  manage the **real, permanent program repos** — superbot, superbot-next, botsite — over the long
+  term: releases, the model-allocation dataset, guard telemetry, ideas-that-ship. The 7
+  domain-breadth Projects below are a separate, throwaway EAP capability eval. Kit-lab has no role
+  reviewing or feeding them.
+- **Today launches kit-lab + 2 test-fleet Projects, not 11.** Kit-lab launches first, alone,
+  through its own §7.2 provisioning checklist. Alongside it, exactly **two** domain-breadth
+  Projects launch today, picked for being the most directly useful right now: **row 4 (coding)
+  run twice** — `codetool-lab-fable5` (Fable 5) and `codetool-lab-opus48` (Opus 4.8) — same task
+  brief, same Custom Instructions template, only the model differs. This drops row 4's original
+  third arm (Sonnet 5) from today's launch and defers every other row (games, non-Discord bots,
+  research, design, personal-friction, wildcard) entirely.
+- **Everything else is a tomorrow decision, not a backlog commitment.** Whether to add the
+  Sonnet 5 arm back, launch more of the 7 rows, or stop at 3 total running Projects (kit-lab +
+  the 2 coding arms) is explicitly deferred to next session, made with real capacity/monitoring
+  data from today's 3 in hand — not pre-committed here.
+
+Everything under "Why a fleet" / the 7-row table / the model-comparison section below still
+describes the **available menu** for that tomorrow decision — it is not today's launch list.
+The "Next-session execution checklist" at the bottom is superseded for today by the trimmed list:
+1. Provision + launch kit-lab per its own §7.2 checklist (P1–P13) — independent of the fleet.
+2. Create `codetool-lab-fable5` and `codetool-lab-opus48` (Contents-API-seeded README, same
+   pattern as `websites`).
+3. Paste the shared Custom Instructions template (below) into each, task brief = row 4's coding
+   brief verbatim, model = Fable 5 / Opus 4.8 respectively.
+4. Do **not** create the other 5 domain repos or the Sonnet 5 arm today.
+5. Next session: review kit-lab + the 2 coding arms' status reports, then decide what (if
+   anything) to add from the remaining menu.
 
 ## Why a fleet, not one more Project
 


### PR DESCRIPTION
## Summary
- Corrects the previous session's EAP fleet plan (#1877): kit-lab is not a peer of, or reviewer over, the domain-breadth test fleet — it's the long-term manager of the *real* program repos (superbot, superbot-next, botsite), per its existing founding plan (unchanged).
- Trims today's actual launch to **kit-lab + 2** test-fleet Projects: `codetool-lab-fable5` and `codetool-lab-opus48` (coding task, row 4 of the original 7-row menu, run on Fable 5 and Opus 4.8 — the Sonnet 5 arm is dropped for today).
- The other 5 domain rows + the Sonnet 5 arm are explicitly deferred to a tomorrow capacity decision, not pre-committed.
- Docs-only change: `docs/planning/eap-project-fleet-2026-07-09.md` gets a new "Corrected launch scope" section superseding its original execution checklist for today's launch; the rest of the doc (the 7-row menu, model-comparison writeup, shared Custom Instructions template) is left intact as the reference menu for future sessions.

## Test plan
- [x] `python3.10 scripts/check_docs.py --strict` — green
- [x] `python3.10 scripts/check_session_log.py` — session card `complete`
- [x] `python3.10 scripts/check_architecture.py --mode strict` — only pre-existing warnings, unrelated to this change (docs-only diff)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VHEs2RDpuLUsiMhzPVcYjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHEs2RDpuLUsiMhzPVcYjQ)_