### PR TITLE
Enforce settle-once consistency for cogs

### DIFF
--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -27,14 +27,14 @@ rules that no import graph can catch (owner directive Q-0170, 2026-06-17):
      atomic claim — the BUG-0013 class the mixin (PRs #1444/#1445) closed by hand.
 
 Scope is **per-rule** (each :class:`Rule` carries a ``roots`` tuple).  Rules 1-2
-scan only ``views/``; rules 3-4 also scan ``cogs/`` — cogs define inline
+scan only ``views/``; rules 3-4 and 6 also scan ``cogs/`` — cogs define inline
 ``discord.ui.View`` subclasses and select-building UI, so the cog layer is a real
 blind spot for those two patterns (BUG-0017, the Cog-Manager ``options[:25]``
 silent drop, lived in ``cogs/admin/cog_manager.py`` and slipped past the linter
 precisely because rules 3-4 were once ``views/``-only).
 
-It is **warn-first and disposable** (Q-0105): every finding is a warning, nothing
-fails CI yet.  A rule graduates to an error + a ``code-quality`` wire-in only once
+It is **warn-first and disposable** (Q-0105): new rules start as warnings and do
+not fail CI yet.  A rule graduates to an error + a ``code-quality`` wire-in only once
 it runs clean on a fresh tree across a few sessions (the Q-0120 / ``dead-unresolved``
 discipline — a noisy checker trains people to ignore it).  The only valid bypass is
 an allowlist entry in ``architecture_rules/consistency_exceptions.yml`` — never
@@ -1000,9 +1000,9 @@ def rule_settle_once_adoption(
     settle taking the claim is harmless (it always wins the first claim), so the
     rule never asks for a wrong change.
 
-    Warn-only (Q-0105 — the mixin is young; graduate to ``error`` once it stays
-    clean across a few sessions).  Runs clean today (all callers adopt).  Scopes
-    ``views/`` + ``services/`` + ``cogs/`` — the 2026-07-07 widening: the
+    Graduated to ``error`` (Q-0105) after the mixin/rule stayed clean; an
+    unguarded caller now fails ``--mode strict``.  Scopes ``views/`` +
+    ``services/`` + ``cogs/`` — the 2026-07-07 widening: the
     deathmatch human-duel view lives in ``cogs/`` and its unguarded W/L write
     was live-confirmed by Gate-V Arm D, so the cog layer is in scope, and the
     tournament payout / deathmatch leaderboard sinks joined the sink set.
@@ -1135,20 +1135,21 @@ RULES: list[Rule] = [
         severity="warning",
         roots=("utils/",),
     ),
-    # Rule 6 scans ``views/`` + ``services/`` (the wager-settle callers + state
-    # objects live in both). Warn-first (Q-0105): added 2026-06-25, promoting the
+    # Rule 6 scans ``views/`` + ``services/`` + ``cogs/`` (the wager-settle
+    # callers + state objects live in all three). Added 2026-06-25, promoting the
     # ``settle-once-architecture-guard-2026-06-24.md`` idea — it mechanizes the
     # by-hand double-settlement review (BUG-0013 + the three sites the #1444/#1445
-    # run found) for a money-safety class. The target primitive
-    # (``SettleOnceMixin``) is young, so this stays warn-only; it runs clean on the
-    # current tree (both wager-settle callers adopt the guard). Graduate to ``error``
-    # once it has stayed quiet across a few sessions (the edit_in_place pattern).
+    # run found) for a money-safety class. Graduated 2026-07-11: it runs clean on
+    # the current tree, and a warn-only money-safety finding is a false-green
+    # gate. The 2026-07-07 cogs widening must be in the registered roots, not just
+    # the rule function default, or full-tree scans never pass cogs/ files to the
+    # rule.
     Rule(
         "settle_once_adoption",
         rule_settle_once_adoption,
         "wager-settle sites (settle_pvp/refund_pvp) not adopting the settle-once guard",
-        severity="warning",
-        roots=("views/", "services/"),
+        severity="error",
+        roots=("views/", "services/", "cogs/"),
     ),
 ]
 

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -1088,6 +1088,27 @@ def test_settle_flags_unguarded_wager_settle(mod, tmp_path, monkeypatch):
     assert findings[0].severity == "warning"
 
 
+def test_strict_mode_fails_unguarded_cog_settle_site(mod, tmp_path, monkeypatch, capsys):
+    """Regression for the false-green gate: Rule 6 must scan cogs/ through the
+    registered roots and fail strict mode, not merely warn, for an unguarded
+    cog-layer settle site.
+    """
+    _write(
+        mod,
+        tmp_path,
+        monkeypatch,
+        "cogs/tourn.py",
+        _SETTLE_COG_TOURNAMENT_NO_GUARD,
+    )
+    monkeypatch.setattr(sys, "argv", ["check_consistency.py", "--mode", "strict"])
+
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "check_consistency — 1 error(s)  0 warning(s)" in out
+    assert "settle_once_adoption" in out
+    assert "cogs/tourn.py" in out
+
+
 def test_settle_class_mixin_is_clean(mod, tmp_path, monkeypatch):
     assert _settle_findings(mod, tmp_path, monkeypatch, _SETTLE_CLASS_MIXIN) == []
 
@@ -1162,15 +1183,15 @@ def test_rule_6_is_registered_and_scoped(mod):
     by_name = {r.name: r for r in mod.RULES}
     assert "settle_once_adoption" in by_name
     rule = by_name["settle_once_adoption"]
-    assert rule.roots == ("views/", "services/")
-    assert rule.severity == "warning"  # warn-first (Q-0105)
+    assert rule.roots == ("views/", "services/", "cogs/")
+    assert rule.severity == "error"
 
 
 def test_settle_once_rule_runs_clean_on_the_live_tree(mod):
     """The live tree's wager-settle callers all adopt the guard — the warn-first
     prerequisite (0 findings) for a future graduation to error."""
     findings = mod.rule_settle_once_adoption(
-        mod._all_files(), mod._load_exceptions(), ("views/", "services/")
+        mod._all_files(), mod._load_exceptions(), ("views/", "services/", "cogs/")
     )
     assert findings == [], "settle_once_adoption flagged the live tree: " + "; ".join(
         f.display(mod.REPO_ROOT) for f in findings


### PR DESCRIPTION
### Motivation
- Fix a false-green money-safety gate: Rule 6 (`settle_once_adoption`) was warn-only and the rule registration omitted `cogs/` from its scan roots, so unguarded cog-layer settle sites could ship unscanned or only produce warnings even though CI runs the checker in strict mode (`--mode strict`).
- CI invokes the checker as `python scripts/check_consistency.py --mode strict` (see `.github/workflows/code-quality.yml`), so only findings with `severity="error"` fail the gate; the rule must therefore be graduated and registered to include `cogs/` to actually block regressions.

### Description
- Update `scripts/check_consistency.py` to graduate Rule 6: set `severity="error"` and register its scan roots to `("views/", "services/", "cogs/")` so full-tree invocations include cog-layer files and an unguarded settle site fails strict mode.
- Clarify the rule documentation/comments to note the graduation and the need for the registered roots to include `cogs/` (the function default alone does not protect full-tree scans).
- Add a regression unit test in `tests/unit/scripts/test_check_consistency.py` that writes an unguarded `cogs/` tournament payout, runs the module in `--mode strict`, and asserts the checker returns failure and emits a `settle_once_adoption` error; update related assertions about the rule's registered roots and severity.
- No changes to runtime economy or mutation code were made; this is a linter/CI-enforcement fix only.

### Testing
- Ran `python scripts/check_consistency.py --mode strict` which completed with the expected check output on the updated tree (no unexpected failures).
- Ran `pytest -q tests/unit/scripts/test_check_consistency.py` and the full unit test file passed (tests updated to assert the new error-severity behavior). 
- Ran `python scripts/check_audit_seam.py --mode strict` which reported 0 findings (audit seam intact).
- Ran `python scripts/check_architecture.py --mode strict` which reported 0 errors (only known/warned layer warnings remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a528d72053883228d17cf80f4dbcaba)