### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-07-19T19:20:46Z",
+    "generated_at": "2026-07-19T19:39:39Z",
     "build": {
-      "commit": "0b72ba13",
-      "subject": "Merge pull request #2160 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-19T19:20:46Z"
+      "commit": "2f9268c8",
+      "subject": "Merge pull request #2162 from menno420/claude/jolly-johnson-k07yo0",
+      "committed_at": "2026-07-19T19:39:39Z"
     },
     "schema_version": 1,
     "counts": {
       "functions": 43,
-      "ideas": 248,
+      "ideas": 249,
       "bugs": 31,
       "reviews": 0,
       "reviews_open": 0,
@@ -1165,6 +1165,14 @@
     }
   ],
   "ideas": [
+    {
+      "file": "reconciliation-cadence-exclude-generated-prs-2026-07-19.md",
+      "title": "Idea: reconciliation cadence should exclude generated / automated PRs",
+      "status": "ideas",
+      "date": "2026-07-19",
+      "summary": "The Q-0107 reconciliation cadence fires when merged **PR numbers** cross a multiple of 30",
+      "subsystems": null
+    },
     {
       "file": "supersede-banner-count-ratchet-2026-07-17.md",
       "title": "Soft ratchet on the supersede-banner warning count (2026-07-17)",
@@ -3421,6 +3429,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-19-reconcile.md",
+      "date": "2026-07-19",
+      "title": "2026-07-19 — Forty-ninth Q-0107 reconciliation pass (band-#2160)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-18-triggers-ender-eap.md",
       "date": "2026-07-18",
       "title": "2026-07-18 · hub session — routine cleanup, session-ender v3.8, EAP evidence",
@@ -3888,14 +3904,6 @@
       "file": "2026-07-11-email2-idle-observability.md",
       "date": "2026-07-11",
       "title": "2026-07-11 — Email #2: idle-Project empty-session-list finding (owner recording) → fig-19 + b6",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-11-email-fleet-handoff.md",
-      "date": "2026-07-11",
-      "title": "2026-07-11 — Anthropic email #2 + fleet-management session (HANDOFF BRIEF)",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -5297,6 +5305,20 @@
     {
       "session": "2026-07-18-triggers-ender-eap",
       "date": "2026-07-18",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-19-reconcile",
+      "date": "2026-07-19",
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "docs-only",


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.