### PR TITLE
docs: address Codex review of #2222 (feed regen + idea-file corrections)

### DIFF
--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,14 +1,22 @@
 {
   "meta": {
-    "generated_at": "2026-07-25T08:34:51Z",
+    "generated_at": "2026-07-25T08:51:26Z",
     "build": {
-      "commit": "690f678c",
-      "subject": "Merge pull request #2220 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-25T08:34:51Z"
+      "commit": "98a07923",
+      "subject": "Merge pull request #2222 from menno420/claude/reconcile-band2220",
+      "committed_at": "2026-07-25T08:51:26Z"
     },
     "schema_version": 1
   },
   "sessions": [
+    {
+      "file": "2026-07-25-reconcile.md",
+      "date": "2026-07-25",
+      "title": "2026-07-25 — Fifty-first Q-0107 reconciliation pass (band-#2220)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
     {
       "file": "2026-07-21-reconcile.md",
       "date": "2026-07-21",
@@ -480,21 +488,13 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
-    },
-    {
-      "file": "2026-07-11-email2-part2-polish.md",
-      "date": "2026-07-11",
-      "title": "2026-07-11 — Email #2: owner's Part 1 landed + agents' Part 2 fact-refresh",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "ideas": {
-    "total": 250,
+    "total": 251,
     "by_status": {
       "historical": 26,
-      "ideas": 221,
+      "ideas": 222,
       "reference": 3
     }
   },
@@ -1985,6 +1985,20 @@
     {
       "session": "2026-07-21-reconcile",
       "date": "2026-07-21",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-25-reconcile",
+      "date": "2026-07-25",
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "docs-only",

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-25T08:34:51Z",
+    "generated_at": "2026-07-25T08:51:26Z",
     "build": {
-      "commit": "690f678c",
-      "subject": "Merge pull request #2220 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-25T08:34:51Z"
+      "commit": "98a07923",
+      "subject": "Merge pull request #2222 from menno420/claude/reconcile-band2220",
+      "committed_at": "2026-07-25T08:51:26Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7738,7 +7738,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "690f678c",
+    "build": "98a07923",
     "title": "New public bot website",
     "changes": [
       {
@@ -7750,7 +7750,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "690f678c",
+    "build": "98a07923",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7762,7 +7762,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "690f678c",
+    "build": "98a07923",
     "title": "Command-alias suggestions",
     "changes": [
       {
@@ -9143,9 +9143,9 @@ const FEATURES = [
 ];
 
 const BUILD = {
-  "commit": "690f678c",
-  "subject": "Merge pull request #2220 from menno420/bot/dashboard-refresh",
-  "committed_at": "2026-07-25T08:34:51Z"
+  "commit": "98a07923",
+  "subject": "Merge pull request #2222 from menno420/claude/reconcile-band2220",
+  "committed_at": "2026-07-25T08:51:26Z"
 };
 
 const COUNTS = {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-07-25T08:34:51Z",
+    "generated_at": "2026-07-25T08:51:26Z",
     "build": {
-      "commit": "690f678c",
-      "subject": "Merge pull request #2220 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-25T08:34:51Z"
+      "commit": "98a07923",
+      "subject": "Merge pull request #2222 from menno420/claude/reconcile-band2220",
+      "committed_at": "2026-07-25T08:51:26Z"
     },
     "schema_version": 1,
     "counts": {
       "functions": 43,
-      "ideas": 250,
+      "ideas": 251,
       "bugs": 31,
       "reviews": 0,
       "reviews_open": 0,
@@ -1165,6 +1165,14 @@
     }
   ],
   "ideas": [
+    {
+      "file": "dashboard-refresh-coalesce-loop-2026-07-25.md",
+      "title": "Idea — coalesce the dashboard-refresh loop into far fewer PRs (attack the churn at the source)",
+      "status": "ideas",
+      "date": "2026-07-25",
+      "summary": "Band-#2220 (#2191–#2220) was **28 merged PRs: 27 were automated `bot/dashboard-refresh`",
+      "subsystems": null
+    },
     {
       "file": "reconcile-thin-flag-standing-vs-newly-raised-2026-07-21.md",
       "title": "Idea — distinguish a *standing* PLAN BACKLOG THIN from a *newly-raised* one",
@@ -3437,6 +3445,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-07-25-reconcile.md",
+      "date": "2026-07-25",
+      "title": "2026-07-25 — Fifty-first Q-0107 reconciliation pass (band-#2220)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-07-21-reconcile.md",
       "date": "2026-07-21",
       "title": "2026-07-21 — Fiftieth Q-0107 reconciliation pass (band-#2190)",
@@ -3904,14 +3920,6 @@
       "file": "2026-07-11-email2-sidebar-correction.md",
       "date": "2026-07-11",
       "title": "2026-07-11 — Email #2: sidebar-nesting correction (owner screenshot)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-07-11-email2-part2-polish.md",
-      "date": "2026-07-11",
-      "title": "2026-07-11 — Email #2: owner's Part 1 landed + agents' Part 2 fact-refresh",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -5341,6 +5349,20 @@
     {
       "session": "2026-07-21-reconcile",
       "date": "2026-07-21",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-07-25-reconcile",
+      "date": "2026-07-25",
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "docs-only",

--- a/docs/ideas/dashboard-refresh-coalesce-loop-2026-07-25.md
+++ b/docs/ideas/dashboard-refresh-coalesce-loop-2026-07-25.md
@@ -34,18 +34,35 @@ cadence.
 Coalesce/debounce the `bot/dashboard-refresh` loop so it produces far fewer, larger PRs.
 Cheapest first:
 
-1. **Single rolling refresh PR (amend-in-place).** Keep **one** open `bot/dashboard-refresh`
-   PR; each refresh tick force-pushes the regenerated artifact onto that same branch (or
-   no-ops when the diff is empty) instead of opening a new PR. It merges on its own schedule
-   (daily, or when a substantive PR lands). One CI run per merge, not per tick.
-2. **Debounced digest cadence.** Run the export loop unchanged but only *open/merge* a refresh
-   PR on a fixed cadence (e.g. once/day) or when the diff exceeds a structural-change threshold
-   (`check_dashboard_data.py --drift` already computes what changed — gate the PR on a non-noise
-   delta). Trivial re-serializations that don't change any surface never mint a PR.
-3. **Skip-if-noise guard.** At minimum, have the loop **not open a PR when the only diff is
+**Starting point — what already exists.** `dashboard-data-refresh.yml` already reuses **one**
+branch (`bot/dashboard-refresh`, force-updated) and is **scheduled every ~2h** (not per-merge), so
+"one rolling PR" is *partly* built. The churn is that each 2-hourly run with drift force-updates the
+PR, it auto-merges, and the next run opens it afresh — ≈one merge per cadence tick over the band.
+The lever is therefore the **cadence + the per-push CI**, not the PR count.
+
+1. **Debounce the pushes/cadence themselves — not just the PR count.** Note the trap Codex flagged
+   on this PR: `code-quality.yml` triggers on **every `pull_request` update** with
+   `cancel-in-progress: false` (a merge-safety invariant, `check_workflow_concurrency.py`), and the
+   refresh workflow force-updates the PR branch — so *every* drift tick starts a **full,
+   un-cancellable** Code Quality run regardless of how rarely the PR merges. Consolidating into one
+   rolling PR alone does **not** yield "one CI run per merge." The real fix debounces the
+   **force-push cadence** (e.g. lengthen the 2h schedule to daily, or only push when a real delta
+   exists) — or changes the gating so an artifact-only refresh PR runs a cheap docs-lane check
+   instead of the full matrix.
+2. **Gate the refresh on a *feed-aware* delta — not `--drift`.** Trap #2 Codex flagged: gating
+   refresh PRs on `check_dashboard_data.py --drift` would **never fire for feed-only updates**,
+   because `--drift` *deliberately* compares only structural identifier sets (cogs/commands/
+   env-vars/settings/catalogue keys) and **ignores the volatile feeds — ideas/sessions/bugs — plus
+   timestamps/build SHA** (its docstring says so). Those feeds are exactly what the scheduled
+   workflow exists to keep current, so on a frozen repo they'd go stale indefinitely. Use a
+   comparison that **excludes build-only metadata (timestamp, `meta.build.commit`) but still treats
+   feed-content changes as meaningful** — i.e. a purpose-built "is this a real content change?"
+   check, not the structural-only `--drift`.
+3. **Skip-if-noise guard.** At minimum, have the loop **not push/open a PR when the only diff is
    `meta.build.commit` / timestamps** — the exact churn the
    [`dashboard-build-sha-post-merge-2026-07-14.md`](dashboard-build-sha-post-merge-2026-07-14.md)
-   idea already flags as a dead PR-branch SHA. That single guard removes the emptiest refreshes.
+   idea already flags as a dead PR-branch SHA. That single guard removes the emptiest refreshes, and
+   is the concrete kernel of the feed-aware delta in (2).
 
 ## Why it's worth having
 


### PR DESCRIPTION
Q-0174 follow-up to the merged 51st-pass reconcile (**#2222**). Codex left 3 P2 review comments; all three verified against source and folded in. Docs/artifact-only — zero `disbot/` runtime.

## Findings addressed
1. **Feed staleness (dashboard.json)** — the #2222 export ran *before* the session card, the new idea, and the telemetry row were added, so the committed feeds were a snapshot behind their own source changes. Regenerated all four outputs (`dashboard/data/dashboard.json` + `botsite/data/{site,console}.json` + `botsite/site/data.js`); **idea count 250 → 251**, console feed now includes `2026-07-25-reconcile`.
2. **`--drift` gate would ignore feeds** — corrected the idea `dashboard-refresh-coalesce-loop`: gating refresh PRs on `check_dashboard_data.py --drift` would never fire for feed-only updates, because `--drift` deliberately compares only structural identifier sets and ignores the ideas/sessions/bugs feeds + timestamps (per its docstring). The idea now calls for a **feed-aware delta** that excludes build-only metadata but treats feed content as meaningful.
3. **Option 1 won't give "one CI run per merge"** — corrected: `code-quality.yml` triggers on every `pull_request` update with `cancel-in-progress: false` (a merge-safety invariant) and the refresh force-updates the branch, so each drift tick starts a full un-cancellable run regardless of merge cadence. The fix must **debounce the push cadence / change gating**, not just consolidate PRs. Also noted the refresh workflow *already* reuses one branch and is 2-hourly scheduled.

`check_docs --strict` and `check_current_state_ledger --strict` green. No session card added (this is a review-fix follow-up), so the session gate does not engage.

---
_Generated by [Claude Code](https://claude.ai/code/session_011UgKjoiRNeQPGLaEhA2Gc2)_