### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-12T15:30:22Z",
+    "generated_at": "2026-07-12T18:59:30Z",
     "build": {
-      "commit": "71e90041",
-      "subject": "docs: append session telemetry row (Q-0194 merge gate)",
-      "committed_at": "2026-07-12T15:30:22Z"
+      "commit": "096bf2f6",
+      "subject": "Merge pull request #2043 from menno420/claude/multi-repo-workflow-setup-qwhu5j",
+      "committed_at": "2026-07-12T18:59:30Z"
     },
     "schema_version": 1,
     "counts": {
@@ -3389,6 +3389,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-07-12-owner-queue-execution.md",
+      "date": "2026-07-12",
+      "title": "Session — 2026-07-12 — owner-queue execution + fleet workflow management",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-12-fleet-drive-and-websites.md",
       "date": "2026-07-12",
       "title": "Session — 2026-07-12 — email finalization → fleet-drive → websites backlog",
@@ -3843,14 +3851,6 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": true
-    },
-    {
-      "file": "2026-07-09-telemetry-gate-guard.md",
-      "date": "2026-07-09",
-      "title": "2026-07-09 — telemetry-gate-guard",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -4845,6 +4845,20 @@
       "date": "2026-07-12",
       "model": "opus-4.8",
       "effort": "medium",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-12-owner-queue-execution",
+      "date": "2026-07-12",
+      "model": "fable-5",
+      "effort": "high",
       "task_class": "docs-only",
       "tokens_out": null,
       "outcome": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.