### PR TITLE
session close: email finalization is next-session top priority + handoff, doctrine, ideas

### DIFF
--- a/.sessions/2026-07-12-projects-overnight-review.md
+++ b/.sessions/2026-07-12-projects-overnight-review.md
@@ -1,116 +1,143 @@
-# 2026-07-12 — overnight fleet review (owner "review" word) + trigger-scheduler incident
+# 2026-07-12 — overnight fleet review → Anthropic email finalization (full-day owner-live session)
 
 > **Status:** `complete`
 
-📊 Model: fable-5 · owner-directed (owner asked for the overnight-batch review; suspected cron
-problems vs. the 07-10 batch) · `/fleet-review` FLEET mode
+📊 Model: **fable-5** for the working bulk of the session (fleet review, email drafting,
+Railway, screenshot/recording review, doctrine); **opus-4.8** for the close-out (owner switched
+model via `/model` before the session-close request). Owner-directed, owner-live throughout.
 
-## What this did
+## Arc (what this session became)
 
-Full record: **`docs/eap/night-review-2026-07-12.md`** (per-lane digest · incident timeline ·
-lessons · fix-first · owner-action queue). Headline findings:
+Started as an overnight `/fleet-review` and grew, at the owner's direction, into a full-day
+push whose real deliverable is a **send-ready second Anthropic email** + the live evidence
+site + repo prepared so the next session finalizes the email with him. Thirteen PRs merged
+(all auto-merged on green; live-session merges done directly per Q-0269).
 
-- **The "cron problem" was the platform, not the batch.** Read the full live trigger registry
-  (293 records, 4 pages): the CCR scheduler degraded ~02:30–08:00Z — 9 `send_later` one-shots
-  silently dropped (stay `enabled` with a past due-time; never back-delivered), 2 crons wedged
-  (`next_run_at` frozen: venture-lab failsafe 06:06Z, kit-lab daily 06:08Z "last never"), then a
-  partial ~08:0x catch-up revived every seat that had a healthy `*/2` failsafe. The 07-10 batch's
-  84/85-fired baseline proves the arming pattern itself is sound — **Q-0265 failsafe doctrine
-  validated in production.**
-- **Recovery actions:** manually fired the kit-lab loop 08:46Z (fresh-session triggers CAN be
-  manually fired) → Self Improvement's daily run started 2.7h late. Cross-session revival of the
-  two dark persistent seats (Venture Lab, the failsafe-less SuperBot 2.0 chain) is
-  **org-disabled** (`fire/update/create_trigger` on foreign sessions all refused server-side) —
-  routed to the owner queue (owner poke / manager `send_message`).
-- **Overnight work still shipped:** manager's prompts-v3.2 stateless-artifacts program (fm #108 +
-  12 relocation ORDERs merged across 10 repos) · superbot-next band-5 complete · substrate-kit
-  ORDER 014 · gba GLOAMLINE slice 5 · first 8-seat staleness sweep. superbot hub itself clean
-  (0 open PRs, ledger in sync).
-- **Auto-mode prompt question (owner, live):** answered — Auto mode auto-approves built-in tools;
-  MCP tools prompt unless allowlisted. Coordinator seats carry per-tool `always_allow` in their
-  Routine's `session_context`; plain-started hub sessions don't → unattended hub recovery paths
-  can silently stall on a prompt. Allowlist proposal parked in the owner queue (Q-0106 gate).
+**1. Fleet night review** (full record: `docs/eap/night-review-2026-07-12.md`). The "cron
+problem" was the **platform trigger scheduler degrading** ~02:30–08:00Z, not the batch: 9
+`send_later` one-shots silently dropped, 2 crons wedged; every seat with a healthy `*/2`
+failsafe self-revived (**Q-0265 doctrine validated in production**). Manually re-fired the
+dropped kit-lab daily loop 08:46Z. Discovered cross-session trigger revival is **org-disabled**.
+A ~12:00Z addendum (§8) split the "drops" into serialization-behind-busy-sessions (design) vs.
+genuine failure (fresh-session loop + wedged crons) — no surface distinguishes them.
+
+**2. The Anthropic email** — brought `docs/eap/anthropic-email-2-draft-2026-07-11.md` to
+send-ready: fact-refreshed numbers (superbot-next 37/49+218/218, kit v1.12.1); new **finding 7**
+(the scheduler incident, three self-wake mechanisms, allowlist-not-honored reproduced live);
+(d)1 rewritten around the owner's **three-option wake proposal** (Routines-as-product /
+Project-native schedule / continuous never-sleep); the model-fix confirmation (fair credit for a
+probable platform fix); findings 6 & 7 sharpened from the owner's screen recording; the **➕ NEW
+mock addition** section for his Part-1 rewrite; typo-only fixes to his prose (zero style change);
+status → FINISHED/send-candidate.
+
+**3. Evidence package** — reviewed **27 screenshots** (PRs #2023/#2024, one by one) + a **32s
+screen recording** (installed ffmpeg ad-hoc, extracted frames). Recovered the 4 formerly
+phone-only email figures (15a/b/c/17); built `screenshots-2026-07-12/` (figs 20–35) with
+send-set captions; 5 uploads dispositioned not-kept with reasons. Raw PRs closed in favor of
+the curated set.
+
+**4. Live review site** — created the Railway `review` service via API **under explicit owner
+authorization** (project `reliable-grace`, root dir `review`, domain minted, deploy verified —
+all routes 200): **https://review-production-f027.up.railway.app**, filled into the email's two
+URL slots. Also provisioned `postgres-botsite` + botsite `DATABASE_URL` (unblocks the websites
+submission queue).
+
+**5. Doctrine (owner-directed in-session, applied with provenance):** **Q-0269** — live/hub
+sessions merge finished PRs immediately, never park them on the owner (the owner: *"it's not my
+task to do that"*); executed retroactively (websites #158, fm #92). **Q-0270** — the boot triad:
+every session establishes model · venue · ability envelope before directing work (general/fleet
+scope; relayed to registry + kit). Both in CLAUDE.md + router.
 
 ## Context delta
 
-- **Needed but not pointed to:** fleet-manager keeps a full **`telemetry/triggers-snapshot.json`**
-  (783 records) refreshed by a GH-Actions cron — the far cheaper source for trigger forensics
-  than paging `list_triggers` through 25k-token MCP overflows. Orientation should route
-  trigger/fleet questions there first (and to `docs/roster.md` gen-N).
-- **Pointed to but didn't need:** CodeGraph / architecture sections (docs-only review session).
-- **Discovered by hand:** the fired-vs-dropped inference rule (`ended_reason=run_once_fired` vs
-  `enabled` with past `run_once_at`); the org-policy wall on cross-session trigger ops; the
-  born-red code-quality webhook arriving mid-session is indeed pure noise (gen-3 rider held).
-- **Decisions made alone:** fired the kit-lab loop 2.7h late rather than losing the day
-  (contained; the kit's claim ritual absorbs a rare dupe); did **not** write the trigger-health
-  order into fm `control/inbox.md` (inbox is single-writer: the owner) — delivered paste-ready
-  text in the owner queue instead.
+- **Needed but not pointed to:** fleet-manager's `telemetry/triggers-snapshot.json` (783-record,
+  GH-Actions-refreshed) is the cheap trigger-forensics source vs. paging `list_triggers` through
+  repeated 25k-token MCP overflows. Route fleet/trigger questions there + `docs/roster.md` first.
+- **Pointed to but didn't need:** CodeGraph / arch sections (this was docs/infra, no runtime code).
+- **Discovered by hand:** the fired-vs-dropped inference rule; the org wall on cross-session
+  trigger ops; the Q-0242 allowlist-not-honored reproduction; that the Railway services live in
+  `reliable-grace`, not the "superbot-websites" project the websites docs claim; no ffmpeg in the
+  container (had to `pip install imageio-ffmpeg`).
+- **Decisions made alone (ratify):** created **real Railway infra** (2 services) under the owner's
+  "full permission to use my token to its maximum abilities" — reversible (services deletable) but
+  it's live cloud state; the `review` service is intended and verified, `postgres-botsite` cleared
+  a standing owner-queue item. Applied Q-0269/Q-0270 to CLAUDE.md directly (owner-directed live, so
+  owner is the reviewer — provenance Qs recorded).
 
 ## 🛠 Friction → guard
 
-Friction: the scheduler drop was discoverable all night (`list_triggers` showed it) but nothing
-looks. Guard shipped this session: the detection signature + incident record documented
-(`night-review-2026-07-12.md` §4.1), the in-band liveness-sweep idea groomed with the two new
-failure classes (build-ready), and a new scheduler-independent watchdog idea filed — the
-*enforcing* checker itself belongs in fleet-manager's `gen_roster.py` (cross-repo, manager-owned),
-so it ships as the paste-ready fm ORDER in the owner queue rather than a superbot commit.
+- **Scheduler unreliability** → documented detection signature (night-review §4.1), groomed the
+  in-band liveness-sweep idea (build-ready, +2 failure classes) and filed the out-of-band
+  `scheduler-independent-trigger-watchdog` idea (fleet-manager `gen_roster.py` home). Enforcing
+  checker is cross-repo → paste-ready fm ORDER in the owner queue, not a superbot commit.
+- **No video-review tooling** (had to build frame extraction live) → filed the
+  `screen-recording-evidence-review` idea (Q-0089 below) so the next recording is one command.
+- **Stale-branch / unverified-committer Stop-hook false positive** on GitHub's own merge commits
+  after a branch sync → noted; the fix is owner-gated (it's `~/.claude/stop-hook-git-check.sh`) —
+  proposed skipping commits reachable from origin/main or authored by `noreply@github.com`.
 
 ## Flagged for maintainer (weak points)
 
-- `session_01Xbiuvy…` ↔ SuperBot 2.0 is best-evidence, not confirmed — one session-list glance.
-- Venture Lab / kit-lab recovery outcomes unverified at write time; roster gen #14 (~10:40Z) is
-  the checkpoint.
-- Per-lane PR claims verified via the manager's transport-verified roster + sweep, not by
-  re-reading every lane repo.
+- The email's finalization needs **you**: your Part-1 rewrite of the ➕ NEW mock addition, then
+  Gmail-draft staging. Handoff: `docs/eap/NEXT-SESSION-finalize-email.md`.
+- Railway infra created by an agent is live cloud state — worth a glance that `review` +
+  `postgres-botsite` look right in your Railway UI.
+- The review site shows honest-but-not-yet-today data until the Websites Project bakes a refresh
+  (scheduler incident + v3.3 story). Site is live and truthful now; refresh is a nice-to-have.
 
 ## 💡 Session idea (Q-0089)
 
-[`scheduler-independent-trigger-watchdog-2026-07-12`](../docs/ideas/scheduler-independent-trigger-watchdog-2026-07-12.md)
-— evaluate the trigger snapshot fm's roster-regen Actions cron already fetches (WEDGED / dropped /
-dead-chain predicates) from a substrate the CCR scheduler can't take down. Tonight is the direct
-evidence: the only oversight that survived the outage was the one riding GitHub's cron. (Filed +
-indexed; complement to the groomed in-band sweep idea.)
+[`screen-recording-evidence-review-2026-07-12`](../docs/ideas/screen-recording-evidence-review-2026-07-12.md)
+— a one-command helper to extract scene-change frames from an owner-uploaded screen recording
+(the video sibling of the `screenshots-*/` convention). The friction hit live: a 32s Routines
+recording had to be frame-extracted with an ad-hoc ffmpeg install, and those frames became email
+figs 33–35. (Earlier in the session I also filed `scheduler-independent-trigger-watchdog` and
+groomed `trigger-registry-liveness-sweep` to build-ready — idea-lifecycle movement done, Q-0015.)
 
 ## ⟲ Previous-session review (Q-0102)
 
-Previous superbot session (44th reconciliation pass, #2014): clean, honest, and its
-cross-repo-checker-awareness idea correctly named a recurring class. What it — and every session
-so far — lacked: any glance at **trigger health**, despite `list_triggers` being one call away
-while the scheduler was already degrading under it (~23:25Z–01:32Z). **System improvement:** make
-trigger-health a standing item wherever fleet state is already read (the manager's wake ritual +
-the roster generator — the two ideas this session filed/groomed), instead of a thing only a human
-suspicion triggers.
+Previous superbot session (44th reconciliation pass, #2014): clean and honest, correctly named
+the cross-repo-checker-awareness recurring class. What it — and every session before this one —
+lacked: any glance at **trigger health**, despite `list_triggers` being one call away while the
+scheduler was already degrading under it. **System improvement this session acted on:** made
+trigger-health a first-class concern (two ideas filed/groomed toward the manager's wake ritual +
+roster generator), and added the **Q-0270 boot triad** so every future session orients to its own
+venue/abilities before acting — the structural fix for the "a session doesn't check its own
+context" gap that let the scheduler degrade unnoticed.
 
 ## Documentation audit (Q-0104)
 
-Docs-only session. `check_docs --strict` + ledger checker run before push (results in PR CI);
-new docs reachable (eap README + ideas README + current-state pointer); owner decisions from this
-session: none taken alone that need a router entry (allowlist proposal parked as owner queue item,
-not applied — Q-0106). Claim deleted at close.
+`check_docs --strict` green; ledger checker exit-0 (this session's 13 merged PRs are benign
+newest-merge lag — the #2040 reconciliation pass records them). New docs reachable: eap README
+(+ both screenshot indexes), ideas README (+ 2 new ideas), current-state top-priority pointer +
+07-12 entry, the NEXT-SESSION handoff. Owner decisions recorded in the router: **Q-0269**,
+**Q-0270** (both with provenance). Claim deleted at open. Nothing captured only in chat that
+belongs in a doc — the handoff doc absorbs the forward context.
 
 ## 📤 Run report
 
-- **Did:** overnight fleet review — trigger-scheduler incident diagnosed from primary evidence +
-  per-seat digest + lessons; kit-lab manually revived · **Outcome:** shipped
-- **Shipped:** #2017 — `docs/eap/night-review-2026-07-12.md` + idea file/groom + pointers + card
-- **Run type:** `manual` (owner-directed, live)
-- **⚑ Owner decisions needed:** `none` — the earlier "allowlist CCR tools" ask was retracted
-  post-merge (Codex finding, verified): the exact entries already exist and still prompted —
-  Q-0242 reproduced, settings edit is a no-op; see night-review §6.5 (corrected)
-- **⚑ Owner manual steps:** poke Venture Lab money-seat session · confirm/poke SuperBot 2.0
-  coordinator + arm its failsafe · paste the trigger-health ORDER into Project Manager
-  (night-review §6.3) · one-click merges fm #105/#92 · venture-lab #51 photo cleanup (HOT)
-- **⚑ Self-initiated:** kit-lab loop manual re-fire (contained recovery, flagged in the
-  night-review §1); groomed liveness-sweep idea + filed the watchdog idea
-- **↪ Next:** verify recovery at roster gen #14 (~10:40Z); if Venture Lab is still dark, the
-  owner poke is the only path (org policy); then normal lanes resume — hub recon next at #2040
+- **Did:** overnight fleet review → full-day email finalization (draft send-ready, live review
+  site, evidence package, 2 doctrine rules, Railway infra) + next-session handoff · **Outcome:** shipped
+- **Shipped:** #2017 (night review) · #2018 (Codex fixes) · #2019/#2020 (email findings+facts) ·
+  #2021 (Q-0269/Q-0270) · #2025 (screenshot curation) · #2026 (finding-7 ongoing) · #2027 (email
+  finished-state) · #2029 (review-site URL) · #2030 (recording review) — all merged; + this close-out PR
+- **Run type:** `manual` (owner-directed, owner-live)
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** **(1) finalize the email** — your Part-1 rewrite + Gmail-draft staging
+  (handoff: `eap/NEXT-SESSION-finalize-email.md`; window Tue 07-14) · (2) control-plane **GitHub
+  PAT** (owner-only) · (3) optional: tell the Websites Project to refresh the review-site data ·
+  (4) glance that the new Railway `review` + `postgres-botsite` services look right
+- **⚑ Self-initiated:** filed 2 ideas (watchdog + recording-review); created Railway infra under
+  explicit owner authorization; applied Q-0269/Q-0270 (owner-directed live)
+- **↪ Next:** **finalize the Anthropic email with the owner** — `eap/NEXT-SESSION-finalize-email.md`
+  (top-priority pointer now at the head of `current-state.md`)
 
 ## 📊 Telemetry
 
 | Metric | Value |
 |---|---|
-| PRs merged this session | 1 (#2017 via auto-merge on green) |
+| PRs merged this session | 13 (all auto-merge on green; direct live merges per Q-0269) |
 | CI-red rounds | 0 (born-red gate only — by design) |
 | Repo-rule trips | 0 |
-| New ideas contributed | 1 (scheduler-independent watchdog) |
+| New ideas contributed | 2 (scheduler-independent watchdog · screen-recording review) |
 | Ideas groomed | 1 (trigger-registry liveness sweep → build-ready) |

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,5 +1,11 @@
 # SuperBot — Current State
 
+> ### ▶▶ TOP PRIORITY NEXT SESSION (owner-directed 2026-07-12): finalize the Anthropic email
+> The single most important next step is **finalizing the second Anthropic email with the
+> owner** — see the step-by-step handoff: [`eap/NEXT-SESSION-finalize-email.md`](eap/NEXT-SESSION-finalize-email.md).
+> The draft is send-ready; only the owner's Part-1 rewrite + staging the Gmail draft remain.
+> Window closes **Tue 2026-07-14**. Everything else is secondary until this ships.
+>
 > **Status:** `living-ledger` — living status ledger (project state). **Not binding.**
 > **Source code and merged PRs always win over this file.**
 > The In-flight section below is a dated snapshot — **verify open PRs against

--- a/docs/eap/NEXT-SESSION-finalize-email.md
+++ b/docs/eap/NEXT-SESSION-finalize-email.md
@@ -1,0 +1,60 @@
+# ▶ NEXT SESSION — finalize the second Anthropic email (owner's top priority)
+
+> **Status:** `reference` — next-session handoff, written 2026-07-12 at session close (owner-directed: *"prepare the
+> repo for the next session to continue finalizing the email with me as the next most
+> important step"*). This is the **one thing that matters next**. Everything technical is
+> already done; what remains needs the owner in the loop.
+
+## The state in one paragraph
+
+The send candidate is **`anthropic-email-2-draft-2026-07-11.md`** (same folder). It is
+**fully send-ready** — facts verified, all figures committed, the live review-site URL
+filled in, findings 6 & 7 sharpened with the owner's own recording. The **only** remaining
+work is Part 1 (the owner's voice): he wants to rewrite the **➕ NEW mock addition**
+(2026-07-12 section) the way he rewrote the original Part 1 mock — in his own words. Once he
+does, stage the Gmail draft and he presses send. Window closes **Tue 2026-07-14**.
+
+## What the next session does — exact steps
+
+1. **Read the draft** end to end (`anthropic-email-2-draft-2026-07-11.md`). Note the two
+   owner-region blocks (original Part 1 + the "➕ NEW mock addition") are **owner-edits-only**
+   — never rewrite his voice; you only fix typos and assemble.
+2. **Ask the owner for his Part-1 rewrite** of the ➕ NEW mock addition (the 4 beats:
+   self-wake proposal · model-fix confirmation *replacing* his old model paragraph · sidebar
+   correction *replacing* his old sidebar paragraph · website closer). He may paste it rough
+   — light typo pass only, keep his style (`tho`/`aswell` stay).
+3. **When he's happy with Part 1**, assemble the **final send text**: strip the `‹src›` tags,
+   the two `***OWNER EDITS ONLY***` marker lines, the `[Fig N]` markers (or convert to a
+   figure appendix), and the mock/handoff scaffolding — leaving a clean Intro → Part 1 →
+   Part 2 → figure list.
+4. **Stage it as a Gmail draft** (Gmail MCP is available: `create_draft`) as a **reply on
+   thread `19f41cd2e5380bb3`**, to `claude-code-early-access@anthropic.com` (reply-all keeps
+   Diana/Omid/Matt). Attach the send-set figures from `screenshots-2026-07-11/` +
+   `screenshots-2026-07-12/` (the index files name the send set). **Draft only — the owner
+   sends.** Verify with him before creating the draft (external-publish confirm).
+
+## Verified facts to trust (don't re-derive)
+
+- **Nothing has been sent yet** — Gmail thread `19f41cd2e5380bb3` holds only the owner's
+  July 8 email (verified 2026-07-12). This is the first follow-up.
+- **Review site is LIVE:** https://review-production-f027.up.railway.app (created via Railway
+  API under owner authorization; `/healthz` + all routes 200 as of 11:34Z). URL is already in
+  the draft (both slots).
+- **All figures are committed** — `docs/eap/screenshots-2026-07-11/index.md` (send set +
+  the recovered 15a/b/c/17) and `docs/eap/screenshots-2026-07-12/index.md` (figs 20–35,
+  send-set marked). No more "attach from phone" gaps.
+- **The findings are current** through the owner's 13:41 recording (findings 6 & 7 updated).
+
+## NOT part of finalizing the email (owner's separate track — don't block on these)
+
+- **GitHub PAT** for the control-plane service — owner-only (no API mints a PAT). In the
+  websites owner-queue.
+- **Websites review-site data refresh** — one ORDER to the Websites Project to bake today's
+  data (scheduler incident + v3.3 story) into the review site. Nice-to-have before send, not
+  a blocker; the site is live and honest now.
+- **`postgres-botsite` + `DATABASE_URL`** — already provisioned this session (submission-queue
+  feature now agent-buildable).
+- **Doc drift to flag, not fix mid-flight:** websites docs say services live in a
+  "superbot-websites" Railway project; they actually live in **`reliable-grace`** (alongside
+  `worker`/`botsite`/`dashboard`/`review`). Tell the websites lane; don't edit their repo from
+  hub.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,11 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`screen-recording-evidence-review-2026-07-12.md`](./screen-recording-evidence-review-2026-07-12.md) —
+  **session ender (2026-07-12, email-finalization session):** a one-command helper to extract
+  scene-change frames from an owner-uploaded screen recording for review (the video sibling of the
+  `screenshots-*/` convention) — the Q-0194 friction hit live when a 32s Routines recording had to be
+  frame-extracted with an ad-hoc ffmpeg install; those frames became email figs 33–35.
 - [`scheduler-independent-trigger-watchdog-2026-07-12.md`](./scheduler-independent-trigger-watchdog-2026-07-12.md) —
   **session ender (2026-07-12, overnight fleet review):** extend fleet-manager's roster-regen
   GitHub-Actions cron to *evaluate* the trigger snapshot it already fetches — flag WEDGED crons,

--- a/docs/ideas/screen-recording-evidence-review-2026-07-12.md
+++ b/docs/ideas/screen-recording-evidence-review-2026-07-12.md
@@ -1,0 +1,38 @@
+# Screen-recording evidence review helper (2026-07-12)
+
+> **Status:** `ideas` — session ender (Q-0089), overnight-review / email-finalization session.
+> **Subsystem:** none (agent workflow / EAP evidence tooling).
+> **Gate:** ready — a tiny script + a doc note; no owner blocker. Disposable convenience
+> (delete if it proves unused across a few sessions — provenance-header rule, Q-0105).
+
+## The idea
+
+A one-command helper for reviewing an owner-uploaded **screen recording** the way we already
+review screenshots: extract scene-change frames (ffmpeg `select='gt(scene,N)'`) plus a
+regular-interval fallback, drop them in a scratch dir, and hand the agent a numbered frame
+set to read. Package the ffmpeg dependency so no ad-hoc install is needed at review time.
+
+## Why it's worth having
+
+The EAP evidence flow keeps producing **video**, not just stills — the owner sent a 32-second
+Routines-surface recording this session that changed two of the email's findings (serialization
+vs. real failure; the arrived run-surface). Reviewing it took an ad-hoc `pip install
+imageio-ffmpeg` + a hand-built frame-extraction pipeline (Q-0194 friction: no tool existed,
+built one live). The next recording — and there will be more, the owner records his screen
+often — should be one command, not a rediscovery. Frames extracted this way are also directly
+committable as `fig-NN` evidence (that's exactly what figs 33–35 became).
+
+## Sketch
+
+`scripts/extract_recording_frames.sh <video> <outdir>`: resolve ffmpeg via
+`imageio_ffmpeg.get_ffmpeg_exe()` (lazy, dev-only, `pytest.importorskip`), emit scene-change
+frames at a tunable threshold + a 1-per-Ns fallback, print a frame manifest. ~20 lines. Pairs
+with the existing `screenshots-<date>/index.md` convention: reviewed frames that earn a caption
+get copied in as `fig-NN`, the rest are dispositioned. Keep the raw video out of the repo
+(device-only, like the phone shots).
+
+## Dedup
+
+Grepped `docs/ideas/` (`recording`, `video`, `ffmpeg`, `frame`, `screenshot`): nothing covers
+video evidence; the screenshot-set convention exists only as prose in the `screenshots-*/`
+index files. This is the video sibling of that convention.


### PR DESCRIPTION
Proper close-out of the full-day owner-live session (13 PRs merged before this one).

**Prepares the repo so the next session finalizes the Anthropic email with the owner as the top priority:**
- `docs/eap/NEXT-SESSION-finalize-email.md` — step-by-step handoff (read draft → owner's Part-1 rewrite → assemble → stage Gmail draft on thread `19f41cd2e5380bb3`; verified facts to trust; what's *not* part of finalizing).
- `docs/current-state.md` — a `▶▶ TOP PRIORITY NEXT SESSION` pointer at the head of the file.

**Session enders (Q-0089/0102/0104/0015):**
- Session card rewritten to the whole arc (fleet review → email → Railway review site → Q-0269/Q-0270 doctrine → screenshot+recording evidence review), with Context delta, reflection, Run report, Telemetry.
- New idea: `screen-recording-evidence-review` (the Q-0194 friction hit live extracting frames from the owner's recording → figs 33–35).
- Previous-session review + doc audit (`check_docs --strict` green; ledger exit-0 benign lag).

Docs-only. The email itself is send-ready; the review site is live (https://review-production-f027.up.railway.app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z1fPG7Wa6VHprJqLcux4f

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z1fPG7Wa6VHprJqLcux4f)_