### PR TITLE
settings: harness-recorded permission grant from the owner-live session

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "Bash(git worktree *)",
       "Bash(python3.10 tools/web_ux/screenshot_pages.py --out /tmp/claude-0/-home-user-superbot/edd8a486-be72-592c-8d0b-0b75eaa16df0/scratchpad/shots)",
       "Bash(python3.10 -c ' *)",
-      "Bash(npm install *)"
+      "Bash(npm install *)",
+      "Bash(python3.10 /home/user/superbot/scripts/extract_video_frames.py \"/root/.claude/uploads/e45607c6-be81-5e83-a7d0-336855b0cf7d/8dbb4788-Screen_Recording_20260712_205929_Samsung_Browser.mp4\")"
     ]
   },
   "skipWorkflowUsageWarning": true


### PR DESCRIPTION
One-line bookkeeping sweep: the harness auto-appended the owner-approved video-frame-extraction permission to `.claude/settings.local.json` during the 2026-07-12 owner-live session (#2043 lineage); the stop hook flagged it uncommitted. No behavior change — the file already tracks prior session grants. No session card added (no gate engagement); docs/settings only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018txGbufVAdkgvf79SJDw6w)_