### PR TITLE
Bump codeql-action to v4.37.1 as one commit, and group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,12 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     labels: ["dependencies"]
+    # Grouped for correctness, not just noise. A multi-step action
+    # (github/codeql-action init + autobuild + analyze) MUST move as one
+    # commit: CodeQL hard-fails with "Not all workflow steps that use
+    # github/codeql-action actions use the same version" if the refs differ,
+    # so an ungrouped bump ships three PRs that are each red by construction
+    # and individually unmergeable. Measured 2026-08-05 on #2171/#2172/#2175.
+    groups:
+      github-actions-all:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: python
           # 'security-extended' adds more security queries than the default set without
@@ -47,9 +47,9 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:python"


### PR DESCRIPTION
Supersedes and closes #2171, #2172 and #2175.

## Why those three were never mergeable

Dependabot split **one atomic change into three PRs** — `init`, `autobuild` and `analyze` bumped separately. Any one of them alone leaves `.github/workflows/codeql.yml` with mismatched `github/codeql-action` refs, and CodeQL hard-fails:

> `1 issue was detected with this workflow: Not all workflow steps that use github/codeql-action actions use the same version.`
> `CodeQL job status was configuration error.`

All three had been red since 2026-07-20 for exactly that reason. Read from outside, that looks like a bad release; it was a split one. I confirmed it is not staleness — the branches were refreshed against current `main` today and failed identically, while CodeQL is green on `main`.

This moves all three refs to `7188fc3` (v4.37.1) in a single commit, so the workflow is never in a mismatched state.

## The structural half

Both `pip` ecosystems in `.github/dependabot.yml` already declare `groups:`. `github-actions` did not — which is why this arrived as three PRs. It now groups, so a multi-step action moves atomically. Comment records the measurement so the reason survives.

## Still open, and not fixed here

`dependabot.yml` says dependabot PRs *"wait for review"*, because the auto-merge enabler is scoped to `claude/*`. Playbook R29 says the owner never reviews PRs. Those two policies are individually reasonable and jointly guarantee an infinite wait — which is why nine dependency PRs were open, seven of them dating from the day the program closed. That is a merge-policy decision, flagged rather than changed.

---
_Generated by [Claude Code](https://claude.ai/code)_