### PR TITLE
docs(eap): mark the second Anthropic email SENT; clear top-priority banner

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,13 +1,13 @@
 # SuperBot — Current State
 
-> ### ▶▶ TOP PRIORITY (owner-directed 2026-07-12): Anthropic email — ✅ STAGED, owner to send
-> The second Anthropic email is **finalized and staged as a clean Gmail draft**
-> (`r9217428483600498478`, a reply on the July 8 thread `19f41cd2e5380bb3`, cc Diana/Omid/Matt)
-> — done with the owner live. Owner's Part 1 kept verbatim; scaffolding stripped; Part 2 cleaned.
-> **Remaining is owner-only:** attach screenshots by hand, delete the stale standalone draft
-> `r-7695257510039698568`, optional final Part-1 glance. Handoff + full details:
-> [`eap/NEXT-SESSION-finalize-email.md`](eap/NEXT-SESSION-finalize-email.md). Window: **Tue 2026-07-14**.
-> Optional non-blocker: refresh the review-site data (live at review-production-f027, 07-11 snapshot) to today.
+> ### ✅ DONE 2026-07-12: the second Anthropic email SHIPPED — top priority cleared
+> The second Anthropic EAP email was **sent by the owner 2026-07-12 13:24Z** — a reply on the
+> July 8 thread `19f41cd2e5380bb3` (msg `19f568051da9e3d6`), To `claude-code-early-access@`,
+> cc Diana/Omid/Matt, with a few final owner tweaks. The ready-to-attach figure gallery is linked
+> from the email ([`eap/email-attachment-set-2026-07-12.md`](eap/email-attachment-set-2026-07-12.md)).
+> Full record: [`eap/NEXT-SESSION-finalize-email.md`](eap/NEXT-SESSION-finalize-email.md).
+> **Watch for:** replies (EAP window through **Tue 2026-07-14**) + Matt's optional 10–15 min interview.
+> **Next action now reverts to the standing program** — per-sector live queues below.
 >
 > **Status:** `living-ledger` — living status ledger (project state). **Not binding.**
 > **Source code and merged PRs always win over this file.**

--- a/docs/eap/NEXT-SESSION-finalize-email.md
+++ b/docs/eap/NEXT-SESSION-finalize-email.md
@@ -1,19 +1,15 @@
 # ▶ NEXT SESSION — finalize the second Anthropic email (owner's top priority)
 
-> **Status:** `reference` — ✅ **STAGED 2026-07-12** — clean draft is in Gmail, ready for the owner to send.
-> The finalization session ran with the owner live. Outcome: the send-ready email is now a
-> **clean Gmail draft** (id `r9217428483600498478`) — a **reply on the July 8 thread**
-> `19f41cd2e5380bb3` (so the original email is quoted below as reference), **To**
-> `claude-code-early-access@anthropic.com`, **cc** `dliu@` / `omid@` / `mattg@`. The owner's
-> Part 1 is kept **verbatim** from his own Gmail edit; all scaffolding (status header, `*****`
-> markers, "Working notes") stripped; Part 2 de-markdowned; figures reduced to a plain key.
-> **Left to the owner only:** (1) attach screenshots by hand (Gmail draft API can't attach —
-> recommend Figs 1/5/7/9/10 + 15a–c); (2) delete the OLD standalone draft
-> `r-7695257510039698568` (thread `19f513094d66637d`) so the uncleaned version isn't sent;
-> (3) optional final glance at two Part-1 spots he was offered ("What I most want out of it
-> manage…" missing verb; empty "My idea:" line) — left untouched per his "keep my sections
-> unchanged". Optional non-blocker: refresh the review-site data (still a 07-11 snapshot) to
-> today. **The section below is the original handoff, kept for provenance.**
+> **Status:** `reference` — ✅ **SENT 2026-07-12 13:24Z** — task complete; kept as the record.
+> The second Anthropic EAP email was **sent by the owner** as a **reply on the July 8 thread**
+> `19f41cd2e5380bb3` (sent msg `19f568051da9e3d6`), **To** `claude-code-early-access@anthropic.com`,
+> **cc** `dliu@` / `omid@` / `mattg@`, with a few final owner tweaks. Assembly: the owner's Part 1
+> kept **verbatim** from his own Gmail edit; all scaffolding (status header, `*****` markers,
+> "Working notes") stripped; Part 2 de-markdowned; figures delivered as the linked gallery
+> [`email-attachment-set-2026-07-12.md`](email-attachment-set-2026-07-12.md) (25 figs, rendered on
+> GitHub) rather than attachments. **Follow-ups (not blocking):** watch the thread for replies
+> through **Tue 2026-07-14**; Matt's optional 10–15 min interview; optional review-site data
+> refresh past the 07-11 snapshot. **The section below is the original handoff, kept for provenance.**
 >
 > **Origin:** next-session handoff, written 2026-07-12 at session close (owner-directed: *"prepare the
 > repo for the next session to continue finalizing the email with me as the next most


### PR DESCRIPTION
## Summary

The owner **sent the second Anthropic EAP email** on 2026-07-12 13:24Z — a reply on the July 8 thread `19f41cd2e5380bb3` (sent message `19f568051da9e3d6`), To `claude-code-early-access@`, cc Diana/Omid/Matt, with a few final owner tweaks and the ready-to-attach figure gallery linked in place of attachments.

This updates project state to match: the top-priority item is complete.

## Changes

- `docs/current-state.md` — replaced the `▶▶ TOP PRIORITY … STAGED` banner with a `✅ DONE 2026-07-12 … SHIPPED` note (records the sent-message id + recipients), and reverted the next action to the standing per-sector program.
- `docs/eap/NEXT-SESSION-finalize-email.md` — flipped the handoff banner from `STAGED` to `SENT`, kept as the record; noted follow-ups (reply window through Tue 2026-07-14, Matt's optional interview, optional review-site data refresh).

## Type of change

- [x] Documentation

## Checks

- [x] `python3.10 scripts/check_docs.py --strict` passes (badge + reachability + callout budget).
- [x] Docs-only; no `disbot/` runtime code; no secrets/tokens added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWXnQ3wmww4zEJnmLH5q4u

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWXnQ3wmww4zEJnmLH5q4u)_