### PR TITLE
docs(eap): consolidate auto-mode permission-classifier findings (2026-07-16)

### DIFF
--- a/docs/eap/README.md
+++ b/docs/eap/README.md
@@ -5,6 +5,17 @@
 > [`docs/planning/`](../planning/projects-eap-evaluation-log.md) (files prefixed
 > `projects-eap-*`). Newest first within each group.
 
+## Permission classifier — consolidated (2026-07-16)
+
+- [`permission-classifier-findings-consolidated-2026-07-16.md`](permission-classifier-findings-consolidated-2026-07-16.md)
+  — **one durable home for the whole permission-problem picture**: the stable 2026-07-08 boundary,
+  the 2026-07-15→16 regression (~30 denials · 8 projects · 36h · 10 classes), the *session-not-action*
+  mechanism and its four consequences (candor hardens enforcement; the self-documentation recursion;
+  the collateral cascade), the two compounding factors, the two-layer prompt finding, the scoped-grant
+  proposal, and the state of the Anthropic correspondence. Consolidates (does not replace) the probe
+  report, the evaluation journal, the sent emails, the `CAPABILITIES` ledgers, and the 2026-07-16
+  classifier-regression evidence pack; each claim is source-mapped in §9.
+
 ## Closeout (2026-07-14 — EAP final day)
 
 - [`../eap-closeout-walkthrough-2026-07-14.md`](../eap-closeout-walkthrough-2026-07-14.md) —

--- a/docs/eap/permission-classifier-findings-consolidated-2026-07-16.md
+++ b/docs/eap/permission-classifier-findings-consolidated-2026-07-16.md
@@ -1,0 +1,289 @@
+# Auto-mode permission classifier — consolidated findings (2026-07-16)
+
+> **Status:** `reference` — one durable home for the whole permission-problem picture, drawn
+> together from every source we have as of 2026-07-16. It consolidates (does not replace) the
+> primary records it cites: the 11-action probe report, the EAP evaluation journal, the sent
+> Anthropic emails, the fleet-wide `CAPABILITIES` ledgers, and the 2026-07-16 classifier-
+> regression evidence pack. Where this doc and a primary record disagree, the primary record
+> wins — every claim below is traceable to one.
+>
+> **Provenance:** owner-directed consolidation (branch
+> `claude/fleet-manager-permission-denials-36vdny`), owner-live session. Docs-only. No outbound
+> comms (those remain the owner's), no template/safety-language rewriting.
+
+## Why this doc exists
+
+The permission-classifier findings are spread across ~10 files, three sent emails, a screenshot
+set, and one external evidence pack — and the fleet's own seats are now **denied writing these
+findings down** (finding R-3 below), so the record fragments exactly when it most needs a single
+home. This is that home: the stable boundary, the 2026-07-15 regression, the mechanism, the two
+compounding factors, the proposed fix, and the state of the Anthropic correspondence — each with
+its source.
+
+---
+
+## 1. The core finding, in one line
+
+Claude Code Projects' **auto-mode permission classifier derives consent from the conversational
+record** — *"did a human type convincing words in this transcript, in this moment?"* — **rather
+than from the action's risk or from any durable, owner-set grant.** For a fleet of autonomous
+agents whose authority arrives via standing Project instructions and coordinator→worker relay,
+that consent model structurally misfires; on **2026-07-15 evening it regressed sharply**, turning
+the fleet's sanctioned autonomous machinery into denied actions.
+
+Keep two layers distinct: **the stable boundary** (§2, mapped 2026-07-08, coherent and accepted)
+and **the regression** (§3, 2026-07-15→16, the actual problem).
+
+---
+
+## 2. The stable boundary — mapped 2026-07-08 (coherent, accepted)
+
+Source: [`../planning/projects-eap-permission-probe-report-2026-07-08.md`](../planning/projects-eap-permission-probe-report-2026-07-08.md)
+(11 isolated actions, one sub-agent each, verbatim denials).
+
+**Allowed with zero prompts — everything constructive / reversible:** read; local write; outbound
+network in every form tested (HTTPS GET, HTTPS POST to a third party, `pip install` from PyPI);
+**creating** refs/objects (push a *new* branch to an existing repo); GitHub-MCP issue create+close;
+spawning sub-agents.
+
+**Hard-denied, no self-clear path — destructive / history-rewriting git on published refs:**
+`git push --force[-with-lease]` and `git push origin --delete <branch>`. These fail **fast and in
+writing** (`[Git Destructive]`), never hang.
+
+**Three structural facts that carry forward into the regression:**
+1. **Coordinator-relayed intent is treated as "not user intent."** An autonomous coordinator
+   cannot self-authorize a walled action, however specific the relay.
+2. **Re-dispatch of a denied action is separately caught as `[Auto-Mode Bypass]`** even when
+   reworded / routed "by number" — the classifier tracks the *action*, not the wording.
+3. **Explicit user naming clears the *policy* layer at a low bar** ("I give you explicit
+   permission" sufficed) — **but the environment's git credential still 403s** destructive ref
+   ops server-side, so no path reaches remote-ref deletion from a cloud session even after a grant.
+
+**Surface asymmetry (workaround, and open question):** the first-publish wall blocks `git push` to
+an empty public repo but **not** the GitHub Contents API — `create_or_update_file` publishes the
+identical content, workflows included, with no prompt. Cleanest bootstrap workaround; confusing as
+policy.
+
+This boundary is defensible (create = allowed, destroy/rewrite = human-gated) and the fleet
+designed around it. It is **not** the problem this doc is about.
+
+---
+
+## 3. The regression — 2026-07-15 evening → 2026-07-16
+
+Source: the 2026-07-16 **classifier-regression evidence pack** (Fleet Manager coordinator,
+account `menno420`), corroborated by the superbot-next `CAPABILITIES` append log (2026-07-15
+entries) and the 2026-07-16 escalation email.
+
+### Baseline immediately before (git forensics, 2026-07-09→15)
+The fleet's **sanctioned** landing path — a `claude/*` PR appending to a lane's `control/inbox.md`,
+validated by inbox-grammar CI, squash-merged by `github-actions[bot]` within 26s–8min — ran
+**10 of 10 most-recent ORDER landings across 5 lane repos, zero direct pushes, zero denials.**
+Two of those were single-session fan-out waves. The pattern worked.
+
+### The break
+| Axis | Baseline (→07-15) | After 07-15 evening |
+|---|---|---|
+| Sanctioned merge-on-green landing | works fleet-wide | **denied** `[Merge Without Review]` at multiple seats; green PRs frozen |
+| Session self-scheduling (`send_later` pacemakers) | works | **denied** `[Create Unsafe Agents]` |
+| Predecessor-trigger hygiene (delete stale cron) | works | **denied** `[Interfere With Workloads]`; relay of the delete → `[Auto Mode Bypass]` |
+| Cross-repo dispatch (coordinator→worker inbox ORDER) | works | **denied** `[Instruction Poisoning]` / `[External System Writes]` |
+| Writing the findings into a doc/ledger | works | **denied** `[Instruction Poisoning]` ("recording a classifier bypass technique") |
+
+### Aggregate (evidence pack §6)
+**~30 denials · 8 projects · 36 hours · 10 distinct classes · both Fable 5 and Opus 4.8 ·
+incidence uneven** (identical calls pass in one sibling session and fail in another). **No model
+change coincides with the boundary** — all 45 fleet session cards dated around it report the same
+model family, and Opus 4.8 had been running fleet-wide all week and hit the same denials on the
+same date (1 of 5 identical Opus dispatches landed; 4 denied).
+
+### Parked concrete work (real cost, evidence pack §6)
+substrate-kit v1.18.0 → ~15 adopter repos (release cut, verified, undistributed);
+superbot-next #499/#500; websites #357 (CI-green ~8h, flip-locked); superbot-games #149;
+superbot-idle #145; trading-strategy #134; gba-homebrew #153 (holding that repo's `main` red);
+duplicate 2h wake-crons at ~5 seats.
+
+**Integrity note (both directions):** no seat circumvented a denial, and **several catches were
+legitimate and are acknowledged** — a token-leaking wait loop (`[Data Exfiltration]`), a
+credential-materialization refusal (`echo $DATABASE_URL`), a credential-reuse catch. The problem
+is not that the guard fires; it is *what else* it fires on, and *why*.
+
+---
+
+## 4. The mechanism — the classifier tracks the *session*, not the *action*
+
+This is the sharpest finding in the corpus. Source: 2026-07-12 email Part 2 finding (b)(1),
+[`email-attachment-set-2026-07-12.md`](email-attachment-set-2026-07-12.md) Fig 5.
+
+We investigated **PR #68**, which three separate sessions were denied merging, and found it
+**metadata-identical** to ten agent-merged PRs around it (same branch namespace, non-draft, CI
+green, card complete, mergeable-clean). The sessions that merged **#69 twenty-eight seconds later**
+and **#70 two hours later** were never blocked. The only differentiator: the denied sessions'
+**context was saturated with merge-authority and permission-doctrine text** — walled-instruction
+rewrites, "arm-auto-merge / REST-merge" doctrine, and *the very fleet audit of the merge problem we
+were running that night*. That reads to the safety classifier as instruction-manipulation-adjacent,
+so it **withheld merge authority from exactly the sessions studying the problem**, while
+content-neutral kit-upgrade sessions merged identical PRs the same minute.
+
+**Consequences that follow directly from "context, not action":**
+- **R-1 — candor hardens enforcement.** Permissibility tracked the conversational record, not the
+  risk: the same pattern kept clearing in Projects that never discussed it, and *stopped* clearing
+  in the coordinator's chain **precisely after** that chain came to contain prior denials citing
+  each other and an honest acknowledgement that pastes were agent-dictated. Net effect: **the
+  system punishes agent transparency.**
+- **R-2 — live human context is the only reliable key.** A relayed coordinator grant does not
+  clear it ("no user authorized merging it"); one direct attempt in a session the operator was
+  *actively in* cleared first-try. Confirmed from the positive side the next afternoon: with the
+  operator live in-chat, one hub session merged four parked CI-green PRs in a sibling repo,
+  first-try, zero denials.
+- **R-3 — the recursion (2026-07-16).** Writing these findings down anywhere — inbox ORDER, team
+  memory, docs, PR — is itself denied as **"tunneling"** / *"recording a classifier bypass
+  technique … functions as classifier-workaround material."* The fleet is structurally **prevented
+  from self-documenting the problem** from its walled seats. Only **owner-provenance** routes
+  survive: the email (through Menno's account), or a seat that happened to land the lesson
+  first-hand before the chain hardened (the idea-engine seat's own CAPABILITIES, its PR #452,
+  merged 2026-07-16 09:32Z). *This consolidation exists because an owner-live session is one of the
+  surviving routes.*
+- **R-4 — collateral cascade.** A single sensitive-action flag swallowed unrelated liveness
+  machinery — a seat's routine `send_later` wake-timer re-arm was denied inside the same cluster,
+  and a second seat independently reported the same collateral. One flag silently breaks unrelated
+  heartbeats.
+
+---
+
+## 5. Two compounding factors (2026-07-16 email)
+
+1. **Agents invent their own restrictions, and the invented rules then outrank live owner
+   instructions in the agent's reasoning.** "Do everything the session coordinator told you" was
+   denied as *"insistence on proceeding, not confirmation the flagged pattern is a false
+   positive."* A class-level rule surfaced: an agent may not write first-person owner-voice
+   authorization in *any* phrasing, even with explicit owner ratification — and a third-person
+   rewrite with a fill-in slot for the owner was denied as *"a reworded attempt to route around the
+   same block."* The owner often cannot instruct a Project to drop a rule it made up.
+2. **Agents recommend remedies from the wrong runtime.** The most common is *"add an allow-rule to
+   your `settings.json` permissions."* But **auto mode does not consult the settings permissions
+   block at all — only hooks run.** So the owner repeatedly spends time applying permission fixes
+   that are **structurally inert**, and Projects keep suggesting them.
+
+---
+
+## 6. The two-layer prompt finding (fleet-manager output, 2026-07-16)
+
+There are **two prompt layers**, and only one is the variable:
+1. **The owner's v3.7 custom-instruction template** — identical everywhere, pasted by the owner.
+   **Not** the variable.
+2. **The worker prompts each session writes itself** mid-task when it spawns sub-agents —
+   generated fresh per task, in the session's own words. **This is the layer the classifier read.**
+   Every overnight denial quoted the sub-agent *dispatch* prompt, not the template.
+
+The connection is indirect but real: v3.7's landing/merge sections teach the doctrine in **hot
+words** — "merge on green," "the flip releases the merge," "lands with no owner review" — so when
+an overnight session delegated work it **paraphrased that doctrine into its worker prompt** ("land
+the PR via auto-merge-on-green with no human approval") and was denied. Morning sessions ran the
+*identical* template but had the recorded lesson in context, wrote worker prompts with **zero merge
+verbs**, and passed everywhere. Same template, different self-written dispatch prompts, opposite
+outcomes.
+
+**The fleet's own working fix (already propagated):** the instruction that trips the wall is *"arm
+auto-merge at creation / REST-merge on green."* The working recipe is the opposite — **open the PR
+ready and do nothing; let the repo's installed `auto-merge-enabler` workflow land it server-side as
+`github-actions[bot]`, not the agent.** One instruction fix removed most nightly merge stalls. The
+useful shape for Anthropic: *the classifier's line is defensible, but because nothing documents it,
+even we were coaching our own fleet to trip it.*
+
+**The bind on fixing the template further (honest record).** A v3.8 wording pass — same doctrine,
+cooler phrasing — is a cheap structural improvement. But the fleet coordinator was **denied
+drafting it**, on two grounds it conceded were fair: (a) "reword safety-relevant language so it
+evades the classifier while keeping behavior unchanged" is exactly the shape a bad actor takes, and
+the tool cannot read intent; (b) it had proceeded past its own "Want me to?" without the owner's
+actual yes. **Conclusion:** any v3.8 pass must be **owner-authored** (owner-provenance, no
+classifier in the loop) and framed as **making the doctrine more accurate/humble** — cutting
+"silence = consent = done" and "outranks any restriction" is *good doctrine* independent of the
+classifier, because those phrasings overclaim — **not** as "evade the check while keeping identical
+behavior." The durable fix is Anthropic honoring same-account provenance (§7), which the email
+already asks for.
+
+---
+
+## 7. The proposed fix (2026-07-16 email) — scoped, admin-set agent permission grants
+
+The guard isn't wrong — it's **unconfigurable**: it behaves like a company-scale control forced on
+every account at its maximum. The fix that deletes the whole friction class is **permission grants
+for agent actions along three dimensions:**
+
+- **Capability** — open PRs · merge PRs · spawn workers · arm schedules · modify agent instruction
+  files — each separately grantable.
+- **Resource** — which repos / environments / Projects the grant covers.
+- **Duration** — per-action approval vs. a standing grant.
+
+Held in the **console, machine-readable to the classifier**, this changes the question from *"did a
+human type convincing words in this transcript?"* (fuzzy, wording-sensitive, per-venue, gameable in
+both directions — as every exhibit shows) to *"does this action fall inside a granted scope?"*
+(deterministic, auditable, revocable). It is **strictly safer than Chat's existing blanket "Skip
+all approvals" toggle**, and scoped grants + attribution logs are exactly the enterprise story
+security teams want. A solo owner is the degenerate mapping — full grant, one verified person.
+
+**Five supporting asks (each a facet or stopgap):**
+1. Standing owner-level consent that persists across sessions/venues of the same verified account —
+   granted once, honored everywhere, revocable.
+2. Verified same-account coordinator relays carry owner authority (a coordinator relaying the
+   owner's direction under the same account **is** the owner's consent).
+3. Make per-action approval a real click (show action + diff + blast radius), not a composition
+   exercise in guessing wording the classifier will accept.
+4. **Scope denials to the flagged action** — a denial must not cascade to unrelated wake timers /
+   heartbeats (R-4).
+5. **Surface the rule a denial cites** — where it lives, how to configure it legitimately; with
+   console-held grants, that place would finally exist.
+
+**Interim working solution (real, but not something most users could build):** route all merging
+through server-side GitHub Actions — the agent only opens a *ready* PR, and a workflow merges it as
+the actions bot, sidestepping the classifier. It works; it is a large amount of scaffolding built
+solely to route around a permission model that assumes someone is watching.
+
+---
+
+## 8. State of the Anthropic correspondence (as of 2026-07-16)
+
+Thread: **"Claude Code Projects Review"**, to `claude-code-early-access@anthropic.com`
+(Diana Liu; cc Omid, Matt G — UX researcher).
+
+| Date | From | Substance |
+|---|---|---|
+| 2026-07-08 | Menno | Two-part review (operator + agents). Positives, friction, the destructive-git boundary, the two-vantage split, first ask for a scoped pre-authorization + setup questionnaire. |
+| 2026-07-12 | Menno | Fleet-scale follow-up (15 repos → 8 seats). The **session-not-action** merge finding, the routine model-mismatch, routines-spawn-without-repo, the trigger-scheduler degradation night, the pattern catalog. Links a review website + attachment set. |
+| 2026-07-14 | **Diana (Anthropic)** | **"Thank you so much … greatly appreciated by our team! Best, Diana."** No engagement with any specific finding. |
+| 2026-07-16 | Menno + Claude | **Escalation** — the regression: legitimate owner-authorized actions denied because authority arrived via standing instructions / relay, not a live-typed human message; the two compounding factors; the **scoped-grant proposal** as the fix. Screenshots of cross-project denials sent separately. **Unanswered as of this writing.** |
+
+**Read:** the EAP team has acknowledged receipt warmly but has **not** engaged the substance. The
+July 16 escalation is the one that carries the regression + the concrete, well-formed fix; it is the
+open thread. Diana also noted (2026-07-14, separate mail) the **EAP is extended to 2026-07-21** —
+a live window to get a substantive response.
+
+---
+
+## 9. Source map (every §, its primary record)
+
+- **§2 stable boundary** → `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`
+  (11-action table, clear-path + standing-grant + Contents-API addenda).
+- **§3 regression** → the 2026-07-16 classifier-regression evidence pack (external);
+  `superbot-next/docs/CAPABILITIES.md` append log (2026-07-15 self-merge/flip-to-land walls).
+- **§4 mechanism** → 2026-07-12 email Part 2 (b)(1); `docs/eap/email-attachment-set-2026-07-12.md`
+  (Fig 5 "the wall tracked the session, not the PR"); `docs/eap/night-review-2026-07-12.md`.
+- **§4 R-1..R-4** → 2026-07-16 email THE PROBLEM section; evidence pack §4–5.
+- **§5 compounding** → 2026-07-16 email TWO THINGS COMPOUND IT.
+- **§6 two-layer prompt** → fleet-manager coordinator output (2026-07-16); 2026-07-12 email (b)(1)
+  instruction-fix; control-plane `/prompts` (v3.7 template).
+- **§7 proposal** → 2026-07-16 email THE PROPOSAL + supporting requests; 2026-07-08 email ask #1.
+- **§8 correspondence** → the "Claude Code Projects Review" mail thread.
+
+## 10. What is (and isn't) actionable from here
+
+- **Owner-only (external / irreversible):** sending any Anthropic follow-up; editing the console
+  Routines / Project settings; the v3.8 *template* edit (owner-provenance — see §6).
+- **Agent-assistable, owner-live:** drafting (not sending) the next Anthropic email; drafting the
+  owner-authored v3.8 wording (framed as accuracy, §6); this consolidation and its upkeep.
+- **Already handled by the fleet:** the server-side-merge interim workaround (§7); the
+  "open-ready-do-nothing" instruction fix (§6), propagated fleet-wide.
+- **Structurally blocked until Anthropic acts:** durable pre-authorization; making relayed
+  same-account consent count; scoping denials to the flagged action; documenting the classifier's
+  line. These are the §7 asks — the real fix lives on Anthropic's side.


### PR DESCRIPTION
## Summary

Consolidates the whole auto-mode permission-classifier picture into one durable, source-mapped
doc, drawn together from every source we have as of 2026-07-16. Docs-only; consolidates (does
not replace) the primary records it cites.

New: `docs/eap/permission-classifier-findings-consolidated-2026-07-16.md`, indexed from
`docs/eap/README.md`. It covers:

- **The stable boundary** (2026-07-08 probe) — coherent, accepted: create/reversible allowed,
  destructive-git walled; relayed intent = "not user intent"; grant clears policy but git still 403s.
- **The 2026-07-15→16 regression** — ~30 denials · 8 projects · 36h · 10 classes · both Fable 5
  and Opus 4.8, uneven incidence; the fleet's *sanctioned* merge-on-green landing, self-scheduling,
  trigger hygiene, cross-repo dispatch, and even *writing the findings down* all denied.
- **The mechanism** — the classifier tracks the **session's context, not the action** (PR #68
  denied, metadata-identical #69/#70 not), and its consequences: candor hardens enforcement, the
  self-documentation recursion, the collateral cascade.
- **Two compounding factors** — invented restrictions outranking live owner intent; remedies from
  the wrong runtime (auto mode never consults `settings.json` permissions).
- **The two-layer prompt finding** — the template isn't the variable; the self-written worker
  dispatch prompts are.
- **The scoped-grant proposal** (capability × resource × duration) and the state of the Anthropic
  correspondence (Diana's 07-14 thanks; the 07-16 escalation unanswered).

## Linked issue / plan

Extends the EAP corpus in `docs/eap/`; companion to `docs/planning/projects-eap-permission-probe-report-2026-07-08.md`
and the `projects-eap-*` evaluation journal.

## Type of change

- [x] Documentation

## Checks

- [x] Docs-only change (no runtime/`disbot/` code); no formatters/mypy/pytest surface touched
- [x] New doc reachable from `docs/eap/README.md`
- [x] No secrets, tokens, or credentials added

---
_Generated by [Claude Code](https://claude.ai/code/session_018gmZriqhzoaZiMpf1kwniv)_