### PR TITLE
Night orders v2 — owner-revised goals, venue model, seed skills (Q-0273)

### DIFF
--- a/.claude/skills/chase-references/SKILL.md
+++ b/.claude/skills/chase-references/SKILL.md
@@ -1,0 +1,46 @@
+# /chase-references — resolve every reference in the ask before acting
+
+> **Owner-directed (Q-0273, 2026-07-12).** Founding incident: the owner opened a session
+> with a comprehensive message containing a direct link to the previous session's brief and
+> multiple sibling repos by name — and the session still oriented superbot-only, costing ~3
+> turns of re-discovery. The lesson graduates here as an on-demand method (his words: "baked
+> into a method, like a skill, that prevents it from taking up too much storage in the
+> claude.md itself, but is still always loadable on demand"). Substrate-kit generalizes this
+> for every repo; this is superbot's copy.
+
+## When this runs
+
+At the start of ANY substantive ask — an opening message, an ORDER, a brief — and again
+whenever a mid-task message introduces new references. Trigger especially on: URLs · file
+paths · doc titles · repo names · PR/issue numbers · Q-numbers · "as discussed in / the plan
+says / the brief covers" phrasings.
+
+## The method
+
+1. **Inventory first.** Before any substantive work, list every reference the ask contains
+   or implies (explicit links, named files, named repos, named plans, "the X doc"). The ask's
+   references ARE its context spec — the author included them because reading them is cheaper
+   than re-deriving them.
+2. **Resolve each one, in this order:**
+   - a local path → Read it;
+   - a superbot doc name → open it (`Glob`/`Grep` if the path is fuzzy);
+   - a **sibling repo or its file** → raw-fetch it (standing-authorized, Q-0272 — see
+     `docs/fleet-reading-path.md`; `python3.10 scripts/fleet_status.py --repo X` for
+     heartbeats);
+   - a PR/issue number → pull it via MCP (own repo) or the heartbeat/raw pointer (sibling);
+   - a Q-number → grep the question router.
+3. **An unfound reference is a search task, never a skip.** Guess the most-logical homes and
+   look there before proceeding: `docs/owner/` (owner guidance/dispatch) → `docs/planning/`
+   (plans) → `.sessions/` (recent session records) → `docs/ideas/` → the named sibling repo's
+   `control/status.md` + `docs/` + `ideas/` via raw. If it is genuinely absent after that,
+   SAY so explicitly ("the brief references X; I could not find it in A/B/C") — silent
+   omission is how wrong pictures get built.
+4. **State the assembled picture back** (Q-0254): one short paragraph of what the references
+   collectively establish, before the work starts. A wrong assumption corrected here costs
+   one line; discovered later it costs the session.
+
+## The bar
+
+You are done chasing when every reference is either **read**, **fetched**, or **explicitly
+reported unfindable with the places you looked**. "I'll read it if it becomes relevant" fails
+the bar for anything the owner linked or named directly — he already decided it was relevant.

--- a/.claude/skills/prep-owner-steps/SKILL.md
+++ b/.claude/skills/prep-owner-steps/SKILL.md
@@ -1,0 +1,51 @@
+# /prep-owner-steps — hand the owner finished steps, not directions
+
+> **Owner-directed (Q-0273, 2026-07-12).** His words: agents give him "directions clearly
+> mapped out — go to github, actions, settings, rule, etc, and paste this file from this
+> github page in this repo — while they could easily lead with the link and the copy/paste
+> ready file in chat as a separate block." The method: before handing the owner any step, ask
+> *"which steps will he face, and are there any text blobs he might need to enter that I can
+> send?"* — then send them. Substrate-kit generalizes this fleet-wide; this is superbot's copy.
+
+## When this runs
+
+Every time work surfaces an **owner-only step** (repo settings, secrets, portal clicks,
+external publish, account actions) or any instruction the owner must execute by hand — in
+chat replies, owner-queue items, ⚑ blocks, and run reports.
+
+## The method — prepare, don't describe
+
+1. **Lead with the direct link.** Deep-link the exact page (the ruleset editor, the Variables
+   tab, the release form) — never a navigation trail when a URL exists. A trail ("Settings →
+   Rules → main") is the *fallback annotation under* the link, for when the deep link 404s.
+2. **Every blob he must enter ships as its own fenced block.** File contents, variable names,
+   one-line replies, commit messages, form fields — each in a separate copy-ready block,
+   labeled with exactly where it goes. Never "paste the file from this github page" — fetch
+   it and paste it INTO the chat/queue item yourself.
+3. **Walk his path once yourself, in your head or via probe.** Enumerate every click/field he
+   will actually face (the screen he lands on, the button names, the confirm dialogs) and
+   pre-answer each. If a step's outcome feeds a later step (a minted token → a variable),
+   say what to carry forward and where it lands.
+4. **Batch to one sitting.** If the task needs owner steps at multiple points, restructure so
+   they cluster into ONE block at the start or end — never interleave "now go click X" through
+   a work narrative he has to babysit.
+5. **State the payoff + verification.** One line each: what completing the steps unblocks,
+   and how he (or the next agent) verifies it worked (the exact URL/command that should now
+   succeed).
+
+## The shape (use it in queue items and chat alike)
+
+```
+⚑ OWNER — <what this unblocks, one line>
+1. <deep link>  (fallback: Settings → … → …)
+   paste ↓ into <exact field>:
+   ```<the blob>```
+2. …
+verify: <command/URL that should now succeed>
+```
+
+## The bar
+
+The owner should be able to complete every step with **clicks and pastes only** — zero
+composing, zero fetching, zero deciding-what-you-meant. If he has to open another page to
+*copy something you could have copied for him*, the preparation failed.

--- a/.sessions/2026-07-12-fleet-rearm-pack.md
+++ b/.sessions/2026-07-12-fleet-rearm-pack.md
@@ -70,6 +70,24 @@ Also this part: the full cross-repo read of the fleet at HEAD (14 files) that re
 reviewed, dossier-cross-checked); owner ruled "tweak first" and the tweak surface was laid
 out in chat (name · visibility · project cut · arm-hardware path · buy-list).
 
+## Part 4 (same session, ~23:00Z) — v2 night orders + venue correction + the seed skills (Q-0273)
+
+The owner delivered three connected directives (recorded verbatim in router Q-0273): the
+**venue correction** (this hub chat is a standing, permanent venue outside the Projects — it
+merges/closes stray PRs and executes sensitive/destructive actions seats can't; the Project
+Manager is the in-fleet tracker/dispatcher; merge/destructive owner-queue items now carry
+`VENUE:hub`), the **revised per-seat night goals** (2.0 max-finalization: core/admin/setup
+production-ready + command/button curation; World: finalize mining/fishing/idle as games +
+the minigame/casino section spec; Ideas Lab: endless any-domain cycle; Venture: both lanes —
+many books incl. multiple versions, wider backtests, WEBSITE-IDEA markers; websites: the
+clarity bar, execute-to-done; Game Lab: mass production incl. browser + mobile foundations),
+and the **self-initiative program** for the kit. Shipped: `fleet-night-orders-2026-07-12.md`
+rewritten to **v2** (blocks superseded in place; v1 in git history; manager-boot-first
+checklist — its successor never woke off the 22:31Z bridge), router **Q-0273**, and two
+**seed skills** as reference implementations for the kit to generalize:
+`.claude/skills/chase-references/` + `.claude/skills/prep-owner-steps/` (the founding
+incident is this session's own opening-message reference miss).
+
 ## Key design decisions (decide-and-flag, Q-0240)
 
 - **Bridge, not fork:** tonight's re-arm rides startup prompts over the currently-pasted

--- a/docs/owner/fleet-night-orders-2026-07-12.md
+++ b/docs/owner/fleet-night-orders-2026-07-12.md
@@ -1,344 +1,353 @@
 # Fleet night orders — 2026-07-12 (post-reboot productivity wave + two new seats)
 
-> **Status:** `owner-guidance` — authored at the owner's direction, 2026-07-12 ~21:00Z (same
-> session as the re-arm pack, superbot PR #2048). **Situation:** the owner manually updated
-> every Project's Custom Instructions, archived the old chats, and dispatched a fresh reboot
-> using **today's earlier-rebuild prompts** (the manager's prompt-rebuild lane), *not* the
-> §4 blocks in [`fleet-rearm-2026-07-12.md`](fleet-rearm-2026-07-12.md) — those remain the
-> doctrine source for the next full re-paste. This doc is the **follow-up wave**: (1) the
-> boot-watch, (2) one short **NIGHT ORDER per seat** that delivers the Q-0271 delta mid-flight
-> and aims each seat at maximum-value work tonight, (3) founding material for the two new
-> seats (Fun Lab — the friend-directed studio — and the Ideas-Lab candidate).
+> **Status:** `owner-guidance` — authored at the owner's direction, 2026-07-12 ~21:00Z
+> (superbot PR #2049), **revised to v2 ~23:00Z at the owner's direction** (superbot PR #2053
+> lane): per-seat goals replaced with the owner's revised night ambitions, the venue
+> correction recorded (§0b), and the manager-boot-first dispatch order (§5). v1's blocks live
+> in git history of this file; **§2 below is the paste source.**
+>
+> **Situation:** the owner manually updated every Project's Custom Instructions (the
+> earlier-rebuild v3.4 prompt bodies), archived the old chats, and dispatched fresh boots.
+> This doc is the follow-up wave: (1) the boot-watch, (2) one **NIGHT ORDER v2 per seat**,
+> (3) founding material for the new seats. The re-arm pack
+> ([fleet-rearm-2026-07-12.md](fleet-rearm-2026-07-12.md)) stays the doctrine source for the
+> next full re-paste.
 
-## 1. Boot-watch — snapshot at 20:53Z + how the watch continues
+## 0 · Relationship to the reboot — and (0b) the venue correction
 
-Mechanical boot signal (trigger registry, full enabled inventory read 20:52–20:56Z):
+**0a.** Tonight's seats run the v3.4 instruction bodies; these orders ride mid-flight and
+carry the Q-0271 delta inline, so nothing depends on which prompt version a seat booted with.
 
-| Seat | Fresh arming (post-20:15Z reboot wave) | Old archived-gen trigger still enabled | Verdict 20:53Z |
-|---|---|---|---|
-| **Venture Lab** | failsafe `45 1-23/2` (20:38) + tick 20:54 + trading grading Fri + T+7/T+14 one-shots | old money-seat failsafe `0 */2` (next 22:06) + old grading + old 16:36Z T+7/T+14 pair | ✅ **BOOTED** — retire the 4 superseded orphans |
-| **SuperBot 2.0** | failsafe `0 1-23/2` (20:42) + tick 21:03 | — (it had none — the gap is FIXED) | ✅ **BOOTED** |
-| **SuperBot World** | failsafe `15 1-23/2` (20:51) | old failsafe `0 */2` (next 22:07) | ✅ **BOOTED** — retire the orphan |
-| **Project Manager** | not yet seen (one unattributed 21:04 tick created 20:48 may be it) | old failsafe `30 */2` (next 22:31) | ⏳ pending |
-| **Ideas Lab** | not yet | old failsafe `0 */2` (next 22:05) | ⏳ pending |
-| **Game Lab** | not yet | old failsafe `50 */2` (next 22:50, created this morning) | ⏳ pending |
-| **Websites** | not yet (review-bake bridge `33 5` from 20:01 is fine) | old failsafe `45 */2` (next 22:45) | ⏳ pending |
-| **Self Improvement** | n/a — its daily `kit-lab loop` (06:08, **fresh-session mode**) survives chat archiving by design | old failsafe `0 */2` (next 22:03) bound to the archived chat | ⏳ pending (loop itself valid) |
+**0b. The venue model (owner correction, ~23:00Z — recorded as router Q-0273).** The standing
+**hub chat** (the owner-live session outside the Projects — the venue this doc was written
+in) is **not** the Project Manager and is never a seat. It must **always exist** because
+Project seats sometimes lack — or wrongly believe they lack — permissions (harness-prompt
+strictness/misreads): the hub venue **merges or closes stray PRs and executes
+sensitive/destructive actions**; in it these actions always work (sometimes with an owner
+permission prompt). The **Project Manager** seat's mission, restated by the owner: **keep
+track of everything the fleet does and keep dispatching orders in the repos while the owner
+is away**, plus help him with general project thinking and ideas. Operational consequence:
+**owner-queue items that are merge- or destructive-shaped now carry a `VENUE:hub` tag** — the
+owner executes them through the hub chat (paste the item; it always works) instead of
+fighting a seat's permission wall.
 
-**What "booted correctly" means, checkably:** a fresh failsafe cron + one future pacemaker
-tick bound to the NEW session, and the seat's first heartbeat stamp. **The orphan rule:** every
-old failsafe above points at an **archived** chat; each seat retires its own after arming the
-new one (the rebind-then-delete recipe, generalized from the manager's boot step) — the
-NIGHT ORDERs below carry that line, and the manager's ORDER-020 sweep catches leftovers.
-**Pending ≠ failed:** seats the owner dispatched minutes ago arm at their first turn-end. The
-watch continues on three layers: the manager's per-wake sweep → this hub session's scheduled
-re-checks (~21:25Z, then on the PR check-in) → your morning roster read.
+## 1 · Boot-watch — final state (23:0xZ)
 
-## 2. NIGHT ORDERS — one short paste per seat (or one relay paste to the manager)
+| Seat | Wake layer | Evidence |
+|---|---|---|
+| Venture Lab · SuperBot 2.0 · SuperBot World · Ideas Lab · Websites · Self Improvement · Game Lab | ✅ fresh failsafes + live pacemakers; archived-generation orphans retired by the seats themselves | registry sweeps 20:53Z/21:33Z + each heartbeat's ROUTINE DISPOSITION block |
+| **Project Manager** | ⚠ **needs the owner's boot paste** — successor never stamped (heartbeat frozen 19:59Z); its designed dead-man bridge (old failsafe, `30 */2`) fired 22:31Z with no revival evidence by 23:0xZ | fleet-manager `control/status.md` at HEAD |
 
-**Delivery (pick one):** (a) **one paste** — send §2.0 to the Project Manager and let it
-`send_message`-relay the 8 orders (exercises the interlock; the manager verifies delivery by
-each seat's next heartbeat and flags unreachable seats); or (b) **eight pastes** — send each
-block to its seat directly (most reliable; use it if the manager hasn't booted by the time you
-dispatch). Every order embeds the same **Q-0271 DELTA** — the discipline that is *new* relative
-to the earlier-rebuild instruction bodies the seats are now running.
+Watch continues via each seat's own failsafe + the hub session's checks. Registry oddity to
+glance at in the Routines UI: a "docs reconciliation" trigger showing `next_run_at
+0001-01-01T00:00:00Z` (recorded by the kit seat, untouched).
 
-### 2.0 The relay order (paste to Project Manager only, option a)
+## 2 · NIGHT ORDERS v2 — one paste per seat (owner-revised goals)
+
+**Delivery:** paste the **manager's boot first** (§5 step 1), then either paste blocks
+§2.2–§2.8 directly per seat (most reliable), or hand the manager ORDER NIGHT-01R:
 
 ```text
-ORDER NIGHT-01 (owner, 2026-07-12): relay the per-seat NIGHT ORDER blocks in
-superbot docs/owner/fleet-night-orders-2026-07-12.md §2.1–§2.8 to each seat's live session
-via send_message, verbatim, tonight. Verify delivery per seat (next heartbeat stamp reflects
-the order); any seat unreachable or unbooted → flag on the owner queue with its state.
-Execute your own block (§2.1) yourself. Done-when: 8/8 delivered-or-flagged, logged in
-control/status.md.
+ORDER NIGHT-01R (owner, 2026-07-12 v2): relay the per-seat NIGHT ORDER v2 blocks in
+superbot docs/owner/fleet-night-orders-2026-07-12.md §2.2–§2.8 to each seat's live session
+via send_message, verbatim. Verify delivery per seat (next heartbeat reflects it); any seat
+unreachable → flag on the owner queue with VENUE:hub if merge/destructive-shaped. Execute
+your own block (§2.1) yourself.
 ```
 
-### 2.1 Project Manager
+Every block opens with the same Q-0271 delta so it works regardless of what a seat already
+received.
+
+### 2.1 Project Manager (paste as its first post-boot order)
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY
-and that is the system's normal state. Silence = consent = done — never hold finished work for
-review. Genuinely-owner-only items (settings/rulesets · secrets/hosts · external publish/spend ·
-destructive prod-data · portal steps) go to the owner-queue and you CONTINUE other work —
-queue-and-continue, never wait-in-place. Uncertainty → SIM-REQUEST to Ideas Lab via outbox,
-then next slice. Never idle on a drained queue — generate work. Keep exactly ONE outstanding
-pacemaker tick; verify your failsafe is alive (future next_run_at) each wake.
-TONIGHT (watchdog + router + records):
-1. Trigger-health sweep NOW + every wake (ORDER 020): the archived-generation failsafes are
-   live orphans — venture 22:06 · World 22:07 · kit 22:03 · Ideas 22:05 · manager-old 22:31 ·
-   websites 22:45 · game-lab 22:50. After each seat's fresh failsafe exists, retire its orphan
-   (rebind-then-delete, account-scoped); sweep for seats with NO fresh arming and
-   send_message-revive them.
-2. Route continuously: Ideas Lab outbox verdicts + every SIM-REQUEST → inbox ORDERs within one
-   wake. Feed Ideas Lab the fleet's open questions if its intake is empty.
-3. Records: roster fresh; re-stamp contradicted heartbeats; owner-queue verify-first curation.
-4. Fold the AUTONOMY RIDER (superbot docs/owner/fleet-rearm-2026-07-12.md §3, Q-0271) into
-   your canonical prompt lane so the next re-paste inherits it.
-5. MORNING ROSTER by ~06:00Z: per seat SHIPPED / QUEUED / STALLED-with-verbatim-error +
-   dropped-tick report + flag the first completed ROUND-TRIP (idea→verdict→routed→built→
-   merged→surfaced, hands-free) — that flag is the night's headline.
-Quota: route-within-one-wake all night; zero unswept wakes.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; never hold finished work for review. An open
+PR never stops you (arm auto-merge in the checks-PENDING window; a real classifier denial →
+park READY+green, queue ONE systemic owner item, take the next slice same turn). Probe before
+declaring any wall (capabilities docs → printenv → attempt once → verbatim error). Owner-only
+classes (settings/rulesets · secrets/hosts · external publish+spend · destructive prod-data ·
+portal steps) → six-field owner-queue item, then CONTINUE. Uncertainty → SIM-REQUEST via
+outbox, keep building. Never idle on a drained queue. Wake hygiene: one outstanding tick;
+verify your failsafe ALIVE each wake; a nothing-to-do wake is a silent no-op.
+
+YOUR MISSION, restated by the owner tonight: keep track of EVERYTHING the fleet does and keep
+dispatching orders in the repos while he is away (you also serve as his general project
+thinking aid when he is present). The standing HUB CHAT outside the Projects handles what
+seats can't: tag owner-queue items that are merge- or destructive-shaped `VENUE:hub` so the
+owner runs them there — never park them against a seat's permission wall.
+TONIGHT:
+1. WATCHDOG (ORDER 020) every wake: wedged/dropped/dead-chain sweep; send_message-revive dark
+   seats; retire your own archived-generation bridge failsafe after rebinding.
+2. RELAY + TRACK: deliver §2.2–§2.8 if the owner hands you NIGHT-01R; then track every seat's
+   quota progress in the roster (SHIPPED / QUEUED / STALLED per seat).
+3. ROUTE continuously: Ideas Lab verdicts + SIM-REQUESTs + venture's website-idea markers (→
+   websites) within one wake each.
+4. RECORDS: roster fresh; stale-doc sweep (kit's ⚑ list still cites fm #122 as pending — it
+   merged 19:49Z; strike that class of stale asks fleet-wide); owner-queue verify-first
+   curation with VENUE:hub tagging.
+5. Fold the AUTONOMY RIDER + the two new superbot skills (chase-references, prep-owner-steps)
+   into your v3.4+ registry lane so the next re-paste inherits them.
+6. MORNING ROSTER ~06:00Z: per-seat quota tally + dropped-tick report + the first completed
+   ROUND-TRIP flag (idea→verdict→routed→built→merged→surfaced).
 ```
 
 ### 2.2 Ideas Lab
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done; never hold work for review. Owner-only items
-(settings/secrets/publish/spend/destructive/portal) → owner-queue, then CONTINUE. Never idle
-on a drained queue — an empty intake is a HARVEST signal. One outstanding tick; verify your
-failsafe alive each wake; after your fresh failsafe exists, retire the archived-generation one
-(next-fire 22:05).
-TONIGHT (R&D engine — verdicts are your finished units; honest nulls count):
-1. Serve SIM-REQUESTs from build seats first (priority intake).
-2. Quota: ≥3 finalized verdicts by 06:00Z (approve/reject/needs-more + best implementation
-   found), posted to outbox for the manager. WIP cap 3, backpressure holds.
-3. Harvest ≥1 new lane + probe ≥2 ideas (8-question battery). Generative rung: mine sibling
-   repos' roadmap "Later" sections, TODO sweeps, venture's product shortlist — via raw reads.
-4. Special probe tonight: "fun-first small games/toys a solo agent can ship in 1–3 days"
-   (candidate menu for the new Fun Lab seat — playable-fast, gift-grade, zero monetization).
-   Post the top-5 menu to outbox by morning.
-When a target completes, take the next — chain slices until the quota is met, then keep going.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; never hold finished work for review. An open
+PR never stops you (arm auto-merge in the checks-PENDING window; a real classifier denial →
+park READY+green, queue ONE systemic owner item, take the next slice same turn). Probe before
+declaring any wall. Owner-only classes → six-field owner-queue item, then CONTINUE. Never
+idle on a drained queue. Wake hygiene: one outstanding tick; failsafe verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT: an ENDLESS CYCLE — keep producing and testing ideas all night,
+for any fleet repo OR completely unrelated to anything. The cycle never drains: an empty
+intake is a harvest signal, and "unrelated to the fleet" is explicitly in-scope material.
+TONIGHT:
+1. Serve SIM-REQUESTs from build seats first (they will come — 2.0 runs a command-curation
+   pass, World runs game reviews, venture runs book/product probes).
+2. CONTINUOUS generate→verify: harvest → probe (8-question battery) → verdict → outbox,
+   repeating all night. WIP cap 3, backpressure holds, honest nulls are wins. Target: a
+   verdict stream the manager can route every wake, not a fixed count.
+3. Carry-overs: the fun-menu top-5 for the friend lane; the makerbench blueprint stays
+   pending the owner's tweak reply (do not build it yet).
+GENERATIVE RUNG: alternate lanes so the stream stays diverse — fleet repos' "Later" sections
+→ venture's book/product space → games mechanics → completely-unrelated domains (the owner
+explicitly wants these too).
 ```
 
 ### 2.3 Venture Lab
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done. External publish/spend stays owner-only: queue the
-click + evidence, then START THE NEXT PRODUCT the same turn — queue-and-continue, never
-wait-in-place. Never idle; one outstanding tick; failsafe verified each wake; retire your
-archived-generation triggers once your fresh layer is confirmed (old failsafe 22:06 + old
-Friday grading + the 16:36Z T+7/T+14 pair — your 20:38–20:50 re-arms supersede them all).
-TONIGHT (revenue engine — the owner's thesis is QUANTITY: 100 publish-ready products beat 10):
-1. Quota: 2 MORE products to publish-READY by 06:00Z (built + priced + listing drafted +
-   checkout tested + sha recorded + click queued). Pick from your shortlist or Ideas Lab
-   verdicts in your inbox.
-2. Extract your existing products' scaffolding into a reusable product-template/ checklist so
-   product N+1 is instantiation, not invention — this is the 10→100 mechanism. Route a note to
-   websites (via manager) for a product page per READY item.
-3. T+7/T+14 checkpoints stay armed; wire in the listing URL only if the owner drops one.
-Chain: finish one → queue its click → start the next, all night.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; never hold finished work for review. An open
+PR never stops you (arm auto-merge in the checks-PENDING window; a real classifier denial →
+park READY+green, queue ONE systemic owner item, take the next slice same turn). External
+publish/spend stays owner-only: queue the click + evidence, then START THE NEXT PRODUCT the
+same turn. Probe before declaring any wall. Never idle. One outstanding tick; failsafe
+verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT: BOTH lanes run tonight — trading is UN-PARKED for research (its
+weekly grading cadence stays; this is the research lane working between gradings).
+TONIGHT — PRODUCTS (quantity is the thesis):
+1. As many FINISHED books + sellable products as possible: each publish-READY (built + priced
+   + listing drafted + checkout/format verified + sha + click queued), then immediately start
+   the next.
+2. BOOKS specifically: generate MULTIPLE new book ideas AND write MULTIPLE VERSIONS of each
+   book (different angles/audiences/lengths) — versions are cheap once the research exists;
+   route the weakest ideas through Ideas Lab as probes rather than discarding unassessed.
+3. WEBSITE IDEAS: anything you spot that should exist as a site/page — mark it explicitly in
+   your outbox as WEBSITE-IDEA for the manager to route to the Websites seat.
+TONIGHT — TRADING (research lane):
+4. Expand the backtest surface: more strategies, more stocks/tickers, more indicators —
+   each addition backtested with the existing engine, results recorded honestly (nulls
+   included); feed anything sim-shaped to Ideas Lab for verification.
+GENERATIVE RUNG: mine the fleet for productizable assets and the book space for series
+potential; the product-template/ checklist makes product N+1 instantiation, not invention.
 ```
 
-### 2.4 SuperBot 2.0
+### 2.4 SuperBot 2.0 (superbot-next + superbot prod)
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done; Q-0241 never-wait governs your whole program. An open
-PR never stops you: update-branch → arm auto-merge in the PENDING window → next slice; a
-ruleset wall gets ONE owner-queue item, not sixteen. Uncertainty → SIM-REQUEST via outbox,
-then keep building. One outstanding tick; failsafe verified each wake (yours is fresh at
-0 1-23/2 — good).
-TONIGHT (flagship program — production-readiness is the mission):
-1. DRAIN THE MERGE WALL agent-side: the open-PR pile oldest-first (update-branch → green →
-   arm auto-merge). Quota: every drainable PR armed or parked-with-verbatim-reason by 06:00Z.
-2. MONEY FIRST: verify F-001/F-002/F-003 at HEAD (they may be in the pile) — fix/land whatever
-   remains, with concurrency-race regression tests.
-3. PROD LANE: build FLAG 1 (60s mining-snapshot relay) + FLAG 2 (HMAC write endpoint) in the
-   superbot repo — specs verbatim in mineverse control/status.md; set the agent-side env pair;
-   post to outbox when each lands (SuperBot World consumes them tonight).
-4. Then port slices per the band plan, sweeping each domain for the unlocked-checkpoint +
-   NATURAL_KEY race class.
-Chain slices all night; the cutover-readiness checklist is your generative rung.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; Q-0241 never-wait governs your program. An
+open PR never stops you (arm auto-merge in the checks-PENDING window; ruleset wall → ONE
+owner item, keep working — the pile drains when the owner clicks). Probe before declaring any
+wall. Owner-only classes → six-field owner-queue item (VENUE:hub if merge-shaped), then
+CONTINUE. Uncertainty → SIM-REQUEST via outbox. Never idle. One outstanding tick; failsafe
+verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT TONIGHT — MAXIMUM FINALIZATION: "as much finalization as possible
+tonight … at least the full core and all admin and setup functions fully complete and
+production ready … everything working as intended, and as finished and finetuned as
+possible." Live-testing follows later; tonight is completeness + polish, evidenced.
+TONIGHT, in order:
+1. All FINISHED features properly implemented: sweep every ported subsystem for
+   half-implemented surfaces (stubs, TODO paths, unwired buttons, missing error copy) and
+   finish them.
+2. THE CORE + ALL ADMIN + ALL SETUP functions to fully-complete, production-ready state —
+   this is the night's hard target. Definition of done per surface: implemented + tested +
+   parity/golden where applicable + error paths handled + copy final.
+3. COMMAND/BUTTON CURATION: run simulations + reviews across the full command and component
+   surface to decide KEEP / REWORK / DROP per command and button — build the evidence file
+   (usage shape, redundancy, confusion risk; the admin-surface audit + settings-prune ledger
+   are prior art). Ship the reworks that are contained; flag the drops for the owner as one
+   curation report (VENUE:hub for any that need force-removal).
+4. MINIGAME/CASINO CONSOLIDATION (the owner's design, mostly existing here): one
+   minigame/casino section, games grouped in sections, guild-configurable enable-all or
+   pick-a-few, panels updating dynamically to the enabled set. Coordinate the game inventory
+   with SuperBot World's outbox note.
+5. Money fixes (F-001/2/3 class) verified at HEAD + FLAG 1/2 in the prod-bot lane (specs in
+   mineverse control/status.md) — these stay from v1.
+6. Fine-tuning pass to close: naming/copy consistency, panel flow, defaults sanity.
+MORNING DELIVERABLE: the curation report + a per-subsystem completeness table (core/admin/
+setup rows all ✅ or honestly flagged).
 ```
 
-### 2.5 SuperBot World
+### 2.5 SuperBot World (superbot-games + superbot-idle + superbot-mineverse)
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done. Open PRs never stop you (arm auto-merge in the PENDING
-window). Balance/design uncertainty → SIM-REQUEST via outbox, then next slice. One outstanding
-tick; failsafe verified (yours is fresh at 15 1-23/2 — good); retire the archived-generation
-failsafe (next-fire 22:07) now that yours is live.
-TONIGHT (the flagship needs its DATA):
-1. Build the mineverse CONSUME side against the FLAG 1/2 specs in your own control/status.md
-   (ingestion validation vs mining_snapshot.v1, fixtures, write-path UI) so real miner data
-   flows the moment SuperBot 2.0's relay lands — watch your inbox for their landing note;
-   never idle waiting on it.
-2. Re-stamp the contradicted superbot-games heartbeat (verify at HEAD first).
-3. Land the small greens: games #59/#60 + idle #74 (update-branch + arm auto-merge).
-4. Idle lane: PLUG-001 adapter prep on the verified plugin contract.
-5. Then improvement sweep: highest-value bug/polish per repo from your backlog docs.
-Quota: targets 1–3 done by 06:00Z; chain into 4–5. Generative rung: play-test your own
-surfaces and fix the roughest edge.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; never hold finished work for review. An open
+PR never stops you (arm auto-merge in the checks-PENDING window; a real classifier denial →
+park READY+green, queue ONE systemic owner item, take the next slice same turn). Probe before
+declaring any wall. Owner-only classes → six-field owner-queue item, then CONTINUE.
+Balance/design uncertainty → SIM-REQUEST via outbox. Never idle. One outstanding tick;
+failsafe verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT TONIGHT — FINALIZE THE GAMES AS GAMES:
+1. MINING: finalize it COMPLETELY as a standalone game AND integrated into the
+   exploration/world hub. It is supposedly mostly finished — REVIEW it end-to-end first
+   (play-test the flows), then extend/improve wherever possible: progression feel, missing
+   loops, rough edges, rewards balance (sim-pin numbers via SIM-REQUEST).
+2. FISHING and IDLE: the same treatment — review → finalize → extend/improve. Idle's 12
+   themes + engine are done; its PLUG-001 adapter (#75, READY+green) is the integration
+   piece.
+3. CARD/MINIGAMES: inventory every card/minigame across the repos and spec the ONE
+   consolidated minigame/casino section (sections, enable-all-or-pick, dynamic panels). The
+   PANEL machinery is superbot-next's job and mostly exists there — your deliverable is the
+   game inventory + section spec + per-game readiness, posted to your outbox for 2.0 tonight.
+4. Mineverse consume-side (FLAG 1/2) stays from v1 — build against the specs; watch the
+   inbox for 2.0's landing notes.
+MORNING DELIVERABLE: per-game state table (standalone ✅ / hub-integrated ✅ / improved-with
+list) + the minigame section spec.
 ```
 
-### 2.6 Game Lab
+### 2.6 Game Lab (gba-homebrew + pokemon-mod-lab)
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done. Open PRs never stop you (arm auto-merge; private-repo
-path = REST merge-on-green). Design uncertainty → SIM-REQUEST via outbox, then next slice.
-One outstanding tick; ARM YOUR FRESH FAILSAFE first thing if the reboot hasn't yet (your only
-enabled failsafe is the archived-generation one, next-fire 22:50 — rebind then retire it).
-TONIGHT (standalone studio; pokemon stays PRIVATE — visibility check first):
-1. gba: next GLOAMLINE slice(s) per plan.
-2. Release-to-one-click: build/verify a workflow_dispatch release workflow so Lumen Drift is
-   ONE owner click — probe whether the dispatch itself is agent-permitted (attempt once,
-   verbatim error if walled) — then queue the click.
-3. Land gba #68/#69 if green (update-branch + arm auto-merge).
-4. pokemon private track: next playtest-gated slice.
-Quota: ≥2 shipped slices + the release workflow proven by 06:00Z. Generative rung: run your
-own game in the emulator and fix the roughest edge you find.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; never hold finished work for review. An open
+PR never stops you (arm auto-merge in the checks-PENDING window; private repo = REST
+merge-on-green; a real classifier denial → park READY+green, queue ONE systemic owner item,
+take the next slice same turn). Probe before declaring any wall. Owner-only classes →
+six-field owner-queue item, then CONTINUE. Design uncertainty → SIM-REQUEST via outbox.
+Never idle. One outstanding tick; failsafe verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT — MASS PRODUCTION, BEYOND THE CURRENT TWO: "produce in mass, like
+venture lab … multiple different games … things we can test, try out, maybe even sell. Not
+just GBA/NDS/Pokemon — web browser games, or the foundations/plans for actual mobile games."
+TONIGHT:
+1. Keep the current tracks shipping: Gloamline + Brineward queued slices land as their parked
+   PRs (#68/#69) merge; pokemon private-track slice per its gate.
+2. START THE BREADTH PROGRAM: stand up MULTIPLE new small games tonight — each a playable
+   prototype slice + a one-page concept (genre, loop, platform, sellability guess). Mix
+   platforms deliberately: at least one WEB BROWSER game (deployable via the websites seat /
+   arcade — coordinate via outbox) and at least one MOBILE-GAME foundation (engine/framework
+   choice + build pipeline + a running skeleton, or an evidenced plan if a wall is hit —
+   probe first).
+3. Route sellability candidates to Venture Lab (outbox marker) and feasibility questions to
+   Ideas Lab (SIM-REQUEST). Public/private track isolation stays hard; pokemon assets never
+   leave the private track.
+MORNING DELIVERABLE: N new game starts (each: concept page + running prototype or evidenced
+wall) + the two current tracks' slice tally.
 ```
 
 ### 2.7 Self Improvement (substrate-kit)
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done. Owner-ratify items (#220/#238 class) stay queued —
-queue-and-continue. Never idle. Your daily fresh-session loop survives the chat archiving by
-design, but it is zero-redundancy: arm a second staggered failsafe layer tonight and retire
-the archived-generation failsafe (next-fire 22:03) after.
-TONIGHT (you are the exemplar — make the property portable):
-1. Graduate the AUTONOMY RIDER into the kit templates (superbot
-   docs/owner/fleet-rearm-2026-07-12.md §3, Q-0271 — same path as the Q-0254 graduation) so
-   every adopter INHERITS the anti-stall posture. Highest-leverage kit change on the board.
-2. Adopter-outcome diff: last night two seats went dark and several presence-gated; you did
-   not. Write up WHICH kit mechanisms produced the difference → adopter guidance + the next
-   patch release.
-3. Sweep adopter repos' control/status.md for kit-shaped friction; ship the top fix.
-Quota: the rider template + one patch release by 06:00Z. Generative rung: your weakest
-measured test/telemetry area.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; never hold finished work for review. An open
+PR never stops you (arm auto-merge in the checks-PENDING window; a real classifier denial →
+park READY+green, queue ONE systemic owner item, take the next slice same turn). Probe before
+declaring any wall. Owner-only classes → six-field owner-queue item, then CONTINUE. Never
+idle — your "backlog DRY" note is hereby refilled by this order. One outstanding tick;
+failsafe verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT — THE SELF-INITIATIVE PROGRAM: you are doing well; continue — and
+spend real time tonight on HOW SESSIONS THINK MORE FOR THEMSELVES: "an agent should be eager
+to initiate helpful actions … rationalise whether certain actions should also be executed …
+turn certain lessons or ideas into permanent solutions." Build the kit machinery that makes
+any future session more prepared, without bloating CLAUDE.md: on-demand loadable METHODS
+(skills) instead of ever-growing instructions.
+TONIGHT:
+1. GENERALIZE THE TWO SEED SKILLS superbot shipped tonight (read them at
+   superbot/.claude/skills/chase-references/SKILL.md + prep-owner-steps/SKILL.md, provenance
+   Q-0273): (a) chase-references — resolve every link/name/reference in an ask before acting
+   (founding incident: a hub session ignored a linked brief + named repos and burned 3
+   turns); (b) prep-owner-steps — lead with the deep link + every paste-ready blob as its own
+   block; map the owner's exact steps; batch to one sitting. Turn both into kit templates so
+   EVERY adopter inherits them, and design the skill-pack mechanism itself (how a kit repo
+   carries on-demand methods discoverable at boot).
+2. THE RATIONALIZATION LAYER: design (and prototype where cheap) the mechanism that makes a
+   session ASK ITSELF at natural checkpoints: "does this lesson/idea deserve a permanent home
+   (skill/checker/template) — and can I ship that home NOW?" — the friction→guard reflex
+   generalized from incidents to opportunities. Measure: adopter sessions should initiate
+   durable improvements unprompted.
+3. AUTONOMY RIDER graduation (carry from v1) — fold Q-0271 into the templates.
+4. Adopter-outcome measurement (carry): which kit mechanisms separated the shipping seats
+   from the stalling ones; write it into adopter guidance.
+MORNING DELIVERABLE: the skill-pack design + the two generalized skills in the kit + the
+rationalization-layer note, released.
 ```
 
 ### 2.8 Websites
 
 ```text
-NIGHT ORDER (owner, 2026-07-12) — Q-0271 DELTA, effective now, all night: the owner is AWAY —
-normal state. Silence = consent = done. Merge=deploy on green; open PRs never stop you.
-Surface gaps → SIM-REQUEST via outbox, then next slice. One outstanding tick; ARM YOUR FRESH
-FAILSAFE first thing if the reboot hasn't yet (your only enabled failsafe is the
-archived-generation one, next-fire 22:45 — rebind then retire; the 05:33 review-bake bridge
-stays).
-TONIGHT (storefront + control room):
-1. THE PROMPT LIBRARY (the reboot enabler): per-seat assembled Custom Instructions + startup
-   prompts + shared ender, version-stamped, copy buttons, sourced from the manager's registry
-   (raw reads), plus the deployed-vs-canonical drift row. The website becomes the paste source.
-2. Fleet freshness page: per repo HEAD / last merge / open PRs / last heartbeat, auto-refreshed
-   via the bake pipeline.
-3. Product pages for venture's publish-READY items (inbox notes will arrive tonight).
-4. Land #194 on green; leave draft card #163.
-5. One cold-browser pass over the live review site (EAP window closes Tue 07-14) — fix what
-   you find same session.
-Quota: targets 1–2 live by 06:00Z; chain into 3–5. Generative rung: crawl your own pages for
-dead links/stale data and fix the worst.
+NIGHT ORDER v2 (owner, 2026-07-12 ~23:00Z — supersedes v1) — Q-0271 DELTA in force all night:
+owner absent = normal; silence = consent = done; merge=deploy on green; never hold finished
+work for review. An open PR never stops you (arm auto-merge in the checks-PENDING window; a
+real classifier denial → park READY+green, queue ONE systemic owner item, take the next slice
+same turn). Probe before declaring any wall. Owner-only classes → six-field owner-queue item,
+then CONTINUE. Surface gaps → SIM-REQUEST via outbox. Never idle. One outstanding tick;
+failsafe verified each wake.
+
+OWNER'S GOAL FOR YOUR SEAT — EXECUTE TO DONE, AND WELL MADE: "continue with all they're doing
+… improving the control plane, making sure everything is properly set up, improving the bot
+websites, improving the Anthropic review website … should not stop until it's all done. And
+actually, well made."
+TONIGHT:
+1. THE CLARITY BAR on every page: each page must immediately show WHAT it is, WHAT it does,
+   and its most important features — audit every live page against that bar and fix the
+   misses (title/lede/feature strip). This is the owner's explicit quality definition.
+2. Keep executing the EXISTING PLAN to completion: control plane, bot sites, review site —
+   plus the prompt library + drift row (carry from v1; it is the reboot enabler).
+3. SCAN THE REPOS AND INITIATE: anything in the fleet that could usefully exist as a site or
+   page (you already carry a drawn idea list) — build the next ones without waiting for
+   routing; log each initiation on your run report. Venture will also send WEBSITE-IDEA
+   markers via the manager — treat them as priority intake.
+4. EAP insurance (carry): one cold-browser pass over the review site before Tue 07-14; fix
+   what you find same session.
+MORNING DELIVERABLE: pages shipped/fixed tally against the clarity bar + plan-completion
+state ("done when it's all done" — report honestly what remains).
 ```
 
-## 3. New seat: FUN LAB (the friend-directed studio) — founding package
+## 3 · New seat: FUN LAB — superseded for tonight by the makerbench thread
 
-**Concept (owner's ask, expanded):** a standing seat whose only mission is **fun** — small,
-finished, gift-grade projects for the owner's friend(s): tiny browser games, toys, personalized
-tools. Explicitly **not** a revenue lane (no pricing pressure, no funnels); the deliverable is
-*delight at a shareable link*. It reuses the whole base: substrate-kit from day one, websites
-hosts the playable builds (Fleet Arcade), Ideas Lab supplies the candidate menu (§2.2 target 4
-is already ordered), the plugin contract if anything wants to live in the bot.
+The Ideas Lab's **makerbench blueprint** (Codex-reviewed, dossier-cross-checked) is the
+richer vehicle for the friend-directed project and is **waiting on the owner's tweak reply**
+(knob table delivered in chat: name · visibility · project cut · arm-hardware path ·
+buy-list). The standing Fun Lab founding package from v1 remains in git history of this file
+— boot it only if the owner wants a *continuous* gift studio beyond the one gift.
 
-**Privacy floor (hard rail, non-negotiable):** no personal data about the friend in any repo —
-no names, photos, chat logs, or identifying details (the venture-lab #51 lesson). The friend is
-represented by an **interest-tag profile** (`control/friend-profile.md`, neutral tags like
-"puzzle games, retro aesthetics, cats") that the owner fills or edits; anything more personal
-arrives only via owner paste in-session and stays out of git.
-
-**Owner pre-clicks (one sitting, ~5 min):**
-1. Create repo `menno420/fun-lab` (public is fine under the privacy floor; private also works —
-   the seat then lands PRs via REST merge-on-green).
-2. Create the Project ("Fun Lab"), paste the Custom Instructions below.
-3. Attach the repo to the Project/routine environment (`python-lab` fits; any works).
-4. (Optional) drop 3–8 interest tags for the friend in the first message.
-5. Paste the boot prompt (below) as the first message.
-
-### 3.1 Custom Instructions (paste-ready; prepend UNIVERSAL/permissions block per registry convention)
-
-```text
-v1 · Fun Lab instructions (2026-07-12)
-
-You are an agent of the FUN LAB Project — the fleet's gift studio. Writable repo:
-menno420/fun-lab. Cross-repo reads via raw. One PR = one project slice.
-
-MISSION: turn a friend's interests into small, FINISHED, fun software projects — playable or
-usable at a shareable link within days, polished over feature-rich. Fun is the product;
-delight is the done-when. This is explicitly NOT a revenue lane: no pricing, no funnels, no
-upsells — ever, unless the owner says otherwise.
-
-PRIVACY FLOOR (hard rail): no personal data about any friend in the repo or any published
-surface — no names, photos, handles, logs, or identifying details. The friend exists in-repo
-only as control/friend-profile.md: neutral interest TAGS the owner curates. If the owner
-pastes anything more personal in-session, use it and do NOT commit it. When in doubt, leave
-it out.
-
-PROJECT BAR (every project): scoped to be playable/usable in 1–3 build days · runs at a
-shareable link (websites-hosted static build, GitHub Pages via workflow, or the bot's test
-guild for Discord toys) · has a 30-second "how to play" · gets one polish pass (feel, sound,
-color, one delightful detail) before it counts as FINISHED. One project at a time, finished
-before the next starts. A finished project = a one-line gift note the owner can forward.
-
-WORK SOURCES ladder: control/inbox.md ORDERs → the owner's interest tags + requests →
-the Ideas Lab fun-menu (via manager routing) → GENERATIVE RUNG: propose 3 candidates scored
-on delight:effort against the profile, build the top one (decide-and-flag).
-
-REUSE THE BASE: adopt substrate-kit at founding; host builds via the websites seat (Fleet
-Arcade — route a note via the manager); route feasibility questions to Ideas Lab as
-SIM-REQUEST and keep building; use the superbot-next plugin contract if a toy wants to live
-in Discord.
-
-AUTONOMY (Q-0271): the owner being away is normal. Silence = consent = done. Open PRs never
-stop you (arm auto-merge in the PENDING window; REST merge-on-green if private). Owner-only
-items (repo settings, secrets, external accounts) → the fleet-manager owner-queue, then
-continue. Never idle on a drained queue. One outstanding pacemaker tick; verify your failsafe
-alive each wake; wake hygiene per the fleet standard.
-
-CONTROL BUS: control/inbox.md manager-written — never edit; control/status.md coordinator-only,
-overwritten LAST after an inbox re-read at HEAD; outbox append-only. LANDING / TRUTH /
-SESSION SHAPE / DISCOVERY: per the fleet's shared blocks. Heartbeat every wake.
-```
-
-### 3.2 Boot prompt (paste as first message)
-
-```text
-BOOT — FUN LAB, founding run (2026-07-12). You are the fleet's new gift studio; your
-instructions are pasted. Boot: establish model/venue/abilities (Q-0270 triad) → bootstrap the
-repo (first commit to an empty repo goes via the Contents API, not git push): README (mission +
-privacy floor), control/{inbox,status,friend-profile}.md, docs/projects-log.md → adopt
-substrate-kit per its one-step-adopt → arm your wake layer (failsafe cron at a free */2 offset
-+ one pacemaker tick; verify via list_triggers) → stamp your first heartbeat.
-Then: if the owner dropped interest tags, seed control/friend-profile.md with them; else write
-the profile scaffold with placeholder tags flagged ⚑ owner-fill. Pull the Ideas Lab fun-menu
-from the manager if routed; otherwise propose your own 3 candidates (delight:effort scored
-against the profile), pick #1 (decide-and-flag), and BUILD — first playable slice tonight,
-finished per the PROJECT BAR within days. Post your morning line to the manager outbox by
-06:00Z: BOOTED + candidate chosen + first-slice state.
-```
-
-## 4. New seat #2: the Ideas-Lab candidate (the 07-13 brief's path)
-
-Per [`next-session-brief-2026-07-13.md`](next-session-brief-2026-07-13.md) §2, the second new
-Project is founded from the idea the Ideas Lab has been gathering material on — **the owner
-names it** (that is the one genuinely-owner input), then the manager drafts its founding
-package from the [next-round founding-prompt kit](next-round-founding-prompts-2026-07-11.md).
-One paste after you name it:
+## 4 · New seat #2: the Ideas-Lab candidate (unchanged)
 
 ```text
 ORDER NIGHT-02 (owner, 2026-07-12): found the new Project for the idea "<OWNER: name it>".
 Draft its 3-file founding package (instructions / coordinator-prompt / failsafe-prompt) from
-the next-round founding-prompt kit + UNIVERSAL, with a MISSION + done-when; include the Q-0271
-autonomy delta. Post the package + the owner pre-click list (repo create · Project create ·
-paste · attach) to the owner queue as one item. Done-when: package ready-to-paste tonight.
+the next-round founding-prompt kit + UNIVERSAL, with a MISSION + done-when; include the
+Q-0271 autonomy delta. Post the package + the owner pre-click list to the owner queue as one
+item. Done-when: package ready-to-paste tonight.
 ```
 
-If you'd rather not name one tonight, the manager routes the Ideas Lab's **top finalized
-verdict** from §2.2's quota into this order tomorrow — no seat is founded on an unverified idea.
+## 5 · Dispatch checklist tonight (revised)
 
-## 5. Your checklist tonight (~6 minutes)
+1. **Boot the Project Manager first** — its successor never woke (§1): open the Project
+   Manager chat, paste its coordinator boot (`projects/fleet-manager/coordinator-prompt.md`
+   at HEAD), then paste §2.1.
+2. **Paste §2.2–§2.8 per seat** (or hand the manager ORDER NIGHT-01R once it's live and let
+   it relay).
+3. Carry-over clicks (unchanged, all one-click): superbot-next ruleset/merge-queue · gba
+   #68/#69 · idle #75 · games #65/#66 · fm #140 · kit P10 check-swap.
+4. When ready: the makerbench tweak reply (§3) and, optionally, ORDER NIGHT-02 (§4).
 
-1. **Night orders:** paste §2.0 to the Project Manager (1 paste — it relays §2.1–§2.8), or
-   paste the 8 blocks yourself if the manager hasn't booted yet.
-2. **Fun Lab:** create `fun-lab` repo + Project → paste §3.1 instructions → attach repo →
-   (optionally) drop the friend's interest tags → paste §3.2 boot prompt.
-3. **Seat #2:** name the Ideas-Lab candidate and paste §4's ORDER NIGHT-02 to the manager —
-   or skip; the verdict-routed path covers it tomorrow.
-4. Done. The boot-watch (manager sweep + this hub session's ~21:25Z re-check) and the morning
-   roster do the rest; the 3 systemic clicks from the re-arm pack §5 remain open if you have
-   two more minutes (superbot-next merge queue · fm #121/#122 · kit #220/#238).
+## 6 · Tomorrow morning — how to read the run
+
+The manager's roster plus each seat's MORNING DELIVERABLE named in its block: 2.0's
+completeness table + curation report · World's per-game state table + minigame spec ·
+venture's products/books/backtests tally · Game Lab's new-game starts · websites' clarity-bar
+tally · kit's skill-pack release · Ideas Lab's verdict stream. Headlines stay: the first
+hands-free ROUND-TRIP and the dropped-tick report. Everything the run teaches feeds the v3.4+
+registry restamp before the next full re-paste.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -9845,3 +9845,46 @@ heartbeat sweep), pointed from `.claude/CLAUDE.md` § Read first, `docs/AGENT_OR
 (new cross-repo read-only route), and the journal Quick reference. (3) **Kit-graduation
 candidate:** the per-repo reading-path pattern should travel via substrate-kit templates so
 every repo names its own siblings — routed to the Self Improvement lane.
+
+### Q-0273 — DIRECTED: the hub-venue model, the v2 night goals, and the self-initiative/skills program (2026-07-12, ~23:00Z)
+
+> **Context.** Owner, live in the hub session (same conversation as Q-0271/Q-0272), three
+> connected directives. **(1) Venue correction**, verbatim: *"I did not paste it's final
+> message here, that was a seperate chat outside the projects like you, and that's currently
+> necessary because the projects don't always have the right permissions, or think they don't
+> have it, because of mis interpreted harness prompts or too strict harness prompts etc,
+> that's why this seperate chat must always exist, to merge or close the stray PRs, execute
+> sensetive or destructive actions, sometimes it works from the projects but sometimes it
+> does't, and in here it always works, just sometimes prompts me."* The Project Manager's
+> mission: *"keep track of everything the fleet does and continue to dispatch orders in their
+> repos while I'm away, it also helps me with general project related things or ideas I might
+> have."* **(2) Revised night goals per seat** (2.0 max-finalization incl. core/admin/setup
+> production-ready + command/button curation; World finalize mining/fishing/idle as games +
+> the one minigame/casino section spec; Ideas Lab endless any-domain cycle; Venture both
+> lanes — many books incl. multiple versions each, more strategies/stocks/indicators,
+> WEBSITE-IDEA markers; websites clarity bar "every page shows immediately what it is, what
+> it does, the most important features" + "should not stop until it's all done. And actually,
+> well made"; Game Lab mass production beyond GBA/NDS — browser + mobile foundations).
+> **(3) The self-initiative program** for substrate-kit, verbatim core: *"an agent should be
+> eager to initiate helpfull actions … they could easily lead with the link and the
+> copy/paste ready file in chat as a seperate block … should be baked into a method, like a
+> skill, that prevents it from taking up too much storage in the claude.md itself, but is
+> still always loadable on demand … 'how do I instruct the owner on it's task and prepare
+> things for him along the way' … 'I got a reference that haven't found yet, I should find
+> out the most logical place where it might be and start looking'. so every agent actually
+> self improves in the usefull ways."* Founding incident he cites: this session's own
+> opening-message reference miss (the linked brief + named repos not read → the ~3-turn
+> Q-0272 discovery).
+
+**Decision (owner-directed in-session).** (1) The **hub venue** (owner-live chat outside the
+Projects) is a standing, permanent part of the fleet model — not a seat: it merges/closes
+stray PRs and executes sensitive/destructive actions that seat venues can't (or believe they
+can't); owner-queue items that are merge/destructive-shaped carry a **`VENUE:hub`** tag.
+(2) The revised goals shipped as **NIGHT ORDERS v2**
+([`fleet-night-orders-2026-07-12.md`](./fleet-night-orders-2026-07-12.md) §2, superseding v1
+in place; v1 in git history). (3) Two **seed skills** shipped in superbot as reference
+implementations for the kit to generalize — `.claude/skills/chase-references/` (resolve every
+reference in an ask before acting) + `.claude/skills/prep-owner-steps/` (lead with the deep
+link + paste-ready blobs; map the owner's steps; batch to one sitting) — and the kit's v2
+order carries the full self-initiative program (skill-pack mechanism + the rationalization
+layer: sessions ask themselves "does this lesson deserve a permanent home I can ship now?").


### PR DESCRIPTION
Owner-directed (same hub session as #2048/#2049/#2051). Three connected directives, all recorded verbatim in router **Q-0273**:

- **`docs/owner/fleet-night-orders-2026-07-12.md` → v2** (blocks superseded in place, v1 in git history): the owner's revised night goals per seat — SuperBot 2.0 **max-finalization** (core/admin/setup production-ready + a command/button KEEP/REWORK/DROP curation pass), SuperBot World **game finalization** (mining standalone + hub-integrated, fishing/idle same, the one minigame/casino section spec), Ideas Lab **endless any-domain cycle**, Venture **both lanes** (many books incl. multiple versions each, wider backtest surface, WEBSITE-IDEA outbox markers), Websites **clarity bar + execute-to-done**, Game Lab **mass production** (browser + mobile-game foundations beyond GBA/NDS). Plus the **venue correction** (§0b): the standing hub chat outside the Projects is permanent fleet structure — merges/closes stray PRs, executes sensitive/destructive actions; merge/destructive owner-queue items now carry `VENUE:hub`. Manager-boot-first dispatch checklist (its successor never woke off the 22:31Z bridge).
- **Two seed skills** as reference implementations for substrate-kit to generalize (the self-initiative program): `.claude/skills/chase-references/` (resolve every reference in an ask before acting — founding incident: this session's own opening-message miss) and `.claude/skills/prep-owner-steps/` (lead with the deep link + paste-ready blobs; map the owner's steps; batch to one sitting).
- Session card part 4.

Docs + two skill files; no `disbot/` runtime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5PjZR5EDJL75BeELkUfr)_