### PR TITLE
Add PR #1911 post-merge review record and update EAP README

### DIFF
--- a/docs/eap/README.md
+++ b/docs/eap/README.md
@@ -23,6 +23,9 @@
   logged including a false "NO ACK" claim inside fleet-manager's own report. Complements
   `gen1-grand-review-2026-07-09.md` §5 (structural completeness across all 6 repos) with
   deep, per-incident evidence verification on the 7 wind-down lanes + seed + ping-test.
+- [`pr1911-post-merge-review-2026-07-10.md`](pr1911-post-merge-review-2026-07-10.md) —
+  post-merge review record for PR #1911 (`527766f`): 0 real defects found; records the
+  checked files, link validation, docs check, and quality-check environment limitation.
 
 ## Fleet reviews and instruments (2026-07-09)
 

--- a/docs/eap/pr1911-post-merge-review-2026-07-10.md
+++ b/docs/eap/pr1911-post-merge-review-2026-07-10.md
@@ -1,0 +1,89 @@
+# PR #1911 post-merge review — no defects found
+
+> **Status:** `reference` — post-merge review record for the most recently merged pull
+> request at review time: `527766f` (`Merge pull request #1911 from
+> menno420/claude/vigilant-rubin-0wuxk2`). Reviewed 2026-07-10 UTC. Scope was the PR diff
+> from first parent `fc3f85e` to merge commit `527766f`; no repository files were changed
+> during the review.
+
+## Result
+
+**Findings:** 0 real defects.
+
+No style-only findings were recorded. The reviewed changes were documentation and telemetry
+only: a Gen-1 grand-review report, a send-ready wrap-up email candidate, an EAP index, a
+session card, and one model-usage JSONL row.
+
+## Review scope
+
+The reviewed diff was:
+
+```text
+.sessions/2026-07-09-gen1-grand-review.md
+docs/eap/README.md
+docs/eap/gen1-grand-review-2026-07-09.md
+docs/eap/gen1-wrapup-email-final-candidate.md
+telemetry/model-usage.jsonl
+```
+
+## Checks performed
+
+- **EAP index / navigation:** checked the added `docs/eap/README.md` entry point and the
+  links it added to the Gen-1 reports, send candidate, superseded draft, doctrine review,
+  wind-down audit, fleet manifest, external review pack, fleet reviews, and campaign
+  self-audit. Link targets existed and the page was coherent as an EAP corpus index.
+- **Grand-review report:** checked the added report's scope/headline, old-vs-new gap map,
+  PR sweep table, and fact-audit framing for internal contradictions or instructions that
+  would cause a reader to take the wrong repo action. None found.
+- **Send-ready email candidate:** checked status/header metadata, send-window notes,
+  remaining owner placeholder disclosure, and finalization notes. The document clearly
+  marks Part 1 as owner-supplied and does not present that placeholder as completed agent
+  content.
+- **Session card:** checked the added `.sessions` log for status, shipped-artifact
+  references, context deltas, and close-out claims. No actionable defect found.
+- **Telemetry JSONL append:** checked the added `telemetry/model-usage.jsonl` row against
+  adjacent rows. The appended line is valid JSONL and matches the existing field shape.
+
+## Commands run
+
+```bash
+git log --merges --oneline -n 5
+git show --stat --oneline --find-renames 527766f
+git show --name-only --format=fuller 527766f
+git diff --find-renames fc3f85e..527766f -- docs/eap/README.md docs/eap/gen1-grand-review-2026-07-09.md docs/eap/gen1-wrapup-email-final-candidate.md .sessions/2026-07-09-gen1-grand-review.md telemetry/model-usage.jsonl
+python - <<'PY'
+import re, pathlib
+files=[pathlib.Path('docs/eap/README.md'), pathlib.Path('docs/eap/gen1-grand-review-2026-07-09.md'), pathlib.Path('docs/eap/gen1-wrapup-email-final-candidate.md'), pathlib.Path('.sessions/2026-07-09-gen1-grand-review.md')]
+for f in files:
+    txt=f.read_text()
+    for i,line in enumerate(txt.splitlines(),1):
+        for m in re.finditer(r'\[[^\]]+\]\(([^)]+)\)', line):
+            href=m.group(1)
+            if '://' in href or href.startswith('#') or href.startswith('mailto:'):
+                continue
+            path=href.split('#')[0]
+            if not path:
+                continue
+            target=(f.parent/path).resolve()
+            if not target.exists():
+                print(f'{f}:{i}: missing {href} -> {target}')
+PY
+python3 scripts/check_docs.py
+python3 scripts/check_quality.py
+```
+
+## Command outcomes
+
+- `git log --merges --oneline -n 5`: identified `527766f` as the most recent merge commit
+  at review time.
+- `git show --stat --oneline --find-renames 527766f`: confirmed the PR touched five files
+  and added docs/telemetry only.
+- `git show --name-only --format=fuller 527766f`: confirmed the merge parents
+  (`fc3f85e`, `a26ee41`) and PR metadata.
+- `git diff --find-renames fc3f85e..527766f -- ...`: supplied the reviewed diff.
+- Markdown link-target script: produced no missing-link output for the reviewed files.
+- `python3 scripts/check_docs.py`: passed.
+- `python3 scripts/check_quality.py`: environment-limited warning — the wrapper attempted
+  `python3.10`, but pyenv did not expose that executable in this shell. The wrapper printed
+  failed subchecks, then exited `0`; this did not change the no-defect review conclusion
+  because the PR diff was docs/telemetry-only and `check_docs` passed separately.


### PR DESCRIPTION
### Motivation

- Record the post-merge review for the most-recent merged PR and surface it in the EAP corpus index. 
- Capture the review conclusion that there were no real defects and document the checks performed for auditability.

### Description

- Add `docs/eap/pr1911-post-merge-review-2026-07-10.md` containing the post-merge review narrative, findings, reviewed-file list, performed checks, and command outputs. 
- Update `docs/eap/README.md` to include a link to the new post-merge review record. 
- The recorded review scope focused on docs and telemetry changes including `.sessions/2026-07-09-gen1-grand-review.md`, `docs/eap/*` files, and `telemetry/model-usage.jsonl` and reports no style-only or real defects. 

### Testing

- Ran `python3 scripts/check_docs.py`, which passed. 
- Ran the project link-validation script (inline Python) against the added files, which reported no missing links. 
- Ran `python3 scripts/check_quality.py`, which emitted an environment-limited warning but exited `0`, and did not change the review conclusion of zero defects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504bae1db88322872b3410ae2abc5c)