### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-25T08:51:26Z",
+    "generated_at": "2026-07-25T09:00:47Z",
     "build": {
-      "commit": "98a07923",
-      "subject": "Merge pull request #2222 from menno420/claude/reconcile-band2220",
-      "committed_at": "2026-07-25T08:51:26Z"
+      "commit": "cdc255d9",
+      "subject": "Merge pull request #2223 from menno420/claude/reconcile-band2220-codex-followup",
+      "committed_at": "2026-07-25T09:00:47Z"
     },
     "schema_version": 1,
     "counts": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.