### PR TITLE
docs(eap): evaluation log — fleet-scale GraphQL quota exhaustion

### DIFF
--- a/docs/planning/projects-eap-evaluation-log.md
+++ b/docs/planning/projects-eap-evaluation-log.md
@@ -286,3 +286,9 @@ product review's analysis — confirm, contradict, or deepen it with lived examp
   (multi-repo env, verified by probe session 13:55Z). · expected: setup-script failure degrades
   gracefully — skip failed steps, boot the session, surface "setup degraded" in the session
   list. · weight: blocked-me · reproducible: yes
+- 2026-07-09 ~16:36Z · axis: reliability/completion · observed: fleet-scale API pressure — the
+  shared token's GraphQL quota exhausted mid-run ("API rate limit already exceeded", 10498/5000
+  used), blocking enable_pr_auto_merge (GraphQL-only) while REST kept working; at current
+  10-Project call volume this recurs ~hourly. Manager workaround: direct REST merge on green as
+  fallback. · expected: auto-merge arming to be REST-reachable, or per-Project token quotas — a
+  10-agent fleet on one user token saturates GraphQL. · weight: friction · reproducible: yes


### PR DESCRIPTION
Appends one entry at the bottom of § Entries in `docs/planning/projects-eap-evaluation-log.md` (house format, guidebook §2 shape): fleet-scale GraphQL quota exhaustion on the shared token (10498/5000) blocking `enable_pr_auto_merge` while REST kept working; manager fallback is direct REST merge on green. Axis: reliability/completion · weight: friction.

`check_docs --strict` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PgczP9p17N6SCB5bwS5fE

---
_Generated by [Claude Code](https://claude.ai/code/session_019PgczP9p17N6SCB5bwS5fE)_