### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-08-05T22:42:38Z",
+    "generated_at": "2026-08-05T23:38:20Z",
     "build": {
-      "commit": "d07e2cc8",
-      "subject": "Merge pull request #2345 from menno420/claude/botsite-uvicorn-remainder",
-      "committed_at": "2026-08-05T22:42:38Z"
+      "commit": "b137f6de",
+      "subject": "Merge pull request #2346 from menno420/bot/dashboard-refresh",
+      "committed_at": "2026-08-05T23:38:20Z"
     },
     "schema_version": 1,
     "counts": {


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.