### PR TITLE
console.json shape contract: versioned contract file + checker guard (the #1883 session idea)

### DIFF
--- a/.sessions/2026-07-09-console-feed-contract.md
+++ b/.sessions/2026-07-09-console-feed-contract.md
@@ -1,21 +1,138 @@
 # Session 2026-07-09 — console.json shape contract (superbot half)
 
-> **Status:** `in-progress` — pinning the console.json feed shape shared with
-> the websites repo's dashboard consumer (the #1883 session idea, executed).
+> **Status:** `complete` — PR #1884, the producer half of the cross-repo
+> console.json contract; the consumer half ships as a companion menno420/websites PR.
 
-## What I'm about to do
+## What I did
 
-Execute the `💡 Session idea` from `.sessions/2026-07-09-kl6-console-telemetry.md`
-(PR #1883): a **versioned shape contract for `botsite/data/console.json`** so the
-two consumers of the committed feed (superbot's own botsite console + the
-websites repo's dashboard `/console` page, which reads it over raw GitHub) stop
-sharing an *implicit* schema. Plan:
+Executed the `💡 Session idea` from `.sessions/2026-07-09-kl6-console-telemetry.md`
+(PR #1883): the committed `botsite/data/console.json` is rendered by TWO repos —
+superbot's own botsite console (`botsite/console/console.js`) and the **websites**
+repo's dashboard `/console` page (fetched over raw.githubusercontent.com) — but
+nothing pinned the shape both sides assume, so a producer-side family/field rename
+silently blanks the consumer (the BUG-0022 desync class). Now it's pinned:
 
-- `botsite/data/console_data_contract.json` — the committed, versioned contract
-  (same pattern as the existing `site_data_contract.json`), the single source of
-  truth both repos cite.
-- Exporter: `console.json` gains `meta.schema_version`; producer constants must
-  match the contract file.
-- `check_dashboard_data.py` gains a `check_console_subset` guard (`--console`)
-  mirroring `check_site_subset`, enforced in CI by tests over the committed file.
-- Companion websites PR pins the contract copy + validates at render time.
+- **`botsite/data/console_data_contract.json`** — the committed, **versioned**
+  shape contract (the existing `site_data_contract.json` pattern applied to this
+  feed): `version` + `top_level` families + guaranteed fields per record
+  (session / ideas / bugs / bug_open / bot_changelog / telemetry /
+  telemetry_outcome / meta). Changing this file (and bumping `version`) is the
+  explicit, reviewable act of changing the cross-repo contract.
+- **Exporter** (`scripts/export_dashboard_data.py`): `build_console_subset` stamps
+  `meta.schema_version = CONSOLE_SCHEMA_VERSION` into every emitted feed;
+  `CONSOLE_CONTRACT_FILE` pins the contract path; the constants block documents
+  the two-consumer reality (the #1883 context-delta gap, now pointed to in source).
+- **Checker** (`scripts/check_dashboard_data.py`): new `check_console_subset`
+  (`--console` CLI flag), mirroring `check_site_subset`, all fail-closed:
+  producer-constants⇄contract **parity** (edit one without the other = red),
+  top-level families **exact both directions** (extra = leak class, missing = the
+  consumer-blanking class), `meta.schema_version` == contract `version`, and
+  per-record guaranteed-field whitelists (sessions/telemetry rows exact incl. the
+  nested `outcome`; meta/ideas/bugs/open-bugs/changelog subset).
+- **Tests** (+13): 12 checker tests — including the **CI-enforcing**
+  `test_committed_console_json_passes_contract` over the committed file — plus an
+  exporter test pinning `meta.schema_version` to the contract file's `version`.
+- `console.json` regenerated (`--targets console`; now carries
+  `meta.schema_version: 1` + this session's telemetry row).
+
+**Consumer half (companion PR in menno420/websites):** pinned contract copy +
+render-time schema-version check on the dashboard `/console` page. Reading the
+consumer against the new contract immediately surfaced a live defect there: the
+console template treats `ideas`/`bugs` as **lists** (`|length`) while the feed
+ships **dicts** (`{total, by_status, …}`) — its stat tiles show dict-key counts.
+Fixed in the websites PR; exactly the class this contract exists to catch.
+
+**Gates:** `check_quality.py --check-only` green · `check_architecture` untouched
+(no `disbot/`) · `tests/unit/scripts/` 34+40 passed · `tests/unit/botsite/` 34
+passed, 4 skipped · `check_dashboard_data --console` OK ·
+`check_generated_artifacts_fresh` OK (4 fresh) · `check_current_state_ledger
+--strict` exit 0 (benign newest-merge lag only) · full suite = CI (auto-merge
+armed on green at PR open).
+
+## Context delta
+
+- **Needed but not pointed to:** which task_class values are legal for a
+  `telemetry/model-usage.jsonl` row — the 8 Q-0248 classes live only in the kit
+  repo's founding plan (§4.2/§5.2), not in superbot's `telemetry/README.md`,
+  which says "the 8 Q-0248 classes verbatim" without listing them.
+- **Pointed to but didn't need:** nothing notable.
+- **Discovered by hand:** loading `check_dashboard_data.py` standalone via
+  `importlib` without registering it in `sys.modules` first breaks its `Issue`
+  dataclass on 3.10 (`_is_type` reads `sys.modules[cls.__module__]`); the repo's
+  `_load_module` convention registers first for exactly this reason.
+- **Decisions made alone:** contract file named `console_data_contract.json`
+  (sibling symmetry with `site_data_contract.json`) rather than the idea's
+  sketched `console.schema.json`; version surfaced as `meta.schema_version`
+  inside the feed (no new top-level family, so no consumer sees an unknown key);
+  sessions/telemetry rows enforced **exact** (producer builds them by whitelist
+  comprehension) while dict families are subset-checked; contract-vs-producer
+  parity lives in the checker (not exporter import time) so a broken contract
+  file can never make the exporter itself unimportable.
+
+## 🛠 Friction → guard
+
+None new this session — the wrong-shape consumer defect found in websites is
+itself the class this session's guard now catches, and the websites-side fix +
+fixture correction ship in the companion PR. (No checker lied; no workflow slip.)
+
+## 💡 Session idea
+
+**Extend the pinned-feed-contract pattern to `dashboard.json`** — the websites
+dashboard renders ~12 pages off the big feed with no contract at all; the console
+contract proves the mechanism (producer parity + fail-closed checker + consumer
+version check) and its first consumer-side pass caught a live defect, so the
+bigger surface is the obvious next pin. Captured with full shape in
+`docs/ideas/pinned-feed-contract-for-dashboard-json-2026-07-09.md` (+ README
+index entry). Dedup-grepped `docs/ideas/` — the nearest neighbours
+(`dashboard-registry-coverage-check`, `generated-artifact-freshness-umbrella`)
+cover registry coverage and freshness, not shape.
+
+## ⟲ Previous-session review (kl6-console-telemetry, #1883)
+
+Strong session: whitelist-by-construction on the new telemetry family, honest
+declared-vs-real lane discipline, and the `merge=union` guard shipped for a
+conflict class it *predicted* rather than suffered. Its best output was arguably
+the session card itself — the context-delta note ("nothing superbot-side mentions
+the second consumer of console.json's shape") plus a precisely-shaped 💡 idea made
+this session executable with near-zero re-discovery. One improvement it surfaces:
+that context-delta observation and the idea were the *same fact* written twice,
+and the cheap in-scope fix (a one-line "two consumers" pointer in the exporter's
+constants block) shipped with neither — it waited a session for this PR. Concrete
+workflow improvement: when a context-delta "needed but not pointed to" item is a
+one-line source-comment fix, ship the pointer in the same session instead of only
+filing it; the session-close skill could ask exactly that question.
+
+## 📄 Documentation audit
+
+- `check_current_state_ledger.py --strict` exit 0 (20 merged PRs newer than
+  marker #1861 = benign newest-merge lag; reconciliation due at #1890 records
+  them — this PR included).
+- `check_docs --strict` green (new idea file reachable via the README index).
+- Durable homes: the two-consumer fact + contract mechanics now live in source
+  (exporter constants block, checker docstring, the contract file's `_comment`);
+  the websites-side pointer ships in the companion PR's docs. Nothing left only
+  in chat.
+
+## 📤 Run report
+
+- **Did:** pinned the console.json cross-repo shape contract (contract file +
+  exporter schema_version + fail-closed checker + tests) · **Outcome:** shipped
+- **Shipped:** #1884 — `console_data_contract.json`, `check_console_subset`
+  (`--console`), `meta.schema_version`, +13 tests, feed regenerated
+- **Run type:** `manual` (coordinator-dispatched kit-lab cross-repo improvement)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (executes the #1883 session idea as dispatched;
+  the new idea filed this session is captured, not built)
+- **↪ Next:** websites companion PR (pinned copy + render-time check + the
+  dict-vs-list console fix); then consider the dashboard.json contract idea
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1884, auto-merge on green) |
+| CI-red rounds | 0 (born-red card gate only) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (dashboard.json pinned-feed contract) |
+| Ideas groomed | 1 (#1883's console-contract idea → implemented, this PR) |

--- a/.sessions/2026-07-09-console-feed-contract.md
+++ b/.sessions/2026-07-09-console-feed-contract.md
@@ -1,0 +1,21 @@
+# Session 2026-07-09 — console.json shape contract (superbot half)
+
+> **Status:** `in-progress` — pinning the console.json feed shape shared with
+> the websites repo's dashboard consumer (the #1883 session idea, executed).
+
+## What I'm about to do
+
+Execute the `💡 Session idea` from `.sessions/2026-07-09-kl6-console-telemetry.md`
+(PR #1883): a **versioned shape contract for `botsite/data/console.json`** so the
+two consumers of the committed feed (superbot's own botsite console + the
+websites repo's dashboard `/console` page, which reads it over raw GitHub) stop
+sharing an *implicit* schema. Plan:
+
+- `botsite/data/console_data_contract.json` — the committed, versioned contract
+  (same pattern as the existing `site_data_contract.json`), the single source of
+  truth both repos cite.
+- Exporter: `console.json` gains `meta.schema_version`; producer constants must
+  match the contract file.
+- `check_dashboard_data.py` gains a `check_console_subset` guard (`--console`)
+  mirroring `check_site_subset`, enforced in CI by tests over the committed file.
+- Companion websites PR pins the contract copy + validates at render time.

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,11 +1,12 @@
 {
   "meta": {
-    "generated_at": "2026-07-09T06:41:17Z",
+    "generated_at": "2026-07-09T07:01:03Z",
     "build": {
-      "commit": "d2334a4",
-      "subject": "KL-6 companion: exporter telemetry family + real console telemetry lane + declared kit-lab lane",
-      "committed_at": "2026-07-09T06:41:17Z"
-    }
+      "commit": "3fd2a56",
+      "subject": "Session card (born-red) + claim: console.json shape contract",
+      "committed_at": "2026-07-09T07:01:03Z"
+    },
+    "schema_version": 1
   },
   "sessions": [
     {
@@ -45,6 +46,14 @@
       "date": "2026-07-09",
       "title": "2026-07-09 — EAP fleet sequencing correction: kit-lab governs real repos, test fleet trimmed to 2",
       "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-09-console-feed-contract.md",
+      "date": "2026-07-09",
+      "title": "Session 2026-07-09 — console.json shape contract (superbot half)",
+      "status": "in-progress",
       "run_type": "",
       "self_initiated": false
     },
@@ -476,14 +485,6 @@
       "file": "2026-07-07-fable5-final-review-brief-prep.md",
       "date": "2026-07-07",
       "title": "2026-07-07 — Prepare Fable-5 ultracode brief for the final rebuild-plan review + Projects-EAP repo prep",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-07-coordinator-kickoff-calibration.md",
-      "date": "2026-07-07",
-      "title": "2026-07-07 — SuperBot Project coordinator: kickoff revision + calibration exchange design",
       "status": "complete",
       "run_type": "",
       "self_initiated": false

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-09T07:01:03Z",
+    "generated_at": "2026-07-09T07:10:35Z",
     "build": {
-      "commit": "3fd2a56",
-      "subject": "Session card (born-red) + claim: console.json shape contract",
-      "committed_at": "2026-07-09T07:01:03Z"
+      "commit": "a19b189",
+      "subject": "Pin the console.json cross-repo shape contract (the #1883 session idea)",
+      "committed_at": "2026-07-09T07:10:35Z"
     },
     "schema_version": 1
   },
@@ -53,8 +53,8 @@
       "file": "2026-07-09-console-feed-contract.md",
       "date": "2026-07-09",
       "title": "Session 2026-07-09 — console.json shape contract (superbot half)",
-      "status": "in-progress",
-      "run_type": "",
+      "status": "complete",
+      "run_type": "manual",
       "self_initiated": false
     },
     {
@@ -491,10 +491,10 @@
     }
   ],
   "ideas": {
-    "total": 219,
+    "total": 220,
     "by_status": {
       "historical": 23,
-      "ideas": 193,
+      "ideas": 194,
       "reference": 3
     }
   },
@@ -584,6 +584,20 @@
   "telemetry": [
     {
       "session": "2026-07-09-kl6-console-telemetry",
+      "date": "2026-07-09",
+      "model": "fable-5",
+      "effort": "high",
+      "task_class": "kernel/architecture design",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-09-console-feed-contract",
       "date": "2026-07-09",
       "model": "fable-5",
       "effort": "high",

--- a/botsite/data/console_data_contract.json
+++ b/botsite/data/console_data_contract.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Canonical shape contract for the committed program-console feed `botsite/data/console.json` — the single source of truth for the TWO consumers of that file: superbot's own botsite console (botsite/console/console.js) and the websites repo's dashboard /console page (menno420/websites dashboard/data_source.py, which fetches the committed file over raw.githubusercontent.com). The producer (scripts/export_dashboard_data.py build_console_subset) and the checker (scripts/check_dashboard_data.py check_console_subset, CI-enforced via tests/unit/scripts/) both validate against this file, so a producer-side family/field rename fails CI here instead of silently blanking a consumer page (the BUG-0022 desync class; idea provenance: PR #1883's session card). Keys list the GUARANTEED fields per record (values may be null); a field or family may only be added/renamed/removed by editing THIS file and bumping `version` — the explicit, reviewable act consumers pin against (console.json carries the version as meta.schema_version).",
+  "version": 1,
+  "top_level": ["meta", "sessions", "ideas", "bugs", "bot_changelog", "telemetry"],
+  "meta": ["generated_at", "build", "schema_version"],
+  "session": ["file", "date", "title", "status", "run_type", "self_initiated"],
+  "ideas": ["total", "by_status"],
+  "bugs": ["total", "by_status", "open_count", "open"],
+  "bug_open": ["id", "title", "status"],
+  "bot_changelog": ["date", "title", "kind", "summary"],
+  "telemetry": ["session", "date", "model", "effort", "task_class", "tokens_out", "outcome"],
+  "telemetry_outcome": ["ci_green_first_push", "checker_findings", "merged_pr", "reverted_within_window"]
+}

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,11 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`pinned-feed-contract-for-dashboard-json-2026-07-09.md`](./pinned-feed-contract-for-dashboard-json-2026-07-09.md) —
+  **session ender (2026-07-09, PR #1884):** extend the pinned-feed-contract pattern (the console.json
+  shape contract, `botsite/data/console_data_contract.json`) to `dashboard.json` — the websites repo's
+  dashboard renders ~12 pages off that feed with no contract at all, the same silent-break class the
+  console contract just closed (and whose first consumer-side pass caught a live dict-vs-list defect).
 - [`live-tree-test-culprit-attribution-2026-07-08.md`](./live-tree-test-culprit-attribution-2026-07-08.md) —
   **grooming capture (2026-07-08, PR #1846 follow-on pass):** live-tree ground-truth tests
   (plan homing etc.) fail on innocent fresh branches whenever an earlier merge shipped tree

--- a/docs/ideas/pinned-feed-contract-for-dashboard-json-2026-07-09.md
+++ b/docs/ideas/pinned-feed-contract-for-dashboard-json-2026-07-09.md
@@ -1,0 +1,48 @@
+# Idea — extend the pinned-feed-contract pattern to `dashboard.json`
+
+> **Status:** `ideas` — not a plan, not approval. Captured 2026-07-09 (Q-0089 session
+> ender, console-feed-contract session / PR #1884).
+> **Subsystem:** none (cross-cutting, `scripts/` + `dashboard/data/` tooling)
+
+## The gap
+
+PR #1884 pinned the shape of `botsite/data/console.json` in a committed, versioned
+contract (`botsite/data/console_data_contract.json`) because TWO repos render it —
+superbot's botsite console and the **websites** repo's dashboard `/console` page —
+and a producer-side rename silently blanked the consumer (the BUG-0022 class). The
+first consumer-side validation pass immediately caught a live defect: websites'
+console page treated the `ideas`/`bugs` families as *lists* when the feed ships
+*dicts*, so its stat tiles showed dict-key counts.
+
+But `console.json` is the **small** feed. The websites dashboard renders **~12
+pages** off `dashboard/data/dashboard.json` (catalogue, cogs+commands, settings,
+access, env-map, ideas, bugs, updates, synonyms…) — a far larger implicit surface
+with **no contract at all**. Every one of those pages carries the same silent-break
+risk the console just had, multiplied.
+
+## The idea
+
+Apply the now-proven pattern to `dashboard.json`, family by family (not one huge
+schema in one go):
+
+- `dashboard/data/dashboard_data_contract.json` — versioned, guaranteed fields per
+  family/record, same semantics as the console contract.
+- Producer parity + committed-file validation in `check_dashboard_data.py` (the
+  checks already exist for counts/required-fields; this adds the contract file as
+  the citable source of truth and `meta.schema_version` to the payload).
+- websites pins the version + validates at render time (its `data_source.py`
+  shaping helpers are exactly the field list to contract).
+
+Start with the families websites actually renders (catalogue / cogs+commands /
+settings / env_usage / ideas / bugs / updates / synonyms / access); leave
+superbot-only families uncontracted until someone consumes them.
+
+## Why it's worth having
+
+- The cross-repo seam is the least-tested surface in the estate: no shared CI, no
+  shared types, raw-URL fetch. A committed contract is the cheapest enforcing pin.
+- The console PR proves the mechanism end-to-end (producer parity + fail-closed
+  checker + consumer version check) — extending is mostly transcription.
+- Kit angle: if this holds up across two feeds, "pinned feed contract" is a
+  portable doctrine candidate for substrate-kit (any producer-repo → consumer-repo
+  committed-artifact seam).

--- a/docs/owner/claims/claude-console-feed-contract.md
+++ b/docs/owner/claims/claude-console-feed-contract.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/console-feed-contract` · console.json shape contract (the #1883 session idea) · `botsite/data/console_data_contract.json` + `scripts/export_dashboard_data.py` + `scripts/check_dashboard_data.py` + tests + regenerated `botsite/data/console.json` · 2026-07-09

--- a/docs/owner/claims/claude-console-feed-contract.md
+++ b/docs/owner/claims/claude-console-feed-contract.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/console-feed-contract` · console.json shape contract (the #1883 session idea) · `botsite/data/console_data_contract.json` + `scripts/export_dashboard_data.py` + `scripts/check_dashboard_data.py` + tests + regenerated `botsite/data/console.json` · 2026-07-09

--- a/scripts/check_dashboard_data.py
+++ b/scripts/check_dashboard_data.py
@@ -19,6 +19,11 @@ Checks:
   command-count-drift class).
 * **required fields** — every command has a name + valid ``type``; every cog has a
   ``file``; every catalogue entry has a ``key``.
+* **console shape contract** (``--console``) — the committed
+  ``botsite/data/console.json`` must match the versioned cross-repo contract
+  ``botsite/data/console_data_contract.json`` (two repos consume the feed:
+  superbot's botsite console + the websites repo's dashboard ``/console``).
+  See :func:`check_console_subset`.
 
 Pure stdlib so it runs in CI with no extra dependencies (the dashboard's web deps
 never enter the bot's ``requirements.txt``). Run::
@@ -55,6 +60,8 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DATA_FILE = REPO_ROOT / "dashboard" / "data" / "dashboard.json"
 SITE_DATA_FILE = REPO_ROOT / "botsite" / "data" / "site.json"
+CONSOLE_DATA_FILE = REPO_ROOT / "botsite" / "data" / "console.json"
+CONSOLE_CONTRACT_FILE = REPO_ROOT / "botsite" / "data" / "console_data_contract.json"
 
 # Real (``is_cog``) cogs that legitimately have NO own SUBSYSTEMS registry entry
 # AND no parent to map to: ``HermesCog`` (ops bridge), ``SetupCog`` (the hub-less
@@ -415,6 +422,232 @@ def check_site_subset(
     return issues
 
 
+def load_console_contract(path: Path = CONSOLE_CONTRACT_FILE) -> dict[str, Any]:
+    """Load the committed console-feed shape contract (cross-repo source of truth)."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _console_record_field_issues(
+    label: str,
+    records: list[Any],
+    allowed: set[str],
+    *,
+    exact: bool = False,
+) -> list[Issue]:
+    """Field-whitelist findings for one console family's records.
+
+    Every record's keys must be a *subset* of the contract's guaranteed fields
+    (a new un-contracted field fails closed — the within-family leak/drift class).
+    With ``exact=True`` a record must also carry *every* contract field (the
+    producer constructs sessions/telemetry rows by whitelist comprehension, so a
+    missing field there means the producer dropped one a consumer relies on).
+    """
+    issues: list[Issue] = []
+    extra: set[str] = set()
+    missing: set[str] = set()
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        extra |= set(record) - allowed
+        if exact:
+            missing |= allowed - set(record)
+    if extra:
+        issues.append(
+            _err(
+                "console_field_not_in_contract",
+                f"console.json {label} carries field(s) {sorted(extra)} not in the "
+                f"contract {sorted(allowed)} — the console feed's shape is a "
+                f"cross-repo contract (websites' dashboard consumes it); add the "
+                f"field to console_data_contract.json and bump its version instead "
+                f"of shipping it implicitly",
+            ),
+        )
+    if missing:
+        issues.append(
+            _err(
+                "console_field_missing",
+                f"console.json {label} is missing guaranteed field(s) "
+                f"{sorted(missing)} — a consumer built against the contract relies "
+                f"on them; restore the field or change the contract (version bump)",
+            ),
+        )
+    return issues
+
+
+def check_console_subset(
+    committed: dict[str, Any] | None = None,
+    *,
+    console_path: Path = CONSOLE_DATA_FILE,
+    contract_path: Path = CONSOLE_CONTRACT_FILE,
+) -> list[Issue]:
+    """Validate ``botsite/data/console.json`` against the cross-repo shape contract.
+
+    The console feed has TWO consumers — superbot's own botsite console AND the
+    websites repo's dashboard ``/console`` page (fetched over raw GitHub) — so its
+    shape is pinned in the committed, versioned
+    ``botsite/data/console_data_contract.json`` (the ``site_data_contract.json``
+    pattern; PR #1883's session idea). Three assertion groups, all **fail-closed**:
+
+    * **producer⇄contract parity** — the exporter's ``CONSOLE_*`` constants and
+      ``CONSOLE_SCHEMA_VERSION`` must match the contract file exactly, so the
+      contract can only change via an explicit, reviewable edit of both.
+    * **family whitelist, both directions** — the committed file's top-level keys
+      must equal the contract's ``top_level`` exactly: an extra family is the leak
+      class, a *missing* family is the consumer-blanking class (BUG-0022).
+      ``meta.schema_version`` must equal the contract ``version``.
+    * **per-record guaranteed fields** — sessions / telemetry (+ nested outcome)
+      rows carry exactly the contract fields; meta / ideas / bugs / open-bug /
+      changelog keys stay a subset of theirs.
+
+    Returns ``[]`` when the console file is absent (generated artifact; freshness
+    is reported elsewhere). A missing/unparseable *contract* file is an error —
+    the contract itself is load-bearing.
+    """
+    issues: list[Issue] = []
+    if committed is None:
+        if not console_path.exists():
+            return issues
+        committed = json.loads(console_path.read_text(encoding="utf-8"))
+
+    try:
+        contract = load_console_contract(contract_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return [
+            _err(
+                "console_contract_unreadable",
+                f"cannot load {contract_path.name}: {exc} — the console feed's "
+                f"cross-repo shape contract must stay committed and valid",
+            ),
+        ]
+
+    # -- producer⇄contract parity (the contract file is the source of truth) --
+    export = _export_module()
+    parity: tuple[tuple[str, Any, Any], ...] = (
+        ("version", contract.get("version"), export.CONSOLE_SCHEMA_VERSION),
+        (
+            "top_level",
+            set(contract.get("top_level", [])),
+            set(export.CONSOLE_TOPLEVEL_KEYS),
+        ),
+        (
+            "session",
+            set(contract.get("session", [])),
+            set(export.CONSOLE_SESSION_FIELDS),
+        ),
+        (
+            "telemetry",
+            set(contract.get("telemetry", [])),
+            set(export.CONSOLE_TELEMETRY_FIELDS),
+        ),
+        (
+            "telemetry_outcome",
+            set(contract.get("telemetry_outcome", [])),
+            set(export.TELEMETRY_OUTCOME_FIELDS),
+        ),
+    )
+    for surface, contracted, produced in parity:
+        if contracted != produced:
+            issues.append(
+                _err(
+                    "console_contract_producer_drift",
+                    f"contract {surface!r} = {contracted!r} but the producer "
+                    f"(export_dashboard_data) emits {produced!r} — change "
+                    f"console_data_contract.json and the CONSOLE_* constants in "
+                    f"the same commit (version bump) so both repos see the move",
+                ),
+            )
+
+    # -- family whitelist, BOTH directions (extra = leak, missing = blanked page) --
+    contracted_families = set(contract.get("top_level", []))
+    extra = set(committed) - contracted_families
+    missing = contracted_families - set(committed)
+    if extra:
+        issues.append(
+            _err(
+                "console_key_not_in_contract",
+                f"console.json has top-level key(s) {sorted(extra)} not in the "
+                f"contract {sorted(contracted_families)} — an un-contracted family "
+                f"must never ship implicitly (two repos consume this feed)",
+            ),
+        )
+    if missing:
+        issues.append(
+            _err(
+                "console_family_missing",
+                f"console.json is missing contracted famil(ies) {sorted(missing)} — "
+                f"a consumer page renders blank on this (the BUG-0022 class); "
+                f"restore the family or change the contract (version bump)",
+            ),
+        )
+
+    # -- schema version --
+    meta = committed.get("meta", {}) if isinstance(committed.get("meta"), dict) else {}
+    if meta.get("schema_version") != contract.get("version"):
+        issues.append(
+            _err(
+                "console_schema_version_mismatch",
+                f"console.json meta.schema_version={meta.get('schema_version')!r} "
+                f"but the contract pins version={contract.get('version')!r} — "
+                f"regenerate the feed (export_dashboard_data --targets console) "
+                f"or reconcile the contract",
+            ),
+        )
+
+    # -- per-record guaranteed fields --
+    issues += _console_record_field_issues(
+        "meta",
+        [meta],
+        set(contract.get("meta", [])),
+    )
+    issues += _console_record_field_issues(
+        "sessions",
+        list(committed.get("sessions", []) or []),
+        set(contract.get("session", [])),
+        exact=True,
+    )
+    telemetry_rows = list(committed.get("telemetry", []) or [])
+    issues += _console_record_field_issues(
+        "telemetry",
+        telemetry_rows,
+        set(contract.get("telemetry", [])),
+        exact=True,
+    )
+    issues += _console_record_field_issues(
+        "telemetry[].outcome",
+        [
+            row.get("outcome")
+            for row in telemetry_rows
+            if isinstance(row, dict) and isinstance(row.get("outcome"), dict)
+        ],
+        set(contract.get("telemetry_outcome", [])),
+    )
+    ideas = committed.get("ideas")
+    if isinstance(ideas, dict):
+        issues += _console_record_field_issues(
+            "ideas",
+            [ideas],
+            set(contract.get("ideas", [])),
+        )
+    bugs = committed.get("bugs")
+    if isinstance(bugs, dict):
+        issues += _console_record_field_issues(
+            "bugs",
+            [bugs],
+            set(contract.get("bugs", [])),
+        )
+        issues += _console_record_field_issues(
+            "bugs.open",
+            list(bugs.get("open", []) or []),
+            set(contract.get("bug_open", [])),
+        )
+    issues += _console_record_field_issues(
+        "bot_changelog",
+        list(committed.get("bot_changelog", []) or []),
+        set(contract.get("bot_changelog", [])),
+    )
+    return issues
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: validate the export, print findings, exit non-zero on error."""
     parser = argparse.ArgumentParser(description="Validate the dashboard data export.")
@@ -434,6 +667,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="also validate the public botsite/data/site.json subset (whitelist + counts)",
     )
+    parser.add_argument(
+        "--console",
+        action="store_true",
+        help="also validate botsite/data/console.json against its cross-repo shape "
+        "contract (console_data_contract.json)",
+    )
     args = parser.parse_args(argv)
 
     if args.fresh:
@@ -444,6 +683,8 @@ def main(argv: list[str] | None = None) -> int:
     issues = validate(data)
     if args.site:
         issues.extend(check_site_subset())
+    if args.console:
+        issues.extend(check_console_subset())
     if args.drift:
         # Compare the committed artifact (never the fresh one, even under --fresh)
         # against a fresh build so the report names what the *committed* file is

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -85,6 +85,20 @@ CONSOLE_OUTPUT_FILE = REPO_ROOT / "botsite" / "data" / "console.json"
 CONSOLE_TOPLEVEL_KEYS: frozenset[str] = frozenset(
     {"meta", "sessions", "ideas", "bugs", "bot_changelog", "telemetry"},
 )
+# The console feed's CROSS-REPO shape contract. ``console.json`` has two consumers —
+# superbot's own botsite console (``botsite/console/console.js``) AND the websites
+# repo's dashboard ``/console`` page (menno420/websites, fetching the committed file
+# over raw GitHub) — so the shape is pinned in the committed, versioned
+# ``botsite/data/console_data_contract.json`` (the ``site_data_contract.json``
+# pattern applied to this feed; PR #1883's session idea). These producer constants
+# must MATCH that file — ``check_dashboard_data.check_console_subset`` enforces the
+# parity (CI via tests/unit/scripts/) — and every emitted ``console.json`` carries
+# the contract version as ``meta.schema_version`` so consumers can cheaply verify
+# the shape they were built against. Changing the shape = edit the contract file
+# and these constants in the same commit and bump the version — the explicit,
+# reviewable act a consumer repo pins against.
+CONSOLE_CONTRACT_FILE = REPO_ROOT / "botsite" / "data" / "console_data_contract.json"
+CONSOLE_SCHEMA_VERSION = 1
 # Per-entry field whitelist for the console's session feed (run reports).
 CONSOLE_SESSION_FIELDS: tuple[str, ...] = (
     "file",
@@ -1311,6 +1325,10 @@ def build_console_subset(data: dict) -> dict:
         "meta": {
             "generated_at": meta.get("generated_at"),
             "build": meta.get("build", {}),
+            # The cross-repo shape-contract version (console_data_contract.json):
+            # consumers (websites' dashboard /console) pin the version they were
+            # built against and verify it here at render time.
+            "schema_version": CONSOLE_SCHEMA_VERSION,
         },
         "sessions": sessions,
         "ideas": {"total": len(ideas), "by_status": _by_status(ideas)},

--- a/telemetry/model-usage.jsonl
+++ b/telemetry/model-usage.jsonl
@@ -1,1 +1,2 @@
 {"date": "2026-07-09", "effort": "high", "model": "fable-5", "outcome": {"checker_findings": null, "ci_green_first_push": null, "merged_pr": null, "reverted_within_window": null}, "session": "2026-07-09-kl6-console-telemetry", "task_class": "kernel/architecture design", "tokens_out": null}
+{"date": "2026-07-09", "effort": "high", "model": "fable-5", "outcome": {"checker_findings": null, "ci_green_first_push": null, "merged_pr": null, "reverted_within_window": null}, "session": "2026-07-09-console-feed-contract", "task_class": "kernel/architecture design", "tokens_out": null}

--- a/tests/unit/scripts/test_check_dashboard_data.py
+++ b/tests/unit/scripts/test_check_dashboard_data.py
@@ -375,3 +375,125 @@ def test_committed_site_json_passes_guard(mod):
 
 def test_main_site_exits_zero(mod):
     assert mod.main(["--site"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# console feed shape contract (botsite/data/console_data_contract.json)
+# ---------------------------------------------------------------------------
+
+
+def _codes(issues):
+    return [i.code for i in issues]
+
+
+@pytest.fixture(scope="module")
+def committed_console(mod):
+    import json
+
+    return json.loads(
+        (mod.REPO_ROOT / "botsite" / "data" / "console.json").read_text(
+            encoding="utf-8",
+        ),
+    )
+
+
+def _clone(payload):
+    import json
+
+    return json.loads(json.dumps(payload))
+
+
+def test_committed_console_json_passes_contract(mod):
+    # THE cross-repo guard: the committed console.json (consumed by superbot's
+    # botsite console AND the websites repo's dashboard /console over raw
+    # GitHub) must match the committed, versioned contract as shipped.
+    errors = [i for i in mod.check_console_subset() if i.severity == "error"]
+    assert errors == [], f"committed console.json breaks its contract: {errors}"
+
+
+def test_fresh_console_subset_passes_contract(mod):
+    export = mod._export_module()
+    fresh = export.build_console_subset(mod._build_fresh())
+    errors = [i for i in mod.check_console_subset(fresh) if i.severity == "error"]
+    assert errors == [], f"fresh console subset breaks the contract: {errors}"
+
+
+def test_console_contract_matches_producer_constants(mod):
+    # The contract file is the cross-repo source of truth; the producer constants
+    # must match it exactly (changing one without the other = CI-red drift).
+    contract = mod.load_console_contract()
+    export = mod._export_module()
+    assert contract["version"] == export.CONSOLE_SCHEMA_VERSION
+    assert set(contract["top_level"]) == set(export.CONSOLE_TOPLEVEL_KEYS)
+    assert set(contract["session"]) == set(export.CONSOLE_SESSION_FIELDS)
+    assert set(contract["telemetry"]) == set(export.CONSOLE_TELEMETRY_FIELDS)
+    assert set(contract["telemetry_outcome"]) == set(export.TELEMETRY_OUTCOME_FIELDS)
+
+
+def test_console_fails_closed_on_uncontracted_family(mod, committed_console):
+    bad = _clone(committed_console)
+    bad["secret_family"] = []
+    assert "console_key_not_in_contract" in _codes(mod.check_console_subset(bad))
+
+
+def test_console_fails_closed_on_missing_family(mod, committed_console):
+    # The consumer-blanking class (BUG-0022): a dropped family is an ERROR, not
+    # a silent shrink — the websites dashboard renders this feed.
+    bad = {k: v for k, v in _clone(committed_console).items() if k != "telemetry"}
+    assert "console_family_missing" in _codes(mod.check_console_subset(bad))
+
+
+def test_console_fails_closed_on_schema_version_mismatch(mod, committed_console):
+    bad = _clone(committed_console)
+    bad["meta"]["schema_version"] = 999
+    assert "console_schema_version_mismatch" in _codes(mod.check_console_subset(bad))
+
+
+def test_console_fails_closed_on_uncontracted_session_field(mod, committed_console):
+    bad = _clone(committed_console)
+    bad["sessions"][0]["guild_id"] = 123  # the per-guild-leak class
+    assert "console_field_not_in_contract" in _codes(mod.check_console_subset(bad))
+
+
+def test_console_fails_closed_on_dropped_guaranteed_field(mod, committed_console):
+    bad = _clone(committed_console)
+    del bad["sessions"][0]["title"]
+    assert "console_field_missing" in _codes(mod.check_console_subset(bad))
+
+
+def test_console_fails_closed_on_uncontracted_telemetry_outcome_field(
+    mod,
+    committed_console,
+):
+    bad = _clone(committed_console)
+    assert bad["telemetry"], "committed telemetry feed unexpectedly empty"
+    bad["telemetry"][0]["outcome"]["surprise"] = True
+    assert "console_field_not_in_contract" in _codes(mod.check_console_subset(bad))
+
+
+def test_console_contract_producer_drift_is_flagged(mod, committed_console, tmp_path):
+    import json
+
+    contract = mod.load_console_contract()
+    contract["session"] = list(contract["session"]) + ["not_a_real_field"]
+    drifted = tmp_path / "console_data_contract.json"
+    drifted.write_text(json.dumps(contract), encoding="utf-8")
+    codes = _codes(
+        mod.check_console_subset(
+            _clone(committed_console),
+            contract_path=drifted,
+        ),
+    )
+    assert "console_contract_producer_drift" in codes
+
+
+def test_console_unreadable_contract_is_an_error(mod, committed_console, tmp_path):
+    missing = tmp_path / "nope.json"
+    codes = _codes(
+        mod.check_console_subset(_clone(committed_console), contract_path=missing),
+    )
+    assert codes == ["console_contract_unreadable"]
+
+
+def test_main_console_exits_zero(mod):
+    assert mod.main(["--console"]) == 0

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -651,6 +651,18 @@ def test_console_subset_whitelist_and_shapes(mod):
         assert outcome is None or set(outcome) == set(mod.TELEMETRY_OUTCOME_FIELDS)
 
 
+def test_console_meta_carries_contract_schema_version(mod):
+    # The cross-repo shape contract (botsite/data/console_data_contract.json):
+    # every emitted console.json stamps the contract version into meta so the
+    # websites-repo consumer can verify the shape it was built against.
+    contract = json.loads(mod.CONSOLE_CONTRACT_FILE.read_text(encoding="utf-8"))
+    subset = mod.build_console_subset(mod.build_data())
+    assert subset["meta"]["schema_version"] == mod.CONSOLE_SCHEMA_VERSION
+    assert subset["meta"]["schema_version"] == contract["version"]
+    # The whole emitted shape stays inside the contract's family list.
+    assert set(subset) == set(contract["top_level"])
+
+
 def test_parse_telemetry_whitelist_and_tolerance(mod, tmp_path):
     """The JSONL reader is tolerant by contract: bad lines skipped, extra fields
     dropped, a malformed ``outcome`` nulled — one bad row never blanks the lane.


### PR DESCRIPTION
Executes the `💡 Session idea` from PR #1883's session card: the committed `botsite/data/console.json` feed is consumed by TWO renderers — superbot's own botsite console and the **websites** repo's dashboard `/console` page (fetched over raw.githubusercontent.com) — but nothing pinned the shape both sides assume; a producer-side family rename silently blanks the consumer (the BUG-0022 desync class).

This PR pins it:

- **`botsite/data/console_data_contract.json`** — the committed, versioned shape contract (same pattern as the existing `site_data_contract.json`): top-level families + per-record guaranteed fields + `version`. Changing this file is the explicit, reviewable act of changing the cross-repo contract.
- **Exporter** (`scripts/export_dashboard_data.py`): `console.json` gains `meta.schema_version` (from `CONSOLE_SCHEMA_VERSION`), so consumers can cheaply verify the version they were built against.
- **Checker** (`scripts/check_dashboard_data.py`): new `check_console_subset` (`--console`) mirroring `check_site_subset` — producer-constant⇄contract parity, committed top-level families exactly the contract's, `meta.schema_version` match, per-record field whitelists (sessions / telemetry / outcome / open bugs / changelog / meta). Enforced in CI by tests over the committed file.
- `botsite/data/console.json` regenerated (`--targets console`).

Companion consumer-side PR lands in **menno420/websites** (pinned contract copy + render-time version check + fixes the dict-vs-list ideas/bugs consumer bug this contract immediately surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJfdy7YxUw8oXj4Wfngdyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJfdy7YxUw8oXj4Wfngdyc)_