### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-18T19:20:16Z",
+    "generated_at": "2026-07-18T23:12:33Z",
     "build": {
-      "commit": "f87fa508",
-      "subject": "Merge pull request #2151 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-18T19:20:16Z"
+      "commit": "2f4658f1",
+      "subject": "Merge pull request #2148 from menno420/claude/eap-followup-evidence-2026-07-18",
+      "committed_at": "2026-07-18T23:12:33Z"
     },
     "schema_version": 1,
     "counts": {
@@ -3421,6 +3421,22 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-18-triggers-ender-eap.md",
+      "date": "2026-07-18",
+      "title": "2026-07-18 · hub session — routine cleanup, session-ender v3.8, EAP evidence",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-07-18-eap-dewall-evidence.md",
+      "date": "2026-07-18",
+      "title": "2026-07-18 · EAP follow-up evidence pack (fleet de-wall + verified capabilities)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-17-reconcile-band2130.md",
       "date": "2026-07-17",
       "title": "2026-07-17 — Forty-eighth Q-0107 reconciliation pass (band-#2130)",
@@ -3883,22 +3899,6 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
-    },
-    {
-      "file": "2026-07-11-dispatch-kit-gen3-lessons.md",
-      "date": "2026-07-11",
-      "title": "2026-07-11 — fold gen-3 coordinator lessons into the dispatch-kit permissions block",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-10-sol-eval-scoring.md",
-      "date": "2026-07-10",
-      "title": "2026-07-10 — GPT-5.6 Sol eval results: scoring the Codex PRs",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -5269,6 +5269,34 @@
     {
       "session": "2026-07-17-reconcile-band2130",
       "date": "2026-07-17",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-18-eap-dewall-evidence",
+      "date": "2026-07-18",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_docs badge/reachable + check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-18-triggers-ender-eap",
+      "date": "2026-07-18",
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "docs-only",


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.