### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-08-03T14:08:50Z",
+    "generated_at": "2026-08-03T14:17:20Z",
     "build": {
-      "commit": "30444015",
-      "subject": "Merge pull request #2312 from menno420/claude/reconcile-band2310",
-      "committed_at": "2026-08-03T14:08:50Z"
+      "commit": "95c514fb",
+      "subject": "Merge pull request #2313 from menno420/claude/reconcile-2310-codex-followup",
+      "committed_at": "2026-08-03T14:17:20Z"
     },
     "schema_version": 1,
     "counts": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.