### PR TITLE
docs: remove false 'agents cannot merge' wall from CLAUDE.md, keep real walls

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -160,12 +160,17 @@ configuration; state it family-level — it also feeds the session card's `📊 
 headless wake · subagent; remote container vs local); **(3) what that venue can and cannot
 do** (the ability envelope: merge authority, permission prompts, cross-session limits,
 push/infra walls — consult the repo's documented walls before probing). Then direct the
-work accordingly: **autonomous/Project sessions must expect real walls now** — since 2026-07-15
-the Anthropic permission classifier denies autonomous coordinator→worker merges and ready-flips,
-so open PRs **ready** and let the repo's server-side `auto-merge-enabler` workflow land them on
-green (never an agent-side merge/flip); park only on a **real** denial and report it verbatim.
-**Owner-live sessions** act directly on the work, but still land merges via the server-side
-workflow, not by hand — no venue is a "no special limitations" venue. When an ability is
+work accordingly: **merging is normal agent work in every venue** — open your PR **ready** and
+**merge your own green PR directly** (MCP/REST), or let the repo's `auto-merge-enabler` workflow
+land it on green; either path is fine, and you never route a mergeable green PR to the owner. The
+only merge gate is **CI green** (plus the `do-not-automerge` carve-out). The **real** walls are
+elsewhere and stay real: ref/branch **deletion** (403 everywhere), **tag-push / release** (403 →
+`workflow_dispatch`), raw `api.github.com` (blocked → use MCP / git-CLI), repo
+**Settings / rulesets / required-checks / branch-protection / Actions secrets & env** (owner
+console), and a direct push to **protected `main`** (open a PR). Consult those documented walls
+before probing them. If a *specific* permission refusal ever occurs on a call, treat it as
+**attempt-once, specific to that one call / venue / permission-mode** — read the refusal, report
+it verbatim, and **never write it into the docs as a new standing wall**. When an ability is
 genuinely uncertain, try it once and read the refusal rather than assuming a wall.
 
 At the **start** of every session, read in this order: **this file**
@@ -268,28 +273,27 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   merge (next bullet) when the work is good, or **close** it with a one-line reason if it should
   not land. Never leave your session PR open at session end. The Stop-hook session-log
   advisory and `scripts/check_session_log.py` remind you; the `/session-close` skill drives it.
-- **You don't merge your session PR by hand — GitHub-native auto-merge does (owner decision
-  Q-0123, 2026-06-13, superseding the Q-0084 manual-merge envelope).** The `auto-merge-enabler`
-  workflow (on `main` since #779) arms native auto-merge on every non-draft `claude/*` PR at
-  open; GitHub merges it the instant the required **Code Quality** check is green — server-side,
-  so it can't "forget" a deferred merge (the #778 failure). You just **open the PR ready**; the
-  Q-0103 terminal state is reached automatically on green (or **close** the PR if it shouldn't
-  land). **If you open the PR via the GitHub MCP (`create_pull_request`), the enabler workflow
-  does NOT fire** — an app/integration token doesn't trigger workflows — so the PR simply waits for
-  the server-side path (the enabler on a branch-pushed PR, or the owner). **Do NOT arm it yourself
-  (`enable_pr_auto_merge`) or REST/MCP-merge it (corrected 2026-07-17, retiring the Q-0127 "arm it
-  yourself" instruction):** since **2026-07-15** the Anthropic permission classifier denies those
-  autonomous coordinator→worker actions, and paraphrasing an "arm auto-merge / REST-merge on green"
-  step into a worker prompt is what trips it
-  (`docs/eap/permission-classifier-findings-consolidated-2026-07-16.md` §6). The one
-  remaining carve-out stays manual — a PR labelled `do-not-automerge` (Q-0114) is never auto-armed.
+- **Merging your session PR is normal agent work — do it yourself, or let auto-merge land it
+  (owner decision Q-0123, 2026-06-13, superseding the Q-0084 manual-merge envelope).** Two paths,
+  both fine: (a) **merge your own green PR directly** (MCP `merge_pull_request` / REST) the moment
+  it's mergeable, or (b) let the `auto-merge-enabler` workflow (on `main` since #779) arm native
+  auto-merge and land it — it arms on every non-draft `claude/*` PR at open, and GitHub merges the
+  instant the required **Code Quality** check is green (server-side, so it can't "forget" the #778
+  deferred-merge failure). You just **open the PR ready**; the Q-0103 terminal state is reached
+  either by your direct merge or automatically on green (or **close** the PR if it shouldn't land).
+  **If you open the PR via the GitHub MCP (`create_pull_request`), the enabler workflow does NOT
+  fire** — an app/integration token doesn't trigger workflows — so on that path either **merge it
+  yourself on green** or arm auto-merge (`enable_pr_auto_merge`); a branch-pushed PR gets the
+  enabler automatically. **Merging, ready-flipping, and arming auto-merge are all normal agent
+  actions — never route a mergeable green PR to the owner.** The one
+  carve-out stays: a PR labelled `do-not-automerge` (Q-0114) is never auto-armed and waits for a deliberate merge.
   **The `needs-hermes-review` carve-out (and its Hermes review-merge gate) is RETIRED (owner directive
   Q-0197, 2026-06-22):** the label was unused and only got in the way of clean merges, so it no longer
   exists — never apply it; every PR auto-merges on green CI. **Owner-directed work is NEVER held for
   review — always merge immediately (owner directive Q-0191, 2026-06-21).** When the owner *personally*
   directs a task (a session prompt, an in-chat instruction, "build PR N / continue the plan"), owner
   direction **is** the review: open the PR **ready**, do **not** label it `do-not-automerge`, and
-  let the server-side workflow land it the instant CI is green (do not arm auto-merge yourself).
+  land it the instant CI is green — merge it yourself or let auto-merge fire, whichever is handy.
   "Merge immediately" means *merge the moment it's mergeable* (still requires CI green), not bypass CI.
   **Merging IS deploying (owner directive Q-0193, 2026-06-21):** Railway auto-redeploys `worker` on every
   merge to `main`, so a merged change is **live on its own within minutes** — you neither perform nor wait
@@ -297,9 +301,9 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   a merge to apply it** (the misinformation this Q corrects). What stays his is **live verification /
   rollback** + any per-PR *data* step a change names (e.g. `!btd6ops seed-data`, or an operator button to
   clear stale rows) — not the deploy. Canonical: `docs/operations/production-deployment.md`. *Agent-side
-  manual merges are no longer a normal carve-out (corrected 2026-07-17 — classifier-denied since
-  2026-07-15):* if the server-side path is down, leave the PR **ready** for the owner rather than merging
-  or arming it yourself, and report the denial verbatim.
+  manual merges are a normal, first-class path:* if auto-merge is slow or unavailable, **merge the green PR
+  yourself** (MCP/REST). Only a *specific* permission refusal on a *specific* call is a reason to stop — read
+  it, report it verbatim, and do not generalize it into a standing "agents can't merge" wall.
 - **Session card gate (owner directive Q-0133, 2026-06-14 — RETIRING 2026-07-17: autonomy
   scaffolding slated for teardown when the Projects are recreated; the CI check stays live until
   then, so honor it but don't extend it).** Historically: the gate fires the instant **Code Quality** is green, so a

--- a/docs/NEXT-TASKS.md
+++ b/docs/NEXT-TASKS.md
@@ -7,9 +7,10 @@
 > churn. Full live status: [`current-state.md`](current-state.md).
 
 Context: the Claude Code Projects EAP goes **read-only Tue 2026-07-21**; the owner is
-**winding down** the autonomous coordinator→worker apparatus (frozen since the 2026-07-15
-permission-classifier regression) and will **recreate the Projects** with better
-coordination. These are the highest-value next steps to pick up in the re-created project.
+**winding down** the autonomous coordinator→worker apparatus and will **recreate the Projects**
+with better coordination. (The mid-July "permission-classifier freeze" belief did not hold —
+agents merge their own green PRs normally; see `current-state.md`.) These are the highest-value
+next steps to pick up in the re-created project.
 
 ## Ranked next steps
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -13,19 +13,26 @@
 > the autonomous coordinator→worker apparatus** and will **recreate the Projects** with better
 > coordination after the read-only cutover.
 >
-> **⚠️ Permission-classifier regression (from 2026-07-15):** around 2026-07-15 an Anthropic
-> permission-classifier change began **denying autonomous coordinator→worker merges and
-> ready-flips**, freezing finished, CI-green PRs across the fleet (and pushing agents to invent
-> restrictions). The owner sent two further escalation emails on **2026-07-16** (email 4 SENT:
-> [`eap/anthropic-email-4-classifier-regression-sent-2026-07-16.md`](eap/anthropic-email-4-classifier-regression-sent-2026-07-16.md)).
-> Consolidated analysis + the working interim fix:
-> [`eap/permission-classifier-findings-consolidated-2026-07-16.md`](eap/permission-classifier-findings-consolidated-2026-07-16.md).
+> **⚠️ The "permission-classifier denies merges" scare did NOT hold (verified 2026-07-18):**
+> mid-July sessions recorded a belief that an Anthropic permission-classifier change was
+> **denying** autonomous merges and ready-flips, and each later session copied and amplified the
+> restriction. **Ground truth: agents CAN merge their own/sibling green PRs, flip draft→ready, and
+> arm auto-merge — merging is normal agent work.** (A direct MCP merge succeeded on 2026-07-18.)
+> The dated escalation emails
+> ([`eap/anthropic-email-4-classifier-regression-sent-2026-07-16.md`](eap/anthropic-email-4-classifier-regression-sent-2026-07-16.md),
+> [`eap/permission-classifier-findings-consolidated-2026-07-16.md`](eap/permission-classifier-findings-consolidated-2026-07-16.md))
+> are **historical records** of that scare, not a current wall — do not re-derive a merge
+> restriction from them.
 >
-> **Merge doctrine (corrected 2026-07-17):** open PRs **READY** and do nothing else — the
-> installed **server-side `auto-merge-enabler` workflow** lands them on green (as
-> `github-actions[bot]`). **Do NOT perform agent-side ready-flips or REST/MCP merges** — those
-> are the exact actions the classifier now denies (since 2026-07-15). Full corrected rule:
-> `.claude/CLAUDE.md` § "Session & plan workflow".
+> **Merge doctrine (corrected 2026-07-18):** open PRs **READY** and **merge your own green PR
+> directly** (MCP/REST) the moment it's mergeable — or let the `auto-merge-enabler` workflow land
+> it on green; either path is fine, and you never route a mergeable green PR to the owner. The one
+> gate is **CI green** (plus the `do-not-automerge` carve-out). If a *specific* permission refusal
+> ever occurs on a call, it's **attempt-once, specific to that call/venue/permission-mode** — read
+> it, report it verbatim, and **never write it into the docs as a new standing wall**. Full rule:
+> `.claude/CLAUDE.md` § "Session & plan workflow". The **real** walls stay real: ref/branch
+> deletion (403), tag-push/release (403), raw `api.github.com` (blocked), and repo
+> Settings/secrets/env (owner console).
 >
 > **✅ 2026-07-17 — fleet-wide PR backlog cleared.** The frozen CI-green work across the fleet
 > was dispositioned/landed; on superbot specifically the open-PR surface is now down to one.

--- a/docs/owner/fleet-vocab.md
+++ b/docs/owner/fleet-vocab.md
@@ -44,12 +44,12 @@
 - **Decide-and-flag** reversible calls; route only genuine product/irreversible forks
   to you.
 - **Guardrails carried in from the 2026-07-11 sessions:** no `delete_trigger` /
-  destructive approval-gated ops unless you say so; in Project sessions never
-  self-merge (classifier wall). **Hub/live sessions don't just *can* merge — they
-  MUST (Q-0269, 2026-07-12): any mergeable PR in finished state (green, complete,
-  READY) is merged immediately by the agent; directing the owner to a green PR is
-  a workflow failure.** Park-READY+green is a Project-seat fallback only, and only
-  after a real classifier denial.
+  destructive approval-gated ops unless you say so. **Merging is normal agent work in
+  every venue — agents don't just *can* merge, they MUST (Q-0269, 2026-07-12): any
+  mergeable PR in finished state (green, complete, READY) is merged immediately by the
+  agent; directing the owner to a green PR is a workflow failure.** Only a *specific*
+  permission refusal on a *specific* call is a reason to park a green PR READY — read it,
+  report it verbatim, and never generalize it into a standing "agents can't merge" wall.
 
 ## Growing this file
 


### PR DESCRIPTION
## What & why

Owner-directed cleanup. Mid-July sessions recorded a belief that an Anthropic permission-classifier change **denied** autonomous coordinator→worker merges and ready-flips, and each later session copied and amplified that restriction into the forward-binding docs. The owner is tired of sessions writing false walls that propagate.

**Ground truth (verified 2026-07-18, automode OFF):** agents CAN merge their own/sibling green PRs, flip draft→ready, arm auto-merge, push commits, create branches. Merging is **normal agent work**, not owner-gated. A specific permission refusal, if it ever occurs, is attempt-once and specific to that call/venue/permission-mode — never a standing wall.

## Files changed
- **`.claude/CLAUDE.md`** — Boot-triad merge paragraph + the "merge your session PR" bullet rewritten to accurate doctrine (agents merge their own green PRs directly, or let auto-merge land them).
- **`docs/current-state.md`** — the "permission-classifier regression" block and "Merge doctrine (corrected 2026-07-17)" block corrected.
- **`docs/NEXT-TASKS.md`** — "frozen since the 2026-07-15 permission-classifier regression" context line.
- **`docs/owner/fleet-vocab.md`** — "in Project sessions never self-merge (classifier wall)" removed; Q-0269 "agents MUST merge mergeable PRs" kept/strengthened.

## TRUE walls kept intact
ref/branch **deletion** (403 everywhere), **tag-push / release** (403 → workflow_dispatch), raw **api.github.com** (blocked → MCP/git-CLI), repo **Settings / rulesets / required-checks / branch-protection / Actions secrets & env** (owner console), direct push to **protected main** (PR required). Plus all valid surrounding rules: CI-green-before-merge, the `do-not-automerge` carve-out (Q-0114), Q-0191 owner-directed-never-held, Q-0193 merge=deploy.

## Out of scope (untouched)
Dated historical artifacts (`eap/`, `retro/`, `planning/`, `audits/`, night-orders) and the append-only question-router decision ledger — records of what a session believed on a date, not forward-binding doctrine. Q-0275 in the router specifically declined a "scrub review language" sweep, so rewriting those entries was deliberately avoided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUQ1Javbrbbe6yMceZV3gx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUQ1Javbrbbe6yMceZV3gx)_