### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-09T17:14:28Z",
+    "generated_at": "2026-07-09T20:14:03Z",
     "build": {
-      "commit": "6f67206e",
-      "subject": "docs(eap): fleet-manifest — manager row: home repo menno420/fleet-manager seeded (#1905)",
-      "committed_at": "2026-07-09T17:14:28Z"
+      "commit": "0c9038c0",
+      "subject": "Merge pull request #1906 from menno420/bot/dashboard-refresh",
+      "committed_at": "2026-07-09T20:14:03Z"
     },
     "counts": {
       "functions": 43,


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.