### PR TITLE
docs: Q-0269 — live sessions merge finished PRs immediately, never park on the owner queue

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -152,6 +152,19 @@ The short version that governs how you work:
 
 ## Read first — agent orientation
 
+**Boot triad — know thyself before directing work (owner directive Q-0270, 2026-07-12,
+general: every session, every repo).** As part of session start, establish three facts and
+let them set your working posture: **(1) what model you are** (from your own system
+configuration; state it family-level — it also feeds the session card's `📊 Model:` line);
+**(2) where you are running** (owner-live chat · autonomous Project seat · routine-fired
+headless wake · subagent; remote container vs local); **(3) what that venue can and cannot
+do** (the ability envelope: merge authority, permission prompts, cross-session limits,
+push/infra walls — consult the repo's documented walls before probing). Then direct the
+work accordingly: **autonomous/Project sessions pre-route around every known stall class**
+(park only on a *real* denial, never preemptively); **owner-live sessions assume NO special
+limitations apply** — act and merge directly (Q-0269); when an ability is genuinely
+uncertain, try it once and read the refusal rather than assuming a wall.
+
 At the **start** of every session, read in this order: **this file**
 (`.claude/CLAUDE.md`, including the Working agreement above) →
 **`docs/collaboration-model.md`** (how we work — binding) →

--- a/docs/owner/fleet-vocab.md
+++ b/docs/owner/fleet-vocab.md
@@ -45,7 +45,11 @@
   to you.
 - **Guardrails carried in from the 2026-07-11 sessions:** no `delete_trigger` /
   destructive approval-gated ops unless you say so; in Project sessions never
-  self-merge (classifier wall) — hub sessions can merge normally.
+  self-merge (classifier wall). **Hub/live sessions don't just *can* merge — they
+  MUST (Q-0269, 2026-07-12): any mergeable PR in finished state (green, complete,
+  READY) is merged immediately by the agent; directing the owner to a green PR is
+  a workflow failure.** Park-READY+green is a Project-seat fallback only, and only
+  after a real classifier denial.
 
 ## Growing this file
 

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -9769,3 +9769,25 @@ denial, not preemptively. Executed under this directive the same minute: website
 updated. What stays genuinely owner-only: infra account actions (Railway service creation,
 tokens), personal-content decisions (venture-lab #51), and PRs whose checks the platform
 never ran (mineverse #42) until the checks are re-triggered.
+
+### Q-0270 — DIRECTED: the boot triad — every new session establishes model · venue · ability envelope before directing its work (2026-07-12)
+
+> **Context.** Owner, live in-session (same conversation as Q-0269), verbatim: *"another
+> addition to the rules, not for just the prjects but in general, when a new session
+> initiates, one of it's goals should be to fnd out what model it's running on, and where
+> the session is running and what that means for the abilities, that decides how the
+> session eventually directs it's work, so project chats avoid anything that stalls,
+> normal sessions with me in the chat should always assume no special limitations apply."*
+
+**Decision (owner-directed in-session; applied to CLAUDE.md § "Read first" with this Q as
+provenance).** Session start includes a self-orientation triad: **(1) model** (state it,
+family-level — feeds the `📊 Model:` card line and the B2 telemetry; also the agent-side
+compensation for the platform's config-vs-reality gap documented in the EAP email);
+**(2) venue** (owner-live chat / autonomous Project seat / routine-fired wake / subagent;
+remote vs local); **(3) ability envelope** (documented walls: merge authority, permission
+prompts, cross-session limits). The triad sets the working posture: autonomous sessions
+pre-route around known stall classes and park only on a real denial; owner-live sessions
+assume no special limitations (Q-0269). **General scope:** this is fleet doctrine, not
+superbot-local — relay to the fleet-manager registry (UNIVERSAL / startup templates) via
+the owner's paste or the manager's next doctrine pass, and to substrate-kit as template
+material so it travels to every future repo.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -9747,3 +9747,25 @@ runbook §3.7 re-point + §6.2 conformed-mapping paste block — part-4e (PR #19
 
 **Routing.** This entry (provenance + the durable line) + the venture-lab relaunch pastes
 carry it implicitly via the money protocol / permissions block — part-4h (PR #1971).
+
+### Q-0269 — DIRECTED: live sessions merge finished PRs themselves — never park green PRs on the owner's queue (2026-07-12)
+
+> **Context.** After the overnight fleet review, the hub session (owner live in-chat) left
+> two verified-green, complete PRs (websites #158, fleet-manager #92) "parked READY+green
+> awaiting the owner's merge click," importing the Project-seat merge wall into a session
+> that doesn't have it. Owner, verbatim: *"you just merge everything, only the projects have
+> trouble with those things, I expect from a normal session that any mergable PR in finished
+> state just gets merged immediatly, we're wasting a lot of time with the fact that agents
+> direct me to PRs, it's not my task to do that."*
+
+**Decision (owner-directed in-session).** In any session where the owner is live (hub
+sessions, help sessions — anything not running as an autonomous Project seat): **a mergeable
+PR in finished state (CI green, card complete, READY) gets merged immediately by the agent.**
+Directing the owner to a green PR is a workflow failure, not a courtesy. "Park READY+green
+for the owner's click" remains **only** the fallback for Project/auto-mode seats that the
+merge classifier actually denies — and even those should first try, then park on a real
+denial, not preemptively. Executed under this directive the same minute: websites #158
+(squash `b925072`) + fleet-manager #92 (squash `9a8518f`); fleet-vocab guardrail line
+updated. What stays genuinely owner-only: infra account actions (Railway service creation,
+tokens), personal-content decisions (venture-lab #51), and PRs whose checks the platform
+never ran (mineverse #42) until the checks are re-triggered.


### PR DESCRIPTION
Records the owner directive (2026-07-12, live in-session, verbatim in the router): in any owner-live session, a mergeable PR in finished state (CI green, card complete, READY) is merged immediately by the agent — directing the owner to a green PR is a workflow failure. Park-READY+green stays a Project/auto-mode-seat fallback only, and only after a real classifier denial.

Executed under it the same minute: websites #158 (`b925072`) + fleet-manager #92 (`9a8518f`) squash-merged; fleet-vocab guardrail line updated to match.

Docs-only; `check_docs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z1fPG7Wa6VHprJqLcux4f

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z1fPG7Wa6VHprJqLcux4f)_