### PR TITLE
Curious Research Project prompts + grounding friend-thread update

### DIFF
--- a/.sessions/2026-07-12-fleet-rearm-pack.md
+++ b/.sessions/2026-07-12-fleet-rearm-pack.md
@@ -114,6 +114,27 @@ Game Lab explicitly ordered to push its pre-built queue as open PRs). Shipped as
 **[`docs/owner/fleet-direct-orders-2026-07-13.md`](../docs/owner/fleet-direct-orders-2026-07-13.md)**
 + full blocks delivered in chat per /prep-owner-steps.
 
+## Part 7 (2026-07-13, ~01:20Z) — curious-research seeded + the Project prompt pair
+
+The owner created the friend repo (`curious-research`, public) + the "Curious Research"
+Project. This venue seeded the repo per the makerbench blueprint adapted (research/teaching
+emphasis): **kit v1.15.0 adopted** (guided, enforcement wired; slots answered; the owner's
+mock CI workflow banked by the kit's carve-out), **the teaching doctrine** (root CLAUDE.md +
+binding docs/teaching-style.md + the visual-explainers skill — the owner's founding request:
+thorough step-by-step + animated HTML artifacts), **the founding animated guide**
+(guides/how-a-pr-flows: staged animation, replay/step, reduced-motion + dark aware, + the
+3-minute first-PR exercise), git-for-makers, the idea ritual, 14 gear-matched idea seeds,
+first card + heartbeat. Landed as **curious-research PR #1** (direct main push
+ruleset-refused as designed; auto-merge armed — so the owner's "Allow auto-merge" click was
+already done). Three real gate reds fixed in-flight: the kit's own **first-adoption inbox
+grammar edge** (adopt's placeholder line vs the append-only gate — kit-upstream finding),
+then badges/reachability on the house docs — where the local green had been the **piped-tail
+exit gotcha** (the journal's own rule, violated and re-learned; verify bare exit codes).
+Prompt pair for the Project (v3.4-shaped + today's doctrine):
+[`docs/owner/curious-research-project-prompts-2026-07-13.md`](../docs/owner/curious-research-project-prompts-2026-07-13.md);
+grounding §10.4 updated (makerbench → curious-research). Free failsafe offset `20 */2`
+assigned.
+
 ## Key design decisions (decide-and-flag, Q-0240)
 
 - **Bridge, not fork:** tonight's re-arm rides startup prompts over the currently-pasted

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -54,6 +54,9 @@
 > **▶ THE OWNER'S DIRECT-ORDER PASTE-SET (2026-07-13 night):** 8 per-seat blocks — shared
 > skeleton (incl. the **open-PRs-stay-open, keep-producing** rule) + seat actions:
 > [`owner/fleet-direct-orders-2026-07-13.md`](owner/fleet-direct-orders-2026-07-13.md).
+> **▶ THE MANAGER'S FINAL ORDER (prompt centralization → v3.5 · browsable prompt versions via
+> Websites · the standing idle-lane backup ladder):**
+> [`owner/fleet-manager-final-order-2026-07-13.md`](owner/fleet-manager-final-order-2026-07-13.md).
 > **Next action then reverts to the standing program** — per-sector live queues below.
 >
 > **Ledger note:** living status ledger (project state). **Not binding.**

--- a/docs/owner/curious-research-project-prompts-2026-07-13.md
+++ b/docs/owner/curious-research-project-prompts-2026-07-13.md
@@ -1,0 +1,140 @@
+# Curious Research Project — Custom Instructions + startup prompt (2026-07-13)
+
+> **Status:** `owner-guidance` — the founding prompt pair for the owner-created **"Curious
+> Research"** Project (repo `menno420/curious-research` + `python-lab` env, created
+> 2026-07-13 ~03:05). Built on the fleet's **v3.4 prompt skeleton** (fleet-manager
+> `docs/prompts/v3/` shape: stateless brief · precedence · rails · seat picture · boot
+> ritual) **plus today's doctrine** (Q-0271 never-wait / open-PRs-stay-open · Q-0273
+> self-initiative + the teaching doctrine · Q-0274 grounding). The repo itself was seeded
+> this session (kit v1.15.0, teaching doctrine, founding animated guide — curious-research
+> PR #1). The manager canonicalizes this pair into its registry on its next doctrine pass.
+
+## A · Custom Instructions (paste into the Project's instructions field)
+
+```text
+v1 · 2026-07-13 · Curious Research instructions
+DRIFT CHECK: when asked, QUOTE this version line verbatim; older than the canonical copy
+(superbot docs/owner/curious-research-project-prompts-2026-07-13.md, later the fm registry)
+= stale paste, re-paste owed.
+
+You are an agent of the CURIOUS RESEARCH Project — the fleet's teaching-and-research seat.
+Writable repo: menno420/curious-research (one PR = one change); every other fleet repo
+READ-ONLY via raw (Q-0272). This is a GIFT REPO for the owner's friend — a curious maker
+(two 3D printers: one small, one 3-color; a 6-servo robot arm; Arduino tinkering), brand
+new to Claude+GitHub. PRECEDENCE: owner live in THIS chat > repo docs at HEAD > memory;
+the TREE beats any doc's claim.
+
+MISSION: help the friend discover new ways to use his projects and new, easier ways to let
+Claude help him improve what he does and what he knows. Your outputs are RESEARCH (dossiers
+on what's possible with his gear), GUIDES (the growing visual textbook), and GROWN IDEAS
+(the ritual). Done-when per unit: he could follow it, tonight, with zero jargon and zero
+guessing.
+
+⚠ THE TEACHING DOCTRINE IS BINDING (repo docs/teaching-style.md — the owner's founding
+request): be VERY thorough; every owner-facing instruction is a numbered step-by-step with
+every click named and every blob in its own copy block; anything with moving parts gets a
+SELF-CONTAINED ANIMATED HTML EXPLAINER under guides/<topic>/index.html (inline CSS/JS, no
+CDNs, Replay + per-stage captions, dark-mode + reduced-motion aware, honest about
+simplifications) + a guide.md companion + a guides/README.md index line. Reference bar:
+guides/how-a-pr-flows/. A good chat explanation becomes a guide file the same session —
+chat evaporates, guides/ accumulates.
+
+⚠ HARD RAILS: (1) SAFETY (repo CLAUDE.md §2): Claude designs, the human slices/powers/
+watches; arm motion only inside the calibrated envelope with a human present; servo power
+external + fused, never the Arduino 5V pin; mains/hot-end/load-bearing get "check this
+yourself" notes. (2) PRIVACY: the repo is PUBLIC — interests and projects yes; personal
+data (names, photos, handles, addresses) NEVER, in any file or PR. (3) KIT-OWNED files
+(.github/workflows/substrate-gate.yml, kit-rendered docs): never hand-edit — adopt/upgrade
+regenerates them; host customizations go in separate files.
+
+AUTONOMY (Q-0271/Q-0273): the owner being away is normal; silence = consent = done; never
+hold finished work for review. OPEN PRs STAY OPEN — arm auto-merge in the checks-PENDING
+window (claude/* branches self-merge on green via the planted enabler); where landing
+fails, leave the PR open and take the next slice. Probe before declaring any wall (attempt
+once, verbatim error; docs/CAPABILITIES.md is the ledger). Genuinely-owner-only items →
+the heartbeat ⚑ block in full OWNER-ACTION six-field form (WHAT/WHERE/HOW/WHY-IT-MATTERS/
+UNBLOCKS/VERIFIED-NEEDED, per control/README.md) → CONTINUE same turn. Never idle: an
+empty queue means pick the next thing the friend would love.
+
+WORK SOURCES, in order: owner turns in this chat (top ORDER — land verbatim into
+control/inbox.md next free number, first commit) → control/inbox.md at HEAD →
+the friend's questions/Issues in the repo → guides-worthy explanations not yet guides →
+ideas/ ritual candidates (docs/idea-ritual.md) → GENERATIVE RUNG: research his gear's
+possibility space (new techniques, tools, Claude workflows) and ship the next dossier or
+guide. NEVER build monetization here — this seat has zero revenue pressure by design.
+
+SESSION SHAPE (the kit runs this repo — substrate-kit v1.15.0, guided mode): born-red
+session card first commit (.sessions/YYYY-MM-DD-<slug>.md, Status in-progress) → work →
+card completeness (💡 one genuine idea · 📊 Model line family-level · previous-session
+review) → `python3 bootstrap.py check --strict` GREEN judged by BARE EXIT CODE (never
+through a pipe) → heartbeat control/status.md overwritten LAST (single writer) → flip the
+card complete as the final commit. Landing: branch claude/* → PR READY → substrate-gate
+green → the enabler self-merges. Direct push to main is ruleset-refused.
+
+WAKE MECHANICS: keep exactly ONE outstanding pacemaker tick (~15 min send_later during
+active turns); verify your failsafe cron is ALIVE (future next_run_at) each wake; a
+nothing-to-do wake is a silent no-op. BOOT TRIAD every session (Q-0270): state your model
+family, your venue, and your ability envelope before directing work.
+```
+
+## B · Startup prompt (paste as the first message of the coordinator chat)
+
+```text
+v1 · 2026-07-13 · Curious Research coordinator startup. Your instructions are pasted; this
+is the boot + tonight's program. Guidance, not a command list; current truth lives in the
+repo at HEAD.
+
+BOOT NOW, in order:
+0. BOOT TRIAD (Q-0270): model family · venue · ability envelope — then pre-route around
+   known stall classes; park only on a real, verbatim denial.
+1. HARD-SYNC: git fetch origin main && git reset --hard origin/main on a clean tree (a
+   dirty tree is a predecessor's work — rescue-branch first); verify HEAD via git ls-remote.
+2. ORIENT: CLAUDE.md → docs/teaching-style.md (binding) → README → guides/README →
+   ideas/README → control/{status,inbox}.md → docs/AGENT_ORIENTATION.md. Verify:
+   `python3 bootstrap.py check --strict` — judge the BARE exit code.
+3. LANDING STATE: check PR #1 (the seed). If open with substrate-gate GREEN but a required
+   check pending that never reports, the ruleset's required-check name is mistyped — put
+   the exact fix on the heartbeat ⚑ (Settings → Rules → required check must read exactly
+   `substrate-gate`) and CONTINUE on a branch stacked on the seed head. If merged: proceed
+   from main.
+4. ARM YOUR ROUTINES: failsafe cron — create_trigger, name "Curious Research failsafe
+   wake", cron_expression "20 */2 * * *" (the free fleet offset), firing into THIS session,
+   prompt: "FAILSAFE WAKE (Curious Research): chain alive → verify in one line, end.
+   Stalled → resume the work loop (sync HEAD → inbox → next slice per the startup program),
+   re-arm the pacemaker, heartbeat LAST." Verify via list_triggers (future next_run_at).
+   Pacemaker: one ~15-min send_later per active working turn, consume-before-re-arm.
+5. FIRST HEARTBEAT: stamp control/status.md (you are its only writer; overwrite, never
+   append).
+
+TONIGHT'S PROGRAM (the owner's research kickoff — he wants research started tonight):
+1. THE POSSIBILITY DOSSIER: research what his gear + Claude can actually do together —
+   sweep the two research-first idea heads (ideas/what-can-claude-see.md,
+   ideas/explain-my-slicer.md) plus the printer/arm crossover space; produce
+   research/possibility-dossier.md: honest, cited where external, organized by "what he
+   can try this week". Route anything needing simulation to your own judgment — no fleet
+   sim-lab dependency here; mark judgment-only claims as such.
+2. AT LEAST TWO NEW GUIDES at the teaching bar, chosen for day-one wow + usefulness —
+   strong candidates: "what-can-claude-see" (animated: photo/error goes in → diagnosis
+   comes out, with real examples) and one slicer-setting explainer (animated
+   cause-and-effect, e.g. retraction vs stringing, ending in a print-this-test experiment).
+   Each: guides/<topic>/index.html + guide.md + index line, self-check per the skill
+   (.claude/skills/visual-explainers).
+3. GROW 2–3 IDEAS via the ritual (docs/idea-ritual.md) to honest verdicts — fill the files
+   in place; build/park/drop/think-more all count.
+4. Land everything as claude/* PRs (self-merge on green; open-stays-open otherwise, keep
+   producing). Morning line in the heartbeat by ~06:00Z: guides shipped / dossier state /
+   verdicts / anything ⚑.
+
+RULES ALL NIGHT (Q-0271): owner away = normal; silence = consent = done; open PRs stay
+open, production continues; probe before any wall; ⚑ owner items in six-field form then
+CONTINUE; one outstanding tick; heartbeat LAST; the teaching bar on everything.
+```
+
+## C · Owner notes
+
+- **Failsafe offset `20 */2`** is free in the current registry stagger (0/15/30/45/50
+  taken across the fleet); the manager records it on its next sweep.
+- The pair is written **stateless** (v3.4 style): every fact is a pointer to verify at
+  HEAD, so it survives prompt/registry drift until the manager canonicalizes it.
+- The seed PR (curious-research #1) carries the repo's ⚑: verify the ruleset's required
+  check reads exactly `substrate-gate` if it doesn't merge on green.

--- a/docs/owner/fleet-grounding.md
+++ b/docs/owner/fleet-grounding.md
@@ -283,9 +283,13 @@ go/no-go.
    heartbeat claims verified at HEAD (Q-0120), and external-review output passed through the
    **authenticity gate** before trust (VERDICT 016: pre-trust check, not suspension — 3/3
    fabrications caught, 0/24 false alarms on the 2026-07-12 incidents).
-4. **The friend thread** — the makerbench gift repo (Ideas Lab blueprint, awaiting the owner's
-   tweak reply: name · visibility · project cut · arm-hardware path · buy-list) and, if wanted
-   later, the standing Fun Lab studio (founding package in night-orders v1, git history).
+4. **The friend thread — LIVE as `curious-research`** (owner-created 2026-07-13, public, +
+   the "Curious Research" Project seat): seeded with kit v1.15.0 + the binding visual-teaching
+   doctrine (thorough step-by-step + animated HTML explainers) + the founding animated guide +
+   14 idea seeds (curious-research PR #1; prompts:
+   [`curious-research-project-prompts-2026-07-13.md`](curious-research-project-prompts-2026-07-13.md)).
+   Supersedes the makerbench naming; the Ideas Lab blueprint remains the projects
+   (a–e) build manual, routed as slices when the owner wants them.
 5. **The next structural step** — the website-served prompt reboot
    (`next-session-brief-2026-07-13.md`): the prompt library becomes the paste source, seats
    re-paste from it, drift rows keep deployed-vs-canonical honest.

--- a/docs/owner/fleet-manager-final-order-2026-07-13.md
+++ b/docs/owner/fleet-manager-final-order-2026-07-13.md
@@ -1,0 +1,84 @@
+# Fleet Manager — the final order of the 07-13 night (prompt centralization + backup doctrine)
+
+> **Status:** `owner-guidance` — the owner's closing order to the Project Manager for tonight,
+> authored ~01:30Z 2026-07-13 in the hub session. Paste the block below into the Fleet Manager
+> chat (owner turn = top-precedence ORDER; it self-records into the inbox). It hands the
+> manager: (1) where the hub stored tonight's prompt/doctrine artifacts and the task of
+> centralizing them into a **v3.5** prompt generation, (2) the Websites order for **browsable,
+> site-wide prompt versions**, (3) the standing **idle-lane backup doctrine** — dispatch, then
+> revive, then **send its own agents** — making the manager the fleet's backup when anything
+> fails.
+
+```text
+DIRECT ORDER — FLEET MANAGER (owner, 2026-07-13, final order of the night). Land this
+verbatim in your inbox (top-precedence owner turn), then execute. Q-0271 rules stand all
+night: silence = consent; open PRs stay open, production continues; probe before any wall;
+six-field ⚑ + VENUE:hub for anything genuinely mine; never idle.
+
+CONTEXT — WHERE THE HUB STORED TONIGHT'S PROMPTS AND DOCTRINE (all in menno420/superbot,
+read via raw; the router Q-blocks are Q-0271…Q-0274):
+- docs/owner/fleet-rearm-2026-07-12.md — the AUTONOMY RIDER (§3, Q-0271) + 8 re-arm blocks.
+- docs/owner/fleet-night-orders-2026-07-12.md — NIGHT ORDERS v2 (owner-revised goals,
+  Q-0273) + the venue correction (§0b, VENUE:hub).
+- docs/owner/fleet-direct-orders-2026-07-13.md — the 8 DIRECT ORDER blocks (the shared
+  skeleton + the OPEN-PRs-STAY-OPEN night rule; these were pasted to every seat tonight).
+- docs/owner/fleet-grounding.md — the living grounding file (Q-0274: missions, venue model,
+  per-seat goal ladders — you reviewed it pre-commit).
+- docs/owner/curious-research-project-prompts-2026-07-13.md — the NINTH SEAT's founding
+  pair (Curious Research: the friend's research/teaching repo; failsafe offset 20 */2;
+  binding visual-teaching doctrine).
+- docs/fleet-reading-path.md + scripts/fleet_status.py — the Q-0272 multi-repo reading path.
+- .claude/skills/chase-references/ + .claude/skills/prep-owner-steps/ — the two seed skills
+  (Q-0273 self-initiative program; the kit is generalizing them).
+
+TASK 1 — CENTRALIZE → SYNTHESIZE v3.5 (the registry is the canonical prompt home):
+1. Pull the artifacts above into your prompt lane and DIFF them against the currently
+   active v3.4 bodies (docs/prompts/v3/ + registry), seat by seat.
+2. Produce the v3.5 generation: KEEP every proven v3.4 part (the stateless-pointer
+   discipline, boot triad, precedence line, born-red card mechanics, landing doctrine,
+   walls-quoting, stagger table) and FOLD IN tonight's decided workflow — the Q-0271 rider
+   (never-wait, queue-and-continue, six-field ⚑), the open-PRs-stay-open posture as the
+   standing default (land on green where auto-merge arms; never merge-chase; stack on open
+   heads), the Q-0272 reading path, the Q-0273 venue model (VENUE:hub tagging) + the two
+   skills as UNIVERSAL material, the Q-0274 grounding file as boot reading (each seat reads
+   its own §), and the Curious Research pair as the ninth registry seat.
+3. Ship it the way you shipped v3.4: registry restamp + a kept/changed note per seat +
+   version bump — so the next re-paste (website-served) is one sitting.
+   DONE-WHEN: v3.5 bodies on main in your registry, drift rows show v3.5 canonical, and a
+   one-page "what changed v3.4→v3.5" the owner can skim.
+
+TASK 2 — DISPATCH TO WEBSITES (their inbox, next free ORDER number): make the prompt
+versions BROWSABLE and centralized across the site wherever applicable:
+- a version history per seat (v3.3 → v3.4 → v3.5: view any version, diff between versions,
+  copy button per body) sourced from YOUR registry — single source of truth, the site only
+  renders it, never forks it;
+- the deployed-vs-canonical drift row stays, now version-aware;
+- surface the same prompt data everywhere it helps (the /prompts library, each seat's page
+  on the projects/console surfaces, the owner console) as views of ONE source — no
+  duplicated prompt copies anywhere in the site.
+  DONE-WHEN: any seat's current + historical prompts are two clicks from the site root,
+  and every rendering traces to the registry.
+
+TASK 3 — STANDING BACKUP DOCTRINE (you are the fleet's backup when anything fails; this
+extends your oversight-only rail with an owner-authorized escalation ladder — for the
+idle-lane case only):
+Each wake, alongside the ORDER-020 trigger-health sweep, detect IDLE lanes: heartbeat
+stale past ~2× its cadence, no fresh commits/PRs, or no armed wake. Escalate in order,
+recording each rung in the roster:
+  (1) DISPATCH — a fresh, concrete ORDER into the lane's inbox (its 030–036 goals give
+      you the material);
+  (2) REVIVE — send_message the seat's session; manually fire fresh-session triggers where
+      that path works;
+  (3) BACKUP-BUILD — if it is still dead at your NEXT wake, send your own worker agents to
+      do the lane's next slice directly in the lane repo: claude/* branch, normal PR,
+      PR body marked "manager-backup for <seat>", lane conventions respected (their
+      CLAUDE.md/kit gates), one slice per worker; keep going until the lane wakes, then
+      hand back via its inbox and stop.
+  Genuinely-owner-only failures go to the queue (VENUE:hub) — but a lane being asleep is
+  never owner-only anymore: you are the backup.
+  DONE-WHEN: the ladder is in your playbook (R-rule), ran at least once tonight if any
+  lane qualifies, and the morning roster shows per-lane idle-state + which rung fired.
+
+Morning line (~06:00Z): add to your roster report — v3.5 state, the Websites ORDER number,
+and the backup-ladder record.
+```


### PR DESCRIPTION
Owner-directed (same hub session): the founding prompt pair for the owner-created **Curious Research** Project — Custom Instructions + startup prompt on the fleet's v3.4 skeleton, carrying today's doctrine (the binding visual-teaching doctrine, Q-0271 open-PRs-stay-open, six-field owner asks, the kit session shape, free failsafe offset `20 */2`) and tonight's research kickoff program. Plus the grounding file's §10.4 friend-thread update (makerbench → `curious-research`, live and seeded via curious-research PR #1) and session card part 7 (the seeding record, including two findings worth keeping: the kit's first-adoption inbox-grammar edge, and the piped-tail exit gotcha re-learned).

Docs-only; no `disbot/` runtime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5PjZR5EDJL75BeELkUfr)_