### PR TITLE
KL-6 companion: exporter `telemetry` family + declared "Kit lab — benchmarks & guards" console lane

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,8 @@ disbot/data/btd6/** linguist-generated=true
 # Reliability (Q-0105): standard git feature; remove these lines to revert.
 docs/owner/active-work.md merge=union
 docs/ideas/README.md merge=union
+
+# The model-allocation telemetry feed (kit-lab plan §5.2 / PL-004): one JSON
+# object per line, appended by every session — the same append-only shape as
+# the ledgers above, so the same union merge applies.
+telemetry/*.jsonl merge=union

--- a/.sessions/2026-07-09-kl6-console-telemetry.md
+++ b/.sessions/2026-07-09-kl6-console-telemetry.md
@@ -1,0 +1,14 @@
+# Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane
+
+> **Status:** `in-progress`
+
+**About to do (kit-lab founding plan §7.3, band KL-6 — the superbot-side
+companion to substrate-kit PR #18):** the exporter gains a `telemetry`
+family (reads `telemetry/model-usage.jsonl`, the PL-004/Q-0248 record —
+superbot's rows are hand-authored until it adopts, plan §4.2/§5.2) rendered
+on the console's declared "Model & spend telemetry" lane (real rows, no more
+pending); the console gains the new declared lane **"Kit lab — benchmarks &
+guards"** with its exact contract (`bench/results/*/index.json → [{date,
+kit_version, family, verdict, headline}]` — declared, not faked: the kit's
+bench results ride an open owner-blessing PR and the cross-repo read waits
+on 👤 P11/P13). `console.json` regenerated; exporter tests extended.

--- a/.sessions/2026-07-09-kl6-console-telemetry.md
+++ b/.sessions/2026-07-09-kl6-console-telemetry.md
@@ -1,14 +1,117 @@
 # Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane
 
-> **Status:** `in-progress`
+> **Status:** `complete` *(PR #1883 — superbot-side half of kit-lab band KL-6;
+> the kit-side half is substrate-kit PR #18.)*
 
-**About to do (kit-lab founding plan §7.3, band KL-6 — the superbot-side
-companion to substrate-kit PR #18):** the exporter gains a `telemetry`
-family (reads `telemetry/model-usage.jsonl`, the PL-004/Q-0248 record —
-superbot's rows are hand-authored until it adopts, plan §4.2/§5.2) rendered
-on the console's declared "Model & spend telemetry" lane (real rows, no more
-pending); the console gains the new declared lane **"Kit lab — benchmarks &
-guards"** with its exact contract (`bench/results/*/index.json → [{date,
-kit_version, family, verdict, headline}]` — declared, not faked: the kit's
-bench results ride an open owner-blessing PR and the cross-repo read waits
-on 👤 P11/P13). `console.json` regenerated; exporter tests extended.
+## What I did
+
+Superbot-side companion to substrate-kit PR #18 (kit-lab founding plan §7.3,
+band KL-6 — the exporter lives here, not in the kit):
+
+- **Exporter `telemetry` family** (`scripts/export_dashboard_data.py`): new
+  `parse_telemetry()` reads `telemetry/model-usage.jsonl` (the PL-004/Q-0248
+  per-session record) into the full payload + the console feed.
+  Field-whitelisted by construction (`CONSOLE_TELEMETRY_FIELDS` +
+  `TELEMETRY_OUTCOME_FIELDS` — the site.json posture); tolerant by contract
+  (a malformed line/row is skipped or nulled, never fatal — one bad append
+  must not blank the lane); capped to the newest 200 rows.
+  `CONSOLE_TOPLEVEL_KEYS` gains `telemetry`.
+- **`telemetry/model-usage.jsonl` seeded** (+ `telemetry/README.md`):
+  superbot is not an adopted kit install, so rows are **hand-authored** at
+  session close against the kit's canonical schema (plan §4.2/§5.2) until it
+  adopts; first row = this session. `telemetry/*.jsonl merge=union` added to
+  `.gitattributes` (same append-only rationale as the existing ledger
+  entries).
+- **Console lane flip** (`botsite/console/console.js`): the declared "Model
+  & spend telemetry" lane renders **real rows** when `data.telemetry` is
+  non-empty (model/effort/task-class badges, null-tolerated `tokens_out` per
+  KF-9) and falls back to the declared pending form when empty — the
+  honest-lane rule unchanged. Contract string corrected to the `.jsonl`
+  source (the kit plan's D-10 refinement: the lane binds to record shape,
+  not file encoding).
+- **New declared lane "Kit lab — benchmarks & guards"** with its exact §7.3
+  contract `bench/results/*/index.json → [{date, kit_version, family,
+  verdict, headline}]` — declared, NOT faked: the kit's results indexes ride
+  the kit's owner-blessing bench PR (substrate-kit #17), and the cross-repo
+  read waits on the kit going public (P11) or the read-only PAT (P13).
+- `dashboard.json` + `console.json` regenerated (site.json/data.js
+  deliberately untouched — no site-family change; the BUG-0022 desync class
+  avoided). Exporter tests extended (+3: whitelist/tolerance, missing-file +
+  cap, console-subset telemetry shape).
+
+**Gates:** `check_quality.py --check-only` green · mypy clean (881 files) ·
+`tests/unit/scripts/` + `tests/unit/botsite/` 1220 passed, 4 skipped ·
+`check_dashboard_data` OK · `check_generated_artifacts_fresh` OK (4 fresh) ·
+`node --check` on console.js. Full suite = CI (auto-merge armed on green).
+
+## Context delta
+
+- **Needed but not pointed to:** the fact that the console *UI* now renders
+  in TWO places — superbot's botsite service (`botsite/console/console.js`)
+  AND the websites repo's dashboard service (reads the same committed
+  `console.json` via raw GitHub) — lives only in websites'
+  `docs/current-state.md`; nothing superbot-side mentions the second
+  consumer of `console.json`'s shape.
+- **Pointed to but didn't need:** nothing notable.
+- **Discovered by hand:** `check_generated_artifacts_fresh` ignores volatile
+  meta, so regenerating only the two changed artifacts is safe and
+  sufficient; the console subset raises on non-whitelisted keys at build
+  time (so the new family HAD to be added to the frozenset first).
+- **Decisions made alone:** telemetry rows enter `build_data()`'s full
+  payload (so `dashboard.json` carries the family too) rather than being
+  read privately by the console subset — the "single producer, subsets
+  whitelist" architecture; the 200-row export cap; the kit-lab lane ships
+  declared-only until the kit feed is readable.
+
+## 🛠 Friction → guard
+
+Two parallel PRs (this one + substrate-kit #17) both append one telemetry
+row at EOF — a guaranteed conflict class on an append-only feed. Shipped the
+guard: `telemetry/*.jsonl merge=union` in `.gitattributes` (checker-free,
+standard git feature, same pattern as the existing ledger entries). Kit-side
+twin shipped in substrate-kit #18.
+
+## 💡 Session idea
+
+**A console.json shape contract shared with the websites repo:** websites'
+dashboard now renders superbot's committed `console.json`, but nothing pins
+the shape both sides assume — a renamed family here silently blanks a page
+there. Cheapest durable form: a `botsite/data/console.schema.json` (or a
+listed-fields doc block) that superbot's exporter test asserts against and
+websites' data_source cites by URL — one source of truth for a two-repo
+contract, exactly the kit's "contract string on the lane" instinct applied
+to the feed itself. Dedup-grepped `docs/ideas/` (no console/feed-contract
+idea exists).
+
+## ⟲ Previous-session review (remove-intree-kit, #1882)
+
+Genuinely clean execution of a named chore: redundancy verified before
+deleting (repo-wide reference grep + post-deletion collection count), the
+deletion flagged prominently with its reversal command, and history left in
+place rather than rewritten — the right instincts for a 101-file deletion.
+One improvement it surfaces: it verified nothing *imports* the deleted tree
+but didn't sweep for *docs that route readers into it* (orientation-route
+links to `substrate-kit/` paths would now 404 for an agent) — a
+"pointer-sweep after deletion" line in the deletion checklist would close
+that class. Not filler: this session's own change relied on finding the
+kit's living docs in the graduated repo instead.
+
+## 📤 Run report
+
+- **Did:** exporter `telemetry` family + real console telemetry lane + declared kit-lab lane (kit-lab KL-6, superbot half) · **Outcome:** shipped
+- **Shipped:** #1883 — exporter telemetry family, console lane flip + new declared kit-lab lane, telemetry/ seeded, artifacts regenerated, tests +3
+- **Run type:** `manual` (coordinator-dispatched kit-lab band work)
+- **⚑ Owner decisions needed:** none new here (the kit-lab band's 👤 P5/P11/P13 items are ledgered in substrate-kit's current-state)
+- **⚑ Owner manual steps:** none superbot-side
+- **⚑ Self-initiated:** none (band KL-6 is planned work — kit `docs/planning/kit-lab-founding-plan-2026-07-07.md` §7.3/§10)
+- **↪ Next:** kit-lab lane flips real once substrate-kit #17 is blessed AND P11-or-P13 makes the kit's `bench/results/*/index.json` readable; superbot sessions append their hand-authored telemetry row at close (`telemetry/README.md`)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1883, auto-merge on green) |
+| CI-red rounds | 0 (born-red card gate only) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (console.json shape contract) |
+| Ideas groomed | 0 (companion-PR session; grooming capacity went to the kit-side band work) |

--- a/.sessions/2026-07-09-kl6-console-telemetry.md
+++ b/.sessions/2026-07-09-kl6-console-telemetry.md
@@ -1,7 +1,7 @@
 # Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane
 
-> **Status:** `complete` *(PR #1883 — superbot-side half of kit-lab band KL-6;
-> the kit-side half is substrate-kit PR #18.)*
+> **Status:** `complete` — PR #1883, the superbot-side half of kit-lab band
+> KL-6 (the kit-side half is substrate-kit PR #18).
 
 ## What I did
 

--- a/botsite/console/console.js
+++ b/botsite/console/console.js
@@ -44,12 +44,21 @@
       <h3>${esc(title)}</h3>${bodyHtml}
     </section>`;
 
-  /* the three declared-contract lanes (render identically with or without data.json) */
-  const declaredLanes = () =>
+  /* the telemetry lane's pending form — used until the exported feed has rows
+     (the lane flips real in render() the moment data.telemetry is non-empty) */
+  const telemetryPendingLane = () =>
     pendingLane(
       "Model & spend telemetry",
-      "No data yet — per-session `model · effort · task-class · outcome` telemetry starts with the program kickoff sessions (Q-0248) and budget data shares the same dataset (Q-0249, observe-first window). This lane renders the cost-quality frontier once the feed lands.",
-      "telemetry/model-usage.json → [{ session, date, model, effort, task_class, tokens_out, outcome }]",
+      "No data yet — per-session `model · effort · task-class · outcome` telemetry (Q-0248) lives in telemetry/model-usage.jsonl (hand-authored rows until superbot adopts the kit) and budget data shares the same dataset (Q-0249, observe-first window). This lane renders the rows the exporter publishes.",
+      "telemetry/model-usage.jsonl → [{ session, date, model, effort, task_class, tokens_out, outcome }]",
+    );
+
+  /* the declared-contract lanes (render identically with or without data.json) */
+  const declaredLanes = () =>
+    pendingLane(
+      "Kit lab — benchmarks & guards",
+      "No data yet — the kit repo's bench/results indexes ride the kit's owner-blessing bench PR, and the cross-repo read waits on the kit going public (P11) or the read-only PAT (P13). Renders the cold-start A/B trend, allocation A/Bs, guard fp-rates and idea outcomes once the feed lands (kit-lab plan §7.3).",
+      "bench/results/*/index.json → [{ date, kit_version, family, verdict, headline }]",
     ) +
     pendingLane(
       "Rebuild port progress",
@@ -128,7 +137,22 @@
     const deployLane = lane("Deploys & user-facing changelog", (changelog || emptyList("No changelog entries.")) +
       `<p class="sb-chart-note">Merging to main IS deploying (Q-0193) — Railway redeploys each service on merge; build above is the live provenance.</p>`);
 
-    app.innerHTML = statRow + `<div class="co-lanes">${runLane}${ideasLane}${bugsLane}${deployLane}${declaredLanes()}</div>`;
+    /* Model & spend telemetry — REAL once the exported feed has rows (kit-lab
+       plan §7.3); honest-lane rule: empty feed = the declared pending form. */
+    const tRows = data.telemetry || [];
+    const tRecent = tRows.slice(-10).reverse(); /* feed is append-only: newest last */
+    const tRowsHtml = tRecent.map((r) => `
+      <div class="co-session">
+        <span class="when">${esc(r.date || "")}</span>
+        <span class="t" title="${esc(r.session || "")}">${esc(r.session || "")}</span>
+        <span class="end"><span class="sb-badge sb-badge-neutral">${esc(r.model || "?")}</span><span class="sb-badge sb-badge-neutral">${esc(r.effort || "?")}</span><span class="sb-badge sb-badge-neutral">${esc(r.task_class || "?")}</span>${r.tokens_out == null ? "" : `<span class="sb-badge sb-badge-neutral">${esc(String(r.tokens_out))} tok</span>`}</span>
+      </div>`).join("");
+    const telemetryLane = tRows.length
+      ? lane(`Model & spend telemetry — ${tRows.length} row${tRows.length === 1 ? "" : "s"}`, tRowsHtml +
+        `<p class="sb-chart-note">Per-session <code class="sb-mono">model · effort · task-class</code> rows (Q-0248) from <code class="sb-mono">telemetry/model-usage.jsonl</code> — hand-authored until superbot adopts the kit; <code class="sb-mono">tokens_out</code> is null-tolerated (no meter exists — KF-9); PR outcomes backfill via the kit-lab sweep (👤 P13).</p>`, { wide: true })
+      : telemetryPendingLane();
+
+    app.innerHTML = statRow + `<div class="co-lanes">${runLane}${ideasLane}${bugsLane}${deployLane}${telemetryLane}${declaredLanes()}</div>`;
 
     /* run-report filter pills */
     const listEl = app.querySelector("[data-run-list]");
@@ -147,7 +171,7 @@
     metaLine.textContent = "The console feed hasn't been exported yet — real lanes are dormant, declared lanes below say what will fill them.";
     app.innerHTML = `
       <div class="sb-error" style="margin-bottom:16px">${icon("alert")}<span><strong>No console feed.</strong> ${esc(reason)} Regenerate with <code class="sb-mono">python3.10 scripts/export_dashboard_data.py --targets console</code> and redeploy.</span></div>
-      <div class="co-lanes">${pendingLane("Run reports — the session feed", "Renders the .sessions/ run-report feed (dates, titles, status, ⚑ self-initiated flags) once console.json is exported.", "botsite/data/console.json → sessions[]", true)}${declaredLanes()}</div>`;
+      <div class="co-lanes">${pendingLane("Run reports — the session feed", "Renders the .sessions/ run-report feed (dates, titles, status, ⚑ self-initiated flags) once console.json is exported.", "botsite/data/console.json → sessions[]", true)}${telemetryPendingLane()}${declaredLanes()}</div>`;
   }
 
   const emptyList = (msg) => `<div class="sb-empty" style="padding:20px 8px">${esc(msg)}</div>`;

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,13 +1,53 @@
 {
   "meta": {
-    "generated_at": "2026-07-08T16:20:05Z",
+    "generated_at": "2026-07-09T06:23:59Z",
     "build": {
-      "commit": "e9988b3b",
-      "subject": "Merge pull request #1861 from menno420/claude/projects-testing-anthropic-feedback-5xqamy",
-      "committed_at": "2026-07-08T16:20:05Z"
+      "commit": "dcbcf7e",
+      "subject": "KL-6 companion: born-red session card + claim",
+      "committed_at": "2026-07-09T06:23:59Z"
     }
   },
   "sessions": [
+    {
+      "file": "2026-07-09-remove-intree-kit.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — Remove the in-tree substrate-kit copy (named follow-up chore)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-kl6-console-telemetry.md",
+      "date": "2026-07-09",
+      "title": "Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane",
+      "status": "",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-kl2-provenance-riders.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — KL-2 companion: program-law provenance riders on the origin Q-blocks",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-kit-version-pin.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — substrate-kit v1.0.0 pin file (kit-lab D2, consumer half)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-eap-fleet-sequencing-correction.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — EAP fleet sequencing correction: kit-lab governs real repos, test fleet trimmed to 2",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
     {
       "file": "2026-07-08-wave1-lane-b-supersede-checker.md",
       "date": "2026-07-08",
@@ -41,11 +81,43 @@
       "self_initiated": false
     },
     {
+      "file": "2026-07-08-reconcile-band1860.md",
+      "date": "2026-07-08",
+      "title": "2026-07-08 — Thirty-ninth Q-0107 reconciliation pass (band-#1860)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
       "file": "2026-07-08-reconcile-band1830.md",
       "date": "2026-07-08",
       "title": "Session — thirty-eighth Q-0107 reconciliation pass (band-#1830)",
       "status": "complete",
       "run_type": "routine",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-08-rebuild-project-kickoff.md",
+      "date": "2026-07-08",
+      "title": "Session — Rebuild Project kickoff (Custom Instructions + startup prompt)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-08-rebuild-direction-handoff.md",
+      "date": "2026-07-08",
+      "title": "Session — Close-out: rebuild-direction handoff + email marked sent",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-08-rebuild-audit-checklist.md",
+      "date": "2026-07-08",
+      "title": "2026-07-08 — Rebuild-direction: owner router answers + audit checklist",
+      "status": "complete",
+      "run_type": "",
       "self_initiated": false
     },
     {
@@ -129,6 +201,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-07-08-eap-email-sign-part2.md",
+      "date": "2026-07-08",
+      "title": "Session — Sign Part 2 of the EAP email as Claude",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-08-eap-email-refresh-forward-only-project.md",
       "date": "2026-07-08",
       "title": "Session — EAP email refresh + forward-only Project instructions",
@@ -140,6 +220,14 @@
       "file": "2026-07-08-eap-email-finalize.md",
       "date": "2026-07-08",
       "title": "Session — Finalize the Anthropic EAP email",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-08-eap-email-assemble-part1.md",
+      "date": "2026-07-08",
+      "title": "Session — Assemble the full EAP email (Part 1 landed + Part 2 made complementary)",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -399,101 +487,13 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-ruff-migration.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Ruff migration (A3): ruff replaces black + isort",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-07-06-reconcile-band1770.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Thirty-sixth Q-0107 reconciliation pass (band-#1770)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-reconcile-band1740.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Thirty-fifth Q-0107 reconciliation pass (band-#1740)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-rebuild-consolidation-fable5.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Rebuild consolidation: one canonical plan + foundational-completeness (Fable 5 Ultracode brief §3)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-07-06-gate-v-verification-fleet-prompts.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Gate V verification-fleet review prompts (documented launch pad)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-gate-v-synthesis.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Gate V final synthesis (Arm Σ)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-gate-v-findings-corrections.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Gate V evidence-findings corrections (Codex C2–C5 + Agent Mode)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-gate-v-c1-and-arm-a-review.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Gate V: verify C1 re-run + Arm A Ultracode review (fleet complete)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-gate-v-arm-d-live-testing.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — GATE V Arm D: empirical live-testing evidence pack",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-07-06-fable5-newrepo-start-brief.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Fable 5 Ultracode launch brief: finalize the new-repo-start method",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-fable-decision-authority-and-foundational-consolidation.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Fable decision authority (Q-0240) + foundational-consolidation brief revision",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "ideas": {
-    "total": 218,
+    "total": 219,
     "by_status": {
       "historical": 23,
-      "ideas": 192,
+      "ideas": 193,
       "reference": 3
     }
   },
@@ -578,6 +578,22 @@
       "title": "Command-alias suggestions",
       "kind": "feature",
       "summary": "You can now suggest a friendly alias for any command from the dashboard's Aliases page,"
+    }
+  ],
+  "telemetry": [
+    {
+      "session": "2026-07-09-kl6-console-telemetry",
+      "date": "2026-07-09",
+      "model": "fable-5",
+      "effort": "high",
+      "task_class": "kernel/architecture design",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
     }
   ]
 }

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-09T06:23:59Z",
+    "generated_at": "2026-07-09T06:41:17Z",
     "build": {
-      "commit": "dcbcf7e",
-      "subject": "KL-6 companion: born-red session card + claim",
-      "committed_at": "2026-07-09T06:23:59Z"
+      "commit": "d2334a4",
+      "subject": "KL-6 companion: exporter telemetry family + real console telemetry lane + declared kit-lab lane",
+      "committed_at": "2026-07-09T06:41:17Z"
     }
   },
   "sessions": [
@@ -20,7 +20,7 @@
       "file": "2026-07-09-kl6-console-telemetry.md",
       "date": "2026-07-09",
       "title": "Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane",
-      "status": "",
+      "status": "complete",
       "run_type": "manual",
       "self_initiated": false
     },

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-09T03:39:40Z",
+    "generated_at": "2026-07-09T06:23:59Z",
     "build": {
-      "commit": "9e351306",
-      "subject": "Merge pull request #1878 from menno420/claude/substrate-kit-planning-yescdw",
-      "committed_at": "2026-07-09T03:39:40Z"
+      "commit": "dcbcf7e",
+      "subject": "KL-6 companion: born-red session card + claim",
+      "committed_at": "2026-07-09T06:23:59Z"
     },
     "counts": {
       "functions": 43,
@@ -3188,6 +3188,38 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-09-remove-intree-kit.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — Remove the in-tree substrate-kit copy (named follow-up chore)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-kl6-console-telemetry.md",
+      "date": "2026-07-09",
+      "title": "Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane",
+      "status": "",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-kl2-provenance-riders.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — KL-2 companion: program-law provenance riders on the origin Q-blocks",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-kit-version-pin.md",
+      "date": "2026-07-09",
+      "title": "2026-07-09 — substrate-kit v1.0.0 pin file (kit-lab D2, consumer half)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-09-eap-fleet-sequencing-correction.md",
       "date": "2026-07-09",
       "title": "2026-07-09 — EAP fleet sequencing correction: kit-lab governs real repos, test fleet trimmed to 2",
@@ -3634,38 +3666,6 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-ruff-migration.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Ruff migration (A3): ruff replaces black + isort",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-07-06-reconcile-band1770.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Thirty-sixth Q-0107 reconciliation pass (band-#1770)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-reconcile-band1740.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Thirty-fifth Q-0107 reconciliation pass (band-#1740)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-06-rebuild-consolidation-fable5.md",
-      "date": "2026-07-06",
-      "title": "2026-07-06 — Rebuild consolidation: one canonical plan + foundational-completeness (Fable 5 Ultracode brief §3)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -3686,6 +3686,22 @@
       "title": "Command-alias suggestions",
       "kind": "feature",
       "summary": "You can now suggest a friendly alias for any command from the dashboard's Aliases page,"
+    }
+  ],
+  "telemetry": [
+    {
+      "session": "2026-07-09-kl6-console-telemetry",
+      "date": "2026-07-09",
+      "model": "fable-5",
+      "effort": "high",
+      "task_class": "kernel/architecture design",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
     }
   ],
   "env_usage": [

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-09T06:23:59Z",
+    "generated_at": "2026-07-09T06:41:17Z",
     "build": {
-      "commit": "dcbcf7e",
-      "subject": "KL-6 companion: born-red session card + claim",
-      "committed_at": "2026-07-09T06:23:59Z"
+      "commit": "d2334a4",
+      "subject": "KL-6 companion: exporter telemetry family + real console telemetry lane + declared kit-lab lane",
+      "committed_at": "2026-07-09T06:41:17Z"
     },
     "counts": {
       "functions": 43,
@@ -3199,7 +3199,7 @@
       "file": "2026-07-09-kl6-console-telemetry.md",
       "date": "2026-07-09",
       "title": "Session 2026-07-09 — KL-6 companion: exporter telemetry family + kit-lab console lane",
-      "status": "",
+      "status": "complete",
       "run_type": "manual",
       "self_initiated": false
     },

--- a/docs/owner/claims/claude-kl6-console-telemetry.md
+++ b/docs/owner/claims/claude-kl6-console-telemetry.md
@@ -1,0 +1,1 @@
+- `claude/kl6-console-telemetry` · kit-lab band KL-6 companion (exporter `telemetry` family + declared kit-lab console lane) · `scripts/export_dashboard_data.py`, `botsite/console/console.js`, `botsite/data/console.json`, `telemetry/`, exporter tests · 2026-07-09

--- a/docs/owner/claims/claude-kl6-console-telemetry.md
+++ b/docs/owner/claims/claude-kl6-console-telemetry.md
@@ -1,1 +1,0 @@
-- `claude/kl6-console-telemetry` · kit-lab band KL-6 companion (exporter `telemetry` family + declared kit-lab console lane) · `scripts/export_dashboard_data.py`, `botsite/console/console.js`, `botsite/data/console.json`, `telemetry/`, exporter tests · 2026-07-09

--- a/docs/owner/claims/claude-rebuild-audit-checklist-4qz195.md
+++ b/docs/owner/claims/claude-rebuild-audit-checklist-4qz195.md
@@ -1,1 +1,0 @@
-- `claude/rebuild-audit-checklist-4qz195` · docs/planning only (rebuild-project audit checklist + README index fix) · `docs/planning/rebuild-project-audit-checklist-2026-07-08.md`, `docs/planning/README.md` · 2026-07-08

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -83,7 +83,7 @@ SITE_TOPLEVEL_KEYS: frozenset[str] = frozenset(
 # ``reviews``) are excluded, and per-guild/user values never enter the producer.
 CONSOLE_OUTPUT_FILE = REPO_ROOT / "botsite" / "data" / "console.json"
 CONSOLE_TOPLEVEL_KEYS: frozenset[str] = frozenset(
-    {"meta", "sessions", "ideas", "bugs", "bot_changelog"},
+    {"meta", "sessions", "ideas", "bugs", "bot_changelog", "telemetry"},
 )
 # Per-entry field whitelist for the console's session feed (run reports).
 CONSOLE_SESSION_FIELDS: tuple[str, ...] = (
@@ -94,6 +94,35 @@ CONSOLE_SESSION_FIELDS: tuple[str, ...] = (
     "run_type",
     "self_initiated",
 )
+# The program's model-allocation telemetry feed (kit-lab founding plan §5.2 /
+# PL-004, Q-0248) — the console's declared "Model & spend telemetry" lane.
+# Superbot's rows are HAND-AUTHORED against the kit's canonical schema until it
+# truly adopts the kit (plan §4.2); the feed is a per-repo append-only JSONL and
+# the exporter renders it as the JSON array the lane contract declares (the
+# D-10 refinement: the lane binds to the record shape, not the file encoding).
+# Same field-whitelist-by-construction posture as the session feed; no value in
+# a row is per-guild/user data (session slug, date, model tier, effort, task
+# class, token count, PR outcome — all repo-development metadata).
+TELEMETRY_FILE = REPO_ROOT / "telemetry" / "model-usage.jsonl"
+CONSOLE_TELEMETRY_FIELDS: tuple[str, ...] = (
+    "session",
+    "date",
+    "model",
+    "effort",
+    "task_class",
+    "tokens_out",
+    "outcome",
+)
+# The structured ``outcome`` object's own whitelist (Q-0248's objective gates).
+TELEMETRY_OUTCOME_FIELDS: tuple[str, ...] = (
+    "ci_green_first_push",
+    "checker_findings",
+    "merged_pr",
+    "reverted_within_window",
+)
+# The exported array is capped to the newest rows so the console feed stays
+# bounded as the JSONL grows; the file itself remains the full record.
+TELEMETRY_ROW_CAP = 200
 # Per-command fields the public ``commands`` reference exposes (no per-guild value
 # ever appears — these are repo-level command metadata). The interactive command
 # browser (plan unit S1.1 / P2) renders these in a clickable detail view:
@@ -618,6 +647,41 @@ _CHANGELOG_KIND_RE = re.compile(
 _VALID_CHANGELOG_KINDS = frozenset({"feature", "fix", "improvement"})
 
 
+def parse_telemetry(path: Path) -> list[dict]:
+    """Parse ``telemetry/model-usage.jsonl`` into whitelisted records (file order).
+
+    One JSON object per line — the PL-004/Q-0248 per-session record. Tolerant by
+    contract: a malformed line, a non-object row, or a missing field is skipped or
+    nulled, never fatal (the JSONL is appended by many parallel sessions and one
+    bad row must not blank the console lane). Every record is rebuilt from the
+    :data:`CONSOLE_TELEMETRY_FIELDS` whitelist (nested ``outcome`` object from
+    :data:`TELEMETRY_OUTCOME_FIELDS`) — unknown extra fields are dropped by
+    construction. Returns at most :data:`TELEMETRY_ROW_CAP` newest rows.
+    """
+    if not path.is_file():
+        return []
+    records: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(raw, dict):
+            continue
+        record = {field: raw.get(field) for field in CONSOLE_TELEMETRY_FIELDS}
+        outcome = raw.get("outcome")
+        record["outcome"] = (
+            {field: outcome.get(field) for field in TELEMETRY_OUTCOME_FIELDS}
+            if isinstance(outcome, dict)
+            else None
+        )
+        records.append(record)
+    return records[-TELEMETRY_ROW_CAP:]
+
+
 def parse_bot_changelog(text: str) -> list[dict]:
     """Parse ``docs/bot-changelog.md`` into date/title/kind/summary records.
 
@@ -732,6 +796,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         if bot_changelog_file.exists()
         else []
     )
+    telemetry = parse_telemetry(repo_root / "telemetry" / "model-usage.jsonl")
 
     scan_root = repo_root / "disbot"
     env_usage = (
@@ -829,6 +894,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         "reviews": reviews,
         "updates": updates,
         "bot_changelog": bot_changelog,
+        "telemetry": telemetry,
         "env_usage": env_usage,
         "cogs": cogs,
         "settings": settings,
@@ -1255,6 +1321,10 @@ def build_console_subset(data: dict) -> dict:
             "open": open_bugs,
         },
         "bot_changelog": data.get("bot_changelog", []),
+        # The declared "Model & spend telemetry" lane's feed (kit-lab plan §7.3):
+        # already field-whitelisted by parse_telemetry — repo-development metadata
+        # only, never per-guild/user values.
+        "telemetry": data.get("telemetry", []) or [],
     }
     extra = set(subset) - CONSOLE_TOPLEVEL_KEYS
     if extra:

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,17 @@
+# telemetry/ — superbot's model-allocation feed (hand-authored)
+
+> **Status:** `living-ledger`
+
+`model-usage.jsonl` carries superbot's per-session **PL-004 / Q-0248 record**
+(`{session, date, model, effort, task_class, tokens_out, outcome}`, one JSON
+object per line, append-only). The **canonical schema + field rules live in
+the kit repo** — `substrate-kit/telemetry/README.md` and the founding plan
+§5.2; superbot is *not* an adopted kit install, so rows here are
+**hand-authored by the session** (kit-lab plan §4.2) until superbot truly
+adopts and the kit's `session-close` harvest takes over. Append your session's
+row at close; `task_class` uses the 8 Q-0248 classes verbatim; `tokens_out`
+is null until a real meter exists (KF-9 — estimates must be labeled).
+`scripts/export_dashboard_data.py` renders the feed onto the program console's
+"Model & spend telemetry" lane (field-whitelisted; capped to the newest 200).
+The `outcome` object's PR fields are backfilled by the kit-lab's telemetry
+sweep once 👤 P13 read scopes exist.

--- a/telemetry/model-usage.jsonl
+++ b/telemetry/model-usage.jsonl
@@ -1,0 +1,1 @@
+{"date": "2026-07-09", "effort": "high", "model": "fable-5", "outcome": {"checker_findings": null, "ci_green_first_push": null, "merged_pr": null, "reverted_within_window": null}, "session": "2026-07-09-kl6-console-telemetry", "task_class": "kernel/architecture design", "tokens_out": null}

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -8,6 +8,7 @@ pure stdlib, so this runs in CI with no extra dependencies.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -643,6 +644,71 @@ def test_console_subset_whitelist_and_shapes(mod):
         # Titles + ids only — never full bug bodies on the console feed.
         assert set(bug) == {"id", "title", "status"}
     assert len(subset["bugs"]["open"]) <= 10
+    # Telemetry rows are rebuilt from the field whitelist (kit-lab plan §7.3).
+    for row in subset["telemetry"]:
+        assert set(row) == set(mod.CONSOLE_TELEMETRY_FIELDS)
+        outcome = row["outcome"]
+        assert outcome is None or set(outcome) == set(mod.TELEMETRY_OUTCOME_FIELDS)
+
+
+def test_parse_telemetry_whitelist_and_tolerance(mod, tmp_path):
+    """The JSONL reader is tolerant by contract: bad lines skipped, extra fields
+    dropped, a malformed ``outcome`` nulled — one bad row never blanks the lane.
+    """
+    feed = tmp_path / "model-usage.jsonl"
+    feed.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "session": "2026-07-09-a",
+                        "date": "2026-07-09",
+                        "model": "fable-5",
+                        "effort": "high",
+                        "task_class": "docs-only",
+                        "tokens_out": None,
+                        "outcome": {
+                            "ci_green_first_push": True,
+                            "checker_findings": 0,
+                            "merged_pr": 1,
+                            "reverted_within_window": None,
+                            "smuggled": "extra",
+                        },
+                        "smuggled_field": "must never pass the whitelist",
+                    },
+                ),
+                "not json at all {",
+                json.dumps(["a", "list", "row"]),
+                json.dumps({"session": "2026-07-09-b", "outcome": "scalar"}),
+                "",
+            ],
+        ),
+        encoding="utf-8",
+    )
+    rows = mod.parse_telemetry(feed)
+    assert [r["session"] for r in rows] == ["2026-07-09-a", "2026-07-09-b"]
+    for row in rows:
+        assert set(row) == set(mod.CONSOLE_TELEMETRY_FIELDS)
+    # Nested outcome is whitelisted too; a non-object outcome is nulled.
+    assert set(rows[0]["outcome"]) == set(mod.TELEMETRY_OUTCOME_FIELDS)
+    assert "smuggled" not in rows[0]["outcome"]
+    assert rows[1]["outcome"] is None
+
+
+def test_parse_telemetry_missing_file_and_cap(mod, tmp_path):
+    assert mod.parse_telemetry(tmp_path / "absent.jsonl") == []
+    feed = tmp_path / "model-usage.jsonl"
+    feed.write_text(
+        "\n".join(
+            json.dumps({"session": f"s{i}", "date": "2026-07-09"})
+            for i in range(mod.TELEMETRY_ROW_CAP + 5)
+        ),
+        encoding="utf-8",
+    )
+    rows = mod.parse_telemetry(feed)
+    assert len(rows) == mod.TELEMETRY_ROW_CAP
+    # Newest rows win the cap (the feed is append-only, newest last).
+    assert rows[-1]["session"] == f"s{mod.TELEMETRY_ROW_CAP + 4}"
 
 
 def test_cli_targets_console_writes_only_console(mod, tmp_path):


### PR DESCRIPTION
Superbot-side companion to substrate-kit PR #18 (kit-lab founding plan §7.3, band KL-6):

- **Exporter `telemetry` family**: `scripts/export_dashboard_data.py` reads `telemetry/model-usage.jsonl` (the PL-004/Q-0248 per-session record; superbot's rows are hand-authored until it truly adopts the kit — plan §4.2/§5.2, first row seeded) into the full payload + the console feed (`CONSOLE_TOPLEVEL_KEYS` gains `telemetry`, field-whitelisted by construction).
- **Console lane flip**: the declared "Model & spend telemetry" lane renders real rows when the feed is non-empty (pending contract otherwise — honest-lane rule unchanged).
- **New declared lane "Kit lab — benchmarks & guards"** with its exact contract `bench/results/*/index.json → [{date, kit_version, family, verdict, headline}]` — declared, not faked: the kit's bench results ride the kit's open owner-blessing PR (#17) and the cross-repo read waits on 👤 P11/P13.
- `console.json` + `dashboard.json` regenerated; exporter tests extended.

Born-red card: `.sessions/2026-07-09-kl6-console-telemetry.md` — flips complete as the last commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJfdy7YxUw8oXj4Wfngdyc)_