### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-22T00:02:02Z",
+    "generated_at": "2026-07-22T01:17:16Z",
     "build": {
-      "commit": "9caa8e8d",
-      "subject": "Merge pull request #2192 from menno420/claude/jolly-johnson-up1xqp",
-      "committed_at": "2026-07-22T00:02:02Z"
+      "commit": "7d6533f8",
+      "subject": "Merge pull request #2193 from menno420/bot/dashboard-refresh",
+      "committed_at": "2026-07-22T01:17:16Z"
     },
     "schema_version": 1,
     "counts": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.