### PR TITLE
orders: fleet self-review 2026-07-11 — ORDER 002

### DIFF
--- a/control/inbox.md
+++ b/control/inbox.md
@@ -16,3 +16,11 @@ executor: superbot hub — next hub-touching session (no standing seat, Q-0264)
 do: Model-attribution ground truth (fleet standing rule, family-level names only per Q-0262): (1) confirm the session-card template carries a `📊 Model:` line — add it if missing; (2) every fired session records the model family its own harness/environment reports (e.g. fable-5, opus-4.8, sonnet-5) on that line in its committed session card — the Routines screen is NOT a reliable attribution surface; (3) n/a — keep the standing rule.
 why: the fleet model matrix (fm docs/findings/model-matrix-2026-07.md) found per-session self-report in commits is the only reliable attribution; cross-surface disagreement is evidenced (websites PR #59 squash 2c89e96: Routines screen fable-5 vs the fired card's claude-sonnet-5).
 done-when: the next fired session's committed card carries a real family-level `📊 Model:` line and the template (if any) includes it.
+
+## ORDER 002 · 2026-07-11T10:01Z · status: new
+priority: P1
+from: fleet-manager on coordinator direction (cse_012o8pySy5K3AV6JWoPKryZL), owner-directed — owner-requested fleet-wide self-review (2026-07-11)
+executor: superbot hub — next hub-touching session (no standing seat, Q-0264)
+do: quick self-review of this lane covering roughly the last 24h (2026-07-10 ~20:00Z → now): (1) anything that WENT WRONG — red CI runs, guard/classifier denials, walls hit, drift found, mistakes made or corrected — each with a citation (PR/run/commit); (2) anything REQUIRING OWNER ATTENTION — owner-only asks, pending vetoes, risky decisions taken decide-and-flag, spend/publish items — click-level and plain language; (3) one-line current health (what shipped, what's next). Commit the review as a dated "Self-review 2026-07-11" section in control/status.md (or this lane's report convention); mirror ⚑ owner-attention items on the heartbeat so the manager sweep collects them.
+why: owner-requested fleet-wide self-review (2026-07-11), relayed by the fleet-manager coordinator on the owner's in-session instruction.
+done-when: the self-review section is on main within this lane's next two wakes.


### PR DESCRIPTION
Appends ORDER 002 to `control/inbox.md`: owner-requested fleet-wide self-review of the last ~24h (2026-07-11), relayed by the fleet-manager coordinator on the owner's in-session instruction. Docs-only, append-only inbox change; no runtime code. No `.sessions/` card added (fleet-manager order landing, not a work session), so the session gate does not engage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZwTxyECtyNW2qUSL3ZFGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZwTxyECtyNW2qUSL3ZFGA)_