### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-07-27T23:29:11Z",
+    "generated_at": "2026-07-27T23:48:17Z",
     "build": {
-      "commit": "93be74a9",
-      "subject": "Merge pull request #2250 from menno420/bot/dashboard-refresh",
-      "committed_at": "2026-07-27T23:29:11Z"
+      "commit": "56540212",
+      "subject": "Merge pull request #2252 from menno420/claude/reconcile-band2250",
+      "committed_at": "2026-07-27T23:48:17Z"
     },
     "schema_version": 1,
     "counts": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.