### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-15T14:54:46Z",
+    "generated_at": "2026-07-15T16:14:32Z",
     "build": {
-      "commit": "3fb5dd06",
-      "subject": "Merge pull request #2111 from menno420/claude/remove-owner-only-labels-oo82ob",
-      "committed_at": "2026-07-15T14:54:46Z"
+      "commit": "8e60e763",
+      "subject": "Merge pull request #2112 from menno420/bot/dashboard-refresh",
+      "committed_at": "2026-07-15T16:14:32Z"
     },
     "schema_version": 1,
     "counts": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.