### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-13T00:45:52Z",
+    "generated_at": "2026-07-13T03:54:30Z",
     "build": {
-      "commit": "da848308",
-      "subject": "Merge pull request #2051 from menno420/claude/project-autonomy-workflow-bo1cjn",
-      "committed_at": "2026-07-13T00:45:52Z"
+      "commit": "45225229",
+      "subject": "Merge pull request #2060 from menno420/claude/project-autonomy-workflow-bo1cjn",
+      "committed_at": "2026-07-13T03:54:30Z"
     },
     "schema_version": 1,
     "counts": {
@@ -3381,6 +3381,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-13-hub-upkeep-codex-p2.md",
+      "date": "2026-07-13",
+      "title": "2026-07-13 — Hub upkeep follow-up: Codex P2 fixes from #2054",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-12-reconcile-band2040.md",
       "date": "2026-07-12",
       "title": "Session — forty-fifth Q-0107 docs reconciliation pass (band-#2040)",
@@ -3408,6 +3416,14 @@
       "file": "2026-07-12-owner-live-part2-mineverse-signin.md",
       "date": "2026-07-12",
       "title": "Session — 2026-07-12 (part 2) — sign-in live, toggles verified, court-spam incident, fleet sweep",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-12-hub-upkeep.md",
+      "date": "2026-07-12",
+      "title": "2026-07-12 — Hub upkeep: stale rebuild pointers in current-state docs",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -3842,22 +3858,6 @@
       "title": "2026-07-10 — EAP docs: two verified factual corrections (from fleet-manager ultracode verification)",
       "status": "complete",
       "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-10-eap-journal-routine-observability.md",
-      "date": "2026-07-10",
-      "title": "2026-07-10 — EAP journal: routine-observability bug entry (round-3 brief §1(d))",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-10-coordinator-close-out.md",
-      "date": "2026-07-10",
-      "title": "2026-07-10 — Gen-1 games-lane coordinator close-out (grand-review prompt + Part 1 questions)",
-      "status": "complete",
-      "run_type": "",
       "self_initiated": false
     }
   ],
@@ -4893,6 +4893,34 @@
     {
       "session": "2026-07-12-fleet-rearm-pack",
       "date": "2026-07-12",
+      "model": "fable-5",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-12-hub-upkeep",
+      "date": "2026-07-12",
+      "model": "fable-5",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-13-hub-upkeep-codex-p2",
+      "date": "2026-07-13",
       "model": "fable-5",
       "effort": "high",
       "task_class": "docs-only",


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.