### PR TITLE
docs: clarify cache ownership, EventBus subscriber behavior, and widget DB helper policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,13 @@ safety net, not the primary invalidation mechanism.  Hot-path guild
 configuration flows through the `core/runtime/guild_config` primitive
 — no ad-hoc per-cog caches.
 
+There is no `services/quantum_cache.py` cache layer.  Do not add or
+revive a service-level cache with that name as a shortcut around this
+taxonomy: pick the row above, then use the documented owner (`guild_config`
+for hot-path guild settings, `governance.cache` for governance-derived
+lookups, or a feature-owned process-local cache with explicit invalidation
+and teardown hooks).
+
 ### Ephemeral session
 
 Lives in `runtime_sessions` + `runtime_session_state` (TTL = 2 h by

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -244,6 +244,16 @@ Adding a new event:
 
 Without step 1 the bus warns (`unknown_event_total{event, op}`).
 
+### EventBus subscriber failure and retry policy
+
+`EventBus.emit` is **publish-accepted**: returning normally means the bus
+accepted the emission and attempted the registered handlers, not that every
+subscriber succeeded. Subscriber exceptions and timeouts are isolated per
+handler, logged/counted, swallowed, and dispatch continues to the remaining
+handlers. The EventBus does **not** retry a failed subscriber during the same
+emit; re-running a subscriber requires a fresh emit/replay from the caller or a
+future durable replay layer.
+
 ---
 
 ## Dependency direction (allow / disallow)
@@ -261,6 +271,11 @@ utils/db/<sub>    →  utils/db/pool, utils/db/codec
 utils/db/pool     →  asyncpg
 utils/<helper>    →  standard library, discord (no I/O)
 ```
+
+`utils.db.get_widget_config()` is not a supported DB helper. If a widget or
+panel needs configuration, use the subsystem's documented read seam (usually a
+`services/*_config.py` policy loader over `utils/settings_keys/*`) or document a
+new owner and helper here before adding it.
 
 ### Disallowed imports
 


### PR DESCRIPTION
### Motivation

- Make the runtime/cache taxonomy explicit and forbid adding a service-level `quantum_cache` to prevent circumvention of documented cache ownership rules.
- Clarify EventBus semantics so authors understand that subscriber failures are isolated, logged, and not retried automatically.
- Prevent ad-hoc DB helper usage by documenting that `utils.db.get_widget_config()` is not a supported seam and directing authors to use the subsystem's documented read paths.

### Description

- Added guidance to `docs/architecture.md` that there is no `services/quantum_cache.py` layer and instructions on which owner/primitive to use instead (e.g. `guild_config`, `governance.cache`, or a feature-owned process-local cache with explicit invalidation). 
- Added an "EventBus subscriber failure and retry policy" section to `docs/ownership.md` describing that `EventBus.emit` is publish-accepted, that handler exceptions/timeouts are isolated and swallowed, and that the bus does not retry failed subscribers during the same emit. 
- Documented that `utils.db.get_widget_config()` is not a supported DB helper and pointed authors to use the subsystem read seam or add a documented owner and helper first.

### Testing

- Built the documentation locally with `mkdocs build` to validate markdown and site rendering, which succeeded. 
- Ran repository linters/pre-commit hooks to validate formatting, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504bcb9bd483229340c43864a6883b)