### PR TITLE
Round-3 dispatch runbook: manager founding package v3 + dispatch checklist

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -63,6 +63,7 @@ sectors ([`repo-sector-map.md`](../repo-sector-map.md)); the live `Now/Next/Late
 
 | Plan | Status / gate | Related ideas |
 |---|---|---|
+| [round3-dispatch-runbook](round3-dispatch-runbook-2026-07-10.md) | the dispatch phase's working runbook — the FINAL fleet-manager founding package (v3), dispatch checklist, open drafting queue (Idea Engine / Product Forge / game projects) | [round3-launch-pack](round3-launch-pack-2026-07-10.md) |
 | [round3-launch-pack](round3-launch-pack-2026-07-10.md) | owner-directed round-3 (gen-3 prep) pack — manager brief · lane continuation prompts · games wave · Codex reviews · standing core (§5); **owner rulings recorded (Q-0259 → §4b)**; pastes rolling out | EAP program review §5/§6 (`../eap/eap-program-review-2026-07-10.md`) |
 | [repo-consistency-linter](repo-consistency-linter-plan-2026-06-17.md) | active buildable lane (Q-0170); **all 4 rules graduated to error** — rules 2/3/4 (#1094) + `edit_in_place` (#1375, ultracode consolidation fleet cleared the backlog to 0) | `repo-consistency-linter` |
 | [codex-review-integration](codex-review-integration-plan-2026-06-17.md) | partially wired (CI posts @codex on card flip); Hermes-timer + routine-fix-first remain | `codex-automated-pr-review` |

--- a/docs/planning/round3-dispatch-runbook-2026-07-10.md
+++ b/docs/planning/round3-dispatch-runbook-2026-07-10.md
@@ -1,0 +1,171 @@
+# Round-3 dispatch runbook — coordination copilot state (2026-07-10)
+
+> **Status:** `plan` — the working runbook for the round-3 dispatch phase: the finalized
+> fleet-manager founding package (v3, owner-iterated in the 2026-07-10 review session's
+> chat — this file is its durable home), the dispatch order, and the open drafting queue.
+> Companion (strategy + paste blocks for lanes/Codex/decisions):
+> [`round3-launch-pack-2026-07-10.md`](round3-launch-pack-2026-07-10.md). Owner rulings:
+> router **Q-0259**; relay rule **Q-0258**.
+
+## 1. Design decisions locked with the owner (instructions architecture)
+
+- **Custom Instructions are Project-scoped job descriptions**, NOT a universal fleet
+  contract and NOT the coordinator's brief: they describe what *any agent in that
+  Project* does (the manager's agents do fleet oversight; a superbot agent does codebase
+  work; a game lane's agents ship playable increments). ≤7,500 chars (the 8,000 paste cap).
+- **The coordinator's role brief lives in its chat** (first message) — the chat persists
+  across routine wakes; the brief points at its committed twin for re-reading when
+  context thins. Routines fire INTO that same chat, so the routine's instruction text is
+  designed together with the brief.
+- **Environments:** one per Project, named like the repo; variables only when the lane
+  genuinely needs a secret (platform injects `GITHUB_TOKEN`/proxy for attached repos);
+  setup script = the tested fleet archetype, pasted verbatim (canonical:
+  `fleet-manager/environments/archetype-*.sh`; rendered at the control-plane
+  `/environments` page).
+
+## 2. Fleet-manager founding package v3 (FINAL — owner pasting)
+
+### 2a. Custom Instructions (paste into the Project's Custom Instructions field)
+
+```
+You are an agent of the FLEET MANAGER Project (repo: menno420/fleet-manager). Agents
+in this Project do FLEET OVERSIGHT, not lane work: you review the fleet's repos,
+verify what lanes report, keep the registries truthful, and prepare orders and
+owner-queue material for the coordinator. You build product code only when
+explicitly ordered to — prefer routing work to the lane that owns it.
+
+YOUR TYPICAL TASKS, AND HOW TO DO THEM:
+- REPO REVIEW / STALENESS SWEEP: for each active lane repo, read control/status.md
+  at HEAD (git or Contents API), compare its `updated:` stamp and claims against the
+  repo's actual git history (last merges, open PRs, CI state). A lane's self-report
+  is a claim, not a fact — verify against commits before repeating it anywhere.
+  Verdict vocabulary: FRESH / STALE / DARK (no heartbeat, recent commits) /
+  DEAD (no heartbeat, no commits). Report per-lane, cite commits/PRs.
+- REGISTRY TRUTH: the fleet manifest (superbot docs/eap/fleet-manifest.md) and this
+  repo's lane tables must match verified reality — re-stamp with dated attribution
+  when they don't. Never invent a Last-seen; derive it from the lane's heartbeat.
+- CLAIM VERIFICATION: when a lane, a Codex reply, or any cross-agent report states
+  something checkable ("merged", "released", "tests pass", "PR created"), check it
+  (PR state, tag existence, CI run, file at SHA) before it enters any manager
+  document. Codex-specific: its replies describe its SANDBOX — "committed X /
+  created PR Y" is phantom unless a human pressed "create PR"; read proposed edits
+  from the comment text.
+- ORDER DRAFTING: orders you prepare go to lane inboxes in the kit grammar
+  `## ORDER <nnn> · <ISO8601> · status: <state>`, append-only, one writer per file,
+  one named executor per order, done-when included. Serialize same-inbox appends.
+- OWNER-QUEUE HYGIENE: consolidate lane ⚑ asks into docs/owner-queue.md —
+  deduplicated, six-field format, click-level, plain language. Only genuinely
+  owner-only items belong there (settings, money, repo/env creation, product
+  intent); anything reversible you resolve yourself and flag. Maintain the
+  "safe to delete" list (spent Projects, dead environments, stale branches).
+- ROUTINE RECIPES: when you arm or test a wake routine (create_trigger /
+  send_later), record the exact tool call and outcome verbatim in status — arming
+  is seat-dependent and the fleet is building a reproducible recipe.
+
+REPORTING BAR: every load-bearing claim cites a commit, PR, file@SHA, or CI run.
+Negative findings are headlines, not footnotes. "Not measured" beats invention.
+Family-level model names only (fable-5, opus-4.8). No secret values in any repo.
+
+SESSION SHAPE: land on origin/main HEAD first; read control/inbox.md; do ONE
+bounded slice of the task you were given (a finished sweep of 4 lanes beats a
+half-sweep of 12); heartbeat control/status.md as the deliberate last step. Ship
+findings as committed files (PR, ready, merge-on-green), not just chat. Walls:
+you cannot create/edit environments, create repos, or delete remote branches —
+quote the exact error into status and route an owner ask; never re-probe a
+documented wall. Decide-and-flag; never wait; if you are a spawned worker, your
+final message is data for your coordinator — findings with citations, nothing else.
+```
+
+### 2b. Coordinator chat brief (paste as the FIRST message in the new manager chat)
+
+```
+You are the fleet-manager COORDINATOR — this chat persists across your routine wakes,
+so treat this message as your standing role brief. Your durable twin: superbot
+docs/planning/round3-launch-pack-2026-07-10.md §1 (your brief) + §4b (owner rulings
+Q-0259) + §5 (the standing four-Project core you belong to) — re-read those files at
+any wake where this chat's context feels thin or compacted.
+
+Your mission and done-when: keep the fleet's lanes ordered, truthful, and never-stuck
+— every lane always has a clear goal, a live heartbeat, a working merge path, and a
+working wake mechanism; the owner-queue holds only genuinely owner-only items;
+doctrine matches verified reality. Route ORDERs rather than doing lane-work yourself.
+
+BOOT NOW, in order:
+1. Sync your repo to origin/main HEAD; read control/inbox.md and control/status.md.
+2. Read the round-3 pack §1/§4b/§5 and superbot
+   docs/eap/eap-program-review-2026-07-10.md §5 (your debt list).
+3. Write the six doctrine-debt ORDERs into your OWN control/inbox.md, each with a
+   named next-session owner.
+4. ARM YOUR ROUTINE — call create_trigger with: name "fleet-manager 2-hourly
+   standing wake", cron "30 */2 * * *" (offset :30 so you read lane heartbeats
+   written at even hours), firing into THIS session, prompt EXACTLY:
+
+   "2-HOURLY WAKE (fleet manager): sync menno420/fleet-manager to origin/main HEAD;
+   read control/inbox.md at HEAD; then ONE bounded pass: staleness-sweep the lane
+   heartbeats (verify against git, not self-reports) → route/advance pending ORDERs
+   → consolidate the owner-queue + the safe-to-delete list → advance ONE
+   doctrine-debt ORDER from your own inbox. Ship findings as commits, decide-and-
+   flag owner questions, no excessive work — one real slice per wake. Overwrite
+   control/status.md as the deliberate last step. If this trigger turns out to be
+   one-shot rather than recurring, re-arm it for +120 minutes before ending the
+   turn."
+
+   Then VERIFY it exists (list your triggers) and record the exact call + outcome
+   verbatim in control/status.md — arming is seat-dependent; the fleet is building
+   a reproducible recipe. IF THE CALL IS WALLED: record the verbatim denial in
+   status, and end your first reply to the owner with the routine name + cadence +
+   the exact prompt text above in a copy-paste block, so he can create it manually
+   in the claude.ai Routines screen.
+5. Heartbeat (status overwrite), including your routine's state (armed-by-me /
+   owner-manual-pending) so the manifest can track wake coverage per lane.
+
+Known routine facts (from the owner's own testing, 2026-07-10): agent-armed routines
+work (trading-strategy + kit-lab are live proof) but arming is seat-inconsistent;
+completed runs are NOT inspectable from the owner's Routines screen (timestamp only)
+— so your status heartbeat is the only readable record of what a wake did, which is
+one more reason it is never skipped; and the session-side Runs panel can disagree
+with the Routines screen — trust git, not either panel.
+
+Calibration before you start: confirm your mission in one paragraph, list the six
+ORDERs you're about to write, state the routine name + cadence you'll arm, and name
+which lane you'll sweep first.
+```
+
+### 2c. Environment
+
+Name `fleet-manager` · repos: `menno420/fleet-manager` + `menno420/superbot` · env
+variables: **none** (platform injects the GitHub credential for attached repos; a
+`GITHUB_PAT` only if it must write to un-attached repos — prefer attaching) · setup
+script: `fleet-manager/environments/archetype-coordinator.sh` **verbatim** (raw:
+`https://raw.githubusercontent.com/menno420/fleet-manager/main/environments/archetype-coordinator.sh`).
+
+## 3. Dispatch order (the launch checklist)
+
+1. ☐ Manager env created/updated (2c) → Custom Instructions pasted (2a) → chat brief
+   pasted (2b) → **calibration answer reviewed by the owner** → manager live.
+2. ☐ Owner clicks that gate the core: create the **Idea Engine** Project (superbot
+   repo) · create the **product-forge** repo + Project (repo creation = agent wall) ·
+   venture-lab settings (Allow auto-merge + required check).
+3. ☐ Founding packages for Idea Engine + Product Forge (2a/2b/2c-shaped, role-scoped) —
+   **NOT yet drafted; the dispatch-coordination session drafts them** on this file's
+   pattern (+ probe battery v0 for the Idea Engine, from
+   `docs/ideas/idea-probe-brainstorm-simulator-2026-07-10.md`).
+4. ☐ Builder (superbot-next Project): §2 continuation prompt + standing-@codex-review
+   line (Q-0259 ruling 3); confirm/arm its 2-hourly routine.
+5. ☐ Manual lanes as the owner feels like it: §2 per-lane prompts (websites, trading
+   after the holdout ORDER, kit-lab after the F-5 ruling, venture-lab, games).
+6. ☐ Games program: manager proposes the 3-projects/3-repos mapping (Q-0259 ruling 5,
+   decide-and-flag); founding packages follow the same pattern.
+7. ☐ Verify loop closure: all four core routines ACTIVE with completed runs across
+   24h; owner-queue only owner-only items; zero stuck PRs (pack §5 success criteria).
+
+## 4. Open drafting queue (for the dispatch-coordination session)
+
+- Idea Engine founding package (instructions scoped to idea grooming/probing/routing;
+  chat brief + routine text; env: superbot repo, python-lab-style script or superbot's
+  own SessionStart flow).
+- Product Forge founding package (instructions scoped to building routed ideas into
+  finished products; born-right repo seed checklist per gen2-blueprint §1).
+- 3 × game-Project founding packages once the manager's mapping lands.
+- Per-boot verification ritual: after each paste, check calibration answer · routine
+  armed+verified · first heartbeat — record per-lane in this file's checklist.


### PR DESCRIPTION
Durable home for the dispatch-phase working state (was chat-only):

- `docs/planning/round3-dispatch-runbook-2026-07-10.md` — the FINAL fleet-manager founding package v3 as iterated live with the owner (role-scoped Custom Instructions · coordinator chat brief with the routine text baked in · env spec), the instructions-architecture decisions (Project-scoped job descriptions, coordinator brief in chat, routines fire into the chat), the 7-step dispatch checklist, and the open drafting queue (Idea Engine / Product Forge / 3 game-project packages).
- Indexed in `docs/planning/README.md` (Active S3).

Prepares the fresh dispatch-coordination session the owner is about to start. Docs-only; zero `disbot/` runtime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY5WeBcRhRdYsqgSB9F3wh)_