### PR TITLE
Bump botsite uvicorn to >=0.52.1 — the last un-landed line

### DIFF
--- a/botsite/requirements.txt
+++ b/botsite/requirements.txt
@@ -3,7 +3,7 @@
 # CI's bot install and the bot's Railway build are unaffected — this is its own
 # Railway service (Root Directory = botsite). Mirrors the dashboard's proven recipe.
 fastapi>=0.141.1,<1.0
-uvicorn[standard]>=0.51.0,<1.0
+uvicorn[standard]>=0.52.1,<1.0
 jinja2>=3.1.6,<4.0
 # asyncpg: the /submit intake INSERTs one pending row into the dashboard-owned
 # submissions DB (botsite/submissions_db.py). Pinned floor matches the bot's so the


### PR DESCRIPTION
The remainder of the overlapping dependabot set, extracted rather than rebased.

`#2316` landed the dashboard bumps and `#2339` landed botsite `fastapi`. That left `#2340` and `#2343` conflict-dirty against main while carrying **one** genuinely new line between them — botsite's `uvicorn`. Rebasing either would have re-opened the same overlap the `/botsite` updater in #2338 exists to prevent, so the remainder is taken directly and both are closed.

Every other line in those two PRs is already at target on `main`, verified file by file before writing this.

---
_Generated by [Claude Code](https://claude.ai/code)_