### PR TITLE
Add return description to format_duration docstring

### DIFF
--- a/disbot/utils/duration.py
+++ b/disbot/utils/duration.py
@@ -47,7 +47,10 @@ def parse_duration(text: str) -> int | None:
 
 
 def format_duration(seconds: int) -> str:
-    """Render seconds as a compact human string (``5400`` → ``"1h 30m"``)."""
+    """Render seconds as a compact human string (``5400`` → ``"1h 30m"``).
+
+    Returns a space-separated duration string using day/hour/minute/second units.
+    """
     if seconds <= 0:
         return "0s"
     parts: list[str] = []


### PR DESCRIPTION
### Motivation
- Clarify the return value of `format_duration` so callers know it produces a compact, human-readable duration string.

### Description
- Added a one-line return description to the docstring of `format_duration` in `disbot/utils/duration.py` stating it returns a space-separated duration string using day/hour/minute/second units.

### Testing
- No automated tests were run for this change per the task constraint; only local verification (git operations) was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504bc22b9c8322979dddf62f6121c9)