### PR TITLE
docs: SUPERSEDED-by-registry banners on the round-3 founding packages + runbook §2 manager package

### DIFF
--- a/docs/planning/round3-dispatch-runbook-2026-07-10.md
+++ b/docs/planning/round3-dispatch-runbook-2026-07-10.md
@@ -32,6 +32,9 @@
 
 ## 2. Fleet-manager founding package v3 (FINAL — owner pasting)
 
+> **SUPERSEDED as live doctrine 2026-07-10** — canonical, version-stamped copies live
+> in fleet-manager `projects/fleet-manager/` (registry PR #39); this file is frozen history.
+
 > **⚠ AMENDED by owner directive Q-0265 (2026-07-10, post-boot):** the "one real slice
 > per wake" pacing in 2a/2b is SUPERSEDED — all six core seats run **continuous** (work
 > loop + send_later continuation chain; crons demoted to dead-man failsafes). Live seats

--- a/docs/planning/round3-founding-package-builder-2026-07-10.md
+++ b/docs/planning/round3-founding-package-builder-2026-07-10.md
@@ -1,5 +1,7 @@
 # Round-3 founding package — Builder Project (superbot-next, 2026-07-10)
 
+> **SUPERSEDED as live doctrine 2026-07-10** — canonical, version-stamped copies live in fleet-manager `projects/superbot-next/` (registry PR #39); this file is frozen history.
+
 > **⚠ AMENDED by owner directive Q-0265 (2026-07-10, after this seat booted):** any
 > "one bounded slice / one real slice per wake" pacing below is SUPERSEDED — the seat
 > runs **continuous** (work loop + send_later continuation chain; the cron demoted to

--- a/docs/planning/round3-founding-package-idea-engine-2026-07-10.md
+++ b/docs/planning/round3-founding-package-idea-engine-2026-07-10.md
@@ -1,5 +1,7 @@
 # Round-3 founding package — Idea Engine Project (v2, own-repo · 2026-07-10)
 
+> **SUPERSEDED as live doctrine 2026-07-10** — canonical, version-stamped copies live in fleet-manager `projects/idea-engine/` (registry PR #39); this file is frozen history.
+
 > **⚠ AMENDED by owner directive Q-0265 (2026-07-10, after this seat booted):** the
 > "ONE bounded slice / one real slice per wake" pacing below is SUPERSEDED — the seat
 > runs **continuous** (work loop + send_later continuation chain; the cron demoted to

--- a/docs/planning/round3-founding-package-product-forge-2026-07-10.md
+++ b/docs/planning/round3-founding-package-product-forge-2026-07-10.md
@@ -1,5 +1,7 @@
 # Round-3 founding package — Product Forge Project (2026-07-10)
 
+> **SUPERSEDED as live doctrine 2026-07-10** — canonical, version-stamped copies live in fleet-manager `projects/product-forge/` (registry PR #39); this file is frozen history.
+
 > **Status:** `plan` — the founding package for the **Product Forge** (seat 4 of the
 > standing four-Project autonomous core, launch pack §5): a NEW `product-forge` repo +
 > Project that builds routed ideas into finished, shippable products (the codetool-labs

--- a/docs/planning/round3-founding-package-simulator-2026-07-10.md
+++ b/docs/planning/round3-founding-package-simulator-2026-07-10.md
@@ -1,5 +1,7 @@
 # Round-3 founding package — Simulator Project (sim-lab, core seat 6 · 2026-07-10)
 
+> **SUPERSEDED as live doctrine 2026-07-10** — canonical, version-stamped copies live in fleet-manager `projects/sim-lab/` (registry PR #39); this file is frozen history.
+
 > **Status:** `plan` — the founding package for the **Simulator Project** (`sim-lab`),
 > **core seat 6 under owner ruling Q-0264** (supersedes the Q-0262.8 superbot-hub pick —
 > that item was ⚑ flagged most-vetoable and the veto arrived). The simulator is the

--- a/docs/planning/round3-founding-package-substrate-kit-2026-07-10.md
+++ b/docs/planning/round3-founding-package-substrate-kit-2026-07-10.md
@@ -1,5 +1,7 @@
 # Round-3 founding package — substrate-kit Project (2026-07-10)
 
+> **SUPERSEDED as live doctrine 2026-07-10** — canonical, version-stamped copies live in fleet-manager `projects/substrate-kit/` (registry PR #39); this file is frozen history.
+
 > **Status:** `plan` — the founding package for the **substrate-kit** core seat (Q-0261
 > core seat 2: the mechanism repo + the fleet's **distribution seat**). Drafted by the
 > dispatch-coordination session on the runbook §2 pattern, under owner ruling **Q-0261.3**:


### PR DESCRIPTION
GAP 4 of the prompt-registry ingest gap-closure (fleet-manager PR #42 is the companion): one-line banner atop each of the five round-3 founding packages (substrate-kit, builder, idea-engine, product-forge, simulator) and the dispatch runbook §2 manager package — "SUPERSEDED as live doctrine 2026-07-10 — canonical, version-stamped copies live in fleet-manager `projects/<seat>/` (registry PR #39); this file is frozen history." Content otherwise untouched (per the dispatch: frozen history, not edited).

Notes:
- Banners are single-line so every file's `> **Status:**` badge stays within check_docs' first-12-lines window; `check_docs --strict` and `check_current_state_ledger --strict` both exit 0.
- check_docs reports SOFT supersede-banner findings (successor is a cross-repo target it cannot link-resolve; badges left `plan` because the dispatch said not to alter content otherwise) — accepted, not CI-failing.

Docs-only; no session card (no card added → session gate does not engage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V66KdPhtbR1AThhK77kDqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01V66KdPhtbR1AThhK77kDqr)_