### PR TITLE
docs(reconcile): band-#2310 Codex follow-up — regen export + fix boundary/wording

### DIFF
--- a/.sessions/2026-08-03-reconcile.md
+++ b/.sessions/2026-08-03-reconcile.md
@@ -22,8 +22,10 @@ Reconciliation actions:
 - **Docs** (`check_docs.py --strict`): green — ratchets intact (top-level 23, Recently-shipped 20). The
   **9 supersede-banner soft warnings are unchanged** (honest cross-repo phantom successors that live in
   fleet-manager; the in-repo checker can't resolve them — carried, not a CI failure).
-- **Ledger check** (`check_current_state_ledger.py --strict`): in sync — last 15 merged PRs all present;
-  the 27 merges newer than the (now #2310) marker are benign lag, recorded by this pass.
+- **Ledger check** (`check_current_state_ledger.py --strict`): in sync — last 15 merged PRs all present.
+  At pass start it counted **27 merges newer than the pre-pass #2280 marker** (benign lag) — the band
+  #2283–#2310 dashboard refreshes this pass then reconciled; after resetting the marker to #2310 the
+  count is zero.
 - **Open-PR disposition:** 9 open PRs, **all Dependabot dep-bumps**
   (#2171/#2172/#2173/#2175/#2176/#2178/#2185/#2247/#2248) — the Q-0256 runtime-dep lane, left in flight
   (not this docs-only pass). No external drive-by and no stale session PR to dispose this band.
@@ -71,6 +73,21 @@ surface a backlog that structurally cannot move. **Lesson / improvement:** a vis
 half a loop; the same pass that adds one should name (or flag the absence of) the consumer. This pass acted
 on that by capturing the no-executor root as the Q-0089 idea and flagging it as an owner decision. No
 filler — the observation is concrete (two dead plans in one grep) and the fix is a real owner call.
+
+## ⟲ Codex-review follow-up (post-merge, PR #2312 → follow-up PR)
+
+PR #2312 auto-merged on green CI before the Codex final review landed (expected — Q-0174). Codex then
+posted three verified-genuine findings against the merged commit; a merged PR is finished, so they are
+fixed here as a **fresh follow-up PR** off `main`:
+- **P2 — stale dashboard export.** `export_dashboard_data.py` was run mid-pass, *before* the card flipped
+  to `complete` and *before* the new idea file existed, so the committed `dashboard.json` + botsite mirrors
+  recorded this run as `in-progress`/`self_initiated:false` and 253 ideas (not 254). Re-ran the exporter
+  against the final tree and committed every mirror (idea count now 254). *Process note:* the dashboard
+  regen must be the **last** step of a pass, after the card is flipped — captured for the next reconcile.
+- **P2 — stale S4 `▶ Next` boundary.** `S4-docs.md`'s live `▶ Next` still said "due once merges cross
+  #2310"; advanced to #2340 to match the marker + hub + run report.
+- **P3 — ledger-lag attribution wording.** The validation note called the 27 merges "newer than the (now
+  #2310) marker" (internally impossible); corrected to attribute them to the pre-pass #2280 marker.
 
 ## 📤 Run report
 

--- a/botsite/data/console.json
+++ b/botsite/data/console.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-08-03T11:52:58Z",
+    "generated_at": "2026-08-03T14:08:50Z",
     "build": {
-      "commit": "46c3ca81",
-      "subject": "docs(reconcile): open band-#2310 Q-0107 pass (born-red card + claim)",
-      "committed_at": "2026-08-03T11:52:58Z"
+      "commit": "30444015",
+      "subject": "Merge pull request #2312 from menno420/claude/reconcile-band2310",
+      "committed_at": "2026-08-03T14:08:50Z"
     },
     "schema_version": 1
   },
@@ -13,9 +13,9 @@
       "file": "2026-08-03-reconcile.md",
       "date": "2026-08-03",
       "title": "2026-08-03 — fifty-fourth Q-0107 docs reconciliation pass (band-#2310)",
-      "status": "in-progress",
+      "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
+      "self_initiated": true
     },
     {
       "file": "2026-07-31-reconcile.md",
@@ -491,10 +491,10 @@
     }
   ],
   "ideas": {
-    "total": 253,
+    "total": 254,
     "by_status": {
       "historical": 26,
-      "ideas": 224,
+      "ideas": 225,
       "reference": 3
     }
   },
@@ -2027,6 +2027,20 @@
     {
       "session": "2026-07-31-reconcile",
       "date": "2026-07-31",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-08-03-reconcile",
+      "date": "2026-08-03",
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "docs-only",

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-08-03T11:52:58Z",
+    "generated_at": "2026-08-03T14:08:50Z",
     "build": {
-      "commit": "46c3ca81",
-      "subject": "docs(reconcile): open band-#2310 Q-0107 pass (born-red card + claim)",
-      "committed_at": "2026-08-03T11:52:58Z"
+      "commit": "30444015",
+      "subject": "Merge pull request #2312 from menno420/claude/reconcile-band2310",
+      "committed_at": "2026-08-03T14:08:50Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -7738,7 +7738,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "46c3ca81",
+    "build": "30444015",
     "title": "New public bot website",
     "changes": [
       {
@@ -7750,7 +7750,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "46c3ca81",
+    "build": "30444015",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -7762,7 +7762,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "46c3ca81",
+    "build": "30444015",
     "title": "Command-alias suggestions",
     "changes": [
       {
@@ -9143,9 +9143,9 @@ const FEATURES = [
 ];
 
 const BUILD = {
-  "commit": "46c3ca81",
-  "subject": "docs(reconcile): open band-#2310 Q-0107 pass (born-red card + claim)",
-  "committed_at": "2026-08-03T11:52:58Z"
+  "commit": "30444015",
+  "subject": "Merge pull request #2312 from menno420/claude/reconcile-band2310",
+  "committed_at": "2026-08-03T14:08:50Z"
 };
 
 const COUNTS = {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-08-03T11:52:58Z",
+    "generated_at": "2026-08-03T14:08:50Z",
     "build": {
-      "commit": "46c3ca81",
-      "subject": "docs(reconcile): open band-#2310 Q-0107 pass (born-red card + claim)",
-      "committed_at": "2026-08-03T11:52:58Z"
+      "commit": "30444015",
+      "subject": "Merge pull request #2312 from menno420/claude/reconcile-band2310",
+      "committed_at": "2026-08-03T14:08:50Z"
     },
     "schema_version": 1,
     "counts": {
       "functions": 43,
-      "ideas": 253,
+      "ideas": 254,
       "bugs": 31,
       "reviews": 0,
       "reviews_open": 0,
@@ -1165,6 +1165,14 @@
     }
   ],
   "ideas": [
+    {
+      "file": "routine-self-improvement-backlog-has-no-executor-2026-08-03.md",
+      "title": "Idea — the reconcile routine's self-improvement backlog has no executor under oracle-freeze",
+      "status": "ideas",
+      "date": "2026-08-03",
+      "summary": "Dedup-checking for this pass's Q-0089 idea, I hit **two already-promoted-but-never-executed**",
+      "subsystems": null
+    },
     {
       "file": "routine-debt-carry-escalation-2026-07-31.md",
       "title": "Idea — escalate carried routine-debt on the reconciliation run report",
@@ -3464,9 +3472,9 @@
       "file": "2026-08-03-reconcile.md",
       "date": "2026-08-03",
       "title": "2026-08-03 — fifty-fourth Q-0107 docs reconciliation pass (band-#2310)",
-      "status": "in-progress",
+      "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
+      "self_initiated": true
     },
     {
       "file": "2026-07-31-reconcile.md",
@@ -5407,6 +5415,20 @@
     {
       "session": "2026-07-31-reconcile",
       "date": "2026-07-31",
+      "model": "opus-4.8",
+      "effort": "high",
+      "task_class": "docs-only",
+      "tokens_out": null,
+      "outcome": {
+        "ci_green_first_push": false,
+        "checker_findings": "check_session_gate telemetry-row (fixed in-PR)",
+        "merged_pr": null,
+        "reverted_within_window": null
+      }
+    },
+    {
+      "session": "2026-08-03-reconcile",
+      "date": "2026-08-03",
       "model": "opus-4.8",
       "effort": "high",
       "task_class": "docs-only",

--- a/docs/current-state/S4-docs.md
+++ b/docs/current-state/S4-docs.md
@@ -118,7 +118,7 @@
   startable slice. Companion: the still-unexecuted
   [orientation-cost-reduction plan](../planning/orientation-cost-reduction-plan-2026-06-30.md)
   (Q-0210 router archive now 3+ passes overdue — B0–B3 should run soon regardless).
-- **Next reconciliation pass due once merged PRs cross #2310** (every multiple of 30, Q-0134) —
+- **Next reconciliation pass due once merged PRs cross #2340** (every multiple of 30, Q-0134) —
   auto-triggered by `reconciliation-trigger.yml`; run by the docs-reconciliation routine, **not** a
   manual session (Q-0124).
 - **⚠️ `PLAN BACKLOG THIN` (raised band-#2160, 2026-07-19)** — the in-repo product backlog is


### PR DESCRIPTION
Post-merge follow-up to the 54th Q-0107 reconciliation pass (#2312, merged). #2312 auto-merged on green CI before the Codex final review landed (expected — Q-0174); Codex then posted three verified-genuine findings against the merged commit. A merged PR is finished, so they are fixed here as a fresh docs-only PR off `main`:

- **P2 — stale dashboard export.** `export_dashboard_data.py` had been run mid-pass, before the session card flipped to `complete` and before the new idea file existed, so the merged `dashboard/data/dashboard.json` + botsite mirrors recorded the run as `in-progress`/`self_initiated:false` and 253 ideas. Re-ran the exporter against the final tree and committed every mirror (idea count now **254**). Process note captured in the session log: the dashboard regen must be the **last** step of a pass.
- **P2 — stale S4 `▶ Next` boundary.** `docs/current-state/S4-docs.md`'s live `▶ Next` still said "due once merges cross #2310"; advanced to **#2340** to match the marker + hub + run report.
- **P3 — ledger-lag attribution wording.** The session log's validation note called the 27 merges "newer than the (now #2310) marker" (internally impossible); corrected to attribute them to the pre-pass **#2280** marker.

Docs + generated artifact only, zero `disbot/` runtime. `check_docs`, `check_current_state_ledger`, `check_session_log`, `check_dashboard_data` all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiQCZuc5cNG2bveW3nv9r1)_