### PR TITLE
docs: address Codex review on the band-#2130 reconciliation (#2132 follow-up)

### DIFF
--- a/.sessions/2026-07-17-reconcile-band2130.md
+++ b/.sessions/2026-07-17-reconcile-band2130.md
@@ -71,7 +71,7 @@ last silent-drift channel in the docs census (the #2000 Rule-6 graduation closed
   export regenerated, pass record + session log + one new idea (supersede-banner count ratchet).
 - **Verification:** `check_current_state_ledger.py --strict` ✓ · `check_docs.py --strict` ✓ ·
   `check_dashboard_data.py --drift` OK ✓.
-- **⚑ Self-initiated:** the supersede-banner count-ratchet idea (docs/ideas) — captured only, not built
-  (docs-only pass; runtime/tooling change routes to a dispatch session).
+- **⚑ Self-initiated:** `none` (docs-only reconciliation; the Q-0089 supersede-banner count-ratchet
+  idea is captured, not promoted — its runtime/tooling change routes to a dispatch session).
 - **⚑ Owner-decisions:** none.
 - **⚑ Owner-manual-steps:** none.

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,14 +1,22 @@
 {
   "meta": {
-    "generated_at": "2026-07-17T12:18:15Z",
+    "generated_at": "2026-07-17T12:36:17Z",
     "build": {
-      "commit": "20851caa",
-      "subject": "Merge pull request #2130 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-17T12:18:15Z"
+      "commit": "38c15cb8",
+      "subject": "Merge pull request #2132 from menno420/claude/jolly-johnson-m3fyun",
+      "committed_at": "2026-07-17T12:36:17Z"
     },
     "schema_version": 1
   },
   "sessions": [
+    {
+      "file": "2026-07-17-reconcile-band2130.md",
+      "date": "2026-07-17",
+      "title": "2026-07-17 — Forty-eighth Q-0107 reconciliation pass (band-#2130)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
     {
       "file": "2026-07-15-order-005-supersede-stubs.md",
       "date": "2026-07-15",
@@ -480,21 +488,13 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": true
-    },
-    {
-      "file": "2026-07-10-shift-e2-coordinator-self-review.md",
-      "date": "2026-07-10",
-      "title": "2026-07-10 — coordinator self-review vs the #1901 retro question set (overnight shift, session E, PR 2)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "ideas": {
-    "total": 247,
+    "total": 248,
     "by_status": {
       "historical": 26,
-      "ideas": 218,
+      "ideas": 219,
       "reference": 3
     }
   },
@@ -1922,6 +1922,20 @@
       "outcome": {
         "ci_green_first_push": null,
         "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-17-reconcile-band2130",
+      "date": "2026-07-17",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
         "merged_pr": null,
         "reverted_within_window": null
       }

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-17T12:18:15Z",
+    "generated_at": "2026-07-17T12:36:17Z",
     "build": {
-      "commit": "20851caa",
-      "subject": "Merge pull request #2130 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-17T12:18:15Z"
+      "commit": "38c15cb8",
+      "subject": "Merge pull request #2132 from menno420/claude/jolly-johnson-m3fyun",
+      "committed_at": "2026-07-17T12:36:17Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7738,7 +7738,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "20851caa",
+    "build": "38c15cb8",
     "title": "New public bot website",
     "changes": [
       {
@@ -7750,7 +7750,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "20851caa",
+    "build": "38c15cb8",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7762,7 +7762,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "20851caa",
+    "build": "38c15cb8",
     "title": "Command-alias suggestions",
     "changes": [
       {
@@ -9143,9 +9143,9 @@ const FEATURES = [
 ];
 
 const BUILD = {
-  "commit": "20851caa",
-  "subject": "Merge pull request #2130 from menno420/bot/dashboard-refresh",
-  "committed_at": "2026-07-17T12:18:15Z"
+  "commit": "38c15cb8",
+  "subject": "Merge pull request #2132 from menno420/claude/jolly-johnson-m3fyun",
+  "committed_at": "2026-07-17T12:36:17Z"
 };
 
 const COUNTS = {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-07-17T12:18:15Z",
+    "generated_at": "2026-07-17T12:36:17Z",
     "build": {
-      "commit": "20851caa",
-      "subject": "Merge pull request #2130 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-17T12:18:15Z"
+      "commit": "38c15cb8",
+      "subject": "Merge pull request #2132 from menno420/claude/jolly-johnson-m3fyun",
+      "committed_at": "2026-07-17T12:36:17Z"
     },
     "schema_version": 1,
     "counts": {
       "functions": 43,
-      "ideas": 247,
+      "ideas": 248,
       "bugs": 31,
       "reviews": 0,
       "reviews_open": 0,
@@ -1165,6 +1165,14 @@
     }
   ],
   "ideas": [
+    {
+      "file": "supersede-banner-count-ratchet-2026-07-17.md",
+      "title": "Soft ratchet on the supersede-banner warning count (2026-07-17)",
+      "status": "ideas",
+      "date": "2026-07-17",
+      "summary": "`check_docs.py`'s supersede-banner integrity check is **warn-only** — it lists every doc whose",
+      "subsystems": null
+    },
     {
       "file": "dashboard-build-sha-post-merge-2026-07-14.md",
       "title": "Idea — dashboard `build.commit` should reflect the deployed (main) SHA, not the PR-branch HEAD",
@@ -3413,6 +3421,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-17-reconcile-band2130.md",
+      "date": "2026-07-17",
+      "title": "2026-07-17 — Forty-eighth Q-0107 reconciliation pass (band-#2130)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-15-order-005-supersede-stubs.md",
       "date": "2026-07-15",
       "title": "2026-07-15 — ORDER 005 supersession stubs + ORDER 003 stale-Schedule annotations",
@@ -3883,14 +3899,6 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": true
-    },
-    {
-      "file": "2026-07-10-shift-e2-coordinator-self-review.md",
-      "date": "2026-07-10",
-      "title": "2026-07-10 — coordinator self-review vs the #1901 retro question set (overnight shift, session E, PR 2)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -5254,6 +5262,20 @@
       "outcome": {
         "ci_green_first_push": null,
         "checker_findings": null,
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-17-reconcile-band2130",
+      "date": "2026-07-17",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
         "merged_pr": null,
         "reverted_within_window": null
       }

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -98,8 +98,9 @@ Current broad captures:
 
 - [`supersede-banner-count-ratchet-2026-07-17.md`](./supersede-banner-count-ratchet-2026-07-17.md) —
   **session ender (2026-07-17, 48th Q-0107 reconciliation pass, band-#2130):** add a soft ratchet on
-  the supersede-banner *warning count* (like the Recently-shipped / top-level ratchets) so net-new
-  banner drift is flagged at the diff, not 30 PRs later — this pass the count grew 5→9 silently.
+  the supersede-banner *warning set* — keyed on banner identity, not a bare count (a count-only floor
+  is defeated by a resolve-one/add-one edit, per Codex on #2132) — so net-new banner drift is flagged
+  at the diff, not 30 PRs later; this pass the set grew 5→9 silently.
   Complements (does not duplicate) the two cross-repo-awareness ideas: they suppress false positives,
   this bounds the count so a real regression can't hide among them. Disposable (Q-0105). Subsystem:
   tooling / docs-system.

--- a/docs/ideas/supersede-banner-count-ratchet-2026-07-17.md
+++ b/docs/ideas/supersede-banner-count-ratchet-2026-07-17.md
@@ -22,29 +22,35 @@ it would land warn-only and go unnoticed until the next pass.
 
 ## The idea
 
-Add a **soft ratchet on the supersede-banner warning *count*** — the same pattern `check_docs.py`
-already applies to Recently-shipped (ratchet 20) and top-level docs (ratchet 22). Record the current
-count as a floor; warn (do not fail) when a run's count **exceeds** the floor, naming the net-new
-banners:
+Add a **soft ratchet on the supersede-banner warning *set*** — the same *spirit* as the ratchets
+`check_docs.py` already applies to Recently-shipped (20) and top-level docs (22), but keyed on
+**banner identity, not a bare count**. Persist the *accepted* warning set (the doc-path + successor-link
+identity of each known warning) as the floor; warn (do not fail) when a run surfaces a banner **not in
+the accepted set**, naming exactly the net-new ones:
 
 ```
-⚠ supersede-banner warnings rose 5 → 9 (ratchet floor 5) — 4 net-new banner(s) added this change:
-    docs/owner/trigger-health-order-2026-07-12.md, ...
-  If these are honest cross-repo supersessions, bump the floor; otherwise fix the banner.
+⚠ supersede-banner: 1 banner not in the accepted set (accepted: 9) — net-new this change:
+    docs/owner/trigger-health-order-2026-07-12.md → <phantom successor>
+  If this is an honest cross-repo supersession, add it to the accepted set; otherwise fix the banner.
 ```
 
-The floor lives beside the existing ratchets (a constant or a small `.ratchets` entry). Bumping it
-is a one-line, deliberate act — exactly like trimming Recently-shipped past its ratchet — so a
-session that *adds* a legitimate cross-repo banner records that intent, and a session that
-accidentally breaks an in-repo banner gets told **at the diff**, not a month later.
+**Why identity, not just a count** (Codex P2 on the introducing PR, #2132): a count-only floor is
+defeated by a resolve-one/add-one edit — if a known cross-repo warning is fixed in the same change
+that introduces a broken in-repo banner, the total is unchanged (or below the floor) and a count check
+stays silent despite a real regression. Comparing the *finding set* against the accepted baseline (or
+against the base revision's findings) is what actually guarantees introduction-time detection. The
+accepted set lives beside the existing ratchets (a small `.ratchets` / sidecar list of banner
+identities); adding an entry is a one-line, deliberate act — exactly like trimming Recently-shipped
+past its ratchet — so a session that *adds* a legitimate cross-repo banner records that intent, and a
+session that accidentally breaks an in-repo banner gets told **at the diff**, not a month later.
 
 ## Why it's worth having
 
 - Catches net-new banner drift **at introduction**, closing the same "warn-only channel hides
   regressions" gap the Rule-6 graduation (#2000) closed for `check_consistency`.
 - Complementary to the two cross-repo-awareness ideas, not a duplicate: those *suppress* the
-  false positives; this *bounds the count* so a real regression can't hide among them even before
-  cross-repo awareness lands.
+  false positives; this *pins the accepted set* so a real regression can't hide among them even
+  before cross-repo awareness lands.
 - Cheap and disposable (Q-0105): one ratchet constant + one comparison; delete it if it proves
   noisy across a few passes.
 


### PR DESCRIPTION
## What this is

Follow-up to the merged forty-eighth Q-0107 reconciliation PR **#2132**, addressing three P2 Codex review findings (each verified against source per Q-0120 before acting). **Docs / generated-data only.**

## Findings addressed

1. **Regenerate exports after adding this pass's sources** (`botsite/data/console.json`) — **confirmed real**: `export_dashboard_data.py` in #2132 ran *before* the new idea file and session card were written, so the committed export showed **247 ideas** (tree has 248) and omitted `2026-07-17-reconcile-band2130.md` from the console/session feeds. `check_dashboard_data.py --drift` passed anyway because it deliberately ignores the volatile ideas/session feeds. Regenerated from the complete tree → **248 ideas**, run now present in the feeds.

2. **Keep capture-only ideas out of the self-initiated flag** (`.sessions/2026-07-17-reconcile-band2130.md`) — **confirmed real**: `_self_initiated()` returns True for any non-`none` text after the marker, so the prose line badged this routine as self-initiated (owner-review) even though the idea was captured, not promoted (Q-0172). Switched to the established `` `none` (…captured, not promoted) `` form used by the preceding reconciliation card; the regenerated console feed now reads `self_initiated: false` for this run.

3. **Track warning identities instead of only their count** (`docs/ideas/supersede-banner-count-ratchet-2026-07-17.md`) — a sound design refinement to the *captured idea*: a count-only floor is defeated by a resolve-one/add-one edit (fix a known cross-repo warning while introducing a broken in-repo banner → count unchanged → silent). Folded in: the ratchet keys on **banner identity / finding-set diff against the accepted baseline**, not a bare count. Idea README index updated to match.

## Checks

- `check_docs.py --strict` ✓ · `check_current_state_ledger.py --strict` ✓ · `check_dashboard_data.py --drift` OK ✓ · `check_session_slug_unique.py` ✓
- Session gate: not gated (modifies an existing card, adds none).

Trigger issue #2131 was closed by #2132; this is the review-cleanup tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vu4rLMqLGoXs9AdnczhEf

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vu4rLMqLGoXs9AdnczhEf)_