### PR TITLE
Add GitHub Actions workflow for Python application

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
This workflow installs Python dependencies, runs linting with flake8, and executes tests with pytest on pushes and pull requests to the main branch.

<!--
Provenance: Q-0177 (2026-06-19). Keep PRs focused. Agent sessions follow
.claude/CLAUDE.md (born-red session card + enders); this template is mainly for
human contributors. The body set by an agent via the API overrides this template.
-->

## Summary

<!-- What does this change, and why? -->

## Linked issue / plan

<!-- "Closes #NN", or link the docs/planning or docs/ideas entry this implements. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tooling / CI
- [ ] Breaking change

## Checks

- [ ] `python3.10 scripts/check_quality.py --full` passes (black + isort + ruff + mypy + pytest)
- [ ] `python3.10 scripts/check_architecture.py --mode strict` passes (exit 0)
- [ ] Docs / ledger updated if behavior or project state changed
- [ ] No secrets, tokens, or credentials added

<!-- CI's "Code Quality" check must be green to merge. claude/* PRs auto-merge on green. -->
