### PR TITLE
docs: correct routine-arming doctrine — agent-armed, never owner-armed

### DIFF
--- a/.sessions/2026-07-11-fleet-dispatch-prompts.md
+++ b/.sessions/2026-07-11-fleet-dispatch-prompts.md
@@ -43,13 +43,16 @@ paste**:
    facts → fact-refresh · the fleet-manager failsafe is bound to an ARCHIVED session → fresh boot
    rebinds-then-deletes.
 
-4. **Routines need a CONCRETE arming recipe + tool availability (real failure — seats reported
-   "unable to open/arm them").** Every coordinator prompt must give the exact calls — pacemaker
-   `send_later({message, delay_minutes:15})`, failsafe `create_trigger({name,cron_expression,prompt})`
-   + `list_triggers` verify — AND the fallback: retry from a worker, else post the config as a ⚑
-   OWNER-ACTION for the owner to arm. **Likely root cause: the claude-code-remote scheduler MCP is
-   not attached to every seat's environment** → owner action to attach it. Recipe is now in the
-   8-seat structure doc's dispatch guidance.
+4. **Routines are AGENT-ARMED — never owner-armed (real failure + a doctrine correction).** Seats
+   reported "unable to open/arm them"; my first fix wrongly routed the fallback to an owner-action.
+   Corrected against the docs: **agent-armed routines work** (owner-verified 2026-07-10;
+   `round3-dispatch-runbook` + the `docs/eap` capability correction retiring the "owner-arms-routines"
+   doctrine as *partially invalid*) — the owner CANNOT arm a project's routines. Every coordinator
+   prompt gives the exact calls — pacemaker `send_later({message, delay_minutes:15})`, failsafe
+   `create_trigger({name,cron_expression,prompt})` + `list_triggers` verify — and, if the
+   coordinator's toolset can't arm (seat-inconsistent), **retry from a WORKER** (worker toolsets
+   differ; the documented self-arm path) and record the recipe + outcome verbatim. NEVER an
+   owner-queue item. Corrected recipe is in the 8-seat structure doc's dispatch guidance.
 
 ## Sequencing note for the Project Manager (its first job)
 When it canonicalizes the 8-seat registry it must: (a) keep each seat's prompt COMPLETE (one

--- a/docs/owner/fleet-8seat-structure-2026-07-11.md
+++ b/docs/owner/fleet-8seat-structure-2026-07-11.md
@@ -78,11 +78,14 @@ chain · **failsafe** cron) + `failsafe-prompt.md` (the cron config). When build
   Ideas Lab = idea-engine+sim-lab · Game Lab = gba+pokemon) need their `coordinator-prompt.md` +
   `failsafe-prompt.md` **composed from the source seats' packages**.
 
-### Routine-arming recipe (every coordinator prompt MUST spell this out — seats were failing to arm)
+### Routine-arming recipe — AGENT-ARMED (every coordinator prompt MUST spell this out)
 
-The routines are armed with the **Claude Code Remote scheduler** MCP (`send_later` /
-`create_trigger` / `list_triggers`). Every seat prompt must give the concrete calls, because
-"unable to arm/open the routine" was a real failure — the scheduler tool is **environment-dependent**:
+**Routine arming is the AGENT's job, never the owner's** — the owner CANNOT arm a project's
+routines from the Routines screen. This is corrected doctrine: **agent-armed routines work**
+(owner-verified 2026-07-10 — trading-strategy, kit, manager, websites are live proof;
+`docs/planning/round3-dispatch-runbook-2026-07-10.md` + the `docs/eap` capability correction that
+retired the old "owner-arms-routines / owner-queue" doctrine as *partially invalid*). Arming is
+**seat-inconsistent**, so every seat prompt must give the concrete calls + the worker-retry path:
 
 1. **PACEMAKER (re-arm every turn, before ending):** `send_later({ message: "continue the work
    loop: sync HEAD → inbox → next slice → re-arm", delay_minutes: 15 })` — fires back into THIS
@@ -90,9 +93,12 @@ The routines are armed with the **Claude Code Remote scheduler** MCP (`send_late
 2. **FAILSAFE (arm once at boot; dead-man backstop):** `create_trigger({ name: "<seat> failsafe
    wake", cron_expression: "<seat cron>", prompt: "<failsafe text>" })` — self-binds persistent to
    this session. Then **verify via `list_triggers`** (never wait for a fire as proof — completed
-   runs aren't inspectable owner-side). Manager only: rebind-then-delete the archived-session one.
-3. **IF ARMING FAILS** (scheduler tool absent, or the call errors): FIRST retry from a spawned
-   **worker** (worker toolsets differ). If still walled, do NOT silently skip — post the exact
-   `create_trigger` args (name · cron · prompt) as a ⚑ **OWNER-ACTION** in `control/status.md` so
-   the owner arms it from the Routines screen, and record the verbatim error. **Root cause to fix:
-   attach the claude-code-remote scheduler MCP to every seat's environment** so seats self-arm.
+   runs aren't inspectable owner-side; the status heartbeat is the only readable wake record).
+   Manager only: rebind-then-delete the archived-session one.
+3. **IF THE COORDINATOR CAN'T ARM** (the scheduler tool isn't in its toolset, or the call errors):
+   **retry the same call from a spawned WORKER** — worker toolsets differ from coordinator
+   toolsets, and this is the documented self-arm path (the permissions grant's "retry a walled
+   call from a worker before flagging"). **Record the exact `create_trigger` call + its outcome
+   verbatim** in `control/status.md`. Routine arming is **NEVER an owner-queue item** — the owner
+   cannot arm it; if even a worker can't, record it as a seat-capability limitation to re-test,
+   not an owner action.


### PR DESCRIPTION
## Summary

Corrects a factual error I merged in #2011. The routine-arming recipe wrongly routed the
"can't arm" fallback to an **owner-action** ("the owner arms it from the Routines screen").

That is the **invalidated old doctrine.** Per the owner's own 2026-07-10 testing
(`docs/planning/round3-dispatch-runbook-2026-07-10.md` + the founding packages) and the
`docs/eap` capability correction: **agent-armed routines work** (trading-strategy, kit, manager,
websites are live proof), arming is **seat-inconsistent**, and the old "owner-arms-routines /
owner-queue" doctrine was retired as *partially invalid*. **The owner cannot arm a project's
routines — the agent must.**

Fixes both places the error landed:
- `docs/owner/fleet-8seat-structure-2026-07-11.md` — the routine-arming recipe now states
  AGENT-ARMED, and the "can't arm" path is **retry from a worker** (worker toolsets differ — the
  documented self-arm path) + record the recipe/outcome verbatim; **never an owner-queue item**.
- `.sessions/2026-07-11-fleet-dispatch-prompts.md` — learning #4 corrected with the same fix + the
  doctrine citation.

## Type of change
- [x] Documentation (correction)

## Checks
- [x] `check_docs.py --strict` clean · docs-only, no `disbot/` code
- [x] No secrets, tokens, or credentials added

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKTZTQjnu3aBu92eeY5XNR)_