### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-14T01:45:40Z",
+    "generated_at": "2026-07-14T04:18:04Z",
     "build": {
-      "commit": "34775943",
-      "subject": "build(deps): bump the python-minor-patch group with 3 updates (#2083)",
-      "committed_at": "2026-07-14T01:45:40Z"
+      "commit": "50481b71",
+      "subject": "Fleet-manager relay: supersession-pointer ORDER (dispatch 2026-07-14) (#2094)",
+      "committed_at": "2026-07-14T04:18:04Z"
     },
     "schema_version": 1,
     "counts": {
@@ -3389,6 +3389,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-14-fm-dispatch-relay.md",
+      "date": "2026-07-14",
+      "title": "2026-07-14 — Fleet-manager relay: supersession-pointer ORDER (dispatch)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-13-websites-data-plane-design.md",
       "date": "2026-07-13",
       "title": "2026-07-13 — Websites fleet-data-plane design (owner ask)",
@@ -3856,14 +3864,6 @@
       "file": "2026-07-10-round3-dispatch-4d-prompt-registry.md",
       "date": "2026-07-10",
       "title": "Session — round-3 dispatch, part 4d: games relay pasted + manager prompt registry",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-10-round3-dispatch-4c-selfawareness.md",
-      "date": "2026-07-10",
-      "title": "Session — round-3 dispatch, part 4c: capability self-awareness + boot verifications",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -5100,6 +5100,20 @@
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "runtime bugfix",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": null,
+        "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-14-fm-dispatch-relay",
+      "date": "2026-07-14",
+      "model": "fable-5",
+      "effort": "high",
+      "task_class": "docs-only",
       "tokens_out": null,
       "outcome": {
         "ci_green_first_push": null,


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.