### PR TITLE
docs: fix 5 verified Codex findings on merged #2017 (Q-0174 post-merge pass)

### DIFF
--- a/.sessions/2026-07-12-projects-overnight-review.md
+++ b/.sessions/2026-07-12-projects-overnight-review.md
@@ -94,8 +94,9 @@ not applied — Q-0106). Claim deleted at close.
   per-seat digest + lessons; kit-lab manually revived · **Outcome:** shipped
 - **Shipped:** #2017 — `docs/eap/night-review-2026-07-12.md` + idea file/groom + pointers + card
 - **Run type:** `manual` (owner-directed, live)
-- **⚑ Owner decisions needed:** allowlist safe CCR MCP subset in hub settings (night-review §6.5,
-  Q-0106-gated) — say the word and it ships
+- **⚑ Owner decisions needed:** `none` — the earlier "allowlist CCR tools" ask was retracted
+  post-merge (Codex finding, verified): the exact entries already exist and still prompted —
+  Q-0242 reproduced, settings edit is a no-op; see night-review §6.5 (corrected)
 - **⚑ Owner manual steps:** poke Venture Lab money-seat session · confirm/poke SuperBot 2.0
   coordinator + arm its failsafe · paste the trigger-health ORDER into Project Manager
   (night-review §6.3) · one-click merges fm #105/#92 · venture-lab #51 photo cleanup (HOT)

--- a/docs/eap/README.md
+++ b/docs/eap/README.md
@@ -7,6 +7,14 @@
 
 ## Gen-2 night reviews (2026-07-11 →)
 
+- [`night-review-2026-07-12.md`](night-review-2026-07-12.md) — owner-directed fleet night
+  review of the 2026-07-12 batch — **the trigger-scheduler incident**: primary-evidence
+  timeline (~02:30–08:00Z degradation: 9 dropped `send_later` one-shots, 2 wedged crons,
+  partial 08:0x catch-up), per-seat digest (manager's prompts-v3.2 + 12 relocation ORDERs
+  led the night; Venture Lab dark, kit-lab manually re-fired), the Q-0265 failsafe doctrine
+  validated in production (coverage must exist *and* be alive), the org-policy discovery that
+  sibling sessions cannot revive each other via triggers, new lessons + fix-first +
+  owner-action queue.
 - [`anthropic-email-2-draft-2026-07-11.md`](anthropic-email-2-draft-2026-07-11.md) — the
   **second Anthropic email** (in progress, owner sends): Part 1 = a MOCK in Menno's voice
   built from his real documented/this-session words for him to rewrite; Part 2 = the agents'
@@ -18,13 +26,6 @@
 - [`screenshots-2026-07-11/index.md`](screenshots-2026-07-11/index.md) — the curated figure
   set for the second email: 16 keepers triaged from 64 uploaded screenshots (fig-NN names +
   captions mapped to the email's figure slots), plus the model-mismatch phone-shot trio.
-- [`night-review-2026-07-12.md`](night-review-2026-07-12.md) — owner-directed fleet night
-  review of the 2026-07-12 batch — **the trigger-scheduler incident**: primary-evidence
-  timeline (~02:30–08:00Z degradation: 9 dropped `send_later` one-shots, 2 wedged crons,
-  partial 08:0x catch-up), per-seat digest (manager's prompts-v3.2 + 12 relocation ORDERs
-  led the night; Venture Lab dark; kit-lab manually re-fired), the Q-0265 failsafe doctrine
-  validated in production, the org-policy discovery that sibling sessions cannot revive each
-  other via triggers, new lessons + fix-first + owner-action queue.
 - [`night-review-2026-07-11.md`](night-review-2026-07-11.md) — owner-directed independent
   night review of the whole fleet (2026-07-10 18:00Z → 07-11 11:40Z): per-lane digest across
   13 active lanes (3 survey agents), what's genuinely valuable / playable, the two evidenced

--- a/docs/eap/night-review-2026-07-12.md
+++ b/docs/eap/night-review-2026-07-12.md
@@ -14,10 +14,12 @@
 **The batch was armed correctly; the platform trigger scheduler degraded.** Between ~02:30Z
 and ~08:00Z the Claude Code Remote scheduler silently dropped one-shot (`send_later`) firings
 and froze several cron Routines (`next_run_at` stuck in the past, still `enabled`). Every seat
-protected by a 2-hourly failsafe cron self-revived at ~08:0xZ when the scheduler partially
-recovered — **the Q-0265 dead-man doctrine worked**. The two seats without that layer went
-dark: **Venture Lab** (failsafe itself wedged) and **Self Improvement** (daily-only loop,
-firing dropped — manually re-fired 08:46Z by this review). Meaningful work still shipped all
+whose 2-hourly failsafe cron **stayed healthy** self-revived at ~08:0xZ when the scheduler
+partially recovered — **the Q-0265 dead-man doctrine worked**. The two dark seats are the ones
+whose protection was missing or itself broken: **Venture Lab** (it *had* a failsafe — the
+failsafe itself wedged) and **Self Improvement** (daily-only loop, no failsafe layer; its one
+firing dropped — manually re-fired 08:46Z by this review). Doctrine takeaway: a failsafe only
+protects while it is *alive* — which is what the trigger-health check below exists to verify. Meaningful work still shipped all
 night, led by the manager's owner-directed prompt-rebuild program.
 
 ## 1. The incident (primary evidence)
@@ -71,8 +73,9 @@ offsets). Nothing agent-side changed between the clean 07-10 batch and this one.
 ## 3. What the incident validated (strong)
 
 1. **Failsafe crons are the load-bearing anti-stall layer (Q-0265) — now production-proven.**
-   Every seat with a `*/2` failsafe came back on its own the moment the scheduler breathed
-   again. The seats that stayed dark are exactly the unprotected ones.
+   Every seat whose `*/2` failsafe stayed healthy came back on its own the moment the scheduler
+   breathed again. The dark seats are exactly the ones with missing (kit-lab: daily-only) or
+   itself-wedged (venture-lab) failsafe coverage — coverage must exist *and* be alive.
 2. **Cross-substrate redundancy works.** The roster-regen moved to a GitHub Actions cron
    (fm #81) — fleet truth (roster gen #12, #13) kept flowing **through** the CCR scheduler
    outage. Anything oversight-critical should live on a second substrate.
@@ -93,10 +96,15 @@ offsets). Nothing agent-side changed between the clean 07-10 batch and this one.
    catch-up · the manager's session-messaging tools (`send_message` — it has them in its MCP
    grant) · an owner poke · manual fire of **fresh-session** triggers (those work — proven on
    kit-lab). The manager is therefore the *only* agent-side watchdog for persistent seats.
-3. **Auto mode ≠ MCP allowlist.** The hub session hit permission prompts on every CCR trigger
-   tool; coordinator seats never do because their Routine's `session_context` carries per-tool
-   `always_allow` grants. **In an unattended session, that prompt is a silent stall.** Any
-   recovery duty assigned to a session must come with the tool grants to execute it.
+3. **Auto mode ≠ MCP allowlist — and the repo-settings allowlist provably doesn't stick for
+   CCR tools.** The hub session hit permission prompts on `fire/update/create_trigger` even
+   though exact `mcp__Claude_Code_Remote__*` allow entries already exist
+   (`.claude/settings.json:68-79`) — fresh evidence for the **Q-0242** record (send_later
+   prompted with an exact entry in 2026-07-07 too). Coordinator seats never prompt because
+   their grants ride a different surface that works: the Routine's spawn-time
+   `session_context` per-tool `always_allow`. **In an unattended session, a prompt is a silent
+   stall** — so any recovery duty must run in a Routine-spawned session carrying its grants,
+   not rely on settings.json.
 4. **A daily-cadence-only seat has zero redundancy.** One dropped firing = a lost day
    (kit-lab). Fresh-session loops need a failsafe layer too — or at least the manager's
    wedge-sweep watching them.
@@ -137,15 +145,18 @@ noise · heartbeats can contradict reality — sweep and re-stamp.
 2. **Poke / confirm SuperBot 2.0's coordinator** — its heartbeat was FRESH 07:55Z; if the
    session shows idle with no armed tick, same poke + have it arm a failsafe cron.
 3. **Paste into Project Manager chat (or fm `control/inbox.md`):** *"ORDER: add a
-   trigger-health check to every wake — list_triggers; any enabled trigger with next_run_at
-   > 15 min in the past is WEDGED (flag in roster + status); any dropped one-shot for a seat
-   session with no future tick means that seat's chain is dead — send_message it to resume.
+   trigger-health check to every wake — list_triggers; any trigger with `enabled=true` and
+   `next_run_at < now − 15min` is WEDGED (flag in roster + status); any dropped one-shot for a
+   seat session with no future tick means that seat's chain is dead — send_message it to resume.
    Done-when: the check runs in gen_roster or the wake ritual and tonight's signature
    (venture 06:06 / kit-lab 06:08 / 9 dropped ticks) would have been caught within one wake."*
 4. **One-click merges:** fm **#105** (staleness sweep) + **#92** (permission-rules port).
-5. **Decide:** allowlist the safe CCR MCP subset (`list_triggers`, `send_later`,
-   `fire_trigger`) in hub `.claude/settings.json` so hub/night sessions don't stall on
-   permission prompts (settings are owner-gated, Q-0106 — say the word and it ships).
+5. **Known platform bug — no settings edit will fix the prompts (Q-0242, reproduced today):**
+   the exact CCR allow entries already exist (`.claude/settings.json:68-79`) and this session
+   still prompted on `fire/update/create_trigger`. Don't re-edit settings (a no-op path). If
+   hub-side recovery should be autonomous, run it from a Routine-spawned session whose
+   `session_context` carries the per-tool grants (the surface that provably works), and add
+   today's evidence to the Q-0242 platform report.
 6. Carry-over HOT: **venture-lab #51** (close + delete branch — 10 personal photos public).
 
 ## 7. Honest limits of this review

--- a/docs/ideas/scheduler-independent-trigger-watchdog-2026-07-12.md
+++ b/docs/ideas/scheduler-independent-trigger-watchdog-2026-07-12.md
@@ -12,7 +12,10 @@ trigger registry into `telemetry/triggers-snapshot.json` every 2h) to *evaluate*
 not just store it. Flag in the generated roster, and open/refresh a single `trigger-health`
 issue when it finds: **WEDGED** crons (`enabled ∧ next_run_at < generated_at − 15min`),
 **dropped one-shots** (`enabled ∧ run_once_at` in the past), and **dead chains** (a seat
-session with no future tick). ~30 lines of Python in `gen_roster.py`; zero new infrastructure.
+session with no future tick — scoped to lanes the roster expects to be running, i.e.
+FRESH/ACTIVE verdicts with a declared wake layer; parked/archived/no-wake seats are excluded so
+expected-idle lanes don't re-flag the issue every run). ~30 lines of Python in `gen_roster.py`;
+zero new infrastructure.
 
 ## Why it's worth having
 


### PR DESCRIPTION
Post-merge fix pass for the Codex review on #2017 (all five findings verified against ground truth before acting, per Q-0120):

1. **TL;DR / §3.1 doctrine wording** — a failsafe only protects while *alive*: Venture Lab HAD a failsafe (it wedged). "Without that layer" → "missing or itself broken" coverage. *(Codex P2 — confirmed)*
2. **§4.3 + §6.5 allowlist ask retracted** — exact `mcp__Claude_Code_Remote__*` entries already exist (`.claude/settings.json:68-79`) and this session still prompted on `fire/update/create_trigger` — the Q-0242 phenomenon reproduced. Remedy corrected to spawn-time `session_context` grants; owner-queue item rewritten so nobody routes a no-op. *(Codex P2 — confirmed against settings.json + router Q-0242)*
3. **§6.3 owner ORDER predicate** — exact formula `enabled=true ∧ next_run_at < now − 15min` (the prose "> 15 min in the past" was misreadable as a comparison on `next_run_at`). *(Codex P2 — confirmed)*
4. **Watchdog idea** — dead-chain alerts scoped to roster-expected-active lanes so parked/no-wake seats don't re-flag every run. *(Codex P2 — confirmed)*
5. **eap README ordering** — 07-12 review moved to the top of the Gen-2 group per the file's own "Newest first within each group" convention. *(Codex P3 — confirmed)*

Session card ⚑ owner-decision line corrected to `none` with the retraction noted. Docs-only; `check_docs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z1fPG7Wa6VHprJqLcux4f

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z1fPG7Wa6VHprJqLcux4f)_